### PR TITLE
fix(quickadd): refuse to read our OWN application's selection (#2413)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -194,6 +194,13 @@ enum QuickAddPanelCopy {
       "No app was in front, so there was nothing to read."
     case .noFocusedElement:
       "That app did not tell us where the cursor is. Click into the text and try again."
+    case .ownApplication:
+      // **Says only what was checked.** Nothing here reads a selection, so this may not describe
+      // one — an earlier wording said "That selection is inside EnviousWispr", which is a confident
+      // sentence about a selection the code never looked at, and is false for a caret sitting in an
+      // empty field of ours. Names no fault and states the one thing that fixes it.
+      "EnviousWispr is in front, so there is nothing of yours to read. Select the word in the app "
+        + "you are writing in, then try again."
     case .selectionUnsupported:
       "That app does not share its selection with other apps. You can still add the word by hand "
         + "below."

--- a/Sources/EnviousWisprServices/AppBundleIdentity.swift
+++ b/Sources/EnviousWisprServices/AppBundleIdentity.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Every bundle identifier THIS APPLICATION ships under.
+///
+/// **A family, not a string, because the two builds do not share one.** `Project.swift:175` gives the
+/// dev build `com.enviouswispr.app.dev` and `:201` gives release `com.enviouswispr.app`, so
+/// `Bundle.main.bundleIdentifier == other.bundleIdentifier` answers NOT OURS for the one pair that
+/// matters on a development machine — a dev build looking at an installed release build, which is
+/// the ordinary state of this machine. #2413's self-read guard shipped with exactly that hole and
+/// cloud review found it.
+///
+/// **The set is CLOSED and `Project.swift` is the authority.** Every other identifier there is
+/// unreachable as a frontmost application: `com.enviouswispr.asrservice[.dev]` is an XPC service
+/// with no UI, and the test hosts (`com.enviouswispr.tests`, `com.enviouswispr.asrtests`) build
+/// products that carry the PRODUCTION identifier, so they are already covered by `production`.
+public enum AppBundleIdentity {
+  /// The shipped app.
+  public static let production = "com.enviouswispr.app"
+  /// The development build, which runs side by side with the shipped app on this machine.
+  public static let development = "com.enviouswispr.app.dev"
+
+  /// Both, as one family.
+  public static let all: Set<String> = [production, development]
+
+  /// Whether an identifier belongs to this application, whichever build is asking.
+  ///
+  /// Takes an optional because every real caller reads it off an `NSRunningApplication`, where it is
+  /// optional — and a missing identifier is NOT ours, since we always have one.
+  public static func isOurs(_ bundleIdentifier: String?) -> Bool {
+    guard let bundleIdentifier else { return false }
+    return all.contains(bundleIdentifier)
+  }
+}

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -151,8 +151,8 @@ public enum SelectionReader {
     isTrusted: Bool,
     frontmostPID: pid_t?,
     ownPID: pid_t = ProcessInfo.processInfo.processIdentifier,
-    frontmostIsOurs: Bool = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-      == Bundle.main.bundleIdentifier
+    frontmostIsOurs: Bool = AppBundleIdentity.isOurs(
+      NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
   ) -> Refusal? {
     guard isTrusted else { return .accessibilityNotTrusted }
     guard let frontmostPID, frontmostPID > 0 else { return .noFrontmostApplication }
@@ -164,11 +164,14 @@ public enum SelectionReader {
     //
     // `ownPID` is a parameter with a live default so the decision is reachable from a test; the
     // production call site never passes it.
-    // **Identity, not just this process.** A second EnviousWispr — an installed build beside a dev
-    // build — has a different pid and would walk straight through a pid-only check. That is the
-    // ordinary state of a development machine, not an exotic one. The pid was a proxy for identity;
-    // this asks the question directly, and keeps the pid comparison as the case that holds when
-    // there is no bundle identifier to read.
+    // **Identity, not just this process, and identity is a FAMILY rather than a string.** A second
+    // EnviousWispr — an installed release build beside a dev build — has a different pid, so a
+    // pid-only check reads its text. That is the ordinary state of a development machine.
+    //
+    // The first version of this guard compared against `Bundle.main.bundleIdentifier`, which is
+    // `.dev` in a dev build and not in a release one, so it answered NOT OURS for precisely the
+    // pair it was written to catch. `AppBundleIdentity` owns the closed set; the pid comparison
+    // stays for the case where there is no identifier to read at all.
     guard frontmostPID != ownPID, !frontmostIsOurs else { return .ownApplication }
 
     // **KNOWN LIMIT, stated rather than left to be found.** `frontmostPID` was sampled by the caller

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -119,14 +119,15 @@ public enum SelectionReader {
     // because this runs on the main run loop from a hotkey or a Service, with events flowing;
     // `NSWorkspace.frontmostApplication` is stale only where nothing is pumping the run loop, which
     // is not a state this entry point can be called from.
-    let frontmost = NSWorkspace.shared.frontmostApplication?.processIdentifier
+    let frontmost = Frontmost.current()
 
-    if let refusal = refusalBeforeReading(isTrusted: AXIsProcessTrusted(), frontmostPID: frontmost)
-    {
+    if let refusal = refusalBeforeReading(isTrusted: AXIsProcessTrusted(), frontmost: frontmost) {
       return .refused(refusal)
     }
-    // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid.
-    guard let pid = frontmost, let focused = PasteService.focusedElementQuery(pid: pid) else {
+    // Safe: `refusalBeforeReading` returns non-nil for a nil or non-positive pid. The pid used for
+    // the element read is the SAME sample the guard judged, so the refusal and the read can never
+    // describe two different applications.
+    guard let pid = frontmost.pid, let focused = PasteService.focusedElementQuery(pid: pid) else {
       return .refused(.noFocusedElement)
     }
 
@@ -140,6 +141,36 @@ public enum SelectionReader {
     return resolve(error: error, value: valueRef)
   }
 
+  // MARK: - The frontmost application, sampled ONCE
+
+  /// Everything the guard needs to know about the frontmost application, from ONE sample.
+  ///
+  /// **A type rather than two parameters, because two parameters is exactly how this went wrong.**
+  /// The pid was read in `read()` and the bundle identity in a DEFAULT ARGUMENT one call later —
+  /// two reads of a mutable global at two moments, which a switch in between makes describe two
+  /// different applications. Found by cloud review on PR #2428, one round after the identity check
+  /// itself was wrong.
+  ///
+  /// The previous version of this file documented a window here as a known limit. That note was
+  /// about a DIFFERENT gap (refusal versus element read) and, worse, it made an unclosable window
+  /// the story while this closable one sat under it.
+  struct Frontmost: Equatable {
+    /// nil when nothing is frontmost, which is a refusal rather than a fact about us.
+    let pid: pid_t?
+    /// Whether that same application is one of ours, by `AppBundleIdentity`.
+    let isOurs: Bool
+
+    /// The live read: one `NSRunningApplication`, both facts taken off it.
+    ///
+    /// The only member of this file that touches the workspace, so it is the only thing a test
+    /// cannot reach — and all it does is sample once. Everything that DECIDES anything is pure.
+    @MainActor
+    static func current() -> Frontmost {
+      let app = NSWorkspace.shared.frontmostApplication
+      return Frontmost(pid: app?.processIdentifier, isOurs: AppBundleIdentity.isOurs(app?.bundleIdentifier))
+    }
+  }
+
   // MARK: - The decisions, which are pure
 
   /// Why a read cannot even be attempted, or nil to go ahead.
@@ -147,15 +178,19 @@ public enum SelectionReader {
   /// Split from `read()` so both refusals are reachable from a test. Trust and frontmost are asked
   /// together because they are the two questions with no Accessibility round trip behind them; the
   /// element read has its own function below rather than four optionals in one.
+  ///
+  /// **No default for `frontmost`, deliberately.** It carried a live `NSWorkspace` read until cloud
+  /// review found that this made a SECOND sample, one call after `read()` took the first. A default
+  /// that reaches out to a mutable global is a second sample waiting for a caller who omits it.
   static func refusalBeforeReading(
     isTrusted: Bool,
-    frontmostPID: pid_t?,
-    ownPID: pid_t = ProcessInfo.processInfo.processIdentifier,
-    frontmostIsOurs: Bool = AppBundleIdentity.isOurs(
-      NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
+    frontmost: Frontmost,
+    ownPID: pid_t = ProcessInfo.processInfo.processIdentifier
   ) -> Refusal? {
     guard isTrusted else { return .accessibilityNotTrusted }
-    guard let frontmostPID, frontmostPID > 0 else { return .noFrontmostApplication }
+    guard let frontmostPID = frontmost.pid, frontmostPID > 0 else {
+      return .noFrontmostApplication
+    }
     // **Refuse our own app (#2413), and no ordering discipline can replace this.** The two comments
     // in this file and in `QuickAddCoordinator.begin` say to read BEFORE activating ourselves, which
     // is right and is what makes the ordinary case work. It cannot help when the user is ALREADY
@@ -172,13 +207,15 @@ public enum SelectionReader {
     // `.dev` in a dev build and not in a release one, so it answered NOT OURS for precisely the
     // pair it was written to catch. `AppBundleIdentity` owns the closed set; the pid comparison
     // stays for the case where there is no identifier to read at all.
-    guard frontmostPID != ownPID, !frontmostIsOurs else { return .ownApplication }
+    guard frontmostPID != ownPID, !frontmost.isOurs else { return .ownApplication }
 
-    // **KNOWN LIMIT, stated rather than left to be found.** `frontmostPID` was sampled by the caller
-    // and the element read happens after this returns, so an application switch in between means the
-    // refusal and the read can describe different applications. Closing it means binding both to one
-    // Accessibility object, which is a restructure of `read` rather than a guard, and the read is
-    // already bound to the SAME pid — so this shrinks the window rather than widening it.
+    // **What remains, now that both facts come from one sample.** The guard judges a snapshot and
+    // the element read uses that snapshot's own pid, so the two cannot describe different
+    // applications. A switch between the sample and the read still means the pid names an
+    // application that is no longer frontmost — but it is the SAME application throughout, and
+    // Accessibility answers for the process rather than for whoever is in front, so the read stays
+    // about the selection the user made. Closing that too would mean asking the workspace to hold
+    // still, which it does not offer.
     return nil
   }
 

--- a/Sources/EnviousWisprServices/SelectionReader.swift
+++ b/Sources/EnviousWisprServices/SelectionReader.swift
@@ -38,6 +38,22 @@ public enum SelectionReader {
     case noFrontmostApplication = "no_frontmost_application"
     /// The frontmost application reported no focused element.
     case noFocusedElement = "no_focused_element"
+    /// **EnviousWispr is the frontmost application, so there is nothing of the user's to read
+    /// (#2413).**
+    ///
+    /// Reachable because the shortcut is GLOBAL and our own Settings window has text fields: press
+    /// it while editing a custom word and, without this, the reader hands back the half-typed edit
+    /// as a word to add.
+    ///
+    /// **Named for what is CHECKED, not for what is assumed.** An earlier version called this
+    /// `ownSelection` and its copy said "That selection is inside EnviousWispr" — but nothing here
+    /// reads a selection, and a caret in an empty field of ours produces this refusal too. Asserting
+    /// a selection the code never looked at is the false-sentence class this guard exists to stop,
+    /// committed inside the guard itself.
+    ///
+    /// Its own member rather than `nothingSelected` because the causes differ and so does the fix:
+    /// this one is "you are in our app", which names no fault of the user's and has one remedy.
+    case ownApplication = "own_application"
     /// The focused element does not expose selected text at all (`kAXErrorAttributeUnsupported`).
     case selectionUnsupported = "selection_unsupported"
     /// The attribute is advertised but answered with no value (`kAXErrorNoValue`).
@@ -131,9 +147,35 @@ public enum SelectionReader {
   /// Split from `read()` so both refusals are reachable from a test. Trust and frontmost are asked
   /// together because they are the two questions with no Accessibility round trip behind them; the
   /// element read has its own function below rather than four optionals in one.
-  static func refusalBeforeReading(isTrusted: Bool, frontmostPID: pid_t?) -> Refusal? {
+  static func refusalBeforeReading(
+    isTrusted: Bool,
+    frontmostPID: pid_t?,
+    ownPID: pid_t = ProcessInfo.processInfo.processIdentifier,
+    frontmostIsOurs: Bool = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+      == Bundle.main.bundleIdentifier
+  ) -> Refusal? {
     guard isTrusted else { return .accessibilityNotTrusted }
     guard let frontmostPID, frontmostPID > 0 else { return .noFrontmostApplication }
+    // **Refuse our own app (#2413), and no ordering discipline can replace this.** The two comments
+    // in this file and in `QuickAddCoordinator.begin` say to read BEFORE activating ourselves, which
+    // is right and is what makes the ordinary case work. It cannot help when the user is ALREADY
+    // inside our app when they press the shortcut — the binding is global, our Settings window has
+    // text fields, and there is no "before" in which another application is frontmost.
+    //
+    // `ownPID` is a parameter with a live default so the decision is reachable from a test; the
+    // production call site never passes it.
+    // **Identity, not just this process.** A second EnviousWispr — an installed build beside a dev
+    // build — has a different pid and would walk straight through a pid-only check. That is the
+    // ordinary state of a development machine, not an exotic one. The pid was a proxy for identity;
+    // this asks the question directly, and keeps the pid comparison as the case that holds when
+    // there is no bundle identifier to read.
+    guard frontmostPID != ownPID, !frontmostIsOurs else { return .ownApplication }
+
+    // **KNOWN LIMIT, stated rather than left to be found.** `frontmostPID` was sampled by the caller
+    // and the element read happens after this returns, so an application switch in between means the
+    // refusal and the read can describe different applications. Closing it means binding both to one
+    // Accessibility object, which is a restructure of `read` rather than a guard, and the read is
+    // already bound to the SAME pid — so this shrinks the window rather than widening it.
     return nil
   }
 

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -25,7 +25,7 @@ struct SelectionReaderTests {
   @Test("Without Accessibility the reason is the one the user can act on")
   func untrustedIsNamed() {
     #expect(
-      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 501)
+      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 501, ownPID: 999, frontmostIsOurs: false)
         == .accessibilityNotTrusted)
   }
 
@@ -34,14 +34,14 @@ struct SelectionReaderTests {
     // Both wrong at once. Reporting "no frontmost application" to someone who simply has not
     // granted permission sends them looking at the wrong thing.
     #expect(
-      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: nil)
+      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: nil, ownPID: 999, frontmostIsOurs: false)
         == .accessibilityNotTrusted)
   }
 
   @Test("No frontmost application is its own reason")
   func noFrontmostApplicationIsNamed() {
     #expect(
-      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil)
+      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil, ownPID: 999, frontmostIsOurs: false)
         == .noFrontmostApplication)
   }
 
@@ -49,15 +49,59 @@ struct SelectionReaderTests {
   func aNonPositivePIDIsRefused() {
     for pid: pid_t in [0, -1] {
       #expect(
-        SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: pid)
+        SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: pid, ownPID: 999, frontmostIsOurs: false)
           == .noFrontmostApplication,
         "pid \(pid) must not reach Accessibility")
     }
   }
 
+  /// **The shortcut is GLOBAL and our own Settings window has text fields (#2413).** Pressed while
+  /// editing a custom word, the frontmost application is US, and without this the reader hands back
+  /// the half-typed edit as a word to add.
+  ///
+  /// **No ordering discipline can replace this guard.** Both this file and `QuickAddCoordinator`
+  /// carry comments saying to read BEFORE activating ourselves — correct, and what makes the
+  /// ordinary case work. It cannot help when the user is already inside our app when they press the
+  /// shortcut: there is no "before" in which another application is frontmost.
+  @Test("Our own application is refused rather than read")
+  func ourOwnApplicationIsRefused() {
+    #expect(
+      SelectionReader.refusalBeforeReading(
+        isTrusted: true, frontmostPID: 4242, ownPID: 4242, frontmostIsOurs: false)
+        == .ownApplication)
+  }
+
+  /// **A SECOND EnviousWispr passes a pid check, and that is the ordinary state of this machine** —
+  /// an installed build beside a dev build. Different pid, our text, straight through.
+  @Test("Another EnviousWispr is refused too, by identity rather than by pid")
+  func aSecondInstanceIsAlsoRefused() {
+    #expect(
+      SelectionReader.refusalBeforeReading(
+        isTrusted: true, frontmostPID: 7777, ownPID: 4242, frontmostIsOurs: true)
+        == .ownApplication,
+      "a pid-only guard would read this one's text")
+  }
+
+  /// The pair, without which the row above passes for a guard that refuses everything.
+  @Test("Another application at the same trust level still goes ahead")
+  func anotherApplicationIsStillRead() {
+    #expect(
+      SelectionReader.refusalBeforeReading(
+        isTrusted: true, frontmostPID: 4243, ownPID: 4242, frontmostIsOurs: false) == nil)
+  }
+
+  /// **Trust outranks it, for the same reason it outranks a missing frontmost app.** Someone who
+  /// has not granted permission must be told THAT, not that their selection was ours.
+  @Test("Untrusted outranks reading our own app")
+  func untrustedOutranksOurOwnSelection() {
+    #expect(
+      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 4242, ownPID: 4242)
+        == .accessibilityNotTrusted)
+  }
+
   @Test("Trusted with a live application goes ahead")
   func trustedAndFrontmostProceeds() {
-    #expect(SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 501) == nil)
+    #expect(SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 501, ownPID: 999, frontmostIsOurs: false) == nil)
   }
 
   // MARK: - What Accessibility answered
