### PR TITLE
feat(quickadd): a menu-bar entry, the one door macOS cannot filter out (#2412)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -223,9 +223,29 @@ final class MenuBarController: NSObject {
   /// residual inaccuracy on an exotic layout is the app-wide one and belongs where that formatter
   /// lives — fixing it HERE alone would make the menu disagree with the Keybinds screen, which is
   /// worse than being consistently approximate.
+  ///
+  /// **Silent when another role owns the same chord, which is not the same as the chord being
+  /// dead.** `ShortcutMatcher.role` gives Record priority on a shared binding, and
+  /// `HotkeyService.quickAddMayHoldItsChord` unregisters Quick Add entirely while a same-binding
+  /// Cancel is armed — and the keybind screen allows the collision. So the configured chord can
+  /// START OR CANCEL A RECORDING, and printing it here teaches the user to fire the heart path while
+  /// trying to add a word. This menu exists because the shortcut can fail; advertising the wrong
+  /// owner is the one thing it must not do.
+  ///
+  /// Omitted rather than resolved to the effective owner: there is no honest short hint for "this
+  /// chord belongs to Start Recording", and the row itself still works. Cloud review, PR #2427.
   static func quickAddShortcutLabel(
-    keyCode: UInt16, modifiers: NSEvent.ModifierFlags
+    keyCode: UInt16, modifiers: NSEvent.ModifierFlags,
+    recordKeyCode: UInt16, recordModifiers: NSEvent.ModifierFlags,
+    cancelKeyCode: UInt16, cancelModifiers: NSEvent.ModifierFlags
   ) -> String? {
+    // Compared as raw pairs rather than as `ShortcutBinding`, which is `package` to another module.
+    // Equality is the same question either way: same key code, same modifiers, same chord.
+    let contested =
+      (keyCode == recordKeyCode && modifiers == recordModifiers)
+      || (keyCode == cancelKeyCode && modifiers == cancelModifiers)
+    guard !contested else { return nil }
+
     let formatted = KeySymbols.format(keyCode: keyCode, modifiers: modifiers)
     // `nameForKeyCode` falls back to `Key <n>` for anything it does not know, which teaches nothing
     // and looks like a bug. Say nothing instead.
@@ -348,10 +368,11 @@ final class MenuBarController: NSObject {
     // controller would be one value shared by every render, and could drift from the title sitting
     // beside it; this cannot, because they are set together and thrown away together. It also keeps
     // this class off its stored-property ceiling, which refused the field and was right to.
-    // Only a READY row carries text. A blocked row is enabled precisely so the panel can state the
-    // refusal, and it must reach `begin` with no override so the panel reads the live reason rather
-    // than being handed a stale one.
-    if case .ready(let selection) = state.quickAdd { quickAddItem.representedObject = selection }
+    // **EVERY row carries its own outcome, not just a ready one.** The previous version attached
+    // text to a ready row and nothing to the others, so the click path had to re-read to find out
+    // what had happened — without this read's cap, and after the menu had closed, by which time a
+    // live read can answer about US rather than about the user's document.
+    quickAddItem.representedObject = state.quickAdd.selectionResult
     menu.addItem(quickAddItem)
 
     // Auto-stop on silence indicator
@@ -470,7 +491,9 @@ final class MenuBarController: NSObject {
 
     return MenuBarViewState(
       quickAddShortcut: Self.quickAddShortcutLabel(
-        keyCode: settings.quickAddKeyCode, modifiers: settings.quickAddModifiers),
+        keyCode: settings.quickAddKeyCode, modifiers: settings.quickAddModifiers,
+        recordKeyCode: settings.toggleKeyCode, recordModifiers: settings.toggleModifiers,
+        cancelKeyCode: settings.cancelKeyCode, cancelModifiers: settings.cancelModifiers),
       quickAdd: quickAdd,
       pipelineState: liveRecordingState.pipelineState,
       asrLabel: backendMetadata.modelLabel,
@@ -495,7 +518,10 @@ final class MenuBarController: NSObject {
   @objc private func addSelectedWordAction(_ sender: NSMenuItem) {
     // A blocked row carries nothing, and passing nil is what lets the panel read the refusal LIVE
     // and say why — rather than repeating a reason captured when the menu was drawn.
-    actions.addSelectedWord(sender.representedObject as? String)
+    // A row we rendered always carries its outcome. The fallback is not a real case — it exists so
+    // a menu item built by something other than `renderMenu` cannot silently add an empty word.
+    actions.addSelectedWord(
+      sender.representedObject as? SelectionReader.Result ?? .refused(.noFocusedElement))
   }
 
   @objc private func continueOnboardingAction() {
@@ -579,7 +605,7 @@ extension MenuBarController: NSMenuDelegate {
           switch SelectionReader.read(timeout: Self.quickAddReadTimeout) {
           case .text(let text): return .ready(text)
           case .noSelection: return .nothingSelected
-          case .refused: return .blocked
+          case .refused(let why): return .blocked(why)
           }
         }()
         renderMenu(into: currentMenu, state: currentViewState(quickAdd: quickAdd))
@@ -593,7 +619,7 @@ extension MenuBarController: NSMenuDelegate {
 /// architecture ceiling parser scores them as a single collaborator slot.
 struct MenuBarActions: Sendable {
   /// Open Quick Add on the text the menu read while the user's own app was still frontmost (#2412).
-  let addSelectedWord: @MainActor (String?) -> Void
+  let addSelectedWord: @MainActor (SelectionReader.Result) -> Void
   let continueOnboarding: @MainActor () -> Void
   let openSettings: @MainActor () -> Void
   let openPermissions: @MainActor () -> Void
@@ -612,8 +638,29 @@ enum QuickAddMenuState: Equatable {
   case ready(String)
   /// The read succeeded and there was nothing selected. Inert.
   case nothingSelected
-  /// The read was refused. Enabled, so the panel can state the reason.
-  case blocked
+  /// The read was refused. Enabled, so the panel can state the reason — and it CARRIES that reason,
+  /// because the panel must be handed the outcome we measured rather than re-deriving it.
+  ///
+  /// **Dropping the refusal is what made the re-read necessary.** With only "blocked", the click
+  /// path had to ask again, without the menu's cap, so a stalled Accessibility provider stalled the
+  /// panel instead of the menu and the bound bought nothing. Cloud review, PR #2427.
+  ///
+  /// It changes no display: every refusal renders the same row. Information kept, not shown.
+  case blocked(SelectionReader.Refusal)
+
+  /// The read outcome behind this state, for handing to the panel.
+  ///
+  /// **On the state rather than on the controller, and not merely to satisfy a ceiling.** It answers
+  /// a different question from `quickAddItem`: that one decides what the row LOOKS like, this one
+  /// decides what the panel is TOLD, and neither needs the controller. They were one function's job
+  /// once, which is how the refusal came to be dropped on the way through.
+  var selectionResult: SelectionReader.Result {
+    switch self {
+    case .ready(let text): return .text(text)
+    case .nothingSelected: return .noSelection
+    case .blocked(let why): return .refused(why)
+    }
+  }
 }
 
 /// Immutable snapshot the menu and icon render from. Extracting it makes

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -158,11 +158,23 @@ final class MenuBarController: NSObject {
       return ("Add Selected Word", false)
     }
     let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
+    // **Collapse INTERNAL whitespace, not just the ends.** A selection spanning two document lines
+    // carries a newline, and a newline in an `NSMenuItem` title renders as a malformed, multi-line
+    // row. Tabs and runs of spaces are the same problem, one character over.
+    //
+    // **Display only.** `representedObject` still carries the ORIGINAL selection, so what gets added
+    // is what the user selected rather than what fitted in a menu — the same separation this cluster
+    // has had to relearn three times, where a sentence was composed from a neighbouring value
+    // instead of from what the write path was given.
+    //
+    // Collapsed BEFORE truncating, so the limit counts characters the user can actually see.
+    let collapsed = trimmed.split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+      .joined(separator: " ")
     let shown =
-      trimmed.unicodeScalars.count > Self.quickAddTitleScalars
-      ? String(String.UnicodeScalarView(trimmed.unicodeScalars.prefix(Self.quickAddTitleScalars)))
+      collapsed.unicodeScalars.count > Self.quickAddTitleScalars
+      ? String(String.UnicodeScalarView(collapsed.unicodeScalars.prefix(Self.quickAddTitleScalars)))
         + "\u{2026}"
-      : trimmed
+      : collapsed
     return ("Add \u{201C}\(shown)\u{201D}", true)
   }
 

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -121,6 +121,32 @@ final class MenuBarController: NSObject {
 
   // MARK: - Menu rendering
 
+  /// What the Quick Add item says, and whether it can be chosen.
+  ///
+  /// **Disabled with a generic title when there is nothing to add, rather than enabled onto a
+  /// refusal.** An item that opens a panel only to say "nothing selected" spends a click to deliver
+  /// news the menu already had — and this cluster has produced three separate defects where a
+  /// sentence was composed from a neighbouring value rather than from what actually happened.
+  ///
+  /// Truncated for display. `SelectionReader` admits up to 512 scalars, and a menu item is not where
+  /// 512 characters belong; the panel shows the whole thing.
+  static func quickAddItem(selection: String?) -> (title: String, enabled: Bool) {
+    guard let selection, !selection.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return ("Add Selected Word", false)
+    }
+    let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
+    let shown =
+      trimmed.unicodeScalars.count > Self.quickAddTitleScalars
+      ? String(String.UnicodeScalarView(trimmed.unicodeScalars.prefix(Self.quickAddTitleScalars)))
+        + "\u{2026}"
+      : trimmed
+    return ("Add \u{201C}\(shown)\u{201D}", true)
+  }
+
+  /// How much of the selection the title shows. Not a limit on what can be ADDED — the reader's
+  /// ceiling is that — only on what fits a menu without pushing the rest of it off screen.
+  static let quickAddTitleScalars = 24
+
   /// Pure menu builder. Fills `menu` from `state`. Logic byte-identical to the
   /// pre-PR-B.3 `AppDelegate.populateMenu(_:)`. Internal (not private) so
   /// `MenuBarControllerTests` can drive it with `MenuBarViewState` fixtures.
@@ -187,6 +213,26 @@ final class MenuBarController: NSObject {
     recordItem.target = self
     recordItem.isEnabled = !(state.pipelineState.isActive && !isRecording)
     menu.addItem(recordItem)
+
+    // Quick Add (#2412). Beside Start Recording because both act on what the user is doing RIGHT
+    // NOW, and above the Settings separator because neither is configuration.
+    let quickAdd = Self.quickAddItem(selection: state.quickAddSelection)
+    let quickAddItem = NSMenuItem(
+      title: quickAdd.title, action: #selector(addSelectedWordAction), keyEquivalent: "w")
+    // Shown, never registered: the real chord is a global hotkey owned by `HotkeyService`, and a
+    // menu key equivalent would be a SECOND registration of one gesture. This displays `⌃⌥W` so the
+    // menu teaches the fast path, which is the discoverability half of this issue.
+    quickAddItem.keyEquivalentModifierMask = [.control, .option]
+    quickAddItem.image = NSImage(
+      systemSymbolName: "text.badge.plus", accessibilityDescription: "Add selected word")
+    quickAddItem.target = self
+    quickAddItem.isEnabled = quickAdd.enabled
+    // **The selection rides on the ITEM, which is AppKit's own place for it.** A field on the
+    // controller would be one value shared by every render, and could drift from the title sitting
+    // beside it; this cannot, because they are set together and thrown away together. It also keeps
+    // this class off its stored-property ceiling, which refused the field and was right to.
+    quickAddItem.representedObject = state.quickAddSelection
+    menu.addItem(quickAddItem)
 
     // Auto-stop on silence indicator
     if state.vadAutoStop {
@@ -276,7 +322,13 @@ final class MenuBarController: NSObject {
   /// Snapshot the live homes into a value the pure renderer/mapper consume.
   /// Reads are byte-identical to the pre-PR-B.3 `AppDelegate.populateMenu` /
   /// `updateIcon` reads.
-  private func currentViewState() -> MenuBarViewState {
+  /// **`quickAddSelection` is a PARAMETER, not a read taken here, and that is deliberate.** This
+  /// builder feeds three paths — the initial menu build, every icon refresh, and the menu-open path —
+  /// and only the last is licensed to read the world: opening a status menu leaves the user's own
+  /// application frontmost (measured twice, #2412), which is exactly what makes the answer theirs.
+  /// An Accessibility round trip on an icon refresh would be work nobody asked for, against a
+  /// frontmost app that may well be us.
+  private func currentViewState(quickAddSelection: String? = nil) -> MenuBarViewState {
     // #1019: read the pending-update state (non-critical only — critical routes
     // to Sparkle's own UX) and the active-dictation guard.
     let pending: UpdateAvailabilityService.AvailableUpdate? = {
@@ -296,6 +348,7 @@ final class MenuBarController: NSObject {
       sparkleUpdateController.updateCoordinator?.installRefusedNow ?? false
 
     return MenuBarViewState(
+      quickAddSelection: quickAddSelection,
       pipelineState: liveRecordingState.pipelineState,
       asrLabel: backendMetadata.modelLabel,
       llmLabel: backendMetadata.llmLabel,
@@ -312,6 +365,14 @@ final class MenuBarController: NSObject {
   }
 
   // MARK: - Menu actions
+
+  /// **Reads nothing. The selection was captured when the menu was RENDERED**, while the user's own
+  /// application was still frontmost; by the time this fires the menu has closed and a read would be
+  /// about us. That ordering is the whole reason this door works.
+  @objc private func addSelectedWordAction(_ sender: NSMenuItem) {
+    guard let selection = sender.representedObject as? String else { return }
+    actions.addSelectedWord(selection)
+  }
 
   @objc private func continueOnboardingAction() {
     actions.continueOnboarding()
@@ -366,16 +427,23 @@ extension MenuBarController: NSMenuDelegate {
   nonisolated func menuNeedsUpdate(_ menu: NSMenu) {
     MainActor.assumeIsolated {
       if let currentMenu = statusItem?.menu {
-        renderMenu(into: currentMenu, state: currentViewState())
+        // The one read, at the one moment it is about the user's document rather than about us.
+        let selection: String? = {
+          if case .text(let text) = SelectionReader.read() { return text }
+          return nil
+        }()
+        renderMenu(into: currentMenu, state: currentViewState(quickAddSelection: selection))
       }
       updateIcon()
     }
   }
 }
 
-/// The five menu-action callbacks, packaged into one `Sendable` struct so the
+/// The menu-action callbacks, packaged into one `Sendable` struct so the
 /// architecture ceiling parser scores them as a single collaborator slot.
 struct MenuBarActions: Sendable {
+  /// Open Quick Add on the text the menu read while the user's own app was still frontmost (#2412).
+  let addSelectedWord: @MainActor (String) -> Void
   let continueOnboarding: @MainActor () -> Void
   let openSettings: @MainActor () -> Void
   let openPermissions: @MainActor () -> Void
@@ -387,6 +455,12 @@ struct MenuBarActions: Sendable {
 /// `renderMenu` / `iconState` pure functions over a value, which is what makes
 /// the menu surface deterministically golden-testable.
 struct MenuBarViewState: Equatable {
+  /// The selection Quick Add would act on, or nil when there is nothing readable (#2412).
+  ///
+  /// **Carried on the state rather than read inside `renderMenu`, deliberately.** That function is
+  /// pure over this value, which is what makes the entire menu surface golden-testable; a world read
+  /// inside it would end that on the surface where a wrong item is most visible.
+  let quickAddSelection: String?
   let pipelineState: PipelineState
   let asrLabel: String
   let llmLabel: String

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -553,13 +553,20 @@ extension MenuBarController: NSMenuDelegate {
       if let currentMenu = statusItem?.menu {
         // The one read, at the one moment it is about the user's document rather than about us.
         //
-        // **That is MEASURED, not assumed — opening a status-bar menu does not activate its owner.**
-        // A standalone AppKit probe with a status item and nothing else read
-        // `NSWorkspace.frontmostApplication` before, during and after: unchanged throughout, and
-        // `isUs=false` inside `menuNeedsUpdate`. It matters because #2413 adds a refusal for "we are
-        // frontmost", which would otherwise make this entry permanently blocked. Limit of that
-        // measurement: the probe opens the menu with `performClick` rather than a real mouse click,
-        // though both enter the same tracking loop.
+        // **MEASURED rather than assumed, and the claim is exactly the measurement.** A standalone
+        // AppKit probe — a status item and nothing else — opened its menu with `performClick` on
+        // macOS 26.7 (build 25G220) and read `NSWorkspace.frontmostApplication` before, inside `menuNeedsUpdate`,
+        // and after: unchanged throughout, `isUs=false` inside the hook. So on that path this read
+        // is about another application's document.
+        //
+        // **What that does NOT establish: a real mouse click, or another macOS version.** Both
+        // enter the same tracking loop, which is why the probe is worth having, but neither was
+        // observed — so this is evidence, not a general fact about AppKit, and a future `isUs=true`
+        // here is a gap in the evidence rather than a contradiction.
+        //
+        // It matters because #2413 adds a refusal for "we are the frontmost application": if
+        // opening this menu DID activate us, the entry would be permanently blocked. Probe and
+        // output are at `docs/audits/2026-08-25-statusmenu-frontmost-{probe.swift,result.txt}`.
         //
         // **Bounded, because `menuNeedsUpdate` must be synchronous.** A frontmost application whose
         // Accessibility provider stalls would otherwise hold the main actor and the menu would not

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -246,10 +246,15 @@ final class MenuBarController: NSObject {
   ///
   /// TWO limits, because they bound different things. Characters are what the user counts;
   /// scalars bound the pathological case where a handful of characters carry hundreds of scalars.
-  /// How long the menu will wait for the frontmost application to answer.
+  /// How long the menu will wait for the frontmost application to answer EACH Accessibility
+  /// operation.
+  ///
+  /// **Per operation, and the read makes two** — the focused-element lookup and the selected-text
+  /// read — so the worst case is 0.5s total, which is the bound the menu was always meant to hold
+  /// to. An earlier version set 0.5 here and claimed 0.5 total, which was wrong by a factor of two.
   ///
   /// Longer than any healthy Accessibility read, shorter than a user tolerates a menu not opening.
-  static let quickAddReadTimeout: Float = 0.5
+  static let quickAddReadTimeout: Float = 0.25
 
   static let quickAddTitleCharacters = 24
   static let quickAddTitleScalars = 96
@@ -548,7 +553,8 @@ extension MenuBarController: NSMenuDelegate {
         //
         // **Bounded, because `menuNeedsUpdate` must be synchronous.** A frontmost application whose
         // Accessibility provider stalls would otherwise hold the main actor and the menu would not
-        // open at all. Half a second is longer than any healthy read and shorter than a user waits.
+        // open at all. The bound is PER OPERATION and the read makes two, so the worst case is
+        // 0.5s — longer than any healthy read, shorter than a user tolerates a dead menu.
         //
         // All three outcomes are carried. A refusal is NOT an empty selection — collapsing them is
         // what made a missing Accessibility permission look identical to having selected nothing.

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -153,10 +153,29 @@ final class MenuBarController: NSObject {
   ///
   /// Truncated for display. `SelectionReader` admits up to 512 scalars, and a menu item is not where
   /// 512 characters belong; the panel shows the whole thing.
-  static func quickAddItem(selection: String?) -> (title: String, enabled: Bool) {
-    guard let selection, !selection.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+  static func quickAddItem(_ state: QuickAddMenuState) -> (title: String, enabled: Bool) {
+    switch state {
+    case .nothingSelected:
       return ("Add Selected Word", false)
+    case .blocked:
+      // **Enabled, and that is the point.** A refused read is not an empty selection: the user has
+      // selected something and we could not read it, usually because Accessibility is off. A greyed
+      // row tells them nothing, so this one opens the panel, which exists to state the reason. The
+      // door that is meant to be the reliable one must not fail silently.
+      return ("Add Selected Word", true)
+    case .ready(let selection):
+      // **A `.ready` carrying only whitespace is the empty case wearing the wrong label.** The
+      // reader trims, so this is not a state it can produce — but the type permits it, and a row
+      // reading `Add “”` that opens a panel on nothing is worse than an inert one.
+      guard !selection.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return ("Add Selected Word", false)
+      }
+      return (Self.readyTitle(selection), true)
     }
+  }
+
+  /// The title for a readable selection.
+  private static func readyTitle(_ selection: String) -> String {
     let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
     // **Collapse INTERNAL whitespace, not just the ends.** A selection spanning two document lines
     // carries a newline, and a newline in an `NSMenuItem` title renders as a malformed, multi-line
@@ -170,12 +189,24 @@ final class MenuBarController: NSObject {
     // Collapsed BEFORE truncating, so the limit counts characters the user can actually see.
     let collapsed = trimmed.split(whereSeparator: { $0.isWhitespace || $0.isNewline })
       .joined(separator: " ")
-    let shown =
-      collapsed.unicodeScalars.count > Self.quickAddTitleScalars
-      ? String(String.UnicodeScalarView(collapsed.unicodeScalars.prefix(Self.quickAddTitleScalars)))
-        + "\u{2026}"
-      : collapsed
-    return ("Add \u{201C}\(shown)\u{201D}", true)
+    // **Truncate on CHARACTERS, not scalars.** A family emoji, a flag, or a letter written as a
+    // base plus a combining mark is several scalars and one character; cutting between them renders
+    // a broken glyph. The scalar ceiling still bounds the worst case, because a character can carry
+    // many scalars — both limits, and the tighter one wins.
+    let shown: String = {
+      guard collapsed.count > Self.quickAddTitleCharacters
+        || collapsed.unicodeScalars.count > Self.quickAddTitleScalars
+      else { return collapsed }
+      var out = ""
+      for character in collapsed {
+        guard out.count < Self.quickAddTitleCharacters,
+          out.unicodeScalars.count + character.unicodeScalars.count <= Self.quickAddTitleScalars
+        else { break }
+        out.append(character)
+      }
+      return out + "\u{2026}"
+    }()
+    return "Add \u{201C}\(shown)\u{201D}"
   }
 
   /// The Quick Add chord as READABLE TEXT, or nil when there is nothing sensible to show.
@@ -212,7 +243,16 @@ final class MenuBarController: NSObject {
 
   /// How much of the selection the title shows. Not a limit on what can be ADDED — the reader's
   /// ceiling is that — only on what fits a menu without pushing the rest of it off screen.
-  static let quickAddTitleScalars = 24
+  ///
+  /// TWO limits, because they bound different things. Characters are what the user counts;
+  /// scalars bound the pathological case where a handful of characters carry hundreds of scalars.
+  /// How long the menu will wait for the frontmost application to answer.
+  ///
+  /// Longer than any healthy Accessibility read, shorter than a user tolerates a menu not opening.
+  static let quickAddReadTimeout: Float = 0.5
+
+  static let quickAddTitleCharacters = 24
+  static let quickAddTitleScalars = 96
 
   /// Pure menu builder. Fills `menu` from `state`. Logic byte-identical to the
   /// pre-PR-B.3 `AppDelegate.populateMenu(_:)`. Internal (not private) so
@@ -283,7 +323,7 @@ final class MenuBarController: NSObject {
 
     // Quick Add (#2412). Beside Start Recording because both act on what the user is doing RIGHT
     // NOW, and above the Settings separator because neither is configuration.
-    let quickAdd = Self.quickAddItem(selection: state.quickAddSelection)
+    let quickAdd = Self.quickAddItem(state.quickAdd)
     // **No key equivalent, deliberately** — see `quickAddShortcutLabel`. The chord rides in the
     // title as text, so the menu teaches the fast path without registering a second way to fire it.
     let quickAddItem = NSMenuItem(
@@ -302,7 +342,10 @@ final class MenuBarController: NSObject {
     // controller would be one value shared by every render, and could drift from the title sitting
     // beside it; this cannot, because they are set together and thrown away together. It also keeps
     // this class off its stored-property ceiling, which refused the field and was right to.
-    quickAddItem.representedObject = state.quickAddSelection
+    // Only a READY row carries text. A blocked row is enabled precisely so the panel can state the
+    // refusal, and it must reach `begin` with no override so the panel reads the live reason rather
+    // than being handed a stale one.
+    if case .ready(let selection) = state.quickAdd { quickAddItem.representedObject = selection }
     menu.addItem(quickAddItem)
 
     // Auto-stop on silence indicator
@@ -393,13 +436,13 @@ final class MenuBarController: NSObject {
   /// Snapshot the live homes into a value the pure renderer/mapper consume.
   /// Reads are byte-identical to the pre-PR-B.3 `AppDelegate.populateMenu` /
   /// `updateIcon` reads.
-  /// **`quickAddSelection` is a PARAMETER, not a read taken here, and that is deliberate.** This
+  /// **`quickAdd` is a PARAMETER, not a read taken here, and that is deliberate.** This
   /// builder feeds three paths — the initial menu build, every icon refresh, and the menu-open path —
   /// and only the last is licensed to read the world: opening a status menu leaves the user's own
   /// application frontmost (measured twice, #2412), which is exactly what makes the answer theirs.
   /// An Accessibility round trip on an icon refresh would be work nobody asked for, against a
   /// frontmost app that may well be us.
-  private func currentViewState(quickAddSelection: String? = nil) -> MenuBarViewState {
+  private func currentViewState(quickAdd: QuickAddMenuState = .nothingSelected) -> MenuBarViewState {
     // #1019: read the pending-update state (non-critical only — critical routes
     // to Sparkle's own UX) and the active-dictation guard.
     let pending: UpdateAvailabilityService.AvailableUpdate? = {
@@ -421,7 +464,7 @@ final class MenuBarController: NSObject {
     return MenuBarViewState(
       quickAddShortcut: Self.quickAddShortcutLabel(
         keyCode: settings.quickAddKeyCode, modifiers: settings.quickAddModifiers),
-      quickAddSelection: quickAddSelection,
+      quickAdd: quickAdd,
       pipelineState: liveRecordingState.pipelineState,
       asrLabel: backendMetadata.modelLabel,
       llmLabel: backendMetadata.llmLabel,
@@ -443,8 +486,9 @@ final class MenuBarController: NSObject {
   /// application was still frontmost; by the time this fires the menu has closed and a read would be
   /// about us. That ordering is the whole reason this door works.
   @objc private func addSelectedWordAction(_ sender: NSMenuItem) {
-    guard let selection = sender.representedObject as? String else { return }
-    actions.addSelectedWord(selection)
+    // A blocked row carries nothing, and passing nil is what lets the panel read the refusal LIVE
+    // and say why — rather than repeating a reason captured when the menu was drawn.
+    actions.addSelectedWord(sender.representedObject as? String)
   }
 
   @objc private func continueOnboardingAction() {
@@ -501,11 +545,21 @@ extension MenuBarController: NSMenuDelegate {
     MainActor.assumeIsolated {
       if let currentMenu = statusItem?.menu {
         // The one read, at the one moment it is about the user's document rather than about us.
-        let selection: String? = {
-          if case .text(let text) = SelectionReader.read() { return text }
-          return nil
+        //
+        // **Bounded, because `menuNeedsUpdate` must be synchronous.** A frontmost application whose
+        // Accessibility provider stalls would otherwise hold the main actor and the menu would not
+        // open at all. Half a second is longer than any healthy read and shorter than a user waits.
+        //
+        // All three outcomes are carried. A refusal is NOT an empty selection — collapsing them is
+        // what made a missing Accessibility permission look identical to having selected nothing.
+        let quickAdd: QuickAddMenuState = {
+          switch SelectionReader.read(timeout: Self.quickAddReadTimeout) {
+          case .text(let text): return .ready(text)
+          case .noSelection: return .nothingSelected
+          case .refused: return .blocked
+          }
         }()
-        renderMenu(into: currentMenu, state: currentViewState(quickAddSelection: selection))
+        renderMenu(into: currentMenu, state: currentViewState(quickAdd: quickAdd))
       }
       updateIcon()
     }
@@ -516,12 +570,27 @@ extension MenuBarController: NSMenuDelegate {
 /// architecture ceiling parser scores them as a single collaborator slot.
 struct MenuBarActions: Sendable {
   /// Open Quick Add on the text the menu read while the user's own app was still frontmost (#2412).
-  let addSelectedWord: @MainActor (String) -> Void
+  let addSelectedWord: @MainActor (String?) -> Void
   let continueOnboarding: @MainActor () -> Void
   let openSettings: @MainActor () -> Void
   let openPermissions: @MainActor () -> Void
   let toggleRecording: @MainActor () async -> Void
   let quit: @MainActor () -> Void
+}
+
+/// What the Quick Add row has to say, in the three states a selection read can produce.
+///
+/// **Three, because a `String?` can only hold two** — and the two it collapsed were "you selected
+/// nothing" and "we could not read what you selected", which need opposite treatment. The first is
+/// nothing to report; the second is the user's Accessibility permission being off, which is exactly
+/// the thing this door exists to be reliable about.
+enum QuickAddMenuState: Equatable {
+  /// A readable selection. The row names it and can be chosen.
+  case ready(String)
+  /// The read succeeded and there was nothing selected. Inert.
+  case nothingSelected
+  /// The read was refused. Enabled, so the panel can state the reason.
+  case blocked
 }
 
 /// Immutable snapshot the menu and icon render from. Extracting it makes
@@ -534,12 +603,11 @@ struct MenuBarViewState: Equatable {
   /// reading `settings` inside it would end that.
   let quickAddShortcut: String?
 
-  /// The selection Quick Add would act on, or nil when there is nothing readable (#2412).
+  /// What the Quick Add row has to say (#2412).
   ///
-  /// **Carried on the state rather than read inside `renderMenu`, deliberately.** That function is
-  /// pure over this value, which is what makes the entire menu surface golden-testable; a world read
-  /// inside it would end that on the surface where a wrong item is most visible.
-  let quickAddSelection: String?
+  /// On the state rather than read inside `renderMenu`, which is pure over this value — that purity
+  /// is what makes the whole menu surface golden-testable.
+  let quickAdd: QuickAddMenuState
   let pipelineState: PipelineState
   let asrLabel: String
   let llmLabel: String

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -239,11 +239,21 @@ final class MenuBarController: NSObject {
     recordKeyCode: UInt16, recordModifiers: NSEvent.ModifierFlags,
     cancelKeyCode: UInt16, cancelModifiers: NSEvent.ModifierFlags
   ) -> String? {
-    // Compared as raw pairs rather than as `ShortcutBinding`, which is `package` to another module.
-    // Equality is the same question either way: same key code, same modifiers, same chord.
+    // **Compared on the CARBON-EFFECTIVE modifiers, not the raw flags.** `HotkeyService`
+    // registers through `carbonModifiers`, which keeps only Command/Option/Control/Shift — so a
+    // binding recorded with Caps Lock, Function or Numeric Pad set differs from Record's RAW flags
+    // while being the SAME CHORD to Carbon. Record registers first, Quick Add's registration then
+    // fails, and a raw comparison calls the binding uncontested and advertises a dead chord. Cloud
+    // review, PR #2427, on the first version of this very guard.
+    //
+    // Compared as masked pairs rather than as `ShortcutBinding`, which is `package` to another
+    // module.
+    let effective = modifiers.intersection(Self.carbonEffectiveModifiers)
     let contested =
-      (keyCode == recordKeyCode && modifiers == recordModifiers)
-      || (keyCode == cancelKeyCode && modifiers == cancelModifiers)
+      (keyCode == recordKeyCode
+        && effective == recordModifiers.intersection(Self.carbonEffectiveModifiers))
+      || (keyCode == cancelKeyCode
+        && effective == cancelModifiers.intersection(Self.carbonEffectiveModifiers))
     guard !contested else { return nil }
 
     let formatted = KeySymbols.format(keyCode: keyCode, modifiers: modifiers)
@@ -276,6 +286,15 @@ final class MenuBarController: NSObject {
   ///
   /// Longer than any healthy Accessibility read, shorter than a user tolerates a menu not opening.
   static let quickAddReadTimeout: Float = 0.25
+
+  /// The modifiers Carbon actually registers, mirroring `HotkeyService.carbonModifiers`.
+  ///
+  /// Every other bit — Caps Lock, Function, Numeric Pad, and the device-dependent flags — is dropped
+  /// on the way to `RegisterEventHotKey`, so two bindings differing only there are ONE chord as far
+  /// as the system is concerned. Comparing anything else here answers a question nobody asked.
+  static let carbonEffectiveModifiers: NSEvent.ModifierFlags = [
+    .command, .option, .control, .shift,
+  ]
 
   static let quickAddTitleCharacters = 24
   static let quickAddTitleScalars = 96
@@ -591,8 +610,19 @@ extension MenuBarController: NSMenuDelegate {
         // here is a gap in the evidence rather than a contradiction.
         //
         // It matters because #2413 adds a refusal for "we are the frontmost application": if
-        // opening this menu DID activate us, the entry would be permanently blocked. Probe and
-        // output are at `docs/audits/2026-08-25-statusmenu-frontmost-{probe.swift,result.txt}`.
+        // opening this menu DID activate us, the entry would be permanently blocked.
+        //
+        // **Reproduce it rather than look for the artifact — `docs/` is gitignored
+        // (`.gitignore:340`), so no checkout will ever hold that probe.** An earlier version of
+        // this comment cited a path there, which is worse than citing nothing: it tells the reader
+        // evidence exists and sends them to find it. Cloud review caught it, PR #2427.
+        //
+        // Thirty lines, no app involved: an `NSApplication` at `.accessory` policy, one
+        // `NSStatusItem` whose menu has this delegate, `NSWorkspace.frontmostApplication` recorded
+        // before `button.performClick(nil)`, inside `menuNeedsUpdate`, and after. Two traps —
+        // `performClick` enters a modal tracking loop where `DispatchQueue.main.async` never runs,
+        // so schedule the dismissal with a `Timer` in `.common`; and write findings to a file as
+        // they are taken, since `print` to a pipe block-buffers and a hang leaves nothing.
         //
         // **Bounded, because `menuNeedsUpdate` must be synchronous.** A frontmost application whose
         // Accessibility provider stalls would otherwise hold the main actor and the menu would not

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -194,8 +194,9 @@ final class MenuBarController: NSObject {
     // a broken glyph. The scalar ceiling still bounds the worst case, because a character can carry
     // many scalars — both limits, and the tighter one wins.
     let shown: String = {
-      guard collapsed.count > Self.quickAddTitleCharacters
-        || collapsed.unicodeScalars.count > Self.quickAddTitleScalars
+      guard
+        collapsed.count > Self.quickAddTitleCharacters
+          || collapsed.unicodeScalars.count > Self.quickAddTitleScalars
       else { return collapsed }
       var out = ""
       for character in collapsed {
@@ -447,7 +448,8 @@ final class MenuBarController: NSObject {
   /// application frontmost (measured twice, #2412), which is exactly what makes the answer theirs.
   /// An Accessibility round trip on an icon refresh would be work nobody asked for, against a
   /// frontmost app that may well be us.
-  private func currentViewState(quickAdd: QuickAddMenuState = .nothingSelected) -> MenuBarViewState {
+  private func currentViewState(quickAdd: QuickAddMenuState = .nothingSelected) -> MenuBarViewState
+  {
     // #1019: read the pending-update state (non-critical only — critical routes
     // to Sparkle's own UX) and the active-dictation guard.
     let pending: UpdateAvailabilityService.AvailableUpdate? = {
@@ -550,6 +552,14 @@ extension MenuBarController: NSMenuDelegate {
     MainActor.assumeIsolated {
       if let currentMenu = statusItem?.menu {
         // The one read, at the one moment it is about the user's document rather than about us.
+        //
+        // **That is MEASURED, not assumed — opening a status-bar menu does not activate its owner.**
+        // A standalone AppKit probe with a status item and nothing else read
+        // `NSWorkspace.frontmostApplication` before, during and after: unchanged throughout, and
+        // `isUs=false` inside `menuNeedsUpdate`. It matters because #2413 adds a refusal for "we are
+        // frontmost", which would otherwise make this entry permanently blocked. Limit of that
+        // measurement: the probe opens the menu with `performClick` rather than a real mouse click,
+        // though both enter the same tracking loop.
         //
         // **Bounded, because `menuNeedsUpdate` must be synchronous.** A frontmost application whose
         // Accessibility provider stalls would otherwise hold the main actor and the menu would not

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -64,8 +64,7 @@ final class MenuBarController: NSObject {
 
     iconAnimator.configure(button: button)
 
-    let menu = NSMenu()
-    menu.delegate = self
+    let menu = Self.makeStatusMenu(delegate: self)
     statusItem?.menu = menu
     renderMenu(into: menu, state: currentViewState())
 
@@ -117,6 +116,30 @@ final class MenuBarController: NSObject {
       // overrides a higher-priority state.
       return state.updateAvailable ? .updatePending : .idle
     }
+  }
+
+  /// Build the status-item menu with auto-enabling OFF.
+  ///
+  /// **Without that, every `isEnabled = false` in `renderMenu` is silently ignored.** `NSMenu`
+  /// auto-enables by default: an item with a valid target and action is enabled whatever the
+  /// property says, unless the target implements `validateMenuItem`. Nothing here did.
+  ///
+  /// Found by Live UAT on #2412 — the Quick Add item rendered ENABLED with no selection, which is
+  /// the one thing it must never be, while its unit test correctly reported the DECISION as false.
+  /// Decision tested, wiring not.
+  ///
+  /// **It was never only the new item.** `recordItem.isEnabled = !(state.pipelineState.isActive &&
+  /// !isRecording)` has been inert for as long as it has existed, so Start Recording stayed
+  /// clickable mid-transcription. Turning auto-enabling off makes every one of those assignments
+  /// mean what it says.
+  ///
+  /// A factory rather than two lines inside `installStatusItem`, so the property is assertable
+  /// without a test seam, a stored property, or a way to tear the status item back down.
+  static func makeStatusMenu(delegate: NSMenuDelegate) -> NSMenu {
+    let menu = NSMenu()
+    menu.autoenablesItems = false
+    menu.delegate = delegate
+    return menu
   }
 
   // MARK: - Menu rendering

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -224,37 +224,39 @@ final class MenuBarController: NSObject {
   /// lives — fixing it HERE alone would make the menu disagree with the Keybinds screen, which is
   /// worse than being consistently approximate.
   ///
-  /// **Silent when another role owns the same chord, which is not the same as the chord being
-  /// dead.** `ShortcutMatcher.role` gives Record priority on a shared binding, and
-  /// `HotkeyService.quickAddMayHoldItsChord` unregisters Quick Add entirely while a same-binding
-  /// Cancel is armed — and the keybind screen allows the collision. So the configured chord can
-  /// START OR CANCEL A RECORDING, and printing it here teaches the user to fire the heart path while
-  /// trying to add a word. This menu exists because the shortcut can fail; advertising the wrong
-  /// owner is the one thing it must not do.
+  /// **Silent unless Quick Add would actually ANSWER the chord, and that question is ASKED rather
+  /// than re-derived.** Three review rounds found three different ways a configured binding can
+  /// belong to someone else — the same binding as Record or Cancel; a binding differing only in a
+  /// modifier Carbon discards; and a bare modifier the record chord reserves. Each fix was correct
+  /// and each exposed the next, which is the signature of describing a set instead of enumerating
+  /// one.
   ///
-  /// Omitted rather than resolved to the effective owner: there is no honest short hint for "this
-  /// chord belongs to Start Recording", and the row itself still works. Cloud review, PR #2427.
+  /// The set is closed by the app's two dispatch paths, and each has an authority that already
+  /// decides ownership with the reasoning attached:
+  ///
+  /// - a BARE MODIFIER is dispatched by `ShortcutMatcher.role(forBareModifierKeyCode:)`, which
+  ///   encodes record-wins-a-tie, cancel-outranks-Quick-Add-while-armed, and the refusal when the
+  ///   record chord needs that modifier;
+  /// - a CHORD is dispatched by Carbon, so it is `HotkeyService.quickAddMayHoldItsChord` plus
+  ///   inequality with Record on the modifiers Carbon actually registers.
+  ///
+  /// `isBareModifier` decides which, so there is no third case to miss.
+  ///
+  /// **Omitted rather than resolved to the effective owner:** there is no honest short hint for
+  /// "this chord belongs to Start Recording", and the row itself still works. This menu exists
+  /// BECAUSE the shortcut can fail, so advertising a chord that starts or cancels a recording is
+  /// the one lie this surface must not tell.
   static func quickAddShortcutLabel(
     keyCode: UInt16, modifiers: NSEvent.ModifierFlags,
     recordKeyCode: UInt16, recordModifiers: NSEvent.ModifierFlags,
     cancelKeyCode: UInt16, cancelModifiers: NSEvent.ModifierFlags
   ) -> String? {
-    // **Compared on the CARBON-EFFECTIVE modifiers, not the raw flags.** `HotkeyService`
-    // registers through `carbonModifiers`, which keeps only Command/Option/Control/Shift — so a
-    // binding recorded with Caps Lock, Function or Numeric Pad set differs from Record's RAW flags
-    // while being the SAME CHORD to Carbon. Record registers first, Quick Add's registration then
-    // fails, and a raw comparison calls the binding uncontested and advertises a dead chord. Cloud
-    // review, PR #2427, on the first version of this very guard.
-    //
-    // Compared as masked pairs rather than as `ShortcutBinding`, which is `package` to another
-    // module.
-    let effective = modifiers.intersection(Self.carbonEffectiveModifiers)
-    let contested =
-      (keyCode == recordKeyCode
-        && effective == recordModifiers.intersection(Self.carbonEffectiveModifiers))
-      || (keyCode == cancelKeyCode
-        && effective == cancelModifiers.intersection(Self.carbonEffectiveModifiers))
-    guard !contested else { return nil }
+    let quickAdd = ShortcutBinding.keyboard(keyCode: keyCode, modifiers: modifiers)
+    let record = ShortcutBinding.keyboard(keyCode: recordKeyCode, modifiers: recordModifiers)
+    let cancel = ShortcutBinding.keyboard(keyCode: cancelKeyCode, modifiers: cancelModifiers)
+    guard ShortcutMatcher.quickAddOwnsItsBinding(quickAdd: quickAdd, record: record, cancel: cancel) else {
+      return nil
+    }
 
     let formatted = KeySymbols.format(keyCode: keyCode, modifiers: modifiers)
     // `nameForKeyCode` falls back to `Key <n>` for anything it does not know, which teaches nothing
@@ -286,15 +288,6 @@ final class MenuBarController: NSObject {
   ///
   /// Longer than any healthy Accessibility read, shorter than a user tolerates a menu not opening.
   static let quickAddReadTimeout: Float = 0.25
-
-  /// The modifiers Carbon actually registers, mirroring `HotkeyService.carbonModifiers`.
-  ///
-  /// Every other bit — Caps Lock, Function, Numeric Pad, and the device-dependent flags — is dropped
-  /// on the way to `RegisterEventHotKey`, so two bindings differing only there are ONE chord as far
-  /// as the system is concerned. Comparing anything else here answers a question nobody asked.
-  static let carbonEffectiveModifiers: NSEvent.ModifierFlags = [
-    .command, .option, .control, .shift,
-  ]
 
   static let quickAddTitleCharacters = 24
   static let quickAddTitleScalars = 96

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -166,28 +166,36 @@ final class MenuBarController: NSObject {
     return ("Add \u{201C}\(shown)\u{201D}", true)
   }
 
-  /// The Quick Add chord as a menu key equivalent, or nil when it cannot be shown exactly.
+  /// The Quick Add chord as READABLE TEXT, or nil when there is nothing sensible to show.
   ///
-  /// **The shortcut is user-editable** (`settings.quickAddKeyCode` / `quickAddModifiers`), so a
-  /// hard-coded `⌃⌥W` teaches the wrong chord the moment anyone rebinds it — and keeps answering the
-  /// old one, because a key equivalent is live rather than decorative.
+  /// **Text, never a key equivalent, and two review rounds went into learning why.** A global hotkey
+  /// is a PHYSICAL key code registered with the system; a menu key equivalent is a CHARACTER matched
+  /// against the active keyboard layout. They coincide on ANSI and diverge on AZERTY or Dvorak — so
+  /// an item carrying a key equivalent can respond to a different physical key than the shortcut it
+  /// claims to advertise. That is not cosmetic, and it is unique to key equivalents.
   ///
-  /// **Nil rather than an approximation.** A key equivalent is a CHARACTER plus a mask, which is
-  /// narrower than a hotkey: a bare modifier has no character, and neither does an arrow or a
-  /// function key. A menu that teaches NOTHING is recoverable; one that teaches a chord the user has
-  /// reassigned is not, because they have no reason to doubt it.
-  ///
-  /// Letters and digits are the representable set, and the shipped default (W) is in it.
-  /// `KeySymbols.nameForKeyCode` is the shipped table rather than a second copy of it.
-  static func quickAddKeyEquivalent(
+  /// Formatted by `KeySymbols.format`, which is what `HotkeyRecorderView`, `MainWindowView` and
+  /// onboarding already use for this same binding, so the menu says exactly what Settings says. Any
+  /// residual inaccuracy on an exotic layout is the app-wide one and belongs where that formatter
+  /// lives — fixing it HERE alone would make the menu disagree with the Keybinds screen, which is
+  /// worse than being consistently approximate.
+  static func quickAddShortcutLabel(
     keyCode: UInt16, modifiers: NSEvent.ModifierFlags
-  ) -> MenuChord? {
-    guard !modifiers.isEmpty, !ModifierKeyCodes.isModifierOnly(keyCode) else { return nil }
-    let name = KeySymbols.nameForKeyCode(keyCode)
-    guard name.count == 1, let scalar = name.unicodeScalars.first,
-      CharacterSet.alphanumerics.contains(scalar), scalar.isASCII
-    else { return nil }
-    return MenuChord(key: name.lowercased(), modifiers: modifiers)
+  ) -> String? {
+    let formatted = KeySymbols.format(keyCode: keyCode, modifiers: modifiers)
+    // `nameForKeyCode` falls back to `Key <n>` for anything it does not know, which teaches nothing
+    // and looks like a bug. Say nothing instead.
+    guard !formatted.isEmpty, !formatted.contains("Key ") else { return nil }
+    return formatted
+  }
+
+  /// The rendered title: what the item does, then the chord that does it faster.
+  ///
+  /// Two spaces rather than one, which is the convention AppKit itself uses when a menu title
+  /// carries its own trailing hint — a single space reads as part of the sentence.
+  static func quickAddTitle(base: String, shortcut: String?) -> String {
+    guard let shortcut, !shortcut.isEmpty else { return base }
+    return "\(base)  \(shortcut)"
   }
 
   /// How much of the selection the title shows. Not a limit on what can be ADDED — the reader's
@@ -264,14 +272,16 @@ final class MenuBarController: NSObject {
     // Quick Add (#2412). Beside Start Recording because both act on what the user is doing RIGHT
     // NOW, and above the Settings separator because neither is configuration.
     let quickAdd = Self.quickAddItem(selection: state.quickAddSelection)
-    let chord = state.quickAddChord
+    // **No key equivalent, deliberately** — see `quickAddShortcutLabel`. The chord rides in the
+    // title as text, so the menu teaches the fast path without registering a second way to fire it.
     let quickAddItem = NSMenuItem(
-      title: quickAdd.title, action: #selector(addSelectedWordAction),
-      keyEquivalent: chord?.key ?? "")
-    // Derived from the user's own binding, and absent when it cannot be represented exactly — see
-    // `quickAddKeyEquivalent`. The menu teaches the fast path, which is the discoverability half of
-    // this issue, and teaches nothing rather than something false.
-    quickAddItem.keyEquivalentModifierMask = chord?.modifiers ?? []
+      title: Self.quickAddTitle(base: quickAdd.title, shortcut: state.quickAddShortcut),
+      action: #selector(addSelectedWordAction), keyEquivalent: "")
+    // **Cleared explicitly, because AppKit does not default it to empty.** A fresh `NSMenuItem`
+    // carries `.command` in its mask whatever its key equivalent is — measured, 1048576 — so leaving
+    // it means the item is one future `keyEquivalent` assignment away from silently claiming a ⌘
+    // chord nobody chose. Found by a test asserting the item carries no chord at all.
+    quickAddItem.keyEquivalentModifierMask = []
     quickAddItem.image = NSImage(
       systemSymbolName: "text.badge.plus", accessibilityDescription: "Add selected word")
     quickAddItem.target = self
@@ -397,7 +407,7 @@ final class MenuBarController: NSObject {
       sparkleUpdateController.updateCoordinator?.installRefusedNow ?? false
 
     return MenuBarViewState(
-      quickAddChord: Self.quickAddKeyEquivalent(
+      quickAddShortcut: Self.quickAddShortcutLabel(
         keyCode: settings.quickAddKeyCode, modifiers: settings.quickAddModifiers),
       quickAddSelection: quickAddSelection,
       pipelineState: liveRecordingState.pipelineState,
@@ -502,24 +512,15 @@ struct MenuBarActions: Sendable {
   let quit: @MainActor () -> Void
 }
 
-/// A chord a menu item can actually display: a character plus a modifier mask.
-///
-/// A named type rather than a tuple because `MenuBarViewState` is `Equatable` and Swift does not
-/// synthesise that through a tuple field.
-struct MenuChord: Equatable {
-  let key: String
-  let modifiers: NSEvent.ModifierFlags
-}
-
 /// Immutable snapshot the menu and icon render from. Extracting it makes
 /// `renderMenu` / `iconState` pure functions over a value, which is what makes
 /// the menu surface deterministically golden-testable.
 struct MenuBarViewState: Equatable {
-  /// The Quick Add chord as a menu key equivalent, or nil when it cannot be shown exactly (#2412).
+  /// The Quick Add chord as readable text, or nil when there is nothing sensible to show (#2412).
   ///
   /// On the state for the same reason as the selection: `renderMenu` is pure over this value, and
   /// reading `settings` inside it would end that.
-  let quickAddChord: MenuChord?
+  let quickAddShortcut: String?
 
   /// The selection Quick Add would act on, or nil when there is nothing readable (#2412).
   ///

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -166,6 +166,30 @@ final class MenuBarController: NSObject {
     return ("Add \u{201C}\(shown)\u{201D}", true)
   }
 
+  /// The Quick Add chord as a menu key equivalent, or nil when it cannot be shown exactly.
+  ///
+  /// **The shortcut is user-editable** (`settings.quickAddKeyCode` / `quickAddModifiers`), so a
+  /// hard-coded `⌃⌥W` teaches the wrong chord the moment anyone rebinds it — and keeps answering the
+  /// old one, because a key equivalent is live rather than decorative.
+  ///
+  /// **Nil rather than an approximation.** A key equivalent is a CHARACTER plus a mask, which is
+  /// narrower than a hotkey: a bare modifier has no character, and neither does an arrow or a
+  /// function key. A menu that teaches NOTHING is recoverable; one that teaches a chord the user has
+  /// reassigned is not, because they have no reason to doubt it.
+  ///
+  /// Letters and digits are the representable set, and the shipped default (W) is in it.
+  /// `KeySymbols.nameForKeyCode` is the shipped table rather than a second copy of it.
+  static func quickAddKeyEquivalent(
+    keyCode: UInt16, modifiers: NSEvent.ModifierFlags
+  ) -> MenuChord? {
+    guard !modifiers.isEmpty, !ModifierKeyCodes.isModifierOnly(keyCode) else { return nil }
+    let name = KeySymbols.nameForKeyCode(keyCode)
+    guard name.count == 1, let scalar = name.unicodeScalars.first,
+      CharacterSet.alphanumerics.contains(scalar), scalar.isASCII
+    else { return nil }
+    return MenuChord(key: name.lowercased(), modifiers: modifiers)
+  }
+
   /// How much of the selection the title shows. Not a limit on what can be ADDED — the reader's
   /// ceiling is that — only on what fits a menu without pushing the rest of it off screen.
   static let quickAddTitleScalars = 24
@@ -240,12 +264,14 @@ final class MenuBarController: NSObject {
     // Quick Add (#2412). Beside Start Recording because both act on what the user is doing RIGHT
     // NOW, and above the Settings separator because neither is configuration.
     let quickAdd = Self.quickAddItem(selection: state.quickAddSelection)
+    let chord = state.quickAddChord
     let quickAddItem = NSMenuItem(
-      title: quickAdd.title, action: #selector(addSelectedWordAction), keyEquivalent: "w")
-    // Shown, never registered: the real chord is a global hotkey owned by `HotkeyService`, and a
-    // menu key equivalent would be a SECOND registration of one gesture. This displays `⌃⌥W` so the
-    // menu teaches the fast path, which is the discoverability half of this issue.
-    quickAddItem.keyEquivalentModifierMask = [.control, .option]
+      title: quickAdd.title, action: #selector(addSelectedWordAction),
+      keyEquivalent: chord?.key ?? "")
+    // Derived from the user's own binding, and absent when it cannot be represented exactly — see
+    // `quickAddKeyEquivalent`. The menu teaches the fast path, which is the discoverability half of
+    // this issue, and teaches nothing rather than something false.
+    quickAddItem.keyEquivalentModifierMask = chord?.modifiers ?? []
     quickAddItem.image = NSImage(
       systemSymbolName: "text.badge.plus", accessibilityDescription: "Add selected word")
     quickAddItem.target = self
@@ -371,6 +397,8 @@ final class MenuBarController: NSObject {
       sparkleUpdateController.updateCoordinator?.installRefusedNow ?? false
 
     return MenuBarViewState(
+      quickAddChord: Self.quickAddKeyEquivalent(
+        keyCode: settings.quickAddKeyCode, modifiers: settings.quickAddModifiers),
       quickAddSelection: quickAddSelection,
       pipelineState: liveRecordingState.pipelineState,
       asrLabel: backendMetadata.modelLabel,
@@ -474,10 +502,25 @@ struct MenuBarActions: Sendable {
   let quit: @MainActor () -> Void
 }
 
+/// A chord a menu item can actually display: a character plus a modifier mask.
+///
+/// A named type rather than a tuple because `MenuBarViewState` is `Equatable` and Swift does not
+/// synthesise that through a tuple field.
+struct MenuChord: Equatable {
+  let key: String
+  let modifiers: NSEvent.ModifierFlags
+}
+
 /// Immutable snapshot the menu and icon render from. Extracting it makes
 /// `renderMenu` / `iconState` pure functions over a value, which is what makes
 /// the menu surface deterministically golden-testable.
 struct MenuBarViewState: Equatable {
+  /// The Quick Add chord as a menu key equivalent, or nil when it cannot be shown exactly (#2412).
+  ///
+  /// On the state for the same reason as the selection: `renderMenu` is pure over this value, and
+  /// reading `settings` inside it would end that.
+  let quickAddChord: MenuChord?
+
   /// The selection Quick Add would act on, or nil when there is nothing readable (#2412).
   ///
   /// **Carried on the state rather than read inside `renderMenu`, deliberately.** That function is

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -127,7 +127,28 @@ final class QuickAddCoordinator {
   /// that caught the accept path reporting success without telling anyone caught this one branch
   /// over. A shortcut that emits telemetry and shows nothing is indistinguishable from a shortcut
   /// that is not registered.
-  func begin(door: QuickAddDoor, selectionOverride: String? = nil) -> QuickAddPanelModel? {
+  /// Where `begin` gets the selection, with one case per door.
+  ///
+  /// **A type rather than a `String?`, because the read has THREE outcomes and an optional holds
+  /// two.** Passing nil to mean "refused" is what let the menu's bounded read be silently repeated
+  /// unbounded: `begin` could not tell "I have nothing for you, go and look" from "I looked, under a
+  /// cap, and was refused". Cloud review found it on PR #2427; it is the same three-state collapse
+  /// `QuickAddMenuState` fixed in the menu, one call later.
+  ///
+  /// `.text` is classified INSIDE `begin` rather than at the call site, so a future door cannot hand
+  /// over raw text and skip the ceiling and the empty check.
+  enum SelectionSource {
+    /// Read it now, live and unbounded. The hotkey door, where the user's app is still frontmost.
+    case live
+    /// Raw text handed to us, to be classified here. The Services door.
+    case text(String)
+    /// An outcome somebody else already obtained, carried through as-is. The menu door, whose read
+    /// happened while the menu was open — under a cap, and at the one moment the answer was about
+    /// the user's document rather than about us.
+    case result(SelectionReader.Result)
+  }
+
+  func begin(door: QuickAddDoor, selection source: SelectionSource = .live) -> QuickAddPanelModel? {
     let startedAt = environment.now()
     let bundleID = environment.frontmostBundleID()
 
@@ -139,8 +160,17 @@ final class QuickAddCoordinator {
     // is what let a whitespace-only selection open a panel on an empty string and an oversized one
     // reach the scorer — the ceiling and the empty check are properties of a SELECTION, not of the
     // door it arrived through.
-    var selection: SelectionReader.Result =
-      selectionOverride.map { SelectionReader.classify($0) } ?? environment.readSelection()
+    //
+    // `.result` is carried UNTOUCHED. It is already a classified outcome, and re-reading it here
+    // would both repeat a stalled read without the caller's cap and, once #2413 lands, risk
+    // answering "EnviousWispr is in front" — true by then, and about the wrong subject.
+    var selection: SelectionReader.Result = {
+      switch source {
+      case .live: return environment.readSelection()
+      case .text(let raw): return SelectionReader.classify(raw)
+      case .result(let already): return already
+      }
+    }()
 
     // Refresh before ranking, every invocation. A sibling instance or the Settings window can have
     // changed the library since launch, and ranking a stale snapshot offers words that no longer

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddCoordinator.swift
@@ -35,6 +35,9 @@ enum QuickAddEvent: Equatable, Sendable {
 enum QuickAddDoor: String, Equatable, Sendable, CaseIterable {
   case hotkey
   case service
+  /// The status-item menu (#2412). A third door, and the only one no OS registration, cache or
+  /// default can filter out — which is what went wrong with `service`.
+  case menuBar
 }
 
 /// How the panel ended. A closed set, so a new ending cannot inherit another's name.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -107,17 +107,21 @@ final class QuickAddWiring {
   /// menu is rendered while the user's own application is still frontmost — measured, twice — so the
   /// read happens there, at the one moment the answer is about their document. Reading it from this
   /// side would run after the click, by which time the menu has closed and the answer is ours.
-  func beginFromMenuBar(text: String?) {
+  func beginFromMenuBar(selection: SelectionReader.Result) {
     guard notAlreadyOpen() else { return }
-    // **Nil is not an error, it is the refusal case.** The menu row is enabled when the read was
-    // REFUSED precisely so the panel can state the reason; passing no override is what makes
-    // `begin` read live and produce that reason rather than a stale one.
-    present(coordinator.begin(door: .menuBar, selectionOverride: text))
+    // **The menu's own outcome is carried through, refusal included.** This used to pass the text
+    // and let nil stand for "refused", which made `begin` read AGAIN — without the menu's cap, so a
+    // stalled Accessibility provider stalled the panel instead of the menu, and the bound that let
+    // the menu open bought nothing. Cloud review, PR #2427.
+    //
+    // Re-reading is also wrong on its own terms here: by the time this runs the menu has closed, so
+    // a live read can answer about US rather than about the document the user was looking at.
+    present(coordinator.begin(door: .menuBar, selection: .result(selection)))
   }
 
   func beginFromService(text: String) {
     guard notAlreadyOpen() else { return }
-    present(coordinator.begin(door: .service, selectionOverride: text))
+    present(coordinator.begin(door: .service, selection: .text(text)))
   }
 
   /// Whether a new capture may start at all.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -107,8 +107,11 @@ final class QuickAddWiring {
   /// menu is rendered while the user's own application is still frontmost — measured, twice — so the
   /// read happens there, at the one moment the answer is about their document. Reading it from this
   /// side would run after the click, by which time the menu has closed and the answer is ours.
-  func beginFromMenuBar(text: String) {
+  func beginFromMenuBar(text: String?) {
     guard notAlreadyOpen() else { return }
+    // **Nil is not an error, it is the refusal case.** The menu row is enabled when the read was
+    // REFUSED precisely so the panel can state the reason; passing no override is what makes
+    // `begin` read live and produce that reason rather than a stale one.
     present(coordinator.begin(door: .menuBar, selectionOverride: text))
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -101,6 +101,17 @@ final class QuickAddWiring {
   }
 
   /// Door B. Separate from the hotkey path only because the Service is HANDED its text.
+  /// The status-item menu handed us text it read while the menu was open.
+  ///
+  /// **Takes the text rather than reading it here, and that is the whole point of the door.** The
+  /// menu is rendered while the user's own application is still frontmost — measured, twice — so the
+  /// read happens there, at the one moment the answer is about their document. Reading it from this
+  /// side would run after the click, by which time the menu has closed and the answer is ours.
+  func beginFromMenuBar(text: String) {
+    guard notAlreadyOpen() else { return }
+    present(coordinator.begin(door: .menuBar, selectionOverride: text))
+  }
+
   func beginFromService(text: String) {
     guard notAlreadyOpen() else { return }
     present(coordinator.begin(door: .service, selectionOverride: text))

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1010,7 +1010,7 @@ public final class WisprBootstrapper {
       settings: settings,
       permissions: permissions,
       actions: MenuBarActions(
-        addSelectedWord: { quickAdd.beginFromMenuBar(text: $0) },
+        addSelectedWord: { quickAdd.beginFromMenuBar(selection: $0) },
         continueOnboarding: { appWindowCoordinator.openOnboardingWindow() },
         openSettings: {
           navigationCoordinator.request(.speechEngine)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -985,6 +985,24 @@ public final class WisprBootstrapper {
     )
 
     // PR-B.3 of #763: menu bar surface home.
+    // **Built HERE rather than at its `self.quickAdd =` assignment below, because the menu-bar
+    // action needs it (#2412) and that assignment is a hundred lines further on.** A closure cannot
+    // reach it there: `[weak self]` is illegal while `self` is still being initialised, and
+    // `[weak quickAdd]` names nothing yet.
+    //
+    // Every dependency it takes already exists well above this line — `customWordsCoordinator`
+    // (:141), `vocabularyPackManager` (:150), `hotkeyService` (:438) — so this is a reorder, not a
+    // new dependency.
+    //
+    // The alternative was a settable seam on `MenuBarController`, and it is worse for a reason this
+    // issue is about: it makes the wiring optional at the type level, so "the menu item does nothing
+    // because nobody set the seam" becomes a state that compiles. A menu entry that silently does
+    // nothing is exactly the failure #2412 exists to route around.
+    let quickAdd = QuickAddWiring(
+      hotkeyService: hotkeyService,
+      customWords: customWordsCoordinator,
+      packManager: vocabularyPackManager)
+
     let menuBarController = MenuBarController(
       liveRecordingState: liveRecordingState,
       backendMetadata: backendMetadata,
@@ -992,6 +1010,7 @@ public final class WisprBootstrapper {
       settings: settings,
       permissions: permissions,
       actions: MenuBarActions(
+        addSelectedWord: { quickAdd.beginFromMenuBar(text: $0) },
         continueOnboarding: { appWindowCoordinator.openOnboardingWindow() },
         openSettings: {
           navigationCoordinator.request(.speechEngine)
@@ -1086,10 +1105,7 @@ public final class WisprBootstrapper {
     self.vocabularyPackManager = vocabularyPackManager
     // #2381. Built from three collaborators this root already holds; it adds no new dependency of
     // its own and reaches nothing the root did not already have.
-    self.quickAdd = QuickAddWiring(
-      hotkeyService: hotkeyService,
-      customWords: customWordsCoordinator,
-      packManager: vocabularyPackManager)
+    self.quickAdd = quickAdd
 
     // #832/#913 PR8: App-owned output-safety classifier holder.
     self.outputClassifierHolder = outputClassifierHolder

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -842,6 +842,13 @@ public enum PasteService {
     return nil
   }
 
+  /// Whether a focused-element query error means "nothing is focused" rather than "the query
+  /// failed".
+  ///
+  /// Pure and separate so the decision is reachable from a test — inside `focusedElement` it sits
+  /// behind a live Accessibility call and nothing can assert it.
+  static func isUnfocusedResponse(_ error: AXError) -> Bool { error == .noValue }
+
   static func focusedElement(
     pid: pid_t,
     messagingTimeout: Double = axMessagingTimeoutSeconds
@@ -858,6 +865,16 @@ public enum PasteService {
     // here as different codes and leave as different outcomes.
     let error = AXUIElementCopyAttributeValue(
       application, kAXFocusedUIElementAttribute as CFString, &focusedRef)
+    // **`.noValue` IS the ordinary unfocused answer, not a failure.** Accessibility reports "this
+    // attribute has no associated value" for an application with nothing focused, so treating every
+    // non-success code as a failed query sends the commonest case to the generic read-failure
+    // message and withholds the one instruction that would help — click into the text. Cloud
+    // review, PR #2427, on the tri-state fix from the round before.
+    //
+    // `.attributeUnsupported` is deliberately NOT here: an app that does not implement the focused
+    // attribute at all will not start doing so because the user clicked somewhere, so that stays a
+    // failure and gets the honest "could not be read" copy.
+    if isUnfocusedResponse(error) { return PasteService.FocusedElement.none }
     guard error == .success else { return .queryFailed(error) }
     guard let focusedValue = focusedRef, CFGetTypeID(focusedValue) == AXUIElementGetTypeID() else {
       // The call succeeded and produced nothing usable — that is an absence, not a failure.

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -814,11 +814,39 @@ public enum PasteService {
   /// the frontmost app and a second implementation of it would be the parallel machine this repo's
   /// adopt-before-inventing rule exists to prevent. Every defensive check above is exactly what a
   /// second copy would have had to reproduce and would eventually have drifted on.
+  /// What asking for the focused element produced.
+  ///
+  /// **Three outcomes, because nil was carrying two of them.** "The app has nothing focused" and
+  /// "the provider failed or timed out" are different facts with different advice, and a caller
+  /// holding only nil has to guess. That was tolerable while every read was unbounded and a timeout
+  /// was rare; #2412's 0.25s menu cap makes the timeout branch the likely one, and the panel was
+  /// telling users to click into the text when nothing they clicked could help. Cloud review,
+  /// PR #2427.
+  enum FocusedElement {
+    /// A focused element belonging to the requested process.
+    case element(AXUIElement)
+    /// The query SUCCEEDED and there is nothing to read — no focus, or it belongs elsewhere.
+    case none
+    /// The query itself failed: not trusted, a bad pid, a wedged provider, or the timeout expiring.
+    case queryFailed(AXError)
+  }
+
+  /// The nil-returning form, kept EXACTLY as it was so the paste path is untouched.
   static func focusedElementQuery(
     pid: pid_t,
     messagingTimeout: Double = axMessagingTimeoutSeconds
   ) -> AXUIElement? {
-    guard AXIsProcessTrusted(), pid > 0 else { return nil }
+    if case .element(let focused) = focusedElement(pid: pid, messagingTimeout: messagingTimeout) {
+      return focused
+    }
+    return nil
+  }
+
+  static func focusedElement(
+    pid: pid_t,
+    messagingTimeout: Double = axMessagingTimeoutSeconds
+  ) -> FocusedElement {
+    guard AXIsProcessTrusted(), pid > 0 else { return .queryFailed(.cannotComplete) }
 
     let application = AXUIElementCreateApplication(pid)
     // Bound every subsequent read. A wedged destination must not hang the
@@ -826,20 +854,24 @@ public enum PasteService {
     AXUIElementSetMessagingTimeout(application, Float(messagingTimeout))
 
     var focusedRef: CFTypeRef?
-    guard
-      AXUIElementCopyAttributeValue(
-        application, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
-      let focusedValue = focusedRef,
-      CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
-    else { return nil }
+    // The ERROR is kept rather than compared away: a timeout and a genuinely unfocused app arrive
+    // here as different codes and leave as different outcomes.
+    let error = AXUIElementCopyAttributeValue(
+      application, kAXFocusedUIElementAttribute as CFString, &focusedRef)
+    guard error == .success else { return .queryFailed(error) }
+    guard let focusedValue = focusedRef, CFGetTypeID(focusedValue) == AXUIElementGetTypeID() else {
+      // The call succeeded and produced nothing usable — that is an absence, not a failure.
+      return PasteService.FocusedElement.none
+    }
     // swift-format-ignore: NeverForceUnwrap — guarded by the CFGetTypeID check.
     let focused = focusedValue as! AXUIElement
 
     var focusedPID: pid_t = 0
     guard AXUIElementGetPid(focused, &focusedPID) == .success, focusedPID == pid else {
-      return nil
+      // Someone else's element is nothing of OURS to read, not a broken provider.
+      return PasteService.FocusedElement.none
     }
-    return focused
+    return .element(focused)
   }
 
   /// Read the text either side of the caret in the app that owns `element`.

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -97,8 +97,14 @@ public enum SelectionReader {
   /// Per-application, never system-wide: `AXUIElementCreateSystemWide()` can answer for a different
   /// process than the one the user is looking at, and the whole point here is to read the app they
   /// just made a selection in.
+  /// `timeout` bounds the Accessibility round trip, in seconds. Nil keeps the system default.
+  ///
+  /// **A caller that must not block passes one.** The menu-bar door renders inside
+  /// `menuNeedsUpdate`, which AppKit requires to be synchronous — so a frontmost application whose
+  /// Accessibility provider stalls would hold the main actor and the menu simply would not open.
+  /// The default is far longer than a menu can wait.
   @MainActor
-  public static func read() -> Result {
+  public static func read(timeout: Float? = nil) -> Result {
     // Frontmost is read here rather than inside the check because it is the LIVE half. Current
     // because this runs on the main run loop from a hotkey or a Service, with events flowing;
     // `NSWorkspace.frontmostApplication` is stale only where nothing is pumping the run loop, which
@@ -110,7 +116,13 @@ public enum SelectionReader {
       return .refused(refusal)
     }
     // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid.
-    guard let pid = frontmost, let focused = PasteService.focusedElementQuery(pid: pid) else {
+    guard let pid = frontmost else { return .refused(.noFocusedElement) }
+    if let timeout {
+      // Set on the APPLICATION element, which is what the focused-element query goes through, and
+      // before that query rather than after it — the stall this bounds can happen on either call.
+      AXUIElementSetMessagingTimeout(AXUIElementCreateApplication(pid), timeout)
+    }
+    guard let focused = PasteService.focusedElementQuery(pid: pid) else {
       return .refused(.noFocusedElement)
     }
 

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -126,25 +126,31 @@ public enum SelectionReader {
     }
     // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid.
     guard let pid = frontmost else { return .refused(.noFocusedElement) }
-    // **Handed to the query rather than set here.** `focusedElementQuery` creates its OWN
-    // application element, so a timeout set on a handle made here reaches nothing — it did not, and
-    // the line that tried is gone. The parameter has existed all along.
-    guard
-      let focused = timeout.map({ PasteService.focusedElementQuery(pid: pid, messagingTimeout: Double($0)) })
-        ?? PasteService.focusedElementQuery(pid: pid)
-    else {
-      return .refused(.noFocusedElement)
+    // **Handed to the query rather than set here.** `focusedElement` creates its OWN application
+    // element, so a timeout set on a handle made here reaches nothing — it did not, and the line
+    // that tried is gone. The parameter has existed all along.
+    //
+    // **Three outcomes, and they are three different sentences to the user.** A failed or timed-out
+    // query is NOT an app that has nothing focused: telling someone to click into the text cannot
+    // help when the provider never answered. The distinction only started mattering when this read
+    // gained a cap, which makes the timeout branch the likely one. Cloud review, PR #2427.
+    let focusedOutcome =
+      timeout.map({ PasteService.focusedElement(pid: pid, messagingTimeout: Double($0)) })
+      ?? PasteService.focusedElement(pid: pid)
+
+    let focused: AXUIElement
+    if case .element(let element) = focusedOutcome {
+      focused = element
+    } else {
+      // Safe: `refusalForFocusedElement` returns non-nil for every non-element outcome.
+      return .refused(refusalForFocusedElement(focusedOutcome) ?? .unreadable)
     }
-    // **And the FOCUSED handle separately, because a descendant does not inherit one.** This repo
-    // learned that in #1332 — `PasteService.firstPasteItem`: "Descendant handles do NOT inherit an
-    // ancestor's messaging timeout", and `findPasteMenuItem`: "The timeout binds ONE element, so
-    // every handle we message has to be bounded, not just this one."
-    if let timeout { AXUIElementSetMessagingTimeout(focused, timeout) }
-    // **And bound the FOCUSED handle separately, because a descendant does not inherit it.** This
+
+    // **And bound the FOCUSED handle separately, because a descendant does not inherit one.** This
     // repo learned that in #1332 and wrote it down twice — `PasteService.firstPasteItem`:
-    // "Descendant handles do NOT inherit an ancestor's messaging timeout", and
-    // `findPasteMenuItem`: "The timeout binds ONE element, so every handle we message has to be
-    // bounded, not just this one."
+    // "Descendant handles do NOT inherit an ancestor's messaging timeout", and `findPasteMenuItem`:
+    // "The timeout binds ONE element, so every handle we message has to be bounded, not just this
+    // one."
     //
     // Bounding only the application is the shape that LOOKS bounded: the app answers the focused
     // query promptly, and then the attribute read below — the call that actually stalls — runs
@@ -162,6 +168,20 @@ public enum SelectionReader {
   }
 
   // MARK: - The decisions, which are pure
+
+  /// Which refusal a focused-element outcome becomes, or nil when there is an element to read.
+  ///
+  /// **Pure and separate from `read()` for the reason the guard below is: otherwise no test can
+  /// reach it.** The distinction it draws is the whole of PR #2427's second finding — a query that
+  /// FAILED or timed out is not an app with nothing focused, and telling the user to click into the
+  /// text cannot help when the provider never answered.
+  static func refusalForFocusedElement(_ outcome: PasteService.FocusedElement) -> Refusal? {
+    switch outcome {
+    case .element: return nil
+    case .none: return .noFocusedElement
+    case .queryFailed: return .unreadable
+    }
+  }
 
   /// Why a read cannot even be attempted, or nil to go ahead.
   ///

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -97,7 +97,15 @@ public enum SelectionReader {
   /// Per-application, never system-wide: `AXUIElementCreateSystemWide()` can answer for a different
   /// process than the one the user is looking at, and the whole point here is to read the app they
   /// just made a selection in.
-  /// `timeout` bounds the Accessibility round trip, in seconds. Nil keeps the system default.
+  /// `timeout` bounds EACH Accessibility operation, in seconds. Nil keeps the system default.
+  ///
+  /// **PER OPERATION, not per call.** This makes two round trips — the focused-element lookup and
+  /// the selected-text read — so the worst case a caller should plan for is TWICE this value. An
+  /// earlier version's comment claimed it bounded how long the menu waits; it did not.
+  ///
+  /// **Zero is refused rather than honoured.** Accessibility reads a zero messaging timeout as
+  /// "use the system default", so `timeout: 0` would REMOVE the bound rather than tighten it — the
+  /// most obviously safe number producing the least safe behaviour.
   ///
   /// **A caller that must not block passes one.** The menu-bar door renders inside
   /// `menuNeedsUpdate`, which AppKit requires to be synchronous — so a frontmost application whose
@@ -105,6 +113,7 @@ public enum SelectionReader {
   /// The default is far longer than a menu can wait.
   @MainActor
   public static func read(timeout: Float? = nil) -> Result {
+    precondition(timeout.map { $0 > 0 } ?? true, "a zero or negative AX timeout removes the bound")
     // Frontmost is read here rather than inside the check because it is the LIVE half. Current
     // because this runs on the main run loop from a hotkey or a Service, with events flowing;
     // `NSWorkspace.frontmostApplication` is stale only where nothing is pumping the run loop, which
@@ -117,13 +126,20 @@ public enum SelectionReader {
     }
     // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid.
     guard let pid = frontmost else { return .refused(.noFocusedElement) }
-    if let timeout {
-      // Bound the application handle, which is what the focused-element query messages.
-      AXUIElementSetMessagingTimeout(AXUIElementCreateApplication(pid), timeout)
-    }
-    guard let focused = PasteService.focusedElementQuery(pid: pid) else {
+    // **Handed to the query rather than set here.** `focusedElementQuery` creates its OWN
+    // application element, so a timeout set on a handle made here reaches nothing — it did not, and
+    // the line that tried is gone. The parameter has existed all along.
+    guard
+      let focused = timeout.map({ PasteService.focusedElementQuery(pid: pid, messagingTimeout: Double($0)) })
+        ?? PasteService.focusedElementQuery(pid: pid)
+    else {
       return .refused(.noFocusedElement)
     }
+    // **And the FOCUSED handle separately, because a descendant does not inherit one.** This repo
+    // learned that in #1332 — `PasteService.firstPasteItem`: "Descendant handles do NOT inherit an
+    // ancestor's messaging timeout", and `findPasteMenuItem`: "The timeout binds ONE element, so
+    // every handle we message has to be bounded, not just this one."
+    if let timeout { AXUIElementSetMessagingTimeout(focused, timeout) }
     // **And bound the FOCUSED handle separately, because a descendant does not inherit it.** This
     // repo learned that in #1332 and wrote it down twice — `PasteService.firstPasteItem`:
     // "Descendant handles do NOT inherit an ancestor's messaging timeout", and

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -118,13 +118,22 @@ public enum SelectionReader {
     // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid.
     guard let pid = frontmost else { return .refused(.noFocusedElement) }
     if let timeout {
-      // Set on the APPLICATION element, which is what the focused-element query goes through, and
-      // before that query rather than after it — the stall this bounds can happen on either call.
+      // Bound the application handle, which is what the focused-element query messages.
       AXUIElementSetMessagingTimeout(AXUIElementCreateApplication(pid), timeout)
     }
     guard let focused = PasteService.focusedElementQuery(pid: pid) else {
       return .refused(.noFocusedElement)
     }
+    // **And bound the FOCUSED handle separately, because a descendant does not inherit it.** This
+    // repo learned that in #1332 and wrote it down twice — `PasteService.firstPasteItem`:
+    // "Descendant handles do NOT inherit an ancestor's messaging timeout", and
+    // `findPasteMenuItem`: "The timeout binds ONE element, so every handle we message has to be
+    // bounded, not just this one."
+    //
+    // Bounding only the application is the shape that LOOKS bounded: the app answers the focused
+    // query promptly, and then the attribute read below — the call that actually stalls — runs
+    // against a handle nothing capped.
+    if let timeout { AXUIElementSetMessagingTimeout(focused, timeout) }
 
     var valueRef: CFTypeRef?
     let error = AXUIElementCopyAttributeValue(

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -180,8 +180,29 @@ package enum ShortcutMatcher {
         forBareModifierKeyCode: keyCode, record: record, cancel: cancel, quickAdd: quickAdd,
         armed: [.record, .cancel, .quickAdd]) == .quickAdd
     }
-    // A CHORD is dispatched by Carbon, so the question is whether another role registers the same
-    // Carbon chord — key code plus the modifiers Carbon actually keeps. Record registers first and
+    // **A CHORD IS NOT DISPATCHED ONLY BY CARBON, WHICH IS WHERE THE PREVIOUS VERSION OF THIS WAS
+    // WRONG.** Pressing Command-W emits the Command press FIRST, and the modifier monitor routes
+    // every bare modifier press through `role(forBareModifierKeyCode:)` before the W ever reaches
+    // Carbon (`HotkeyService.installModifierMonitors`, and the dispatch at its
+    // `ShortcutMatcher.role` call). So a chord whose modifier is a higher-priority role's BARE
+    // binding is intercepted: Record on bare Command and Quick Add on Command-W means the user
+    // starts a recording while following this hint.
+    //
+    // That is the exact mirror of the refusal `role` already makes in the other direction — it
+    // rejects a bare Quick Add modifier the record CHORD needs. Both directions now exist.
+    //
+    // **The closure claim, stated so it can be falsified rather than hoped for:** a press reaches
+    // exactly two mechanisms, the modifier monitor and Carbon, and a chord press produces exactly
+    // two events, its modifiers and its key. Both are checked below. A further finding would have
+    // to name a THIRD dispatch mechanism, not another combination of these two.
+    for flag in [NSEvent.ModifierFlags.command, .option, .control, .shift]
+    where quickAdd.requiredModifiers.contains(flag) {
+      for other in [record, cancel] where other.isBareModifier {
+        if case .keyboard(let ok, _) = other, ModifierKeyCodes.flag(for: ok) == flag { return false }
+      }
+    }
+
+    // And the Carbon half: whether another role registers the same chord — key code plus the modifiers Carbon actually keeps. Record registers first and
     // cancel takes the chord for the whole of every recording, so either one owning it means this
     // label is a promise we cannot keep.
     //

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -155,6 +155,53 @@ package enum ShortcutMatcher {
   /// slice's work and is NOT implemented here. This comment says so rather than
   /// implying a guard exists, and no unused `conflicts(...)` helper ships ahead
   /// of the consumers that would call it.
+  /// The modifiers Carbon actually registers, mirroring `HotkeyService.carbonModifiers`.
+  ///
+  /// Every other bit — Caps Lock, Function, Numeric Pad, and the device-dependent flags — is
+  /// dropped on the way to `RegisterEventHotKey`, so two bindings differing only there are ONE
+  /// chord as far as the system is concerned. Comparing anything else answers a question nobody
+  /// asked.
+  package static let carbonEffectiveModifiers: NSEvent.ModifierFlags = [
+    .command, .option, .control, .shift,
+  ]
+
+  /// Whether Quick Add would answer its own binding, asked of the code that dispatches it.
+  ///
+  /// **Both arms assume the service is running and cancel may be armed at any moment**, which is the
+  /// honest question for a menu label: a hint is a standing promise, not a claim about this instant,
+  /// so a chord that stops working the moment a recording starts must not be advertised.
+  package static func quickAddOwnsItsBinding(
+    quickAdd: ShortcutBinding, record: ShortcutBinding, cancel: ShortcutBinding
+  ) -> Bool {
+    if case .keyboard(let keyCode, _) = quickAdd, quickAdd.isBareModifier {
+      // `armed` carries cancel too: a label promising a key that cancel takes over for the whole of
+      // every recording is worse than no label.
+      return role(
+        forBareModifierKeyCode: keyCode, record: record, cancel: cancel, quickAdd: quickAdd,
+        armed: [.record, .cancel, .quickAdd]) == .quickAdd
+    }
+    // A CHORD is dispatched by Carbon, so the question is whether another role registers the same
+    // Carbon chord — key code plus the modifiers Carbon actually keeps. Record registers first and
+    // cancel takes the chord for the whole of every recording, so either one owning it means this
+    // label is a promise we cannot keep.
+    //
+    // **`HotkeyService.quickAddMayHoldItsChord` is deliberately NOT called here**, for two reasons
+    // worth stating rather than leaving as a silent choice. Its `isEnabled`/`isSuspended` arguments
+    // are runtime state a menu label does not have, so calling it means inventing values to get an
+    // answer. And it compares bindings with raw `==`, which is the very defect three review rounds
+    // found in this label — so delegating to it would reintroduce the bug in the name of reuse.
+    // That raw comparison looks like a real defect in the REGISTRATION path too (Quick Add would
+    // not be unregistered for a cancel chord differing only in a dropped modifier); it is reported
+    // separately rather than fixed from here, because it is the heart path.
+    guard case .keyboard(let qk, let qm) = quickAdd else { return true }
+    let mine = qm.intersection(carbonEffectiveModifiers)
+    for other in [record, cancel] {
+      guard case .keyboard(let ok, let om) = other else { continue }
+      if qk == ok, mine == om.intersection(carbonEffectiveModifiers) { return false }
+    }
+    return true
+  }
+
   package static func role(
     forBareModifierKeyCode keyCode: UInt16,
     record: ShortcutBinding,

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -211,7 +211,7 @@ struct MenuBarControllerTests {
 
     let ready = NSMenu()
     controller.renderMenu(
-      into: ready, state: fixture(pipelineState: .idle, quickAddSelection: "clawwed"))
+      into: ready, state: fixture(pipelineState: .idle, quickAdd: .ready("clawwed")))
     let live = itemPrefixed(ready, "Add \u{201C}clawwed\u{201D}")
     #expect(live?.isEnabled == true)
     #expect(live?.target as AnyObject? === controller)
@@ -237,7 +237,7 @@ struct MenuBarControllerTests {
     let controller = makeController(spy: spy)
     let menu = NSMenu()
     controller.renderMenu(
-      into: menu, state: fixture(pipelineState: .idle, quickAddSelection: "clawwed\nmachine"))
+      into: menu, state: fixture(pipelineState: .idle, quickAdd: .ready("clawwed\nmachine")))
 
     let row = itemPrefixed(menu, "Add \u{201C}clawwed machine\u{201D}")
     #expect(row != nil, "the TITLE is collapsed")
@@ -256,7 +256,7 @@ struct MenuBarControllerTests {
     controller.renderMenu(
       into: menu,
       state: fixture(
-        pipelineState: .idle, quickAddSelection: "clawwed", quickAddShortcut: "\u{2318}\u{21E7} J"))
+        pipelineState: .idle, quickAdd: .ready("clawwed"), quickAddShortcut: "\u{2318}\u{21E7} J"))
 
     let row = itemPrefixed(menu, "Add \u{201C}clawwed\u{201D}")
     #expect(row?.title == "Add \u{201C}clawwed\u{201D}  \u{2318}\u{21E7} J")
@@ -271,7 +271,7 @@ struct MenuBarControllerTests {
     let menu = NSMenu()
     controller.renderMenu(
       into: menu,
-      state: fixture(pipelineState: .idle, quickAddSelection: "clawwed", quickAddShortcut: nil))
+      state: fixture(pipelineState: .idle, quickAdd: .ready("clawwed"), quickAddShortcut: nil))
 
     #expect(item(menu, "Add \u{201C}clawwed\u{201D}") != nil, "the title carries no trailing hint")
   }
@@ -459,12 +459,12 @@ struct MenuBarControllerTests {
     updateDisplayVersion: String? = nil,
     installEnabled: Bool = false,
     appearancePreference: AppearancePreference = .system,
-    quickAddSelection: String? = nil,
+    quickAdd: QuickAddMenuState = .nothingSelected,
     quickAddShortcut: String? = "\u{2303}\u{2325} W"
   ) -> MenuBarViewState {
     MenuBarViewState(
       quickAddShortcut: quickAddShortcut,
-      quickAddSelection: quickAddSelection,
+      quickAdd: quickAdd,
       pipelineState: pipelineState,
       asrLabel: "Parakeet v3",
       llmLabel: "LLM Deactivated",
@@ -514,7 +514,7 @@ struct MenuBarControllerTests {
       settings: settings,
       permissions: PermissionsService(),
       actions: MenuBarActions(
-        addSelectedWord: { spy.fired.append("addSelectedWord:\($0)") },
+        addSelectedWord: { spy.fired.append("addSelectedWord:\($0 ?? "<none>")") },
         continueOnboarding: { spy.fired.append("continueOnboarding") },
         openSettings: { spy.fired.append("openSettings") },
         openPermissions: { spy.fired.append("openPermissions") },
@@ -556,7 +556,7 @@ struct QuickAddMenuItemTests {
   /// can still correct it; the menu should not be a guess.
   @Test("A readable selection is named in the title, and the item can be chosen")
   func aSelectionIsNamedAndEnabled() {
-    let item = MenuBarController.quickAddItem(selection: "clawwed")
+    let item = MenuBarController.quickAddItem(.ready("clawwed"))
     #expect(item.title == "Add \u{201C}clawwed\u{201D}")
     #expect(item.enabled)
   }
@@ -565,10 +565,14 @@ struct QuickAddMenuItemTests {
   /// "nothing selected" spends a click to deliver news the menu already had.
   @Test("Nothing to add leaves the item disabled and generically titled")
   func nothingSelectedIsDisabled() {
-    for selection in [nil, "", "   ", "\n\t "] as [String?] {
-      let item = MenuBarController.quickAddItem(selection: selection)
-      #expect(item.title == "Add Selected Word", "for \(String(describing: selection))")
-      #expect(!item.enabled, "for \(String(describing: selection))")
+    #expect(MenuBarController.quickAddItem(.nothingSelected).title == "Add Selected Word")
+    #expect(!MenuBarController.quickAddItem(.nothingSelected).enabled)
+    // A `.ready` carrying only whitespace is the same non-event: the reader trims, so this is the
+    // belt to that brace rather than a state the reader can actually produce.
+    for blank in ["", "   ", "\n\t "] {
+      let item = MenuBarController.quickAddItem(.ready(blank))
+      #expect(item.title == "Add Selected Word", "for \(blank.debugDescription)")
+      #expect(!item.enabled, "for \(blank.debugDescription)")
     }
   }
 
@@ -576,7 +580,7 @@ struct QuickAddMenuItemTests {
   /// boundary is the ordinary case, not an edge one.
   @Test("Surrounding whitespace does not reach the title")
   func whitespaceIsTrimmed() {
-    #expect(MenuBarController.quickAddItem(selection: "  clawwed \n").title == "Add \u{201C}clawwed\u{201D}")
+    #expect(MenuBarController.quickAddItem(.ready("  clawwed \n")).title == "Add \u{201C}clawwed\u{201D}")
   }
 
   /// **A selection spanning two lines carries a newline, and a newline in a native menu title
@@ -585,11 +589,45 @@ struct QuickAddMenuItemTests {
   @Test("Internal line breaks and tabs are collapsed for display")
   func internalWhitespaceIsCollapsed() {
     #expect(
-      MenuBarController.quickAddItem(selection: "clawwed\nmachine").title
+      MenuBarController.quickAddItem(.ready("clawwed\nmachine")).title
         == "Add \u{201C}clawwed machine\u{201D}")
     #expect(
-      MenuBarController.quickAddItem(selection: "one\ttwo   three").title
+      MenuBarController.quickAddItem(.ready("one\ttwo   three")).title
         == "Add \u{201C}one two three\u{201D}")
+  }
+
+  /// **A refused read is NOT an empty selection, and collapsing them hid a missing permission.**
+  /// With Accessibility off the user HAS selected something and we could not read it; a greyed row
+  /// tells them nothing. Enabled, so the panel opens and states the reason.
+  @Test("A refused read stays clickable so the panel can say why")
+  func aRefusedReadIsNotAnEmptySelection() {
+    let blocked = MenuBarController.quickAddItem(.blocked)
+    #expect(blocked.enabled, "the door that must be reliable cannot fail silently")
+    #expect(blocked.title == "Add Selected Word")
+
+    let empty = MenuBarController.quickAddItem(.nothingSelected)
+    #expect(!empty.enabled, "and genuinely nothing selected is still inert")
+    #expect(
+      blocked.title == empty.title,
+      "the titles match; it is the ENABLED state that separates them, which is the whole finding")
+  }
+
+  /// **Cutting on scalars can land inside a character.** A family emoji is several scalars and one
+  /// glyph; splitting it renders as rubble.
+  @Test("Truncation never splits a character")
+  func truncationRespectsGraphemes() {
+    let families = String(repeating: "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}", count: 40)
+    let title = MenuBarController.quickAddItem(.ready(families)).title
+
+    #expect(title.hasSuffix("\u{2026}\u{201D}"))
+    // Every character between the quotes is a whole family, never a fragment of one.
+    let inner = title.dropFirst(5).dropLast(2)
+    #expect(
+      inner.allSatisfy { $0 == "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}" },
+      "a split grapheme would appear here as a lone person or a stray joiner: \(inner)")
+    #expect(
+      title.unicodeScalars.count <= MenuBarController.quickAddTitleScalars + 7,
+      "and the scalar ceiling still bounds the pathological case")
   }
 
   /// **The reader admits 512 scalars and a menu is not where 512 characters belong.** This bounds
@@ -597,21 +635,21 @@ struct QuickAddMenuItemTests {
   @Test("A long selection is truncated for display, with an ellipsis")
   func aLongSelectionIsTruncated() {
     let long = String(repeating: "a", count: 200)
-    let item = MenuBarController.quickAddItem(selection: long)
+    let item = MenuBarController.quickAddItem(.ready(long))
 
     #expect(item.enabled)
     #expect(item.title.hasSuffix("\u{2026}\u{201D}"), "the user is told it was cut")
     #expect(
-      item.title.unicodeScalars.count == MenuBarController.quickAddTitleScalars + 7,
-      "`Add ` is four scalars, plus two quotes and the ellipsis")
+      item.title.count == MenuBarController.quickAddTitleCharacters + 7,
+      "`Add ` is four characters, plus two quotes and the ellipsis")
   }
 
   /// A selection exactly at the boundary is NOT truncated — the paired case, without which the row
   /// above passes for a truncation that fires one scalar early.
   @Test("A selection exactly at the display limit keeps all of it")
   func theBoundaryIsNotTruncated() {
-    let exact = String(repeating: "a", count: MenuBarController.quickAddTitleScalars)
-    let item = MenuBarController.quickAddItem(selection: exact)
+    let exact = String(repeating: "a", count: MenuBarController.quickAddTitleCharacters)
+    let item = MenuBarController.quickAddItem(.ready(exact))
 
     #expect(!item.title.contains("\u{2026}"))
     #expect(item.title == "Add \u{201C}\(exact)\u{201D}")

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -116,6 +116,7 @@ struct MenuBarControllerTests {
         "Version: \(AppConstants.appVersion)",
         "",  // separator
         "Start Recording",
+        "Add Selected Word",  // #2412, disabled with no selection
         "",  // separator
         "Settings...",
         "Appearance",  // #1047 submenu parent
@@ -129,8 +130,8 @@ struct MenuBarControllerTests {
     #expect(menu.items[1].isEnabled == false)
     // Separators are separators.
     #expect(menu.items[2].isSeparatorItem)
-    #expect(menu.items[4].isSeparatorItem)
-    #expect(menu.items[7].isSeparatorItem)
+    #expect(menu.items[5].isSeparatorItem)
+    #expect(menu.items[8].isSeparatorItem)
     // Settings carries the comma key-equivalent; Quit carries "q".
     #expect(item(menu, "Settings...")?.keyEquivalent == ",")
     #expect(item(menu, "Quit \(AppConstants.appName)")?.keyEquivalent == "q")
@@ -174,6 +175,36 @@ struct MenuBarControllerTests {
       #expect(sub.representedObject as? String != nil, "\(sub.title) must carry its rawValue")
       #expect(sub.target as AnyObject? === controller, "\(sub.title) should target the controller")
     }
+  }
+
+  /// **The item is inert with nothing selected, and live with something.** Both halves matter: an
+  /// enabled item over no selection spends a click to report a refusal the menu already knew about,
+  /// and a disabled item over a real selection is the door not opening at all.
+  @Test("The Quick Add item follows the selection, and carries it to the action")
+  func theQuickAddItemFollowsTheSelection() {
+    let spy = ActionSpy()
+    let controller = makeController(spy: spy)
+
+    let empty = NSMenu()
+    controller.renderMenu(into: empty, state: fixture(pipelineState: .idle))
+    let inert = item(empty, "Add Selected Word")
+    #expect(inert?.isEnabled == false)
+
+    let ready = NSMenu()
+    controller.renderMenu(
+      into: ready, state: fixture(pipelineState: .idle, quickAddSelection: "clawwed"))
+    let live = item(ready, "Add \u{201C}clawwed\u{201D}")
+    #expect(live?.isEnabled == true)
+    #expect(live?.target as AnyObject? === controller)
+    // Shown, never registered — the real chord is a global hotkey, and a menu key equivalent would
+    // be a second registration of one gesture.
+    #expect(live?.keyEquivalent == "w")
+    #expect(live?.keyEquivalentModifierMask == [.control, .option])
+
+    perform(live)
+    #expect(
+      spy.fired == ["addSelectedWord:clawwed"],
+      "the action must carry the text the TITLE quoted, not a fresh read taken after the menu closed")
   }
 
   @Test("renderMenu (b): recording → Stop Recording, record item enabled")
@@ -335,9 +366,11 @@ struct MenuBarControllerTests {
     updateAvailable: Bool = false,
     updateDisplayVersion: String? = nil,
     installEnabled: Bool = false,
-    appearancePreference: AppearancePreference = .system
+    appearancePreference: AppearancePreference = .system,
+    quickAddSelection: String? = nil
   ) -> MenuBarViewState {
     MenuBarViewState(
+      quickAddSelection: quickAddSelection,
       pipelineState: pipelineState,
       asrLabel: "Parakeet v3",
       llmLabel: "LLM Deactivated",
@@ -387,6 +420,7 @@ struct MenuBarControllerTests {
       settings: settings,
       permissions: PermissionsService(),
       actions: MenuBarActions(
+        addSelectedWord: { spy.fired.append("addSelectedWord:\($0)") },
         continueOnboarding: { spy.fired.append("continueOnboarding") },
         openSettings: { spy.fired.append("openSettings") },
         openPermissions: { spy.fired.append("openPermissions") },
@@ -409,6 +443,62 @@ struct MenuBarControllerTests {
       return
     }
     target.perform(action, with: menuItem)
+  }
+}
+
+@Suite("Quick Add's menu-bar door (#2412)", .tags(.productOutcome))
+@MainActor
+struct QuickAddMenuItemTests {
+  /// **The title quotes the word, so the user sees WHICH one before spending a click.** The panel
+  /// can still correct it; the menu should not be a guess.
+  @Test("A readable selection is named in the title, and the item can be chosen")
+  func aSelectionIsNamedAndEnabled() {
+    let item = MenuBarController.quickAddItem(selection: "clawwed")
+    #expect(item.title == "Add \u{201C}clawwed\u{201D}")
+    #expect(item.enabled)
+  }
+
+  /// **Disabled rather than enabled-onto-a-refusal.** An item that opens a panel only to report
+  /// "nothing selected" spends a click to deliver news the menu already had.
+  @Test("Nothing to add leaves the item disabled and generically titled")
+  func nothingSelectedIsDisabled() {
+    for selection in [nil, "", "   ", "\n\t "] as [String?] {
+      let item = MenuBarController.quickAddItem(selection: selection)
+      #expect(item.title == "Add Selected Word", "for \(String(describing: selection))")
+      #expect(!item.enabled, "for \(String(describing: selection))")
+    }
+  }
+
+  /// Whitespace around a real word is trimmed rather than quoted — a selection dragged past a word
+  /// boundary is the ordinary case, not an edge one.
+  @Test("Surrounding whitespace does not reach the title")
+  func whitespaceIsTrimmed() {
+    #expect(MenuBarController.quickAddItem(selection: "  clawwed \n").title == "Add \u{201C}clawwed\u{201D}")
+  }
+
+  /// **The reader admits 512 scalars and a menu is not where 512 characters belong.** This bounds
+  /// the TITLE only; the panel still receives and can add the whole selection.
+  @Test("A long selection is truncated for display, with an ellipsis")
+  func aLongSelectionIsTruncated() {
+    let long = String(repeating: "a", count: 200)
+    let item = MenuBarController.quickAddItem(selection: long)
+
+    #expect(item.enabled)
+    #expect(item.title.hasSuffix("\u{2026}\u{201D}"), "the user is told it was cut")
+    #expect(
+      item.title.unicodeScalars.count == MenuBarController.quickAddTitleScalars + 7,
+      "`Add ` is four scalars, plus two quotes and the ellipsis")
+  }
+
+  /// A selection exactly at the boundary is NOT truncated — the paired case, without which the row
+  /// above passes for a truncation that fires one scalar early.
+  @Test("A selection exactly at the display limit keeps all of it")
+  func theBoundaryIsNotTruncated() {
+    let exact = String(repeating: "a", count: MenuBarController.quickAddTitleScalars)
+    let item = MenuBarController.quickAddItem(selection: exact)
+
+    #expect(!item.title.contains("\u{2026}"))
+    #expect(item.title == "Add \u{201C}\(exact)\u{201D}")
   }
 }
 

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -302,6 +302,25 @@ struct MenuBarControllerTests {
   /// armed — so the advertised chord can START OR CANCEL A RECORDING. This menu exists because the
   /// shortcut can fail; sending the user to the heart path instead is the one lie it must not tell.
   /// Cloud review, PR #2427.
+  /// **Ownership is decided on the CARBON-EFFECTIVE modifiers, not the raw flags.**
+  /// `HotkeyService.carbonModifiers` keeps only Command/Option/Control/Shift, so a binding recorded
+  /// with Caps Lock, Function or Numeric Pad set is the SAME CHORD to Carbon as one without —
+  /// Record registers first, Quick Add's registration fails, and a raw comparison would call the
+  /// binding uncontested and advertise a dead chord. Cloud review, PR #2427, on the first version
+  /// of this guard.
+  @Test("A chord that differs only in a modifier Carbon drops is still contested")
+  func modifiersAreComparedAsCarbonSeesThem() {
+    // Quick Add carries an extra bit Carbon discards; Record does not. Same chord in practice.
+    #expect(Self.label(49, [.command, .capsLock], record: (49, [.command])) == nil)
+    // And the other direction, so this is not a rule about which side carries the extra bit.
+    #expect(Self.label(49, [.command], record: (49, [.command, .function])) == nil)
+    #expect(Self.label(53, [.control, .numericPad], cancel: (53, [.control])) == nil)
+
+    // Paired: a modifier Carbon DOES register still separates two bindings, or the masking would
+    // have swallowed every real difference and called everything contested.
+    #expect(Self.label(49, [.command, .shift], record: (49, [.command])) != nil)
+  }
+
   @Test("A chord Record or Cancel owns is not advertised as Quick Add's")
   func acontestedChordIsNotAdvertised() {
     // The shipped default is uncontested and still shows, so the guard cannot be a blanket nil.

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -116,7 +116,7 @@ struct MenuBarControllerTests {
         "Version: \(AppConstants.appVersion)",
         "",  // separator
         "Start Recording",
-        "Add Selected Word",  // #2412, disabled with no selection
+        "Add Selected Word  \u{2303}\u{2325} W",  // #2412, disabled; the chord rides in the title
         "",  // separator
         "Settings...",
         "Appearance",  // #1047 submenu parent
@@ -206,19 +206,20 @@ struct MenuBarControllerTests {
 
     let empty = NSMenu()
     controller.renderMenu(into: empty, state: fixture(pipelineState: .idle))
-    let inert = item(empty, "Add Selected Word")
+    let inert = itemPrefixed(empty, "Add Selected Word")
     #expect(inert?.isEnabled == false)
 
     let ready = NSMenu()
     controller.renderMenu(
       into: ready, state: fixture(pipelineState: .idle, quickAddSelection: "clawwed"))
-    let live = item(ready, "Add \u{201C}clawwed\u{201D}")
+    let live = itemPrefixed(ready, "Add \u{201C}clawwed\u{201D}")
     #expect(live?.isEnabled == true)
     #expect(live?.target as AnyObject? === controller)
-    // Derived from the CONFIGURED binding, never hard-coded — the fixture's default is the shipped
-    // chord, and the rebind cases are asserted separately below.
-    #expect(live?.keyEquivalent == "w")
-    #expect(live?.keyEquivalentModifierMask == [.control, .option])
+    // **No key equivalent at all.** A global hotkey is a physical key code; a key equivalent is a
+    // character matched against the active layout. On AZERTY they are different keys, so an item
+    // carrying one can respond to a chord that is not the user's.
+    #expect(live?.keyEquivalent == "")
+    #expect(live?.keyEquivalentModifierMask == [])
 
     perform(live)
     #expect(
@@ -227,8 +228,7 @@ struct MenuBarControllerTests {
   }
 
   /// **The shortcut is user-editable, so advertising a hard-coded one teaches a lie after a
-  /// rebind** — and keeps answering the old chord, because a key equivalent is live rather than
-  /// decorative.
+  /// rebind.** Shown as text rather than as a key equivalent — see `quickAddShortcutLabel`.
   @Test("A rebound shortcut is what the menu advertises")
   func theMenuFollowsTheConfiguredBinding() {
     let controller = makeController()
@@ -236,12 +236,11 @@ struct MenuBarControllerTests {
     controller.renderMenu(
       into: menu,
       state: fixture(
-        pipelineState: .idle, quickAddSelection: "clawwed",
-        quickAddChord: MenuChord(key: "j", modifiers: [.command, .shift])))
+        pipelineState: .idle, quickAddSelection: "clawwed", quickAddShortcut: "\u{2318}\u{21E7} J"))
 
-    let row = item(menu, "Add \u{201C}clawwed\u{201D}")
-    #expect(row?.keyEquivalent == "j")
-    #expect(row?.keyEquivalentModifierMask == [.command, .shift])
+    let row = itemPrefixed(menu, "Add \u{201C}clawwed\u{201D}")
+    #expect(row?.title == "Add \u{201C}clawwed\u{201D}  \u{2318}\u{21E7} J")
+    #expect(row?.keyEquivalent == "", "never a key equivalent, whatever the binding")
   }
 
   /// **Nothing rather than an approximation.** A menu that teaches no shortcut is recoverable; one
@@ -252,26 +251,32 @@ struct MenuBarControllerTests {
     let menu = NSMenu()
     controller.renderMenu(
       into: menu,
-      state: fixture(pipelineState: .idle, quickAddSelection: "clawwed", quickAddChord: nil))
+      state: fixture(pipelineState: .idle, quickAddSelection: "clawwed", quickAddShortcut: nil))
 
-    let row = item(menu, "Add \u{201C}clawwed\u{201D}")
-    #expect(row?.keyEquivalent == "")
-    #expect(row?.keyEquivalentModifierMask == [])
+    #expect(item(menu, "Add \u{201C}clawwed\u{201D}") != nil, "the title carries no trailing hint")
   }
 
-  /// The mapping itself: what a menu can show exactly, and what it must decline to.
-  @Test("Only a modified letter or digit becomes a key equivalent")
-  func onlyRepresentableChordsMap() {
-    // 13 is W, the shipped default.
+  /// The mapping itself: what is worth showing, and what is not.
+  @Test("An unknown key code advertises nothing rather than `Key 999`")
+  func onlyKnownChordsAreAdvertised() {
     #expect(
-      MenuBarController.quickAddKeyEquivalent(keyCode: 13, modifiers: [.control, .option])
-        == MenuChord(key: "w", modifiers: [.control, .option]))
-    // A bare modifier has no character to be.
-    #expect(MenuBarController.quickAddKeyEquivalent(keyCode: 61, modifiers: []) == nil)
-    // An arrow has a symbol, not a character a key equivalent can carry.
-    #expect(MenuBarController.quickAddKeyEquivalent(keyCode: 123, modifiers: [.command]) == nil)
-    // No modifiers at all is not a chord a menu should claim.
-    #expect(MenuBarController.quickAddKeyEquivalent(keyCode: 13, modifiers: []) == nil)
+      MenuBarController.quickAddShortcutLabel(keyCode: 13, modifiers: [.control, .option])
+        == "\u{2303}\u{2325} W")
+    #expect(MenuBarController.quickAddShortcutLabel(keyCode: 999, modifiers: [.command]) == nil)
+  }
+
+  /// The title composer, paired so a missing hint cannot leave trailing whitespace.
+  @Test("The chord is appended, and its absence leaves the title untouched")
+  func theTitleCarriesTheChord() {
+    #expect(
+      MenuBarController.quickAddTitle(base: "Add Selected Word", shortcut: "\u{2303}\u{2325} W")
+        == "Add Selected Word  \u{2303}\u{2325} W")
+    #expect(
+      MenuBarController.quickAddTitle(base: "Add Selected Word", shortcut: nil)
+        == "Add Selected Word")
+    #expect(
+      MenuBarController.quickAddTitle(base: "Add Selected Word", shortcut: "")
+        == "Add Selected Word", "an empty hint must not leave trailing spaces")
   }
 
   @Test("renderMenu (b): recording → Stop Recording, record item enabled")
@@ -435,10 +440,10 @@ struct MenuBarControllerTests {
     installEnabled: Bool = false,
     appearancePreference: AppearancePreference = .system,
     quickAddSelection: String? = nil,
-    quickAddChord: MenuChord? = MenuChord(key: "w", modifiers: [.control, .option])
+    quickAddShortcut: String? = "\u{2303}\u{2325} W"
   ) -> MenuBarViewState {
     MenuBarViewState(
-      quickAddChord: quickAddChord,
+      quickAddShortcut: quickAddShortcut,
       quickAddSelection: quickAddSelection,
       pipelineState: pipelineState,
       asrLabel: "Parakeet v3",
@@ -502,6 +507,15 @@ struct MenuBarControllerTests {
 
   private func item(_ menu: NSMenu, _ title: String) -> NSMenuItem? {
     menu.items.first { $0.title == title }
+  }
+
+  /// Find by what the item SAYS IT DOES, ignoring the shortcut hint appended to its title.
+  ///
+  /// The Quick Add row carries its chord as trailing text rather than as a key equivalent (#2412),
+  /// so an exact-title lookup finds nothing the moment a binding changes — which is a property of
+  /// the test, not of the menu.
+  private func itemPrefixed(_ menu: NSMenu, _ prefix: String) -> NSMenuItem? {
+    menu.items.first { $0.title.hasPrefix(prefix) }
   }
 
   private func perform(_ menuItem: NSMenuItem?) {

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -215,8 +215,8 @@ struct MenuBarControllerTests {
     let live = item(ready, "Add \u{201C}clawwed\u{201D}")
     #expect(live?.isEnabled == true)
     #expect(live?.target as AnyObject? === controller)
-    // Shown, never registered — the real chord is a global hotkey, and a menu key equivalent would
-    // be a second registration of one gesture.
+    // Derived from the CONFIGURED binding, never hard-coded — the fixture's default is the shipped
+    // chord, and the rebind cases are asserted separately below.
     #expect(live?.keyEquivalent == "w")
     #expect(live?.keyEquivalentModifierMask == [.control, .option])
 
@@ -224,6 +224,54 @@ struct MenuBarControllerTests {
     #expect(
       spy.fired == ["addSelectedWord:clawwed"],
       "the action must carry the text the TITLE quoted, not a fresh read taken after the menu closed")
+  }
+
+  /// **The shortcut is user-editable, so advertising a hard-coded one teaches a lie after a
+  /// rebind** — and keeps answering the old chord, because a key equivalent is live rather than
+  /// decorative.
+  @Test("A rebound shortcut is what the menu advertises")
+  func theMenuFollowsTheConfiguredBinding() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu,
+      state: fixture(
+        pipelineState: .idle, quickAddSelection: "clawwed",
+        quickAddChord: MenuChord(key: "j", modifiers: [.command, .shift])))
+
+    let row = item(menu, "Add \u{201C}clawwed\u{201D}")
+    #expect(row?.keyEquivalent == "j")
+    #expect(row?.keyEquivalentModifierMask == [.command, .shift])
+  }
+
+  /// **Nothing rather than an approximation.** A menu that teaches no shortcut is recoverable; one
+  /// that teaches a chord the user reassigned is not, because they have no reason to doubt it.
+  @Test("An unrepresentable chord advertises nothing at all")
+  func anUnrepresentableChordShowsNothing() {
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu,
+      state: fixture(pipelineState: .idle, quickAddSelection: "clawwed", quickAddChord: nil))
+
+    let row = item(menu, "Add \u{201C}clawwed\u{201D}")
+    #expect(row?.keyEquivalent == "")
+    #expect(row?.keyEquivalentModifierMask == [])
+  }
+
+  /// The mapping itself: what a menu can show exactly, and what it must decline to.
+  @Test("Only a modified letter or digit becomes a key equivalent")
+  func onlyRepresentableChordsMap() {
+    // 13 is W, the shipped default.
+    #expect(
+      MenuBarController.quickAddKeyEquivalent(keyCode: 13, modifiers: [.control, .option])
+        == MenuChord(key: "w", modifiers: [.control, .option]))
+    // A bare modifier has no character to be.
+    #expect(MenuBarController.quickAddKeyEquivalent(keyCode: 61, modifiers: []) == nil)
+    // An arrow has a symbol, not a character a key equivalent can carry.
+    #expect(MenuBarController.quickAddKeyEquivalent(keyCode: 123, modifiers: [.command]) == nil)
+    // No modifiers at all is not a chord a menu should claim.
+    #expect(MenuBarController.quickAddKeyEquivalent(keyCode: 13, modifiers: []) == nil)
   }
 
   @Test("renderMenu (b): recording → Stop Recording, record item enabled")
@@ -386,9 +434,11 @@ struct MenuBarControllerTests {
     updateDisplayVersion: String? = nil,
     installEnabled: Bool = false,
     appearancePreference: AppearancePreference = .system,
-    quickAddSelection: String? = nil
+    quickAddSelection: String? = nil,
+    quickAddChord: MenuChord? = MenuChord(key: "w", modifiers: [.control, .option])
   ) -> MenuBarViewState {
     MenuBarViewState(
+      quickAddChord: quickAddChord,
       quickAddSelection: quickAddSelection,
       pipelineState: pipelineState,
       asrLabel: "Parakeet v3",

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -227,6 +227,26 @@ struct MenuBarControllerTests {
       "the action must carry the text the TITLE quoted, not a fresh read taken after the menu closed")
   }
 
+  // Re-homed from `QuickAddMenuItemTests`, which owns the PURE title decisions and has no
+  // controller, no fixture and no way to click anything. `the-rig-decides-where-a-test-lives`: this
+  // case needs a rendered menu and an action spy, and those live here.
+  /// The pairing: what the menu SHOWS is normalised, what the action CARRIES is not.
+  @Test("The action receives the original selection, newline and all")
+  func theActionCarriesTheUnmodifiedSelection() {
+    let spy = ActionSpy()
+    let controller = makeController(spy: spy)
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, quickAddSelection: "clawwed\nmachine"))
+
+    let row = itemPrefixed(menu, "Add \u{201C}clawwed machine\u{201D}")
+    #expect(row != nil, "the TITLE is collapsed")
+    perform(row)
+    #expect(
+      spy.fired == ["addSelectedWord:clawwed\nmachine"],
+      "the ACTION carries the original, because that is what the user selected")
+  }
+
   /// **The shortcut is user-editable, so advertising a hard-coded one teaches a lie after a
   /// rebind.** Shown as text rather than as a key equivalent — see `quickAddShortcutLabel`.
   @Test("A rebound shortcut is what the menu advertises")
@@ -557,6 +577,19 @@ struct QuickAddMenuItemTests {
   @Test("Surrounding whitespace does not reach the title")
   func whitespaceIsTrimmed() {
     #expect(MenuBarController.quickAddItem(selection: "  clawwed \n").title == "Add \u{201C}clawwed\u{201D}")
+  }
+
+  /// **A selection spanning two lines carries a newline, and a newline in a native menu title
+  /// renders as a malformed multi-line row.** Collapsed for DISPLAY only — the original still
+  /// reaches the panel, so what gets added is what was selected rather than what fitted in a menu.
+  @Test("Internal line breaks and tabs are collapsed for display")
+  func internalWhitespaceIsCollapsed() {
+    #expect(
+      MenuBarController.quickAddItem(selection: "clawwed\nmachine").title
+        == "Add \u{201C}clawwed machine\u{201D}")
+    #expect(
+      MenuBarController.quickAddItem(selection: "one\ttwo   three").title
+        == "Add \u{201C}one two three\u{201D}")
   }
 
   /// **The reader admits 512 scalars and a menu is not where 512 characters belong.** This bounds

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -177,6 +177,25 @@ struct MenuBarControllerTests {
     }
   }
 
+  /// **The property has to MEAN something, and for the life of this menu it did not.** `NSMenu`
+  /// auto-enables by default, so an item with a target and an action is enabled whatever
+  /// `isEnabled` says. Live UAT caught the Quick Add item rendering enabled with no selection while
+  /// this file's own assertions read false — they inspect the property on a menu AppKit never
+  /// validated, which is a claim about the decision and not about the menu the user sees.
+  ///
+  /// Asserted on the FACTORY the status item is built from, which is where the property is set —
+  /// a detached `NSMenu()` would assert AppKit's default and prove nothing about our menu.
+  @Test("The status-item menu does not auto-enable, so a disabled item is really disabled")
+  func theMenuDoesNotAutoEnable() {
+    let controller = makeController()
+    let menu = MenuBarController.makeStatusMenu(delegate: controller)
+
+    #expect(
+      menu.autoenablesItems == false,
+      "with auto-enabling on, every isEnabled=false in renderMenu is silently ignored")
+    #expect(menu.delegate as AnyObject? === controller, "and it still repopulates on open")
+  }
+
   /// **The item is inert with nothing selected, and live with something.** Both halves matter: an
   /// enabled item over no selection spends a click to report a refusal the menu already knew about,
   /// and a disabled item over a real selection is the door not opening at all.

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -321,6 +321,32 @@ struct MenuBarControllerTests {
     #expect(Self.label(49, [.command, .shift], record: (49, [.command])) != nil)
   }
 
+  /// **A BARE MODIFIER the record chord reserves is not Quick Add's either, and no comparison of
+  /// the two bindings can see it.** Quick Add on bare Left Command with Record on Command-D are
+  /// different bindings by every equality this file used to apply — yet `ShortcutMatcher.role`
+  /// returns nil for that press, because a bare Command is indistinguishable from the start of the
+  /// record chord and accepting it would open a panel that takes key focus while the user is trying
+  /// to dictate. Third round on this one root, and the reason the label now ASKS the dispatcher
+  /// instead of re-deriving the rules. Cloud review, PR #2427.
+  @Test("A bare modifier the record chord reserves is not advertised")
+  func aBareModifierReservedByRecordIsNotAdvertised() {
+    // Record is Command-D (key code 2), Quick Add is bare Left Command.
+    #expect(Self.label(ModifierKeyCodes.leftCommand, [], record: (2, [.command])) == nil)
+    #expect(Self.label(ModifierKeyCodes.rightCommand, [], record: (2, [.command])) == nil)
+
+    // Paired: with the record chord NOT needing Command, the same bare key is genuinely Quick
+    // Add's and must still be advertised — or this guard would silence every bare modifier.
+    #expect(Self.label(ModifierKeyCodes.leftCommand, [], record: (2, [.option])) != nil)
+  }
+
+  /// Cancel takes a shared chord for the whole of every recording, so a label promising it is a
+  /// promise we cannot keep even though the binding is Quick Add's most of the time.
+  @Test("A chord cancel takes during recording is not advertised")
+  func aChordCancelClaimsIsNotAdvertised() {
+    #expect(Self.label(53, [.control], cancel: (53, [.control])) == nil)
+    #expect(Self.label(53, [.control], cancel: (53, [.command])) != nil)
+  }
+
   @Test("A chord Record or Cancel owns is not advertised as Quick Add's")
   func acontestedChordIsNotAdvertised() {
     // The shipped default is uncontested and still shows, so the guard cannot be a blanket nil.

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -339,6 +339,30 @@ struct MenuBarControllerTests {
     #expect(Self.label(ModifierKeyCodes.leftCommand, [], record: (2, [.option])) != nil)
   }
 
+  /// **A CHORD is intercepted by a bare-modifier role, which is the mirror of the case above and
+  /// the reason `isBareModifier` does not partition the dispatch paths.** Pressing Command-W emits
+  /// the Command press first, and the modifier monitor routes every bare modifier press through
+  /// `ShortcutMatcher.role` before the W reaches Carbon — so Record on bare Command means the user
+  /// starts a recording while following this hint. Fourth round on this root; cloud review, #2427.
+  @Test("A chord whose modifier a bare role owns is not advertised")
+  func aChordInterceptedByABareModifierIsNotAdvertised() {
+    // Quick Add Command-W (key code 13), Record on bare Left Command.
+    #expect(Self.label(13, [.command], record: (ModifierKeyCodes.leftCommand, [])) == nil)
+    // Cancel too — it holds its bare modifier for the whole of every recording.
+    #expect(Self.label(13, [.command], cancel: (ModifierKeyCodes.rightCommand, [])) == nil)
+    // A chord needing SEVERAL modifiers is intercepted if ANY of them is claimed.
+    #expect(
+      Self.label(13, [.command, .option], record: (ModifierKeyCodes.leftOption, [])) == nil,
+      "the option half is enough; the chord never completes")
+
+    // Paired, or this would silence every chord the moment any bare binding existed: a bare role on
+    // a modifier the chord does NOT need leaves the hint honest.
+    #expect(Self.label(13, [.command], record: (ModifierKeyCodes.leftOption, [])) != nil)
+    #expect(
+      Self.label(13, [.control, .option], cancel: (ModifierKeyCodes.leftCommand, [])) != nil,
+      "cancel owns Command; this chord needs Control and Option")
+  }
+
   /// Cancel takes a shared chord for the whole of every recording, so a label promising it is a
   /// promise we cannot keep even though the binding is Quick Add's most of the time.
   @Test("A chord cancel takes during recording is not advertised")

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -276,13 +276,48 @@ struct MenuBarControllerTests {
     #expect(item(menu, "Add \u{201C}clawwed\u{201D}") != nil, "the title carries no trailing hint")
   }
 
+  /// Every case is paired with its opposite, or a function that returned nil for everything would
+  /// look exactly like this one passing.
+  private static func label(
+    _ keyCode: UInt16, _ modifiers: NSEvent.ModifierFlags,
+    record: (UInt16, NSEvent.ModifierFlags) = (49, []),
+    cancel: (UInt16, NSEvent.ModifierFlags) = (53, [])
+  ) -> String? {
+    MenuBarController.quickAddShortcutLabel(
+      keyCode: keyCode, modifiers: modifiers,
+      recordKeyCode: record.0, recordModifiers: record.1,
+      cancelKeyCode: cancel.0, cancelModifiers: cancel.1)
+  }
+
   /// The mapping itself: what is worth showing, and what is not.
   @Test("An unknown key code advertises nothing rather than `Key 999`")
   func onlyKnownChordsAreAdvertised() {
+    #expect(Self.label(13, [.control, .option]) == "\u{2303}\u{2325} W")
+    #expect(Self.label(999, [.command]) == nil)
+  }
+
+  /// **A chord another role owns must not be advertised here, and this is worse than a dead hint.**
+  /// `ShortcutMatcher.role` gives Record priority on a shared binding and
+  /// `HotkeyService.quickAddMayHoldItsChord` unregisters Quick Add while a same-binding Cancel is
+  /// armed — so the advertised chord can START OR CANCEL A RECORDING. This menu exists because the
+  /// shortcut can fail; sending the user to the heart path instead is the one lie it must not tell.
+  /// Cloud review, PR #2427.
+  @Test("A chord Record or Cancel owns is not advertised as Quick Add's")
+  func acontestedChordIsNotAdvertised() {
+    // The shipped default is uncontested and still shows, so the guard cannot be a blanket nil.
+    #expect(Self.label(13, [.control, .option]) != nil, "the default is nobody else's")
+
+    #expect(Self.label(49, [], record: (49, [])) == nil, "Record owns this chord")
+    #expect(Self.label(53, [], cancel: (53, [])) == nil, "Cancel owns this chord")
+
+    // MODIFIERS are half the identity: the same key code under a different chord is a different
+    // shortcut, and refusing it too would silence a hint that is perfectly honest.
     #expect(
-      MenuBarController.quickAddShortcutLabel(keyCode: 13, modifiers: [.control, .option])
-        == "\u{2303}\u{2325} W")
-    #expect(MenuBarController.quickAddShortcutLabel(keyCode: 999, modifiers: [.command]) == nil)
+      Self.label(49, [.control, .option], record: (49, [])) != nil,
+      "same key, different chord — not a collision")
+    #expect(
+      Self.label(49, [], record: (49, [.command])) != nil,
+      "and the other way round, or the check is comparing key codes alone")
   }
 
   /// The title composer, paired so a missing hint cannot leave trailing whitespace.
@@ -514,7 +549,15 @@ struct MenuBarControllerTests {
       settings: settings,
       permissions: PermissionsService(),
       actions: MenuBarActions(
-        addSelectedWord: { spy.fired.append("addSelectedWord:\($0 ?? "<none>")") },
+        // Rendered per CASE rather than through a description, so a refusal reaching the panel is
+        // visible in the assertion instead of collapsing into the same string as an empty read.
+        addSelectedWord: {
+          switch $0 {
+          case .text(let t): spy.fired.append("addSelectedWord:\(t)")
+          case .noSelection: spy.fired.append("addSelectedWord:<none>")
+          case .refused(let why): spy.fired.append("addSelectedWord:refused:\(why.rawValue)")
+          }
+        },
         continueOnboarding: { spy.fired.append("continueOnboarding") },
         openSettings: { spy.fired.append("openSettings") },
         openPermissions: { spy.fired.append("openPermissions") },
@@ -601,9 +644,21 @@ struct QuickAddMenuItemTests {
   /// tells them nothing. Enabled, so the panel opens and states the reason.
   @Test("A refused read stays clickable so the panel can say why")
   func aRefusedReadIsNotAnEmptySelection() {
-    let blocked = MenuBarController.quickAddItem(.blocked)
+    let blocked = MenuBarController.quickAddItem(.blocked(.accessibilityNotTrusted))
     #expect(blocked.enabled, "the door that must be reliable cannot fail silently")
     #expect(blocked.title == "Add Selected Word")
+
+    // **Every refusal renders the SAME row, and the state still carries which one it was.** The
+    // display is deliberately uniform — the panel states the reason, not the menu — but dropping the
+    // reason here is what forced the click path to re-read without the menu's cap (PR #2427).
+    for why in SelectionReader.Refusal.allCases where why != .accessibilityNotTrusted {
+      #expect(MenuBarController.quickAddItem(.blocked(why)) == blocked, "one row for every refusal")
+      #expect(
+        QuickAddMenuState.blocked(why).selectionResult == .refused(why),
+        "and the panel is handed the refusal we measured, not a fresh guess")
+    }
+    #expect(QuickAddMenuState.nothingSelected.selectionResult == .noSelection)
+    #expect(QuickAddMenuState.ready("clawwed").selectionResult == .text("clawwed"))
 
     let empty = MenuBarController.quickAddItem(.nothingSelected)
     #expect(!empty.enabled, "and genuinely nothing selected is still inert")

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -19,6 +19,8 @@ import Testing
 struct QuickAddCoordinatorTests {
 
   private final class Recorder {
+    /// How many times `begin` went to the live reader. The menu door must never.
+    var selectionReads = 0
     var events: [QuickAddEvent] = []
     var saved: [CustomWord] = []
     var savedSpellings: [String] = []
@@ -59,6 +61,38 @@ struct QuickAddCoordinatorTests {
   /// `begin` plus the presentation callback, which is what the wiring does and what a test asserting
   /// an `opened` event must reproduce.
   ///
+  /// **The menu door carries its own outcome and must not read again.**
+  ///
+  /// The menu reads under a 0.25s-per-operation cap so a stalled Accessibility provider cannot hold
+  /// the menu shut. Passing `nil` for a refusal made `begin` read AGAIN through the uncapped live
+  /// reader, so clicking the deliberately-enabled blocked row repeated the same stalled operations
+  /// under the system default — the stall moved from the menu to the panel and the bound bought
+  /// nothing. Cloud review, PR #2427.
+  ///
+  /// The read COUNT is the assertion, not the refusal that comes out: a re-read of the same fixture
+  /// produces the same refusal, so asserting the reason alone passes either way.
+  @Test("A menu-door refusal is carried, never re-read")
+  func theMenuDoorDoesNotReadAgain() throws {
+    let (coordinator, recorder) = makeCoordinator(selection: .text("codecs"))
+
+    let model = coordinator.begin(
+      door: .menuBar, selection: .result(.refused(.accessibilityNotTrusted)))
+
+    #expect(recorder.selectionReads == 0, "the uncapped reader must not be reached at all")
+    #expect(
+      try #require(model).refusal == .accessibilityNotTrusted,
+      "and the panel states the reason the MENU measured, not one derived after it closed")
+  }
+
+  /// The live door still reads, or the assertion above would pass against a coordinator that never
+  /// reads anything.
+  @Test("The hotkey door does read live")
+  func theHotkeyDoorReadsLive() {
+    let (coordinator, recorder) = makeCoordinator(selection: .text("codecs"))
+    _ = coordinator.begin(door: .hotkey)
+    #expect(recorder.selectionReads == 1)
+  }
+
   /// The two are separate in production on purpose: `opened` names an event the user can SEE, so it
   /// fires when a panel is on screen. Emitting it from `begin` made a panel that could not be
   /// measured leave an open with nothing to resolve it.
@@ -66,7 +100,10 @@ struct QuickAddCoordinatorTests {
     _ coordinator: QuickAddCoordinator, door: QuickAddDoor = .hotkey,
     selectionOverride: String? = nil
   ) -> QuickAddPanelModel? {
-    let model = coordinator.begin(door: door, selectionOverride: selectionOverride)
+    // The helper still takes text, because that is what almost every row is about. It maps to
+    // `.text`, which is the Services door's shape — classification still happens inside `begin`.
+    let model = coordinator.begin(
+      door: door, selection: selectionOverride.map { .text($0) } ?? .live)
     if model != nil { coordinator.didOpen() }
     return model
   }
@@ -82,7 +119,13 @@ struct QuickAddCoordinatorTests {
     recorder.userWords = userWords
     var clock = Date(timeIntervalSince1970: 0)
     let environment = QuickAddCoordinator.Environment(
-      readSelection: { selection },
+      readSelection: {
+        // Counted, because the menu door's whole fix is that it does NOT reach this closure: it
+        // carries the outcome the menu already obtained under a cap. Without a count, "the refusal
+        // survived" passes whether it was carried or re-derived (PR #2427).
+        recorder.selectionReads += 1
+        return selection
+      },
       frontmostBundleID: { "com.apple.TextEdit" },
       refreshWords: {
         recorder.refreshCalls += 1

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -594,7 +594,7 @@ struct QuickAddCoordinatorTests {
     #expect(recorder.outcomes == [.cancelled])
   }
 
-  @Test("Both doors are reported, and they are the only two")
+  @Test("Every door is reported, and the set is closed")
   func bothDoorsAreReported() throws {
     let (coordinator, recorder) = makeCoordinator()
 
@@ -602,7 +602,10 @@ struct QuickAddCoordinatorTests {
     guard case .opened(let door, _, _, _, _, _, _) = try #require(recorder.opened) else { return }
 
     #expect(door == .service)
-    #expect(QuickAddDoor.allCases.count == 2)
+    // Three since #2412 added the status-item menu. The count is here so a new door cannot be added
+    // without someone reading the funnel — which is what happened.
+    #expect(QuickAddDoor.allCases.count == 3)
+    #expect(QuickAddDoor.allCases.contains(.menuBar))
   }
 
   @Test("The Service door uses the pasteboard text and does not read Accessibility")

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -282,4 +282,25 @@ struct SelectionReaderTests {
     #expect(seen.contains { if case .refused = $0 { true } else { false } })
   }
 
+
+  /// **A failed query is not an empty one, and they need different sentences.**
+  ///
+  /// `focusedElementQuery` collapsed both to nil, which was tolerable while every read was
+  /// unbounded and a timeout was rare. #2412's 0.25s menu cap makes the timeout branch the likely
+  /// one, so the panel was routinely telling users to click into the text when nothing they clicked
+  /// could help. Cloud review, PR #2427.
+  @Test("A timed-out or failed focus query is unreadable, not an unfocused app")
+  func aFailedFocusQueryIsNotAnEmptyOne() {
+    #expect(SelectionReader.refusalForFocusedElement(.none) == .noFocusedElement)
+    #expect(SelectionReader.refusalForFocusedElement(.queryFailed(.cannotComplete)) == .unreadable)
+    // The timeout arrives as its own error code and must not be special-cased into the empty case.
+    #expect(
+      SelectionReader.refusalForFocusedElement(.queryFailed(.actionUnsupported)) == .unreadable,
+      "every query failure is unreadable; only a SUCCESSFUL empty query is noFocusedElement")
+    // The two must stay DISTINCT refusals; the wording each maps to is the copy table's suite,
+    // in another module. What matters here is that nothing collapses them back together.
+    #expect(
+      SelectionReader.refusalForFocusedElement(.none)
+        != SelectionReader.refusalForFocusedElement(.queryFailed(.cannotComplete)))
+  }
 }

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -377,6 +377,18 @@ struct SelectionReaderTests {
   @Test("A timed-out or failed focus query is unreadable, not an unfocused app")
   func aFailedFocusQueryIsNotAnEmptyOne() {
     #expect(SelectionReader.refusalForFocusedElement(.none) == .noFocusedElement)
+    // **`.noValue` is Accessibility's ordinary "nothing is focused" answer**, so it must reach the
+    // click-into-the-text advice rather than the generic read failure. Asserted on the classifier
+    // itself: routing it to `.queryFailed` and checking the refusal differs would pass whatever the
+    // classifier does, which is a test about nothing.
+    #expect(PasteService.isUnfocusedResponse(.noValue), "the commonest case is not a failure")
+    // Paired, or a classifier that answered true to everything would look identical.
+    #expect(!PasteService.isUnfocusedResponse(.cannotComplete), "a timeout IS a failure")
+    #expect(
+      !PasteService.isUnfocusedResponse(.attributeUnsupported),
+      "an app that never implements the attribute will not start because the user clicked")
+    #expect(!PasteService.isUnfocusedResponse(.apiDisabled))
+    #expect(!PasteService.isUnfocusedResponse(.invalidUIElement))
     #expect(SelectionReader.refusalForFocusedElement(.queryFailed(.cannotComplete)) == .unreadable)
     // The timeout arrives as its own error code and must not be special-cased into the empty case.
     #expect(


### PR DESCRIPTION
feat(quickadd): a menu-bar entry, the one door macOS cannot filter out (#2412)

Quick Add shipped with two doors and one of them does not render. The Service is declared correctly,
registered exactly once at the running bundle, not disabled, and `NSPerformService` opens the panel
with the selection read — and it is still absent from TextEdit's Services submenu after a flush, an
`NSUpdateDynamicServices()` and a restart. Two hypotheses were tested and refuted (#2412 body). Root
cause unresolved and deliberately not chased here.

So this is not a consolation prize: it is the only route we fully control, and the one no OS
registration, cache or default can filter out.

**THE DESIGN QUESTION WAS SETTLED BY MEASUREMENT, NOT BY REASONING, AND THAT IS WHY THERE IS NO
STASH.** The issue flagged one thing that could go subtly wrong — if opening the menu makes us
frontmost, a selection read at render time is about OUR app, which is the wrong-subject class #2381
closed twice. Measured twice on a live build: frontmost is `com.mitchellh.ghostty` before, during and
after. A status menu is tracked by the system rather than by the owning app, so the read at render
time is about the user's document. No cache, no capture-before-show, no last-known value.

WHERE THE READ GOES, and it is one call site of three. `currentViewState()` feeds the initial menu
build, every icon refresh, and the menu-open path; only the last is licensed by that measurement, and
an Accessibility round trip on an icon refresh is work nobody asked for against a frontmost app that
may well be us. So the selection arrives as a PARAMETER defaulting to nil, supplied only by
`menuNeedsUpdate`. `renderMenu` stays pure over `MenuBarViewState`, which is what keeps the whole
menu surface golden-testable.

HONEST WHEN THERE IS NOTHING TO ADD: disabled, generic title, rather than enabled onto a panel that
immediately reports a refusal. An item that spends a click to deliver news the menu already had is
the false-sentence shape this cluster has produced three times.

**FOUR GUARDS FIRED ON THE FIRST FULL RUN AND ALL FOUR WERE RIGHT.** Recorded because none was a
nuisance and one changed the design:
  - `MenuBarController`'s stored-property ceiling refused a field holding the rendered selection.
    Not raised. `NSMenuItem.representedObject` is AppKit's own place for per-item data, it lives on
    the item the user clicked rather than in one slot shared by every render, and it cannot drift
    from the title beside it — which was the field's entire purpose. **A better design, arrived at
    by a ceiling refusing.**
  - `QuickAddDoor.allCases.count == 2` — a drift guard that exists so a door cannot be added without
    someone reading the funnel. Now three, with the member named.
  - The golden menu fixture did not know about the new row, including the separator indices.
  - My own truncation arithmetic was wrong: `Add ` is four scalars, so the title is `limit + 7`. The
    code was right and the TEST was wrong, which is exactly where it is tempting to edit the subject.

The bootstrapper builds `QuickAddWiring` before the menu bar rather than at its `self.quickAdd =`
assignment a hundred lines later — a closure cannot reach it there, because `[weak self]` is illegal
mid-initialisation and `[weak quickAdd]` names nothing yet. Every dependency it takes already exists
by line 438, so this is a reorder and not a new dependency. **A settable seam was the alternative and
is worse**: it makes the wiring optional at the type level, so "the menu item does nothing because
nobody set it" becomes a state that compiles — which is the exact failure this issue routes around.

Telemetry gains one door value on a closed set. No new event, no user content over the network.
Neither existing door is changed.

Debug 7010 / Release 6358, both PASS, each reconciled against its own per-bundle lines, with the new
cases verified present in the run by name.

NOT LIVE-UAT VERIFIED YET: the item renders from a pure function that is tested, but "the menu shows
it and clicking it opens the panel on the right word" is an AppKit claim. That is a Live UAT item and
is the next step, not a gap being hidden.

Refs #2412

Self-audit-grep: git grep -n "quickAddItem\|quickAddSelection\|addSelectedWord\|beginFromMenuBar\|menuBar" -- Sources Tests
Self-audit-owner: Sources/EnviousWisprAppKit/App/MenuBarController.swift