@@ -268,9 +312,9 @@ struct SelectionReaderTests {
       SelectionReader.resolve(error: .success, value: "codecs" as CFString),
     ]
     for refusal in [
-      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 1),
-      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil),
-      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 0),
+      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 1, ownPID: 999, frontmostIsOurs: false),
+      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil, ownPID: 999, frontmostIsOurs: false),
+      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 0, ownPID: 999, frontmostIsOurs: false),
     ] {
       if let refusal { seen.append(.refused(refusal)) }
     }

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -73,13 +73,42 @@ struct SelectionReaderTests {
 
   /// **A SECOND EnviousWispr passes a pid check, and that is the ordinary state of this machine** —
   /// an installed build beside a dev build. Different pid, our text, straight through.
-  @Test("Another EnviousWispr is refused too, by identity rather than by pid")
-  func aSecondInstanceIsAlsoRefused() {
+  ///
+  /// **Driven by the REAL identifiers, not by an injected verdict.** The first version of this row
+  /// passed `frontmostIsOurs: true`, which asserts the guard acts on the answer and says nothing
+  /// about how the answer is COMPUTED — and the computation was wrong in exactly this case, because
+  /// a dev build's `Bundle.main.bundleIdentifier` does not equal a release build's. A fixture that
+  /// hands over the conclusion cannot observe the step that produces it.
+  @Test(
+    "Another EnviousWispr is refused too, whichever build is asking",
+    arguments: [
+      (AppBundleIdentity.production, AppBundleIdentity.development),
+      (AppBundleIdentity.development, AppBundleIdentity.production),
+      (AppBundleIdentity.production, AppBundleIdentity.production),
+    ])
+  func aSecondInstanceIsAlsoRefused(frontmost: String, own: String) {
     #expect(
       SelectionReader.refusalBeforeReading(
-        isTrusted: true, frontmostPID: 7777, ownPID: 4242, frontmostIsOurs: true)
+        isTrusted: true, frontmostPID: 7777, ownPID: 4242,
+        frontmostIsOurs: AppBundleIdentity.isOurs(frontmost))
         == .ownApplication,
-      "a pid-only guard would read this one's text")
+      "a \(own) build must refuse a frontmost \(frontmost) build; a pid-only guard reads its text")
+  }
+
+  /// The family is CLOSED, and a row per member so adding one without deciding is visible.
+  @Test("Only our own identifiers are the app; everything else is somebody's document")
+  func theIdentityFamilyIsExactlyOurTwoBuilds() {
+    #expect(AppBundleIdentity.isOurs(AppBundleIdentity.production))
+    #expect(AppBundleIdentity.isOurs(AppBundleIdentity.development))
+    #expect(AppBundleIdentity.all.count == 2)
+    // Paired rejections, or a predicate that says yes to everything looks identical to this one.
+    #expect(!AppBundleIdentity.isOurs(nil))
+    #expect(!AppBundleIdentity.isOurs(""))
+    #expect(!AppBundleIdentity.isOurs("com.apple.TextEdit"))
+    // Our OWN neighbours, which are the near misses a prefix check would swallow.
+    #expect(!AppBundleIdentity.isOurs("com.enviouswispr.asrservice"))
+    #expect(!AppBundleIdentity.isOurs("com.enviouswispr.app.dev.extra"))
+    #expect(!AppBundleIdentity.isOurs("com.enviouswispr"))
   }
 
   /// The pair, without which the row above passes for a guard that refuses everything.

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -25,7 +25,8 @@ struct SelectionReaderTests {
   @Test("Without Accessibility the reason is the one the user can act on")
   func untrustedIsNamed() {
     #expect(
-      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 501, ownPID: 999, frontmostIsOurs: false)
+      SelectionReader.refusalBeforeReading(
+        isTrusted: false, frontmost: .init(pid: 501, isOurs: false), ownPID: 999)
         == .accessibilityNotTrusted)
   }
 
@@ -34,14 +35,16 @@ struct SelectionReaderTests {
     // Both wrong at once. Reporting "no frontmost application" to someone who simply has not
     // granted permission sends them looking at the wrong thing.
     #expect(
-      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: nil, ownPID: 999, frontmostIsOurs: false)
+      SelectionReader.refusalBeforeReading(
+        isTrusted: false, frontmost: .init(pid: nil, isOurs: false), ownPID: 999)
         == .accessibilityNotTrusted)
   }
 
   @Test("No frontmost application is its own reason")
   func noFrontmostApplicationIsNamed() {
     #expect(
-      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil, ownPID: 999, frontmostIsOurs: false)
+      SelectionReader.refusalBeforeReading(
+        isTrusted: true, frontmost: .init(pid: nil, isOurs: false), ownPID: 999)
         == .noFrontmostApplication)
   }
 
@@ -49,7 +52,8 @@ struct SelectionReaderTests {
   func aNonPositivePIDIsRefused() {
     for pid: pid_t in [0, -1] {
       #expect(
-        SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: pid, ownPID: 999, frontmostIsOurs: false)
+        SelectionReader.refusalBeforeReading(
+          isTrusted: true, frontmost: .init(pid: pid, isOurs: false), ownPID: 999)
           == .noFrontmostApplication,
         "pid \(pid) must not reach Accessibility")
     }
@@ -67,7 +71,7 @@ struct SelectionReaderTests {
   func ourOwnApplicationIsRefused() {
     #expect(
       SelectionReader.refusalBeforeReading(
-        isTrusted: true, frontmostPID: 4242, ownPID: 4242, frontmostIsOurs: false)
+        isTrusted: true, frontmost: .init(pid: 4242, isOurs: false), ownPID: 4242)
         == .ownApplication)
   }
 
@@ -75,10 +79,11 @@ struct SelectionReaderTests {
   /// an installed build beside a dev build. Different pid, our text, straight through.
   ///
   /// **Driven by the REAL identifiers, not by an injected verdict.** The first version of this row
-  /// passed `frontmostIsOurs: true`, which asserts the guard acts on the answer and says nothing
-  /// about how the answer is COMPUTED — and the computation was wrong in exactly this case, because
-  /// a dev build's `Bundle.main.bundleIdentifier` does not equal a release build's. A fixture that
-  /// hands over the conclusion cannot observe the step that produces it.
+  /// handed the guard a hardcoded `true` for the ownership question, which asserts that the guard
+  /// ACTS on the answer and says nothing about how the answer is COMPUTED — and the computation was
+  /// wrong in exactly this case, because a dev build's `Bundle.main.bundleIdentifier` does not equal
+  /// a release build's. A fixture that hands over the conclusion cannot observe the step that
+  /// produces it, so the row runs `AppBundleIdentity.isOurs` over the real pair instead.
   @Test(
     "Another EnviousWispr is refused too, whichever build is asking",
     arguments: [
@@ -89,8 +94,9 @@ struct SelectionReaderTests {
   func aSecondInstanceIsAlsoRefused(frontmost: String, own: String) {
     #expect(
       SelectionReader.refusalBeforeReading(
-        isTrusted: true, frontmostPID: 7777, ownPID: 4242,
-        frontmostIsOurs: AppBundleIdentity.isOurs(frontmost))
+        isTrusted: true,
+        frontmost: .init(pid: 7777, isOurs: AppBundleIdentity.isOurs(frontmost)),
+        ownPID: 4242)
         == .ownApplication,
       "a \(own) build must refuse a frontmost \(frontmost) build; a pid-only guard reads its text")
   }
@@ -116,7 +122,7 @@ struct SelectionReaderTests {
   func anotherApplicationIsStillRead() {
     #expect(
       SelectionReader.refusalBeforeReading(
-        isTrusted: true, frontmostPID: 4243, ownPID: 4242, frontmostIsOurs: false) == nil)
+        isTrusted: true, frontmost: .init(pid: 4243, isOurs: false), ownPID: 4242) == nil)
   }
 
   /// **Trust outranks it, for the same reason it outranks a missing frontmost app.** Someone who
@@ -124,13 +130,16 @@ struct SelectionReaderTests {
   @Test("Untrusted outranks reading our own app")
   func untrustedOutranksOurOwnSelection() {
     #expect(
-      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 4242, ownPID: 4242)
+      SelectionReader.refusalBeforeReading(
+        isTrusted: false, frontmost: .init(pid: 4242, isOurs: true), ownPID: 4242)
         == .accessibilityNotTrusted)
   }
 
   @Test("Trusted with a live application goes ahead")
   func trustedAndFrontmostProceeds() {
-    #expect(SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 501, ownPID: 999, frontmostIsOurs: false) == nil)
+    #expect(
+      SelectionReader.refusalBeforeReading(
+        isTrusted: true, frontmost: .init(pid: 501, isOurs: false), ownPID: 999) == nil)
   }
 
   // MARK: - What Accessibility answered
@@ -341,9 +350,12 @@ struct SelectionReaderTests {
       SelectionReader.resolve(error: .success, value: "codecs" as CFString),
     ]
     for refusal in [
-      SelectionReader.refusalBeforeReading(isTrusted: false, frontmostPID: 1, ownPID: 999, frontmostIsOurs: false),
-      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: nil, ownPID: 999, frontmostIsOurs: false),
-      SelectionReader.refusalBeforeReading(isTrusted: true, frontmostPID: 0, ownPID: 999, frontmostIsOurs: false),
+      SelectionReader.refusalBeforeReading(
+        isTrusted: false, frontmost: .init(pid: 1, isOurs: false), ownPID: 999),
+      SelectionReader.refusalBeforeReading(
+        isTrusted: true, frontmost: .init(pid: nil, isOurs: false), ownPID: 999),
+      SelectionReader.refusalBeforeReading(
+        isTrusted: true, frontmost: .init(pid: 0, isOurs: false), ownPID: 999),
     ] {
       if let refusal { seen.append(.refused(refusal)) }
     }


### PR DESCRIPTION
Founder, testing the shipped build: *"If I do the shortcut while I'm having a custom word open, it will glitch out. If I'm editing a custom word and then I use a shortcut, it gets all messy."*

## What was wrong

`SelectionReader.refusalBeforeReading` is the complete set of reasons a read is refused before it is attempted: Accessibility trusted, and a positive frontmost pid. **Nothing compared the frontmost application against our own**, so pressing Quick Add while editing a custom word read the text field the user was typing in and offered their half-finished edit back as a word to add.

## Why no ordering discipline could have covered it

Two comments name the hazard precisely and both are correct:

| Site | Comment |
|---|---|
| `SelectionReader.read` | "Call this BEFORE activating our own app" |
| `QuickAddCoordinator.begin` | "Read BEFORE anything activates our app" |

Both are about ordering **within our own invocation** — read first, activate second — and that discipline is what makes the ordinary case work. It cannot help when the user is **already inside our app before the invocation starts**: the binding is global, our Settings window has text fields, and there is no "before" in which another application is frontmost. So the fix is a new refusal, not a reordering.

## What the second-pass review found

This is the first change written after `RULE: second-pass-review-before-the-cloud` existed, and the pass returned six findings on a 102-line diff. Three were one root:

**I wrote a false sentence while fixing a false sentence.** The member was `ownSelection`, the copy read *"That selection is inside EnviousWispr"*, and the comment said *"the selection would be our own"* — and nothing here reads a selection. It proves we are FRONTMOST. A caret sitting in an empty field of ours produces this refusal too, and would have been told about a selection nobody looked at. That is the exact class this cluster keeps producing, committed inside the guard written to stop it. Renamed `ownApplication`, with copy that asserts only what was checked.

**A second EnviousWispr walks through a pid check.** An installed build beside a dev build has a different pid — the ordinary state of this machine, true four separate times today. Now matched on bundle identity, with the pid comparison kept for the case where there is no identifier to read.

## Known limit, stated at the guard rather than left to be found

`frontmostPID` is sampled by the caller and the element read happens after this returns, so an application switch in between means the refusal and the read can describe different applications. Closing it means binding both to one Accessibility object — a restructure of `read` rather than a guard — and the read is already bound to the same pid, so this **narrows** the window rather than widening it.

## Scope — this does not close the issue

Hypothesis 2 in #2413 — a key-capable panel over an app-modal sheet — is untouched and remains open. "Messy" could be either, and they need different fixes. This explains a wrong-subject READ and nothing about window behaviour.

## Validation

| | |
|---|---|
| Debug lane | **PASS**, 7008 tests (6802 + 206, reconciled) |
| Release lane | **PASS**, 6356 tests (6150 + 206, reconciled) |
| Crash probe | 0 `Fatal error`, 0 `Crash:` in both lanes |
| New cases executed | both display names present in **both** lanes |

Member sweep, because a new enum case is a new member of a set: no worker reads these raw values (a Swift enum member has broken `workers/` before), and of the three exhaustive switches the compiler covered two, leaving the copy table as the one needing a human.

Existing guard tests used an invented pid and depended on it not colliding with the test runner's own. Now explicit about both identities, so no case can pass by luck.

**Live UAT is not possible unattended and is not claimed here.** Quick Add's default binding is Control-Option-W — a chord, deliberately, so it takes the Carbon `RegisterEventHotKey` path, and macOS 26 does not deliver synthetic events to Carbon hotkeys (`tools-and-apps.md` FACT: synthetic-escape-does-not-reach-a-carbon-hotkey). The menu-bar entry on #2412 reaches the same flow with no hotkey and would make this drivable; that branch is not merged.

Part of #2413
