### PR TITLE
Pill refactor Phase 6 chunk 1: the instrument, before the change it will judge (#2377)

### DIFF
--- a/Sources/EnviousWispr/AppDelegate.swift
+++ b/Sources/EnviousWispr/AppDelegate.swift
@@ -29,11 +29,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationWillFinishLaunching(_ notification: Notification) {
     assertAttached()
     bootstrapper?.applicationWillFinishLaunching()
+    // #2377 Phase 6: arm the DEBUG marker sink here — in the callback BEFORE the
+    // measured one, and AFTER this callback's own production work.
+    //
+    // Before `applicationDidFinishLaunching` because that interval is what is
+    // measured, and the sink's one-time setup must not land inside it once
+    // Phase 6 moves root construction earlier. After the forwarding above
+    // because #739 requires Sparkle's cross-launch correlation to run at the
+    // earliest callback, and putting measurement in front of it would make a
+    // DEBUG instrument the first thing a launch does.
+    #if DEBUG
+      OverlayFirstRenderMarkers.prepare()
+    #endif
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     assertAttached()
+    // #2377 Phase 6: DEBUG-only measurement of this forwarding call, which is
+    // where launch work happens. `capture` reads the clock and nothing else; the
+    // environment read, the string and the write all run in `emit`, after the
+    // interval has closed.
+    #if DEBUG
+      let launchEnter = OverlayFirstRenderMarkers.capture(.launchEnter)
+    #endif
     bootstrapper?.applicationDidFinishLaunching()
+    #if DEBUG
+      OverlayFirstRenderMarkers.emit(
+        launchEnter, OverlayFirstRenderMarkers.capture(.launchExit))
+    #endif
   }
 
   func applicationDidBecomeActive(_ notification: Notification) {

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -1,0 +1,199 @@
+#if DEBUG
+  import Darwin
+  import Foundation
+
+  /// DEBUG-only timing markers for the #2377 Phase 6 first-render benchmark.
+  ///
+  /// **Measurement only. Nothing here is read at runtime and no behaviour is
+  /// conditional on a marker.** The app writes; the harness judges. A production
+  /// path that consulted these would make the instrument part of the thing it
+  /// measures.
+  ///
+  /// Three properties are load-bearing and each one is a defect this avoids:
+  ///
+  /// **1. `AppLogger` is deliberately not used.** Its file sink is gated behind
+  /// both `#if DEBUG` and the in-app Debug Mode setting, so a benchmark written
+  /// through it would silently depend on a preference — a run with Debug Mode off
+  /// produces no markers and looks exactly like a build with no emitter. Its
+  /// actor hop and formatting would also land inside the interval being measured.
+  ///
+  /// **2. `capture` reads the clock and nothing else.** The environment lookup,
+  /// the string building and the `write(2)` all happen in `emit`, which callers
+  /// place AFTER the measured work. The cost of recording a measurement must not
+  /// be inside the measurement.
+  ///
+  /// **3. The file is opened WITHOUT `O_CREAT`.** The harness pre-creates it, so
+  /// an app launched with a stale or wrong path writes nothing rather than
+  /// creating a file somewhere the harness will never read — an absence the
+  /// harness reports as a block, instead of a plausible file that is missing
+  /// markers for a reason nobody can recover.
+  ///
+  /// Absent either environment variable this is a strict no-op: no file is
+  /// opened and nothing is written, on any launch, ever. It is not allocation
+  /// free — resolving the sink reads `ProcessInfo.environment`, which builds a
+  /// dictionary — but that happens exactly once, in `prepare()`, which the call
+  /// site places before any measured interval.
+  public enum OverlayFirstRenderMarkers {
+    /// The exact strings the harness parses. Changing one is a schema change and
+    /// belongs with a bump of `SCHEMA` in `measure_overlay_first_render.py`,
+    /// whose parser refuses an unknown event rather than skipping it.
+    public enum Event: String, Sendable {
+      case launchEnter = "launch.enter"
+      case launchExit = "launch.exit"
+      case rootConstructStart = "root.construct.start"
+      case rootConstructEnd = "root.construct.end"
+      case hostOrderFrontComplete = "host.order_front.complete"
+    }
+
+    /// One clock reading bound to the event it belongs to.
+    ///
+    /// Carrying the event with the tick count is what lets a caller take both
+    /// endpoints of an interval and write them afterwards, rather than writing
+    /// the first one while the interval is still running.
+    public struct Capture: Sendable {
+      let event: Event
+      let ticks: UInt64
+      /// The CGWindow number the event concerns, or `0` where it concerns none.
+      ///
+      /// **Only `host.order_front.complete` carries one, and it is what lets the
+      /// harness name its subject instead of guessing at it.** Without it the
+      /// harness can only watch for "a new window owned by this process", and an
+      /// unrelated window — settings, onboarding, a permission prompt — that
+      /// appears before the pill reaches WindowServer is accepted as the pill.
+      /// The result is a plausible latency measured against the wrong window,
+      /// which is worse than no measurement because nothing about it looks
+      /// wrong.
+      let window: Int
+    }
+
+    /// Force the sink open BEFORE the first measured interval begins.
+    ///
+    /// **Without this the instrument is sensitive to the change it exists to
+    /// measure.** The sink is a lazy `static let`, so whichever `emit` runs first
+    /// pays for reading the environment, opening the file and building the
+    /// constant prefix. Today root construction is lazy and happens on the first
+    /// presentation, comfortably after launch — so the first `emit` is the launch
+    /// pair's own, which runs after that interval has closed, and the cost lands
+    /// nowhere. Phase 6 exists to MOVE root construction earlier. The moment it
+    /// runs during `applicationDidFinishLaunching`, its `emit` becomes the first
+    /// one and the setup cost lands inside the launch measurement — inflating
+    /// exactly the number the move is being judged on, in the direction that
+    /// makes the change look worse than it is.
+    ///
+    /// So the call site arms this at the top of launch, before any `capture`.
+    /// A no-op when the environment is absent, like everything else here.
+    public static func prepare() {
+      _ = sink
+    }
+
+    /// Read the clock. This is the ONLY thing that happens at a measured boundary.
+    ///
+    /// `mach_absolute_time` rather than `Date`: these are sub-10 ms quantities
+    /// against an 8 ms bound, and wall time can step. Raw ticks are emitted
+    /// unconverted — `mach_timebase_info` is applied by the harness, so no
+    /// arithmetic runs inside the interval.
+    public static func capture(_ event: Event, window: Int = 0) -> Capture {
+      Capture(event: event, ticks: mach_absolute_time(), window: window)
+    }
+
+    /// Write captures, in one `write(2)`, after the measured work has finished.
+    public static func emit(_ captures: Capture...) {
+      emit(captures)
+    }
+
+    public static func emit(_ captures: [Capture]) {
+      guard let sink, !captures.isEmpty else { return }
+      var payload = ""
+      payload.reserveCapacity((sink.prefix.count + 64) * captures.count)
+      for capture in captures {
+        payload += sink.prefix
+        payload += "event=\(capture.event.rawValue)\tticks=\(capture.ticks)"
+        payload += "\twindow=\(capture.window)\n"
+      }
+      sink.write(payload)
+    }
+
+    /// Emit at most once per process, for an event whose CALL SITE runs many
+    /// times but whose measurement is about the first occurrence.
+    ///
+    /// `host.order_front.complete` is the case: the host orders a panel front on
+    /// every presentation, and a launch that showed two pills would write the
+    /// event twice. The harness treats every event as a singleton and blocks on a
+    /// duplicate, correctly — two order-fronts in one file give a "first render"
+    /// figure that is a mix of a first render and a later one. The latch is here
+    /// rather than at the call site so the property the harness depends on lives
+    /// with the contract, not with one of its callers.
+    ///
+    /// `@MainActor` because all three call sites already are, which is cheaper
+    /// and more honest than a lock defending state nothing else touches.
+    @MainActor
+    public static func emitFirst(_ capture: Capture) {
+      guard emittedOnce.insert(capture.event).inserted else { return }
+      emit([capture])
+    }
+
+    @MainActor private static var emittedOnce: Set<Event> = []
+
+    // MARK: - the sink
+
+    private struct Sink {
+      let descriptor: Int32
+      /// Everything constant for this process, built once: schema, run id, pid
+      /// and bundle id, tab-terminated so a line is a concatenation.
+      let prefix: String
+
+      func write(_ text: String) {
+        var bytes = Array(text.utf8)
+        bytes.withUnsafeBufferPointer { buffer in
+          guard var pointer = buffer.baseAddress else { return }
+          var remaining = buffer.count
+          // A regular file's `write` normally completes in full, but a short
+          // write is legal and a silently truncated marker line reads to the
+          // harness as a malformed one — an instrument fault wearing an app
+          // fault's clothes. Looping costs nothing here: this runs after the
+          // interval it describes.
+          while remaining > 0 {
+            let written = Darwin.write(descriptor, pointer, remaining)
+            if written <= 0 {
+              if errno == EINTR { continue }
+              return
+            }
+            pointer += Int(written)
+            remaining -= Int(written)
+          }
+        }
+      }
+    }
+
+    /// Resolved once, on the first `emit` — which every caller places after a
+    /// measured interval, so the environment read and the `open` never land
+    /// inside one.
+    private static let sink: Sink? = {
+      let environment = ProcessInfo.processInfo.environment
+      guard let path = environment["EW_OVERLAY_FIRST_RENDER_MARKER_PATH"],
+        let runID = environment["EW_OVERLAY_FIRST_RENDER_RUN_ID"],
+        !path.isEmpty, !runID.isEmpty
+      else { return nil }
+
+      // No `O_CREAT`: see the type's documentation.
+      //
+      // `O_APPEND` is load-bearing rather than conventional. `emit` is
+      // nonisolated and writes one whole payload per call, and O_APPEND makes
+      // each of those land atomically at the end of the file - so two emits
+      // racing cannot interleave into one corrupt line. Without it the harness
+      // would report `BLOCKED_MALFORMED_MARKER`, which reads as a drifted app
+      // format rather than as a write race.
+      //
+      // `O_CLOEXEC` so a child process cannot inherit the descriptor and write
+      // into the same file, which would present as duplicate markers - a
+      // different refusal, for a different reason, from the same cause.
+      let descriptor = path.withCString { open($0, O_WRONLY | O_APPEND | O_CLOEXEC) }
+      guard descriptor >= 0 else { return nil }
+
+      let bundleID = Bundle.main.bundleIdentifier ?? "unknown"
+      let prefix =
+        "EW_OVERLAY_FIRST_RENDER_V1\trun=\(runID)\tpid=\(getpid())\tbundle=\(bundleID)\t"
+      return Sink(descriptor: descriptor, prefix: prefix)
+    }()
+  }
+#endif

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -232,9 +232,19 @@
     /// Consequence worth stating: a launch that never orders a panel front
     /// writes no root markers at all, and the harness blocks it as incomplete.
     /// That is the honest reading — no first render happened.
+    ///
+    /// **One capture at a time, never variadic (#2377, C1 repair).** A
+    /// variadic parameter is bundled into a temporary `[Capture]` at the
+    /// CALL SITE before this function's body ever runs — the same
+    /// asymmetric-cost shape `prepare()`'s `reserveCapacity` exists to
+    /// avoid one level down. `hold(a, b)` inside the lazy root constructor
+    /// pays for that array in the baseline bundle's keypress interval and
+    /// outside it in the prewarmed bundle's. Two calls to this
+    /// single-capture form append directly into the already-reserved
+    /// `pending` storage instead.
     @MainActor
-    public static func hold(_ captures: Capture...) {
-      pending.append(contentsOf: captures)
+    public static func hold(_ capture: Capture) {
+      pending.append(capture)
     }
 
     @MainActor private static var pending: [Capture] = []

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -62,8 +62,8 @@
       case rootConstructStart = "root.construct.start"
       case rootConstructEnd = "root.construct.end"
       case hostOrderFrontComplete = "host.order_front.complete"
-      /// #2377, C1 repair — the smoke ruling. Emitted once the launch-time
-      /// warm-up path (`WisprBootstrapper`) re-reads the ACTUALLY-selected
+      /// #2377, C1 repair. Emitted once the launch-time warm-up path
+      /// (`WisprBootstrapper`) re-reads the ACTUALLY-selected
       /// engine as `.ready`, so the harness can wait for it before sending a
       /// synthetic keypress. Without this, a keypress sent right after
       /// `launch.exit` races `ColdPressGuard` (#879), which correctly refuses
@@ -359,10 +359,10 @@
       // V2: adds the `intent` field (#2377, C1 repair) — a schema bump because
       // an old harness reading a V2 line would silently misparse the eighth
       // field as belonging to no key it expects.
-      // V3: adds the `engine.ready` event (#2377, C1 repair, Codex's smoke
-      // ruling) — a schema bump because a V2 harness's `Event` set does not
-      // recognize it and would refuse the line outright rather than silently
-      // misread it, which is the correct failure for an unknown event.
+      // V3: adds the `engine.ready` event (#2377, C1 repair) — a schema bump
+      // because a V2 harness's `Event` set does not recognize it and would
+      // refuse the line outright rather than silently misread it, which is
+      // the correct failure for an unknown event.
       let prefix =
         "EW_OVERLAY_FIRST_RENDER_V3\trun=\(runID)\tpid=\(getpid())\tbundle=\(bundleID)\t"
       return Sink(descriptor: descriptor, prefix: prefix)

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -35,10 +35,20 @@
   /// site places before any measured interval.
   public enum OverlayFirstRenderMarkers {
     /// The AX identifier the harness polls for (#2377, C1 repair, cloud review
-    /// P1). CGWindow-list membership can precede SwiftUI content actually being
-    /// composited, so the harness's stopwatch endpoint moved to "does an
-    /// `AXWindow` bearing this identifier exist under the app" — set on the ONE
-    /// retained panel once, in `OverlayWindowHost.ensurePanel()`, DEBUG-only.
+    /// P1). CGWindow-list registration can precede SwiftUI content actually
+    /// being composited, so the harness's stopwatch endpoint moved to "does an
+    /// `AXWindow` bearing this identifier exist under the app" — the plan's
+    /// OWN "first-AX-overlay" language, not a stronger claim than that. AX
+    /// membership still is not proof of the first COMPOSITED pixel; a real
+    /// screen recording is (`wispr_eyes.record()`), and that proof belongs to
+    /// C5, not to this polling instrument.
+    ///
+    /// Set on the ONE retained panel, AFTER `orderFrontRegardless()` —
+    /// `OverlayWindowHost.present()`, DEBUG-only, never in `ensurePanel()`.
+    /// `accessibilityWindows` enumerates every application window regardless
+    /// of visibility, so setting it at construction would let the harness's
+    /// poll match a panel with no content, never ordered front.
+    ///
     /// A string constant here rather than duplicated in Swift and Python is
     /// what keeps the two from drifting apart the way the schema strings do.
     public static let axPanelIdentifier = "EW_OVERLAY_FIRST_RENDER_PANEL"

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -62,6 +62,20 @@
       case rootConstructStart = "root.construct.start"
       case rootConstructEnd = "root.construct.end"
       case hostOrderFrontComplete = "host.order_front.complete"
+      /// #2377, C1 repair — the smoke ruling. Emitted once the launch-time
+      /// warm-up path (`WisprBootstrapper`) re-reads the ACTUALLY-selected
+      /// engine as `.ready`, so the harness can wait for it before sending a
+      /// synthetic keypress. Without this, a keypress sent right after
+      /// `launch.exit` races `ColdPressGuard` (#879), which correctly refuses
+      /// a press while the engine is still `.warming` — a real product policy,
+      /// not an instrument defect, but one this instrument's own synthetic
+      /// input must not trip. Carries `window=0`, `intent=.none`: it concerns
+      /// no presentation and is deliberately NOT part of the launch/root
+      /// causal chain the Python adjudicator enforces (`EVENTS`) — engine
+      /// warm-up and first render are two different things happening on two
+      /// different schedules, and folding one into the other's ordering check
+      /// would make an instrument change what it is trying only to observe.
+      case engineReady = "engine.ready"
     }
 
     /// Which presentation a `host.order_front.complete` marker belongs to.
@@ -265,6 +279,26 @@
 
     @MainActor private static var emittedIntents: Set<Intent> = []
 
+    /// Emit `engine.ready` at most once per launch.
+    ///
+    /// **The caller, not this function, decides readiness** — it must check
+    /// the driver's `engineReadiness == .ready` itself before calling this.
+    /// This function only owns the "at most once" property, the same reason
+    /// `emitFirst` exists: two launch warm-up paths exist (parakeet's launch
+    /// `Task` and WhisperKit's `preloadAction`), only one of which runs for a
+    /// given launch (keyed on the selected backend), so in practice this
+    /// fires from whichever path actually ran. A simple boolean latch is
+    /// correct here — unlike `emitFirst`'s per-INTENT latching, there is only
+    /// ever one presentation-free readiness fact to report.
+    @MainActor
+    public static func emitEngineReadyOnce() {
+      guard !engineReadyEmitted else { return }
+      engineReadyEmitted = true
+      emit(capture(.engineReady))
+    }
+
+    @MainActor private static var engineReadyEmitted = false
+
     // MARK: - the sink
 
     private struct Sink {
@@ -325,8 +359,12 @@
       // V2: adds the `intent` field (#2377, C1 repair) — a schema bump because
       // an old harness reading a V2 line would silently misparse the eighth
       // field as belonging to no key it expects.
+      // V3: adds the `engine.ready` event (#2377, C1 repair, Codex's smoke
+      // ruling) — a schema bump because a V2 harness's `Event` set does not
+      // recognize it and would refuse the line outright rather than silently
+      // misread it, which is the correct failure for an unknown event.
       let prefix =
-        "EW_OVERLAY_FIRST_RENDER_V2\trun=\(runID)\tpid=\(getpid())\tbundle=\(bundleID)\t"
+        "EW_OVERLAY_FIRST_RENDER_V3\trun=\(runID)\tpid=\(getpid())\tbundle=\(bundleID)\t"
       return Sink(descriptor: descriptor, prefix: prefix)
     }()
   }

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -113,6 +113,35 @@
       sink.write(payload)
     }
 
+    /// Hold captures until the first order-front, instead of writing them now.
+    ///
+    /// **A marker's own write must not sit inside a measured interval in one
+    /// bundle and outside it in the other.** Root construction is the interval
+    /// Phase 6 MOVES. In the baseline bundle it runs after key-down and before
+    /// the panel is ordered front, so emitting there puts this string building
+    /// and `write(2)` inside the keypress interval; in the prewarmed bundle the
+    /// same construction happens before key-down, so the identical cost falls
+    /// outside it. The benchmark would then credit the change for removing
+    /// marker I/O that is not production work — the instrument paying the
+    /// variant it is supposed to be judging.
+    ///
+    /// Holding them means BOTH bundles write the same three lines at the same
+    /// point, immediately after `orderFrontRegardless()`. The cost is identical
+    /// on both sides, so it cancels in every bound this phase is judged on —
+    /// all three are stated as regressions against the other bundle, and the
+    /// one absolute bound (root construction p95) measures an interval this
+    /// write is not inside.
+    ///
+    /// Consequence worth stating: a launch that never orders a panel front
+    /// writes no root markers at all, and the harness blocks it as incomplete.
+    /// That is the honest reading — no first render happened.
+    @MainActor
+    public static func hold(_ captures: Capture...) {
+      pending.append(contentsOf: captures)
+    }
+
+    @MainActor private static var pending: [Capture] = []
+
     /// Emit at most once per process, for an event whose CALL SITE runs many
     /// times but whose measurement is about the first occurrence.
     ///
@@ -129,7 +158,11 @@
     @MainActor
     public static func emitFirst(_ capture: Capture) {
       guard emittedOnce.insert(capture.event).inserted else { return }
-      emit([capture])
+      // Everything held so far flushes with this one, in capture order, so the
+      // file order matches the causal order the harness enforces.
+      let batch = pending + [capture]
+      pending.removeAll()
+      emit(batch)
     }
 
     @MainActor private static var emittedOnce: Set<Event> = []

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -82,8 +82,21 @@
     ///
     /// So the call site arms this at the top of launch, before any `capture`.
     /// A no-op when the environment is absent, like everything else here.
+    ///
+    /// It also reserves the held-capture storage, for the same reason one level
+    /// down: `pending` starts empty, so the FIRST `hold` allocates its buffer.
+    /// In the baseline bundle that first `hold` happens after key-down and
+    /// before the panel is ordered front — inside the keypress interval — while
+    /// in the prewarmed bundle it happens before key-down. A malloc is small and
+    /// the asymmetry is not: it is a fixed cost charged to one side of a
+    /// comparison whose whole purpose is to detect a small difference.
+    ///
+    /// Three captures is the whole of it — two root, one order-front — and the
+    /// flush keeps the capacity rather than freeing it inside the same interval.
+    @MainActor
     public static func prepare() {
       _ = sink
+      pending.reserveCapacity(4)
     }
 
     /// Read the clock. This is the ONLY thing that happens at a measured boundary.
@@ -161,7 +174,7 @@
       // Everything held so far flushes with this one, in capture order, so the
       // file order matches the causal order the harness enforces.
       let batch = pending + [capture]
-      pending.removeAll()
+      pending.removeAll(keepingCapacity: true)
       emit(batch)
     }
 

--- a/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
+++ b/Sources/EnviousWisprAppKit/App/Debug/OverlayFirstRenderMarkers.swift
@@ -34,6 +34,15 @@
   /// dictionary — but that happens exactly once, in `prepare()`, which the call
   /// site places before any measured interval.
   public enum OverlayFirstRenderMarkers {
+    /// The AX identifier the harness polls for (#2377, C1 repair, cloud review
+    /// P1). CGWindow-list membership can precede SwiftUI content actually being
+    /// composited, so the harness's stopwatch endpoint moved to "does an
+    /// `AXWindow` bearing this identifier exist under the app" — set on the ONE
+    /// retained panel once, in `OverlayWindowHost.ensurePanel()`, DEBUG-only.
+    /// A string constant here rather than duplicated in Swift and Python is
+    /// what keeps the two from drifting apart the way the schema strings do.
+    public static let axPanelIdentifier = "EW_OVERLAY_FIRST_RENDER_PANEL"
+
     /// The exact strings the harness parses. Changing one is a schema change and
     /// belongs with a bump of `SCHEMA` in `measure_overlay_first_render.py`,
     /// whose parser refuses an unknown event rather than skipping it.
@@ -43,6 +52,25 @@
       case rootConstructStart = "root.construct.start"
       case rootConstructEnd = "root.construct.end"
       case hostOrderFrontComplete = "host.order_front.complete"
+    }
+
+    /// Which presentation a `host.order_front.complete` marker belongs to.
+    ///
+    /// **Added because the shared retained panel makes every presentation look
+    /// identical to the marker.** The Host does not know why it was asked to
+    /// present; the Director does (`OverlayDirector.isRecording`). Without this,
+    /// an unrelated presentation — the crash-recovery card
+    /// `WisprBootstrapper.applicationDidFinishLaunching` can show on ANY
+    /// launch — that wins the presentation race binds the marker instead of the
+    /// keypress-triggered one, and the harness reports a plausible latency for
+    /// work the keypress did not cause.
+    public enum Intent: String, Sendable {
+      /// Launch/root markers concern no presentation.
+      case none
+      /// The presentation the benchmark measures.
+      case recording
+      /// Any other presentation sharing the retained panel.
+      case other
     }
 
     /// One clock reading bound to the event it belongs to.
@@ -64,6 +92,10 @@
       /// which is worse than no measurement because nothing about it looks
       /// wrong.
       let window: Int
+      /// `.none` for launch/root events. For `host.order_front.complete`, the
+      /// ambient value `withPresentationIntent` set for the call that produced
+      /// this presentation.
+      let intent: Intent
     }
 
     /// Force the sink open BEFORE the first measured interval begins.
@@ -105,9 +137,37 @@
     /// against an 8 ms bound, and wall time can step. Raw ticks are emitted
     /// unconverted — `mach_timebase_info` is applied by the harness, so no
     /// arithmetic runs inside the interval.
+    ///
+    /// Only `hostOrderFrontComplete` ever carries a non-`.none` intent — every
+    /// other event concerns no presentation, so its intent is fixed at `.none`
+    /// regardless of the ambient value, which is what keeps a launch/root
+    /// marker from accidentally inheriting whatever `withPresentationIntent`
+    /// last set.
+    @MainActor
     public static func capture(_ event: Event, window: Int = 0) -> Capture {
-      Capture(event: event, ticks: mach_absolute_time(), window: window)
+      let intent: Intent = event == .hostOrderFrontComplete ? currentIntent : .none
+      return Capture(event: event, ticks: mach_absolute_time(), window: window, intent: intent)
     }
+
+    /// The intent the NEXT `hostOrderFrontComplete` capture will carry.
+    ///
+    /// **Ambient rather than a parameter, because the Host must not learn why
+    /// it was asked to present.** `OverlayWindowHosting` is deliberately
+    /// minimal (`OverlayWindowHost.swift`'s own doc comment says so), and
+    /// presentation intent is measurement-only — widening the production seam
+    /// to carry it would put a DEBUG-only concept in a protocol production code
+    /// depends on. The Director sets this immediately around its one
+    /// `host.present` call, using the SAME `isRecording` classification that
+    /// already decides `isFresh`.
+    @MainActor
+    public static func withPresentationIntent<T>(_ intent: Intent, _ body: () -> T) -> T {
+      let previous = currentIntent
+      currentIntent = intent
+      defer { currentIntent = previous }
+      return body()
+    }
+
+    @MainActor private static var currentIntent: Intent = .other
 
     /// Write captures, in one `write(2)`, after the measured work has finished.
     public static func emit(_ captures: Capture...) {
@@ -117,11 +177,11 @@
     public static func emit(_ captures: [Capture]) {
       guard let sink, !captures.isEmpty else { return }
       var payload = ""
-      payload.reserveCapacity((sink.prefix.count + 64) * captures.count)
+      payload.reserveCapacity((sink.prefix.count + 80) * captures.count)
       for capture in captures {
         payload += sink.prefix
         payload += "event=\(capture.event.rawValue)\tticks=\(capture.ticks)"
-        payload += "\twindow=\(capture.window)\n"
+        payload += "\twindow=\(capture.window)\tintent=\(capture.intent.rawValue)\n"
       }
       sink.write(payload)
     }
@@ -155,30 +215,45 @@
 
     @MainActor private static var pending: [Capture] = []
 
-    /// Emit at most once per process, for an event whose CALL SITE runs many
-    /// times but whose measurement is about the first occurrence.
+    /// Emit at most once PER INTENT, for a call site that runs many times but
+    /// whose measurement is about the first occurrence of each presentation
+    /// kind.
     ///
     /// `host.order_front.complete` is the case: the host orders a panel front on
-    /// every presentation, and a launch that showed two pills would write the
-    /// event twice. The harness treats every event as a singleton and blocks on a
-    /// duplicate, correctly — two order-fronts in one file give a "first render"
-    /// figure that is a mix of a first render and a later one. The latch is here
-    /// rather than at the call site so the property the harness depends on lives
-    /// with the contract, not with one of its callers.
+    /// every presentation. Latching per EVENT alone (the pre-intent design)
+    /// meant whichever presentation reached this call first — the keypress
+    /// recording, or an unrelated one racing it — silently won the marker,
+    /// with nothing in the file to say which. Latching per INTENT keeps that
+    /// singleton property for each kind separately: at most one `.recording`
+    /// marker ever, and at most one `.other` marker ever, so the harness can
+    /// tell "a recording happened" from "something else happened" instead of
+    /// reading one merged, unlabelled event.
+    ///
+    /// **Only `.recording` flushes the held root markers.** Root construction
+    /// timing is meaningful paired with the RECORDING's own first render; an
+    /// unrelated `.other` presentation winning the race first must not consume
+    /// that flush, or the recording's later marker would find `pending` already
+    /// emptied and its root timing lost. An `.other` marker before any
+    /// `.recording` is written on its own, and the harness blocks on it
+    /// (`BLOCKED_WRONG_PRESENTATION`) — see the Python adjudicator.
     ///
     /// `@MainActor` because all three call sites already are, which is cheaper
     /// and more honest than a lock defending state nothing else touches.
     @MainActor
     public static func emitFirst(_ capture: Capture) {
-      guard emittedOnce.insert(capture.event).inserted else { return }
-      // Everything held so far flushes with this one, in capture order, so the
-      // file order matches the causal order the harness enforces.
-      let batch = pending + [capture]
-      pending.removeAll(keepingCapacity: true)
-      emit(batch)
+      guard emittedIntents.insert(capture.intent).inserted else { return }
+      if capture.intent == .recording {
+        // Everything held so far flushes with this one, in capture order, so
+        // the file order matches the causal order the harness enforces.
+        let batch = pending + [capture]
+        pending.removeAll(keepingCapacity: true)
+        emit(batch)
+      } else {
+        emit(capture)
+      }
     }
 
-    @MainActor private static var emittedOnce: Set<Event> = []
+    @MainActor private static var emittedIntents: Set<Intent> = []
 
     // MARK: - the sink
 
@@ -237,8 +312,11 @@
       guard descriptor >= 0 else { return nil }
 
       let bundleID = Bundle.main.bundleIdentifier ?? "unknown"
+      // V2: adds the `intent` field (#2377, C1 repair) — a schema bump because
+      // an old harness reading a V2 line would silently misparse the eighth
+      // field as belonging to no key it expects.
       let prefix =
-        "EW_OVERLAY_FIRST_RENDER_V1\trun=\(runID)\tpid=\(getpid())\tbundle=\(bundleID)\t"
+        "EW_OVERLAY_FIRST_RENDER_V2\trun=\(runID)\tpid=\(getpid())\tbundle=\(bundleID)\t"
       return Sink(descriptor: descriptor, prefix: prefix)
     }()
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -159,11 +159,23 @@ final class OverlayDirector {
 
   private var rootHostingView: NSView {
     if let builtRootView { return builtRootView }
+    // #2377 Phase 6: DEBUG-only measurement of root construction, the cost this
+    // phase moves. Memoised above, so this runs once per launch and the marker
+    // is naturally a singleton.
+    #if DEBUG
+      let constructStart = OverlayFirstRenderMarkers.capture(.rootConstructStart)
+    #endif
     let view = NSHostingView(
       rootView: OverlayRootView(
         model: model,
         sendEvent: { [weak self] event in self?.handle(event, binding: .none) }))
+    #if DEBUG
+      let constructEnd = OverlayFirstRenderMarkers.capture(.rootConstructEnd)
+    #endif
     builtRootView = view
+    #if DEBUG
+      OverlayFirstRenderMarkers.emit(constructStart, constructEnd)
+    #endif
     return view
   }
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -1,9 +1,9 @@
 import AppKit
-import SwiftUI
 import CoreGraphics
 import EnviousWisprCore
 import EnviousWisprPipeline
 import Foundation
+import SwiftUI
 
 /// Owns the presentation TRANSACTION (#2292, chunk C4b).
 ///
@@ -155,7 +155,6 @@ final class OverlayDirector {
   /// gate left the flag true with nothing built, so the next presentation did
   /// the same. Cloud review caught both in one finding.
   private var builtRootView: NSView?
-
 
   private var rootHostingView: NSView {
     if let builtRootView { return builtRootView }
@@ -1055,7 +1054,8 @@ final class OverlayDirector {
     // A CONTINUING recording is excluded by the id check: the reducer keeps one
     // identity across audio-level morphs, so a tick is not a new lifecycle and
     // must not re-anchor.
-    let isFresh = presentedID == nil || (Self.isRecording(presentation) && presentedID != presentation.id)
+    let isFresh =
+      presentedID == nil || (Self.isRecording(presentation) && presentedID != presentation.id)
     presentedID = presentation.id
     let recordingGeometry = geometry(for: presentation)
     // **One position per presentation, not two reads of a provider.** The
@@ -1075,12 +1075,34 @@ final class OverlayDirector {
     } else {
       anchor = position()
     }
-    let presented = host.present(
-      rootHostingView,
-      width: recordingGeometry.width,
-      fixedHeight: recordingGeometry.fixedHeight,
-      isFresh: isFresh,
-      position: anchor)
+    // #2377 Phase 6, C1 repair: DEBUG-only presentation-intent tagging around
+    // the ONE call to `host.present`. The Host has no way to know why it was
+    // asked to present — `OverlayWindowHosting` is deliberately minimal — but
+    // this Director already classifies every presentation via `isRecording`
+    // (the same call `isFresh` above uses). Setting the ambient intent here,
+    // for the duration of this synchronous call, is what lets the marker the
+    // Host emits inside `present` say which presentation it belongs to,
+    // without widening the production seam to carry a measurement-only
+    // concept. See `OverlayFirstRenderMarkers.withPresentationIntent`.
+    #if DEBUG
+      let presented = OverlayFirstRenderMarkers.withPresentationIntent(
+        Self.isRecording(presentation) ? .recording : .other
+      ) {
+        host.present(
+          rootHostingView,
+          width: recordingGeometry.width,
+          fixedHeight: recordingGeometry.fixedHeight,
+          isFresh: isFresh,
+          position: anchor)
+      }
+    #else
+      let presented = host.present(
+        rootHostingView,
+        width: recordingGeometry.width,
+        fixedHeight: recordingGeometry.fixedHeight,
+        isFresh: isFresh,
+        position: anchor)
+    #endif
     if !presented {
       // The host refused — no screen, or a presentation it could not size — and
       // it returns BEFORE touching the panel, so a window that was already up

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -174,7 +174,10 @@ final class OverlayDirector {
     #endif
     builtRootView = view
     #if DEBUG
-      OverlayFirstRenderMarkers.emit(constructStart, constructEnd)
+      // HELD, not emitted. Writing here would put the marker's own cost inside
+      // the keypress interval in the baseline bundle and outside it in the
+      // prewarmed one — see `OverlayFirstRenderMarkers.hold`.
+      OverlayFirstRenderMarkers.hold(constructStart, constructEnd)
     #endif
     return view
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -175,8 +175,12 @@ final class OverlayDirector {
     #if DEBUG
       // HELD, not emitted. Writing here would put the marker's own cost inside
       // the keypress interval in the baseline bundle and outside it in the
-      // prewarmed one — see `OverlayFirstRenderMarkers.hold`.
-      OverlayFirstRenderMarkers.hold(constructStart, constructEnd)
+      // prewarmed one — see `OverlayFirstRenderMarkers.hold`. Two single-
+      // capture calls, never one variadic call: a variadic argument list
+      // allocates its own temporary array at THIS call site before `hold`
+      // runs, which is the same asymmetric cost one level up.
+      OverlayFirstRenderMarkers.hold(constructStart)
+      OverlayFirstRenderMarkers.hold(constructEnd)
     #endif
     return view
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
@@ -215,6 +215,17 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
     view.frame = NSRect(origin: .zero, size: size)
     panel.contentView = view
     panel.orderFrontRegardless()
+    // #2377 Phase 6: DEBUG-only, and `emitFirst` rather than `emit` because the
+    // host orders a panel front on EVERY presentation while the benchmark is
+    // about the first one. See `OverlayFirstRenderMarkers.emitFirst`.
+    #if DEBUG
+      // The window number is the whole point of this marker: it lets the harness
+      // NAME the window whose appearance ends the keypress interval, instead of
+      // accepting whichever window it happens to notice first.
+      OverlayFirstRenderMarkers.emitFirst(
+        OverlayFirstRenderMarkers.capture(
+          .hostOrderFrontComplete, window: panel.windowNumber))
+    #endif
     return true
   }
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
@@ -219,6 +219,16 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
     // host orders a panel front on EVERY presentation while the benchmark is
     // about the first one. See `OverlayFirstRenderMarkers.emitFirst`.
     #if DEBUG
+      // **The AX identifier is set HERE, after `orderFrontRegardless()`, never
+      // in `ensurePanel()` (cloud review P1, C1 repair round 2).**
+      // `accessibilityWindows` enumerates every application window, visible or
+      // not — setting the identifier at construction would make the harness's
+      // AX poll match the panel the instant it exists, before content is
+      // attached or the panel is ordered front, timing something the user
+      // cannot see. Setting it AFTER the same two calls the marker already
+      // waits on keeps both signals — AX identity and the marker — bound to
+      // the same real event.
+      panel.setAccessibilityIdentifier(OverlayFirstRenderMarkers.axPanelIdentifier)
       // The window number is the whole point of this marker: it lets the harness
       // NAME the window whose appearance ends the keypress interval, instead of
       // accepting whichever window it happens to notice first.
@@ -295,13 +305,6 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
     p.isMovableByWindowBackground = true
     p.hasShadow = true
     p.delegate = self
-    // #2377 Phase 6, C1 repair (cloud review P1): the harness's stopwatch
-    // endpoint polls AX, not CGWindow membership, so it needs a stable way to
-    // name THIS panel in the AX tree. Set once, on the one retained panel;
-    // every later presentation reuses it.
-    #if DEBUG
-      p.setAccessibilityIdentifier(OverlayFirstRenderMarkers.axPanelIdentifier)
-    #endif
     panel = p
     return p
   }

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
@@ -90,11 +90,7 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
   /// not flagged.
   private var programmaticMoveDepth = 0
 
-  #if DEBUG
-    /// The #2292 acceptance metric: reads 1 after a full dictation exercising
-    /// every transition.
-    private(set) var panelConstructionCount = 0
-  #endif
+  private let panelFactory: OverlayPanelFactory
 
   /// Registered here rather than on the panel because **every fact this
   /// callback needs already lives in this object**: the placement anchor, the
@@ -107,8 +103,12 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
   /// pill reacts to the swipe.
   private nonisolated(unsafe) var spaceChangeObserver: NSObjectProtocol?
 
-  init(screens: @escaping () -> OverlayScreenResolver = { .live }) {
+  init(
+    screens: @escaping () -> OverlayScreenResolver = { .live },
+    panelFactory: OverlayPanelFactory = .live
+  ) {
     self.screens = screens
+    self.panelFactory = panelFactory
     super.init()
     spaceChangeObserver = NSWorkspace.shared.notificationCenter.addObserver(
       forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main
@@ -281,16 +281,12 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
 
   private func ensurePanel() -> NSPanel {
     if let panel { return panel }
-    #if DEBUG
-      panelConstructionCount += 1
-    #endif
-    // Configuration copied verbatim from `05411427:Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift`
-    // so this chunk changes the panel's LIFETIME and nothing about its identity.
-    let p = NSPanel(
-      contentRect: NSRect(x: 0, y: 0, width: 185, height: 44),
-      styleMask: [.borderless, .nonactivatingPanel],
-      backing: .buffered,
-      defer: false)
+    // Configuration below is copied verbatim from
+    // `05411427:Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift` so
+    // this chunk changes the panel's LIFETIME and nothing about its identity;
+    // the panel object itself comes from the injected factory so a test can
+    // observe every AppKit command issued against it.
+    let p = panelFactory.makePanel()
     p.isReleasedWhenClosed = false
     p.isOpaque = false
     p.backgroundColor = .clear
@@ -408,11 +404,29 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
     }
   }
 
-  #if DEBUG
-    var placementForTesting: OverlayPlacementState { placement }
-    var panelForTesting: NSPanel? { panel }
-    var isProgrammaticallyMovingForTesting: Bool { programmaticMoveDepth > 0 }
-  #endif
+}
+
+/// How the host builds its `NSPanel`.
+///
+/// A seam rather than a direct construction, mirroring `OverlayScreenResolver`
+/// immediately below: a test injects a recording subclass through this same
+/// point instead of reading private state off the host, so the real AppKit
+/// commands the host issues are what a test observes (#2377, P6-C2).
+@MainActor
+struct OverlayPanelFactory {
+  let makePanel: () -> NSPanel
+
+  init(makePanel: @escaping () -> NSPanel) {
+    self.makePanel = makePanel
+  }
+
+  static let live = OverlayPanelFactory {
+    NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 185, height: 44),
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false)
+  }
 }
 
 /// How the host learns about screens.

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
@@ -295,6 +295,13 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
     p.isMovableByWindowBackground = true
     p.hasShadow = true
     p.delegate = self
+    // #2377 Phase 6, C1 repair (cloud review P1): the harness's stopwatch
+    // endpoint polls AX, not CGWindow membership, so it needs a stable way to
+    // name THIS panel in the AX tree. Set once, on the one retained panel;
+    // every later presentation reuses it.
+    #if DEBUG
+      p.setAccessibilityIdentifier(OverlayFirstRenderMarkers.axPanelIdentifier)
+    #endif
     panel = p
     return p
   }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -433,12 +433,11 @@ public final class WisprBootstrapper {
         await whisperKitKernelDriver?.ensureEngineWarm(reason: .launch)
         #if DEBUG
           // Re-check the SELECTED and ACTIVE backend, not just this driver's
-          // own readiness (#2377, C1 repair round 4, Codex HIGH). A backend
-          // switch mid-await can leave this driver `.ready` while it is no
-          // longer the one a press would actually route to — emitting on its
-          // readiness alone would tell the harness the wrong engine warmed,
-          // recreating the exact ColdPressGuard (#879) false alarm this round
-          // exists to remove.
+          // own readiness (#2377, C1 repair). A backend switch mid-await can
+          // leave this driver `.ready` while it is no longer the one a press
+          // would actually route to — emitting on its readiness alone would
+          // tell the harness the wrong engine warmed, recreating the exact
+          // ColdPressGuard (#879) false alarm this marker exists to avoid.
           if settings.selectedBackend == .whisperKit,
             asrManager.activeBackendType == .whisperKit,
             whisperKitKernelDriver?.engineReadiness == .ready
@@ -702,7 +701,7 @@ public final class WisprBootstrapper {
         #if DEBUG
           // Same re-check as the WhisperKit path, mirrored: the SELECTED and
           // ACTIVE backend, not just this driver's own readiness (#2377, C1
-          // repair round 4, Codex HIGH).
+          // repair).
           if settings.selectedBackend == .parakeet,
             asrManager.activeBackendType == .parakeet,
             kernelDriver?.engineReadiness == .ready

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -429,10 +429,20 @@ public final class WisprBootstrapper {
       runDocumentsMigration: { [weak whisperKitRetirement] in
         await whisperKitRetirement?.runLaunch()
       },
-      preloadAction: { [weak whisperKitKernelDriver] in
+      preloadAction: { [weak whisperKitKernelDriver, asrManager] in
         await whisperKitKernelDriver?.ensureEngineWarm(reason: .launch)
         #if DEBUG
-          if whisperKitKernelDriver?.engineReadiness == .ready {
+          // Re-check the SELECTED and ACTIVE backend, not just this driver's
+          // own readiness (#2377, C1 repair round 4, Codex HIGH). A backend
+          // switch mid-await can leave this driver `.ready` while it is no
+          // longer the one a press would actually route to — emitting on its
+          // readiness alone would tell the harness the wrong engine warmed,
+          // recreating the exact ColdPressGuard (#879) false alarm this round
+          // exists to remove.
+          if settings.selectedBackend == .whisperKit,
+            asrManager.activeBackendType == .whisperKit,
+            whisperKitKernelDriver?.engineReadiness == .ready
+          {
             OverlayFirstRenderMarkers.emitEngineReadyOnce()
           }
         #endif
@@ -685,12 +695,18 @@ public final class WisprBootstrapper {
     // WhisperKit: observation-based (waits for setupState to become .ready
     // first, then `preloadAction` → `ensureEngineWarm`).
     if settings.selectedBackend == .parakeet {
-      Task { [weak kernelDriver] in
+      Task { [weak kernelDriver, asrManager] in
         // Discard the outcome so the Task's Success type stays Void
         // (`EngineWarmupOutcome` does not declare Sendable conformance).
         _ = await kernelDriver?.ensureEngineWarm(reason: .launch)
         #if DEBUG
-          if kernelDriver?.engineReadiness == .ready {
+          // Same re-check as the WhisperKit path, mirrored: the SELECTED and
+          // ACTIVE backend, not just this driver's own readiness (#2377, C1
+          // repair round 4, Codex HIGH).
+          if settings.selectedBackend == .parakeet,
+            asrManager.activeBackendType == .parakeet,
+            kernelDriver?.engineReadiness == .ready
+          {
             OverlayFirstRenderMarkers.emitEngineReadyOnce()
           }
         #endif

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -431,6 +431,11 @@ public final class WisprBootstrapper {
       },
       preloadAction: { [weak whisperKitKernelDriver] in
         await whisperKitKernelDriver?.ensureEngineWarm(reason: .launch)
+        #if DEBUG
+          if whisperKitKernelDriver?.engineReadiness == .ready {
+            OverlayFirstRenderMarkers.emitEngineReadyOnce()
+          }
+        #endif
       }
     )
 
@@ -457,8 +462,6 @@ public final class WisprBootstrapper {
       ollamaRemotenessLookup: PipelineSettingsSync.liveOllamaRemotenessLookup(setup.ollamaSetup)
     )
     settingsSync.applyInitialSettings(settings)
-
-
 
     // #1988: the live-preview limb, wired ONLY to the overlay. See the installer.
     //
@@ -686,6 +689,11 @@ public final class WisprBootstrapper {
         // Discard the outcome so the Task's Success type stays Void
         // (`EngineWarmupOutcome` does not declare Sendable conformance).
         _ = await kernelDriver?.ensureEngineWarm(reason: .launch)
+        #if DEBUG
+          if kernelDriver?.engineReadiness == .ready {
+            OverlayFirstRenderMarkers.emitEngineReadyOnce()
+          }
+        #endif
       }
     }
 
@@ -716,7 +724,6 @@ public final class WisprBootstrapper {
         }
       }
     }
-
 
     let updateCoordinatorHolder = UpdateCoordinatorHolder()
     let sparkleUpdateController = SparkleUpdateController(holder: updateCoordinatorHolder)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -429,7 +429,7 @@ public final class WisprBootstrapper {
       runDocumentsMigration: { [weak whisperKitRetirement] in
         await whisperKitRetirement?.runLaunch()
       },
-      preloadAction: { [weak whisperKitKernelDriver, asrManager] in
+      preloadAction: { [weak whisperKitKernelDriver] in
         await whisperKitKernelDriver?.ensureEngineWarm(reason: .launch)
         #if DEBUG
           // Re-check the SELECTED and ACTIVE backend, not just this driver's
@@ -694,7 +694,7 @@ public final class WisprBootstrapper {
     // WhisperKit: observation-based (waits for setupState to become .ready
     // first, then `preloadAction` → `ensureEngineWarm`).
     if settings.selectedBackend == .parakeet {
-      Task { [weak kernelDriver, asrManager] in
+      Task { [weak kernelDriver] in
         // Discard the outcome so the Task's Success type stays Void
         // (`EngineWarmupOutcome` does not declare Sendable conformance).
         _ = await kernelDriver?.ensureEngineWarm(reason: .launch)

--- a/Tests/EnviousWisprTests/App/Debug/OverlayFirstRenderMarkersIntentTests.swift
+++ b/Tests/EnviousWisprTests/App/Debug/OverlayFirstRenderMarkersIntentTests.swift
@@ -20,7 +20,11 @@
   /// calling it would either pollute every other test in this process or
   /// need the kind of DEBUG-only reset hatch this migration exists to
   /// delete. `capture()` and `withPresentationIntent` are pure enough to test
-  /// directly without touching that state at all.
+  /// directly without touching that state at all. The same reasoning excludes
+  /// `emitEngineReadyOnce`'s `engineReadyEmitted` latch (#2377, C1 repair,
+  /// Codex's smoke ruling) — its call-site binding (guard-then-emit at both
+  /// launch warm-up paths) is proved instead by the Python suite's mutation-
+  /// tested `test_the_host_marker_is_emitted_with_a_real_window_number`.
   @MainActor
   @Suite(.tags(.harnessContract))
   struct OverlayFirstRenderMarkersIntentTests {

--- a/Tests/EnviousWisprTests/App/Debug/OverlayFirstRenderMarkersIntentTests.swift
+++ b/Tests/EnviousWisprTests/App/Debug/OverlayFirstRenderMarkersIntentTests.swift
@@ -1,0 +1,70 @@
+#if DEBUG
+  import Testing
+
+  @testable import EnviousWisprAppKit
+
+  /// `withPresentationIntent`'s nesting and per-event defaulting, tested
+  /// directly (#2377, C1 repair, cloud review P1).
+  ///
+  /// **Harness contract, not product outcome.** `OverlayFirstRenderMarkers`
+  /// exists only to measure; when this suite fails, no user sees anything —
+  /// the benchmark's own evidence becomes untrustworthy instead. The Python
+  /// suite proves the ADJUDICATOR reads `intent` correctly from marker text
+  /// it fabricates; nothing there can see whether the ambient the Director
+  /// sets ever reaches `capture()` correctly through a NESTED scope, or
+  /// whether a non-host event stays `.none` no matter what the ambient is —
+  /// this file is where those two facts are pinned.
+  ///
+  /// `emitFirst`'s own state (`pending`, `emittedIntents`) is deliberately
+  /// NOT exercised here: it is a once-per-PROCESS latch by design, so a test
+  /// calling it would either pollute every other test in this process or
+  /// need the kind of DEBUG-only reset hatch this migration exists to
+  /// delete. `capture()` and `withPresentationIntent` are pure enough to test
+  /// directly without touching that state at all.
+  @MainActor
+  @Suite(.tags(.harnessContract))
+  struct OverlayFirstRenderMarkersIntentTests {
+
+    @Test("a nested scope's intent does not leak into the outer one")
+    func nestedScopesRestoreTheOuterIntent() {
+      let outerIntent = OverlayFirstRenderMarkers.withPresentationIntent(.recording) {
+        () -> OverlayFirstRenderMarkers.Intent in
+        let innerIntent = OverlayFirstRenderMarkers.withPresentationIntent(.other) {
+          OverlayFirstRenderMarkers.capture(.hostOrderFrontComplete).intent
+        }
+        #expect(innerIntent == .other, "the inner scope did not see its own intent")
+        // The inner scope has returned; the ambient must be back to what the
+        // OUTER scope set, not whatever the inner scope left behind.
+        return OverlayFirstRenderMarkers.capture(.hostOrderFrontComplete).intent
+      }
+      #expect(
+        outerIntent == .recording,
+        "the outer scope's intent did not survive a nested inner scope")
+    }
+
+    @Test("non-host events carry .none regardless of the ambient intent")
+    func nonHostEventsIgnoreTheAmbientIntent() {
+      OverlayFirstRenderMarkers.withPresentationIntent(.recording) {
+        #expect(OverlayFirstRenderMarkers.capture(.launchEnter).intent == .none)
+        #expect(OverlayFirstRenderMarkers.capture(.launchExit).intent == .none)
+        #expect(OverlayFirstRenderMarkers.capture(.rootConstructStart).intent == .none)
+        #expect(OverlayFirstRenderMarkers.capture(.rootConstructEnd).intent == .none)
+      }
+      // TWIN: the same four events under a DIFFERENT ambient intent still
+      // read `.none` — proving the exemption is about the EVENT, not about
+      // which intent happens to be active when it is read.
+      OverlayFirstRenderMarkers.withPresentationIntent(.other) {
+        #expect(OverlayFirstRenderMarkers.capture(.launchEnter).intent == .none)
+        #expect(OverlayFirstRenderMarkers.capture(.rootConstructEnd).intent == .none)
+      }
+    }
+
+    @Test("only the host event reads the ambient intent at all")
+    func onlyTheHostEventReadsTheAmbientIntent() {
+      let hostIntent = OverlayFirstRenderMarkers.withPresentationIntent(.other) {
+        OverlayFirstRenderMarkers.capture(.hostOrderFrontComplete).intent
+      }
+      #expect(hostIntent == .other, "hostOrderFrontComplete did not read the ambient intent")
+    }
+  }
+#endif

--- a/Tests/EnviousWisprTests/App/Debug/OverlayFirstRenderMarkersIntentTests.swift
+++ b/Tests/EnviousWisprTests/App/Debug/OverlayFirstRenderMarkersIntentTests.swift
@@ -21,8 +21,8 @@
   /// need the kind of DEBUG-only reset hatch this migration exists to
   /// delete. `capture()` and `withPresentationIntent` are pure enough to test
   /// directly without touching that state at all. The same reasoning excludes
-  /// `emitEngineReadyOnce`'s `engineReadyEmitted` latch (#2377, C1 repair,
-  /// Codex's smoke ruling) — its call-site binding (guard-then-emit at both
+  /// `emitEngineReadyOnce`'s `engineReadyEmitted` latch (#2377, C1 repair)
+  /// — its call-site binding (guard-then-emit at both
   /// launch warm-up paths) is proved instead by the Python suite's mutation-
   /// tested `test_the_host_marker_is_emitted_with_a_real_window_number`.
   @MainActor

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
@@ -17,9 +17,9 @@ import Testing
 ///
 /// Scoped to what both can honestly claim: a presentation succeeds, a hide takes
 /// it down, and the director's own view of the world follows. Geometry, window
-/// ordering and `panelConstructionCount` are NOT here — the fake has no frame
-/// and must not be encouraged to invent one. `OverlayWindowHostTests` owns those
-/// and always will.
+/// ordering and the panel construction count are NOT here — the fake has no
+/// frame and must not be encouraged to invent one. `OverlayWindowHostTests`
+/// owns those and always will.
 ///
 /// **The split below used to be a LANE split and is now only a subject split.**
 /// The cross-host comparisons read `presentedIDForTesting` and
@@ -48,7 +48,8 @@ struct OverlayHostingContractTests {
   func theFakeNeverRefuses() {
     let host = WindowlessOverlayHost()
     let d = OverlayDirector(
-      host: host,       announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
+      host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      selections: { .shipped },
       deferFirstRender: { $0() })
 
     d.present(.warning(reason: .polishFailed))
@@ -97,7 +98,8 @@ struct OverlayHostingParityTests {
 
   private static func director(on host: any OverlayWindowHosting) -> OverlayDirector {
     OverlayDirector(
-      host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
+      host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      selections: { .shipped },
       deferFirstRender: { $0() })
   }
 

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
@@ -64,14 +64,9 @@ final class OverlayPanelCommandRecorder {
 /// never calls `close()`.
 ///
 /// **`setFrame` is normalized to one receipt per Host call.** `NSWindow`
-/// exposes both an animated and a non-animated `setFrame`, and the Host uses
-/// both (`display:` alone from `present`/`resizeCurrentPresentation`,
-/// `display:animate:` from `repositionForActiveSpaceChange`). AppKit's own
-/// animated overload is not guaranteed to skip the non-animated one internally,
-/// so `animatedSetFrameDepth` suppresses a second receipt for the SAME call —
-/// without it, a single Host call could silently produce two commands instead
-/// of one, which is a Host-call count no assertion here would notice going
-/// wrong in the direction that inflates rather than drops evidence.
+/// exposes animated and non-animated overloads. `animatedSetFrameDepth`
+/// normalizes either AppKit implementation: independent overloads or an
+/// animated overload that internally routes through the non-animated one.
 private final class CommandRecordingPanel: NSPanel {
   private weak var recorder: OverlayPanelCommandRecorder?
   private var animatedSetFrameDepth = 0

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
@@ -58,21 +58,23 @@ final class OverlayPanelCommandRecorder {
 /// recorder — the panel behaves exactly as the production one does; only the
 /// reporting is added.
 ///
-/// **`close()` records BEFORE calling `super`, every other override AFTER.**
-/// `isReleasedWhenClosed` can make `super.close()` deallocate `self`; recording
-/// first means the receipt survives even where the production configuration
-/// (`isReleasedWhenClosed = false`, set by `ensurePanel()` right after
-/// construction) did not — which is exactly the case a `.close()` this suite
-/// exists to catch would be violating.
+/// **`close()` records BEFORE calling `super`; every successful command records
+/// AFTER.** Closing is a negative tripwire on the attempted call itself, so its
+/// receipt must not depend on the superclass operation completing. Production
+/// never calls `close()`.
 ///
 /// **`setFrame` is normalized to one receipt per Host call.** `NSWindow`
 /// exposes both an animated and a non-animated `setFrame`, and the Host uses
 /// both (`display:` alone from `present`/`resizeCurrentPresentation`,
-/// `display:animate:` from `repositionForActiveSpaceChange`); overriding both
-/// and routing each through the same recorder call keeps that a Host-call-shaped
-/// fact rather than an AppKit-dispatch-shaped one.
+/// `display:animate:` from `repositionForActiveSpaceChange`). AppKit's own
+/// animated overload is not guaranteed to skip the non-animated one internally,
+/// so `animatedSetFrameDepth` suppresses a second receipt for the SAME call —
+/// without it, a single Host call could silently produce two commands instead
+/// of one, which is a Host-call count no assertion here would notice going
+/// wrong in the direction that inflates rather than drops evidence.
 private final class CommandRecordingPanel: NSPanel {
   private weak var recorder: OverlayPanelCommandRecorder?
+  private var animatedSetFrameDepth = 0
 
   init(recorder: OverlayPanelCommandRecorder?) {
     self.recorder = recorder
@@ -85,6 +87,7 @@ private final class CommandRecordingPanel: NSPanel {
 
   override func setFrame(_ frameRect: NSRect, display displayFlag: Bool) {
     super.setFrame(frameRect, display: displayFlag)
+    guard animatedSetFrameDepth == 0 else { return }
     recorder?.commands.append(
       .setFrame(
         panel: ObjectIdentifier(self), frame: frameRect, display: displayFlag, animated: false))
@@ -92,6 +95,8 @@ private final class CommandRecordingPanel: NSPanel {
 
   override func setFrame(_ frameRect: NSRect, display displayFlag: Bool, animate animateFlag: Bool)
   {
+    animatedSetFrameDepth += 1
+    defer { animatedSetFrameDepth -= 1 }
     super.setFrame(frameRect, display: displayFlag, animate: animateFlag)
     recorder?.commands.append(
       .setFrame(

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
@@ -1,0 +1,127 @@
+import AppKit
+import CoreGraphics
+
+@testable import EnviousWisprAppKit
+
+/// One AppKit command `OverlayWindowHost` issued against a panel (#2377, P6-C2).
+///
+/// **These observe the actual overridden AppKit calls, not the host's INTENT.**
+/// A receipt shaped `.presented(width:height:isFresh:position:)` would restate
+/// what the host meant to do and could stay green after the real command
+/// disappeared from `present()` — exactly the risk the deleted `*ForTesting`
+/// accessors carried, one layer down. `setFrame`/`setContentView`/
+/// `orderFrontRegardless`/`orderOut`/`close` are the actual AppKit surface the
+/// host drives; recording those, and nothing higher-level, is what makes a
+/// missing call visible instead of a missing INTENTION.
+enum OverlayPanelCommand: Equatable {
+  case constructed(panel: ObjectIdentifier)
+  case setFrame(panel: ObjectIdentifier, frame: CGRect, display: Bool, animated: Bool)
+  case setContentView(panel: ObjectIdentifier, view: ObjectIdentifier?)
+  case orderFrontRegardless(panel: ObjectIdentifier)
+  case orderOut(panel: ObjectIdentifier)
+  case close(panel: ObjectIdentifier)
+}
+
+/// Owns every panel `OverlayPanelFactory` has produced and the commands each
+/// one received.
+///
+/// **One recorder per test, one factory closure per recorder.** `panel`
+/// answers `panelForTesting`'s old question (the current occupant) without
+/// reading private host state; `constructionCount` answers
+/// `panelConstructionCount`'s old question by counting `.constructed` receipts
+/// instead of keeping a second, independently-incrementable counter — one
+/// authority for "how many panels exist" instead of two that could drift.
+@MainActor
+final class OverlayPanelCommandRecorder {
+  fileprivate(set) var commands: [OverlayPanelCommand] = []
+  fileprivate(set) var panels: [NSPanel] = []
+
+  var panel: NSPanel? { panels.last }
+
+  var constructionCount: Int {
+    commands.reduce(into: 0) { count, command in
+      if case .constructed = command { count += 1 }
+    }
+  }
+
+  func makeFactory() -> OverlayPanelFactory {
+    OverlayPanelFactory { [weak self] in
+      let p = CommandRecordingPanel(recorder: self)
+      self?.panels.append(p)
+      self?.commands.append(.constructed(panel: ObjectIdentifier(p)))
+      return p
+    }
+  }
+}
+
+/// A real `NSPanel` that reports every command this suite cares about to its
+/// recorder — the panel behaves exactly as the production one does; only the
+/// reporting is added.
+///
+/// **`close()` records BEFORE calling `super`, every other override AFTER.**
+/// `isReleasedWhenClosed` can make `super.close()` deallocate `self`; recording
+/// first means the receipt survives even where the production configuration
+/// (`isReleasedWhenClosed = false`, set by `ensurePanel()` right after
+/// construction) did not — which is exactly the case a `.close()` this suite
+/// exists to catch would be violating.
+///
+/// **`setFrame` is normalized to one receipt per Host call.** `NSWindow`
+/// exposes both an animated and a non-animated `setFrame`, and the Host uses
+/// both (`display:` alone from `present`/`resizeCurrentPresentation`,
+/// `display:animate:` from `repositionForActiveSpaceChange`); overriding both
+/// and routing each through the same recorder call keeps that a Host-call-shaped
+/// fact rather than an AppKit-dispatch-shaped one.
+private final class CommandRecordingPanel: NSPanel {
+  private weak var recorder: OverlayPanelCommandRecorder?
+
+  init(recorder: OverlayPanelCommandRecorder?) {
+    self.recorder = recorder
+    super.init(
+      contentRect: NSRect(x: 0, y: 0, width: 185, height: 44),
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false)
+  }
+
+  override func setFrame(_ frameRect: NSRect, display displayFlag: Bool) {
+    super.setFrame(frameRect, display: displayFlag)
+    recorder?.commands.append(
+      .setFrame(
+        panel: ObjectIdentifier(self), frame: frameRect, display: displayFlag, animated: false))
+  }
+
+  override func setFrame(_ frameRect: NSRect, display displayFlag: Bool, animate animateFlag: Bool)
+  {
+    super.setFrame(frameRect, display: displayFlag, animate: animateFlag)
+    recorder?.commands.append(
+      .setFrame(
+        panel: ObjectIdentifier(self), frame: frameRect, display: displayFlag,
+        animated: animateFlag))
+  }
+
+  override var contentView: NSView? {
+    get { super.contentView }
+    set {
+      super.contentView = newValue
+      recorder?.commands.append(
+        .setContentView(
+          panel: ObjectIdentifier(self),
+          view: newValue.map(ObjectIdentifier.init)))
+    }
+  }
+
+  override func orderFrontRegardless() {
+    super.orderFrontRegardless()
+    recorder?.commands.append(.orderFrontRegardless(panel: ObjectIdentifier(self)))
+  }
+
+  override func orderOut(_ sender: Any?) {
+    super.orderOut(sender)
+    recorder?.commands.append(.orderOut(panel: ObjectIdentifier(self)))
+  }
+
+  override func close() {
+    recorder?.commands.append(.close(panel: ObjectIdentifier(self)))
+    super.close()
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
@@ -11,7 +11,7 @@ import Testing
 /// **Drift Guard, and the class matters here.** When this fails we changed our
 /// own code; the user sees nothing at the moment of failure. It must never be
 /// cited as evidence that the pill renders correctly — the behavioural proof is
-/// the §11.1 Live UAT, reading panelConstructionCountForTesting after a real
+/// the §11.1 Live UAT, reading the panel construction count after a real
 /// dictation.
 ///
 /// ## Why this is structural rather than behavioural
@@ -176,103 +176,174 @@ struct OverlayRetainedWindowTests {
       """)
   }
 }
-// **Only the BEHAVIOURAL suite below is DEBUG-only.** It reads
-// panelConstructionCountForTesting, which lives inside `#if DEBUG` on the
-// panel, so without this guard the RELEASE build of the test target does not
-// compile — something a Debug-only local run cannot see by construction.
-//
-// The three guards ABOVE it read source files and need no seam at all. Wrapping
-// the whole file, which is what the first repair did, silently dropped two
-// configuration-independent structural guards out of the Release lane: a fix
-// that created the next defect, which is the shape this migration keeps
-// producing.
-#if DEBUG
-  /// The BEHAVIOURAL half, which I had wrongly concluded was untestable.
-  ///
-  /// **Product Outcome**, and the sentence finishes: when this fails the user sees
-  /// the pill blink as it is destroyed and rebuilt — the stated root cause of #930.
-  ///
-  /// I moved this claim to Live UAT after finding that a synchronous test creates
-  /// no window (every `showPanel` is queued with `DispatchQueue.main.async`) and
-  /// that observing it seemed to need a run-loop pump, which
-  /// the local test-timing guard rejects the pump. Asked directly whether I had talked myself
-  /// out of a guard I should have written, cloud review said yes and named the
-  /// mechanism: **a main-queue barrier is a SIGNAL, not a clock.** Enqueueing a
-  /// continuation behind the work under test resumes only after that work has run,
-  /// so it waits on the subject rather than on time — exactly what
-  /// `never-guess-when-the-subject-is-finished` asks for, and no annotation needed.
-  @MainActor
-  @Suite(.tags(.productOutcome))
-  struct OverlayRetainedWindowBehaviourTests {
+/// The BEHAVIOURAL half, migrated off the deleted `#if DEBUG` accessors onto
+/// `OverlayPanelCommandRecorder` (#2377, P6-C2) — this whole suite is now
+/// Release-visible, closing the gap the earlier `#if DEBUG` wrapper (which used
+/// to cover this whole file) left in `build-release`.
+///
+/// **Product Outcome**, and the sentence finishes: when this fails the user sees
+/// the pill blink as it is destroyed and rebuilt — the stated root cause of #930.
+///
+/// A synchronous test creates no window on its own (every `showPanel` is
+/// queued with `DispatchQueue.main.async`) and observing it needs a run-loop
+/// pump, which the local test-timing guard rejects. **A main-queue barrier is
+/// a SIGNAL, not a clock.** Enqueueing a continuation behind the work under
+/// test resumes only after that work has run, so it waits on the subject
+/// rather than on time — exactly what `never-guess-when-the-subject-is-finished`
+/// asks for, and no annotation needed.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayRetainedWindowBehaviourTests {
 
-    init() { _ = NSApplication.shared }
+  init() { _ = NSApplication.shared }
 
-    /// Resumes after everything already queued on the main queue has run —
-    /// including the deferred panel creation. FIFO ordering is the whole
-    /// mechanism; there is no interval anywhere in it.
-    private func drainMainQueue() async {
-      await withCheckedContinuation { continuation in
-        DispatchQueue.main.async { continuation.resume() }
-      }
-    }
-
-    /// **The property this whole migration exists to establish.** Several
-    /// transitions, ONE window. Every rebuild is the #930 flicker, and the four
-    /// compensating mechanisms #2292 removes — generations, pending work, drag
-    /// deferrals, `CATransaction.flush` — exist only to paper over it.
-    ///
-    /// **Rewritten rather than deleted at the cutover.** It used to drive the
-    /// panel's `showPolishing` / `showAccessibilityToast` / `showWarning`; those
-    /// methods are gone with the class, and the same three transitions are now
-    /// three intents. Deleting it would have removed the only guard on the claim
-    /// the branch is named for.
-    @Test("several transitions build one window")
-    func transitionsReuseTheRetainedWindow() async {
-      let host = OverlayWindowHost()
-      let d = OverlayDirector(
-        host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
-        deferFirstRender: { $0() })
-      defer { host.panelForTesting?.orderOut(nil) }
-
-      d.present(.processing(phase: .polishing))
-      await drainMainQueue()
-      #expect(
-        host.panelConstructionCount == 1,
-        "no window was built at all — this guard is asserting nothing")
-
-      d.present(.accessibilityNotice)
-      await drainMainQueue()
-      d.present(.warning(reason: .polishFailed))
-      await drainMainQueue()
-
-      #expect(
-        host.panelConstructionCount == 1,
-        """
-        the overlay built a second window for a transition. Every rebuild is the \
-        #930 flicker this migration removes.
-        """)
-    }
-
-    /// Hiding must ORDER OUT, never close: a closed `NSPanel` is a destroyed one,
-    /// and the next presentation would have to build another.
-    @Test("hiding and showing again reuses the same window")
-    func hideThenShowReusesTheWindow() async {
-      let host = OverlayWindowHost()
-      let d = OverlayDirector(
-        host: host,         announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
-        deferFirstRender: { $0() })
-      defer { host.panelForTesting?.orderOut(nil) }
-
-      for _ in 0..<4 {
-        d.present(.processing(phase: .polishing))
-        await drainMainQueue()
-        d.dismissCurrent(.silent)
-        await drainMainQueue()
-      }
-
-      #expect(
-        host.panelConstructionCount == 1,
-        "hiding released the window, so the next presentation had to build a new one")
+  /// Resumes after everything already queued on the main queue has run —
+  /// including the deferred panel creation. FIFO ordering is the whole
+  /// mechanism; there is no interval anywhere in it.
+  private func drainMainQueue() async {
+    await withCheckedContinuation { continuation in
+      DispatchQueue.main.async { continuation.resume() }
     }
   }
-#endif
+
+  /// **The property this whole migration exists to establish.** Several
+  /// transitions, ONE window. Every rebuild is the #930 flicker, and the four
+  /// compensating mechanisms #2292 removes — generations, pending work, drag
+  /// deferrals, `CATransaction.flush` — exist only to paper over it.
+  ///
+  /// **Rewritten rather than deleted at the cutover.** It used to drive the
+  /// panel's `showPolishing` / `showAccessibilityToast` / `showWarning`; those
+  /// methods are gone with the class, and the same three transitions are now
+  /// three intents. Deleting it would have removed the only guard on the claim
+  /// the branch is named for.
+  @Test("several transitions build one window")
+  func transitionsReuseTheRetainedWindow() async {
+    let recorder = OverlayPanelCommandRecorder()
+    let host = OverlayWindowHost(panelFactory: recorder.makeFactory())
+    let d = OverlayDirector(
+      host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      selections: { .shipped },
+      deferFirstRender: { $0() })
+    defer { recorder.panel?.orderOut(nil) }
+
+    d.present(.processing(phase: .polishing))
+    await drainMainQueue()
+    #expect(
+      recorder.constructionCount == 1,
+      "no window was built at all — this guard is asserting nothing")
+
+    d.present(.accessibilityNotice)
+    await drainMainQueue()
+    d.present(.warning(reason: .polishFailed))
+    await drainMainQueue()
+
+    #expect(
+      recorder.constructionCount == 1,
+      """
+      the overlay built a second window for a transition. Every rebuild is the \
+      #930 flicker this migration removes.
+      """)
+  }
+
+  /// Hiding must ORDER OUT, never close: a closed `NSPanel` is a destroyed one,
+  /// and the next presentation would have to build another.
+  @Test("hiding and showing again reuses the same window")
+  func hideThenShowReusesTheWindow() async {
+    let recorder = OverlayPanelCommandRecorder()
+    let host = OverlayWindowHost(panelFactory: recorder.makeFactory())
+    let d = OverlayDirector(
+      host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      selections: { .shipped },
+      deferFirstRender: { $0() })
+    defer { recorder.panel?.orderOut(nil) }
+
+    for _ in 0..<4 {
+      d.present(.processing(phase: .polishing))
+      await drainMainQueue()
+      d.dismissCurrent(.silent)
+      await drainMainQueue()
+    }
+
+    #expect(
+      recorder.constructionCount == 1,
+      "hiding released the window, so the next presentation had to build a new one")
+  }
+}
+
+/// **The real-panel integration Codex ruled C2 needed (#2377): retained
+/// identity proven with a genuine base `NSPanel`, not the recording subclass.**
+///
+/// The recorder above proves the host issues the right AppKit COMMANDS; it says
+/// nothing about what a real `NSPanel` does in response to them, because the
+/// recording subclass overrides those same methods. This suite injects
+/// `OverlayPanelFactory.live` itself — the identical factory production uses —
+/// so the panel under test is exactly what ships.
+///
+/// **Show / hide / show, asserting identity across all three, not just the
+/// last one.** A host that rebuilt on hide would still show correctly the
+/// second time; only comparing the SAME `ObjectIdentifier` across the full
+/// cycle catches that.
+///
+/// **`willCloseNotification`, not just final visibility.** `isVisible == false`
+/// is what BOTH `orderOut` and `close` leave behind on a panel with
+/// `isReleasedWhenClosed = false` — the earlier mutation control found exactly
+/// this (`compensatingMechanismsStayGone`'s sibling test up the file). The
+/// notification is the only observation that tells them apart without reading
+/// private host state.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayRetainedWindowRealPanelTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static let screen = ScreenGeometry(
+    id: ScreenID(rawValue: 1),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
+
+  @Test("a real panel survives show, hide, show with identity intact")
+  func showHideShowRetainsTheRealPanel() throws {
+    let host = OverlayWindowHost(
+      screens: { OverlayScreenResolver { Self.screen } }, panelFactory: .live)
+
+    nonisolated(unsafe) var closed = false
+    var closeToken: NSObjectProtocol?
+    defer { closeToken.map(NotificationCenter.default.removeObserver) }
+
+    let firstView = NSView(frame: NSRect(x: 0, y: 0, width: 185, height: 44))
+    #expect(
+      host.present(
+        firstView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
+    )
+    // The panel exists only after the first `present`, so the close observer is
+    // attached here rather than before — there is nothing to observe earlier.
+    let panel = try #require(firstView.window)
+    closeToken = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification, object: panel, queue: nil
+    ) { _ in closed = true }
+    defer { host.hide() }
+
+    #expect(panel.isVisible, "show did not put the panel on screen")
+    #expect(panel.contentView === firstView, "show did not attach the content view")
+
+    host.hide()
+    #expect(panel.isVisible == false, "hide left the panel on screen")
+    #expect(panel.contentView == nil, "hide left the previous content attached")
+
+    let secondView = NSView(frame: NSRect(x: 0, y: 0, width: 185, height: 44))
+    #expect(
+      host.present(
+        secondView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
+    )
+    let secondPanel = try #require(secondView.window)
+
+    #expect(
+      ObjectIdentifier(secondPanel) == ObjectIdentifier(panel),
+      "show after hide built a NEW panel — the window is not retained")
+    #expect(secondPanel.isVisible, "the second show did not put the panel back on screen")
+    #expect(secondPanel.contentView === secondView, "the second show kept the old content view")
+    #expect(
+      closed == false,
+      "the panel was CLOSED at some point in show/hide/show — orderOut never posts this")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
@@ -303,8 +303,21 @@ struct OverlayRetainedWindowRealPanelTests {
 
   @Test("a real panel survives show, hide, show with identity intact")
   func showHideShowRetainsTheRealPanel() throws {
+    // **A CAPTURING factory, not `firstView.window`.** Reading the panel off
+    // the attached view can only see the panel that ended up attached — it is
+    // blind to an extra real panel constructed and then discarded before or
+    // instead of that one. Wrapping `.live` itself, so every panel it
+    // constructs is genuinely production configuration, is what lets
+    // `constructedPanels.count == 1` prove there was only ever ONE.
+    let live = OverlayPanelFactory.live
+    var constructedPanels: [NSPanel] = []
+    let capturingFactory = OverlayPanelFactory {
+      let panel = live.makePanel()
+      constructedPanels.append(panel)
+      return panel
+    }
     let host = OverlayWindowHost(
-      screens: { OverlayScreenResolver { Self.screen } }, panelFactory: .live)
+      screens: { OverlayScreenResolver { Self.screen } }, panelFactory: capturingFactory)
 
     nonisolated(unsafe) var closed = false
     var closeToken: NSObjectProtocol?
@@ -315,9 +328,9 @@ struct OverlayRetainedWindowRealPanelTests {
       host.present(
         firstView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
     )
-    // The panel exists only after the first `present`, so the close observer is
-    // attached here rather than before — there is nothing to observe earlier.
-    let panel = try #require(firstView.window)
+    #expect(constructedPanels.count == 1, "the first presentation built more than one panel")
+    let panel = try #require(constructedPanels.first)
+    #expect(firstView.window === panel, "the view attached to a DIFFERENT panel than was built")
     closeToken = NotificationCenter.default.addObserver(
       forName: NSWindow.willCloseNotification, object: panel, queue: nil
     ) { _ in closed = true }
@@ -335,6 +348,9 @@ struct OverlayRetainedWindowRealPanelTests {
       host.present(
         secondView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
     )
+    #expect(
+      constructedPanels.count == 1,
+      "showing after a hide built a SECOND real panel — the window is not retained")
     let secondPanel = try #require(secondView.window)
 
     #expect(

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
@@ -1,678 +1,757 @@
-#if DEBUG
-// **The whole file is DEBUG-only, and that is structural rather than stylistic.**
-// Every case here reads a `*ForTesting` accessor, and those live inside `#if
-// DEBUG` on the types they belong to. Without this wrapper the RELEASE build of
-// the test target does not compile — which a Debug-only local run cannot see, by
-// construction, and which CI's `build-release` job catches instead.
-  import AppKit
-  import CoreGraphics
-  import EnviousWisprCore
-  import SwiftUI
-  import Testing
-
-  @testable import EnviousWisprAppKit
-
-  /// #2292 chunk C3. The retained window.
-  ///
-  /// **Product Outcome.** When these fail the user sees the pill flicker as it is
-  /// destroyed and rebuilt (#930), jump sideways after they dragged it (#2195), or
-  /// a hidden window keeps swallowing clicks over an empty patch of screen.
-  ///
-  /// These touch AppKit, so they build a real `NSPanel` — that is the point. The
-  /// probe on 2026-08-21 established what a retained panel costs
-  /// (`docs/audits/2026-08-21-overlay-probe-results.md`); this suite establishes
-  /// that OUR host retains exactly one and places it correctly. Screens are faked
-  /// so geometry is deterministic and a full-screen space is reachable, neither of
-  /// which a test can arrange on a real display.
-  @MainActor
-  @Suite(.tags(.productOutcome))
-  struct OverlayWindowHostTests {
-
-    init() { _ = NSApplication.shared }
-
-    private static let screen = ScreenGeometry(
-      id: ScreenID(rawValue: 1),
-      frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
-      visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
-
-    /// The same display with a full-screen space present. `visibleFrame` does NOT
-    /// shrink when another app goes full screen (#1341, measured 2026-07-17), so
-    /// the Bottom rule drops to the true screen edge instead.
-    private static let fullScreened = ScreenGeometry(
-      id: ScreenID(rawValue: 1),
-      frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
-      visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860),
-      hasFullScreenSpace: true)
-
-    /// **Orders the panel out when the test ends.**
-    ///
-    /// These tests build REAL `NSPanel`s and `orderFrontRegardless()` them, which
-    /// is the point — the suite is about window behaviour. But `NSApp` retains an
-    /// ordered-in window, so without this every case leaves a floating pill on the
-    /// developer's screen for the life of the xctest process. Measured: 34 of them
-    /// stacked over the founder's terminal, from one lane.
-    ///
-    /// Not a production change and not a seam on a guard: the test orders out what
-    /// the test ordered in, using the DEBUG accessor that already exists.
-    private static func makeHost(
-      _ geometry: @escaping @autoclosure () -> ScreenGeometry = screen
-    ) -> OverlayWindowHost {
-      OverlayWindowHost(screens: { OverlayScreenResolver { geometry() } })
-    }
-
-    private static func host() -> OverlayWindowHost { makeHost() }
-
-    /// A view whose FRAME and FITTING size are independently settable.
-    ///
-    /// **The earlier fixture made every value coincide**, so no test could tell a
-    /// `.fixed` width from a fitting size from a frame fallback — three different
-    /// code paths producing one indistinguishable number. Cloud review named it;
-    /// a plain `NSView` also reports `fittingSize == .zero`, which is what made
-    /// the coincidence invisible.
-    private final class SizedView: NSView {
-      var fitting: NSSize = .zero
-      override var intrinsicContentSize: NSSize { fitting }
-    }
-
-    private static func view(
-      width: CGFloat, height: CGFloat, fitting: NSSize? = nil
-    ) -> SizedView {
-      let v = SizedView(frame: NSRect(x: 0, y: 0, width: width, height: height))
-      v.fitting = fitting ?? .zero
-      return v
-    }
-
-    /// **The headline metric of the whole change.** The shipped panel destroys and
-    /// rebuilds itself on every panel-replacing transition, and four compensating
-    /// mechanisms exist only because of that.
-    @Test("one panel is constructed however many presentations arrive")
-    func onePanelForEveryPresentation() {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      for i in 0..<12 {
-        h.present(
-          Self.view(width: 185 + CGFloat(i), height: 44), width: .fixed(185 + CGFloat(i)),
-          fixedHeight: nil, isFresh: i == 0, position: .bottom)
-      }
-      h.hide()
-      h.present(
-        Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-
-      #expect(h.panelConstructionCount == 1)
-    }
-
-    /// #2195 end to end through the host, not just through the placement value.
-    @Test("a continuing presentation keeps the pill where the user dragged it")
-    func continuingKeepsTheDraggedPosition() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-
-      // The user drags it well left of centre. `windowDidMove` is how the host
-      // learns; there is no rebuild for the fact to survive.
-      panel.setFrameOrigin(NSPoint(x: 120, y: 85))
-      h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
-
-      h.present(
-        Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: false,
-        position: .bottom)
-
-      #expect(panel.frame.origin.x == 120, "the pill snapped back to centre — this is #2195")
-    }
-
-    /// The paired case: a genuinely FRESH presentation must still centre, or the
-    /// guard above is satisfied by a host that never centres anything.
-    @Test("a fresh presentation is centred even after a drag")
-    func freshRecentresAfterADrag() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      panel.setFrameOrigin(NSPoint(x: 120, y: 85))
-      h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
-      h.hide()
-
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-
-      // Within a point, not exact: **AppKit aligns a window frame to whole
-      // points**, so a placement value of 663.5 lands at 663.0. The value type is
-      // right and the window is right; an exact float comparison against the
-      // unrounded computation is what was wrong. Half a point is tight enough that
-      // a pill left at 120 still fails this.
-      #expect(abs(panel.frame.origin.x - (Self.screen.visibleFrame.midX - 92.5)) <= 0.5)
-    }
-
-    /// **A programmatic move is not a drag**, and telling them apart is what makes
-    /// anchor promotion safe. The probe measured `NSEvent.pressedMouseButtons`
-    /// reading 0 even mid-drag, so the depth flag is the only working
-    /// discriminator and this is its guard.
-    @Test("the host's own frame changes never count as a user drag")
-    func programmaticMovesAreNotDrags() {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      // Every present/resize/reposition below moves the panel, and each fires
-      // `windowDidMove` for real.
-      h.resizeCurrentPresentation(to: CGSize(width: 240, height: 60))
-      h.repositionForActiveSpaceChange()
-      h.present(
-        Self.view(width: 300, height: 60), width: .fixed(300), fixedHeight: nil, isFresh: false,
-        position: .bottom)
-
-      #expect(
-        h.placementForTesting.isUserAnchored(on: Self.screen.id) == false,
-        "the host mistook its own frame change for the user dragging the pill")
-    }
-
-    @Test("a real drag does count")
-    func aRealDragCounts() throws {
-      // Paired with the case above: a host that never promotes would pass it.
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      panel.setFrameOrigin(NSPoint(x: 400, y: 300))
-      h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
-
-      #expect(h.placementForTesting.isUserAnchored(on: Self.screen.id))
-    }
-
-    /// `orderOut`, never `close`. Closing is what forces the rebuild.
-    @Test("hiding orders the panel out and keeps it alive")
-    func hideOrdersOutWithoutClosing() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      #expect(panel.isVisible)
-
-      h.hide()
-
-      #expect(panel.isVisible == false, "a hidden panel still on screen swallows clicks")
-      #expect(h.panelForTesting === panel, "hiding released the panel — it must be retained")
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      #expect(h.panelConstructionCount == 1, "showing after a hide rebuilt the panel")
-    }
-
-    /// **`hide()` must ORDER OUT, and a mutation control is what proved this test
-    /// was needed.** Substituting `close()` for `orderOut` left all eight cases
-    /// green: with `isReleasedWhenClosed = false` a closed panel is still alive,
-    /// still the same instance, still `isVisible == false`, and the construction
-    /// count is unchanged — every assertion the suite had. The distinction that
-    /// matters is not observable through any of them.
-    ///
-    /// `close()` posts `willCloseNotification`; `orderOut` does not. Observing the
-    /// notification needs no production seam and no text matching, so it holds
-    /// whatever the method is called. The C5 freeze assertion (zero `.close()`
-    /// calls in the overlay module) is a second, structural protection — but it
-    /// does not exist yet, and deferring to it would have left the central claim
-    /// of this change unguarded for two chunks.
-    @Test("hiding never closes the window")
-    func hideNeverCloses() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-
-      nonisolated(unsafe) var closed = false
-      let token = NotificationCenter.default.addObserver(
-        forName: NSWindow.willCloseNotification, object: panel, queue: nil
-      ) { _ in closed = true }
-      defer { NotificationCenter.default.removeObserver(token) }
-
-      h.hide()
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      h.hide()
-
-      #expect(
-        closed == false,
-        "the panel was CLOSED rather than ordered out — every rebuild this change removes comes from that")
-    }
-
-    /// **Three sizing paths, three DIFFERENT numbers**, so each is separable.
-    @Test("fixed, fitting and frame-fallback widths are told apart")
-    func sizingPathsAreDistinguishable() throws {
-      // fixed 300, fitting 211, frame 150 — no two alike.
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      let v = Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58))
-
-      h.present(v, width: .fixed(300), fixedHeight: nil, isFresh: true, position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      #expect(panel.frame.width == 300, "a fixed width was not honoured")
-      #expect(panel.frame.height == 58, "height did not come from the fitting size")
-
-      h.present(
-        Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58)),
-        width: .measured, fixedHeight: nil, isFresh: true, position: .bottom)
-      #expect(panel.frame.width == 211, "a measured width did not come from the fitting size")
-
-      // Fitting size zero: the frame is the only remaining truth.
-      h.present(
-        Self.view(width: 150, height: 40), width: .measured, fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      #expect(panel.frame.width == 150, "the frame fallback did not apply")
-    }
-
-    /// A presentation that cannot be sized must not present. A zero-sized panel is
-    /// an invisible pill that reports success — the failure nothing would report.
-    @Test("a presentation that cannot be sized is refused, not shown at zero")
-    func unsizablePresentationIsRefused() {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      let empty = Self.view(width: 0, height: 0)
-      h.present(empty, width: .measured, fixedHeight: nil, isFresh: true, position: .bottom)
-
-      #expect(h.panelForTesting == nil, "an unsizable presentation created a zero-sized window")
-      #expect(h.panelConstructionCount == 0)
-      // A retained panel makes `panel != nil` useless as a success signal, and the
-      // shipped import-status owner depends on exactly that check.
-      #expect(
-        h.present(empty, width: .measured, fixedHeight: nil, isFresh: true, position: .bottom)
-          == false,
-        "a refused presentation reported success — the slot owner would claim it")
-    }
-
-    /// A morph must actually swap the content. Nothing else in this suite would
-    /// notice a host that resized the panel and left the old view in it.
-    @Test("morphing replaces the panel's content view")
-    func morphReplacesContent() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-
-      let replacement = Self.view(width: 320, height: 120)
-      h.present(replacement, width: .fixed(320), fixedHeight: nil, isFresh: false, position: .bottom)
-
-      #expect(panel.contentView === replacement, "the panel kept the previous presentation's view")
-    }
-
-    /// **The copied panel configuration is pinned.** Removing the floating level,
-    /// all-Spaces behaviour, movability or the shadow would otherwise leave every
-    /// test green while changing what the user sees: a pill behind other windows,
-    /// one that vanishes on a Space swipe, or one that cannot be dragged.
-    @Test("the panel's shipped configuration is unchanged")
-    func panelConfigurationIsPinned() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-
-      #expect(panel.level == .floating)
-      #expect(panel.collectionBehavior == [.canJoinAllSpaces, .fullScreenAuxiliary])
-      #expect(panel.isMovableByWindowBackground)
-      #expect(panel.hasShadow)
-      #expect(panel.isOpaque == false)
-      #expect(panel.isReleasedWhenClosed == false, "a released panel cannot be retained")
-      #expect(panel.styleMask.contains(.borderless))
-      #expect(panel.styleMask.contains(.nonactivatingPanel))
-    }
-
-    /// Top continuity through the HOST, not just the placement value: a
-    /// content-sized outgoing pill re-anchors by its top edge, a fixed-height one
-    /// by its centre. Nothing at host level distinguished these.
-    @Test("Top continuity re-anchors by top edge when the outgoing pill was content-sized")
-    func topContinuityContentSized() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44, fitting: NSSize(width: 185, height: 44)),
-        width: .fixed(185), fixedHeight: nil, isFresh: true, position: .top)
-      let panel = try #require(h.panelForTesting)
-      let before = panel.frame
-
-      h.present(
-        Self.view(width: 185, height: 92, fitting: NSSize(width: 185, height: 92)),
-        width: .fixed(185), fixedHeight: nil, isFresh: false, position: .top)
-
-      #expect(abs(panel.frame.maxY - before.maxY) <= 0.5, "the top edge moved")
-    }
-
-    @Test("Top continuity re-anchors by centre when the outgoing pill had a fixed height")
-    func topContinuityFixedHeight() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
-        position: .top)
-      let panel = try #require(h.panelForTesting)
-      let before = panel.frame
-
-      h.present(
-        Self.view(width: 185, height: 44, fitting: NSSize(width: 185, height: 44)),
-        width: .fixed(185), fixedHeight: nil, isFresh: false, position: .top)
-
-      #expect(abs(panel.frame.midY - before.midY) <= 0.5, "the centre moved")
-    }
-
-    /// **Component-contract guard, NOT product evidence.** Asked directly whether
-    /// this pairing is reachable, cloud review answered no: no current production
-    /// path produces a measured width with a fixed height, since a faithful
-    /// wiring yields either `fitToContent -> (.measured, nil)` or fixed
-    /// dimensions, and the only reserved height belongs to the fixed-width
-    /// recording pill. It is kept because `present` deliberately exposes the two
-    /// axes independently, so the contract is real even where no caller uses it —
-    /// but it must never be cited as coverage of a shipped behaviour.
-    ///
-    /// **The one combination that separates the two sizing predicates.**
-    ///
-    /// `currentWasContentSized` keys on HEIGHT. The earlier predicate ORed the
-    /// axes — `width == .measured || fixedHeight == nil` — which agrees with the
-    /// correct one everywhere EXCEPT a measured width with a fixed height. Without
-    /// this case the fix is real and completely unguarded: a mutant restoring the
-    /// old predicate stays green.
-    ///
-    /// A measured-width, fixed-height pill is content-sized HORIZONTALLY and fixed
-    /// VERTICALLY, so Top continuity must re-anchor it by its CENTRE.
-    @Test("a measured width with a fixed height is not content-sized vertically")
-    func measuredWidthWithFixedHeightIsNotContentSized() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58)),
-        width: .measured, fixedHeight: 92, isFresh: true, position: .top)
-      let panel = try #require(h.panelForTesting)
-      #expect(panel.frame.width == 211)
-      #expect(panel.frame.height == 92)
-      let before = panel.frame
-
-      h.present(
-        Self.view(width: 185, height: 44, fitting: NSSize(width: 185, height: 44)),
-        width: .fixed(185), fixedHeight: nil, isFresh: false, position: .top)
-
-      #expect(
-        abs(panel.frame.midY - before.midY) <= 0.5,
-        "re-anchored by top edge — the outgoing pill's fixed HEIGHT makes it centre-anchored")
-    }
-
-    /// **Hiding must release the hosting view, and nothing observed that until a
-    /// mutant survived.** The shipped panel got this for free by being destroyed.
-    /// `RecordingOverlayView` runs a `.task` polling the audio level every 50 ms
-    /// and `OverlayCapsuleBackground` runs a `repeatForever` animation; a retained
-    /// panel that is merely ordered out keeps both running for the rest of the
-    /// session, invisibly and forever.
-    ///
-    /// The window is correctly hidden either way, so no visibility assertion can
-    /// see it — this had to be a direct observation of the content view.
-    @Test("hiding releases the hosting view so its work stops")
-    func hideReleasesTheHostingView() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      #expect(panel.contentView != nil)
-
-      h.hide()
-
-      #expect(
-        panel.contentView == nil,
-        "a hidden pill kept its view, so its 50ms polling loop runs for the rest of the session")
-    }
-
-    /// **The host observes Space changes itself, and nothing in the suite covered
-    /// this before it moved.** The panel used to own the observer and hand the
-    /// geometry back across the seam; every fact the callback needs — the anchor,
-    /// the screen, the window — already lives here.
-    ///
-    /// Posting the real `NSWorkspace` notification is the observation: it proves
-    /// the host is REGISTERED, which a direct call to
-    /// `repositionForActiveSpaceChange()` would not.
-    @Test("the host re-anchors a Bottom pill when the active Space changes")
-    func spaceChangeReachesTheHost() throws {
-      var geometry = Self.screen
-      let h = OverlayWindowHost(screens: { OverlayScreenResolver { geometry } })
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      #expect(panel.frame.origin.y == 85)
-
-      // A full-screen space appears: `visibleFrame` does not shrink, so the pill
-      // must drop to the true screen edge (#1341).
-      geometry = Self.fullScreened
-      NSWorkspace.shared.notificationCenter.post(
-        name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
-      RunLoop.main.run(until: Date())  // settle: deliver a posted notification, no polling
-
-      #expect(
-        panel.frame.origin.y == 0,
-        "the Space-change notification never reached the host — it is not registered")
-
-      // **A SECOND swipe, and this is the assertion that matters.** The first one
-      // proves only that the host is listening. The host moves the window itself
-      // to re-anchor, and that move fires `windowDidMove` — so if the programmatic
-      // guard did not hold, the host would record its OWN reposition as the user
-      // dragging the pill and refuse to follow Spaces ever again. One swipe cannot
-      // see that; the pill would look correct and then silently stop.
-      geometry = Self.screen
-      NSWorkspace.shared.notificationCenter.post(
-        name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
-      RunLoop.main.run(until: Date())  // settle: deliver a posted notification, no polling
-
-      #expect(
-        panel.frame.origin.y == 85,
-        "the first automatic Space move was mistaken for a drag, so the pill stopped following Spaces")
-    }
-
-    /// A `.measured` width must come from the view, and no default may stand in
-    /// for it. Escape Recovery's real width is computed from text metrics, so a
-    /// literal there would look plausible and silently disagree with the pill.
-    @Test("a measured width is taken from the view, not from a default")
-    func measuredWidthComesFromTheView() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 271, height: 58), width: .measured, fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      #expect(panel.frame.width == 271)
-    }
-
-    /// The #1060 reserved interaction frame survives the migration. It is NOT
-    /// universal — only the non-preview recording pill asks for it — so the host
-    /// must honour a fixed height when given one and measure when not.
-    @Test("a fixed height is honoured and overrides the view's own")
-    func fixedHeightIsHonoured() throws {
-      let h = Self.host()
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-      #expect(panel.frame.height == 92)
-    }
-
-    // MARK: - A continuation stays on ITS OWN display (#2292 C10)
-
-    /// A SHORT second display, and short is the whole point.
-    ///
-    /// The clamp is `min(requestedY, visibleFrame.maxY - height - margin)`, so
-    /// reading the wrong screen only MOVES the pill when the wrong screen's
-    /// ceiling is LOWER. Two displays of the same height give identical answers
-    /// and the defect is invisible; so does a taller second display, because a
-    /// looser clamp changes nothing. A short one is the case that bites, and the
-    /// first version of this test used a tall one and passed against the bug.
-    private static let shortSecondary = ScreenGeometry(
-      id: ScreenID(rawValue: 2),
-      frame: CGRect(x: 0, y: 0, width: 1512, height: 400),
-      visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 380))
-
-    /// A host whose POINTER screen and CONTAINING screen can disagree, which is
-    /// exactly the situation a moved pointer creates.
-    private static func splitHost(
-      pointer: @escaping () -> ScreenGeometry,
-      containing: @escaping (CGRect) -> ScreenGeometry?
-    ) -> OverlayWindowHost {
-      OverlayWindowHost(
-        screens: { OverlayScreenResolver(containing: containing, current: pointer) })
-    }
-
-    /// **The regression, stated as the user sees it.** Start dictating on the
-    /// main display, move the pointer to a shorter second display, and the
-    /// recording-to-processing transition yanks the pill downward on the display
-    /// it is still sitting on.
-    ///
-    /// The mechanism is a coordinate-space mix: the continuation inherits
-    /// `panel.frame`, which is in the ORIGINAL display's space, while the clamp
-    /// measured it against the POINTER's display. A Top pill sits at 845 on the
-    /// tall display; the short display's ceiling is 280, so the wrong anchor
-    /// drags it 565 points down a screen the pointer is not even on.
-    @Test("a continuation is clamped against the display it is on, not the pointer's")
-    func continuationKeepsItsOwnScreen() throws {
-      var pointer = Self.screen
-      let h = Self.splitHost(pointer: { pointer }, containing: { _ in Self.screen })
-      defer { h.panelForTesting?.orderOut(nil) }
-
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
-        position: .top)
-      let first = try #require(h.panelForTesting).frame
-
-      // The pointer moves to the SHORT display. The panel has not moved.
-      pointer = Self.shortSecondary
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: false,
-        position: .top)
-      let after = try #require(h.panelForTesting).frame
-
-      #expect(
-        after.origin.y == first.origin.y,
-        "the pill was dragged down its own display by a clamp read off the pointer's screen")
-      #expect(after.origin.x == first.origin.x, "a continuation must preserve X (#2195)")
-    }
-
-    /// **The fallback is the disconnected-display case.** When nothing contains
-    /// the panel any more, the pointer's screen is the right answer: re-home the
-    /// pill onto a screen that exists rather than clamp it against one that does
-    /// not. Asserted so the `?? screen` is a decision rather than an accident.
-    @Test("a continuation with no containing screen falls back to the pointer's")
-    func continuationFallsBackWhenItsScreenIsGone() throws {
-      let h = Self.splitHost(pointer: { Self.screen }, containing: { _ in nil })
-      defer { h.panelForTesting?.orderOut(nil) }
-
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
-        position: .top)
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: false,
-        position: .top)
-
-      let panel = try #require(h.panelForTesting)
-      #expect(
-        panel.frame.maxY <= Self.screen.visibleFrame.maxY - OverlayPlacementState.topClampMargin,
-        "the fallback produced a frame outside the only screen that exists")
-    }
-
-    /// **The twin C10 missed, found by the review gate and unguarded until now.**
-    /// A resize is a continuation by definition — the pill is on screen and Live
-    /// Preview is growing it — so it has exactly the same coordinate-space
-    /// problem as a transition, in a different method.
-    ///
-    /// This case exists because the mutation control for the fix came back
-    /// UNCAUGHT: the repair was right and nothing would have failed if it were
-    /// reverted, which is the state that let the defect live in two methods in
-    /// the first place.
-    @Test("a resize is clamped against the display the pill is on")
-    func resizeKeepsItsOwnScreen() throws {
-      var pointer = Self.screen
-      let h = Self.splitHost(pointer: { pointer }, containing: { _ in Self.screen })
-      defer { h.panelForTesting?.orderOut(nil) }
-
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
-        position: .top)
-      let before = try #require(h.panelForTesting).frame
-
-      // Live Preview grows the pill while the pointer sits on the SHORT display.
-      pointer = Self.shortSecondary
-      h.resizeCurrentPresentation(to: CGSize(width: 185, height: 92))
-
-      let after = try #require(h.panelForTesting).frame
-      #expect(
-        after.origin.y == before.origin.y,
-        "the growing pill was dragged down its own display by the pointer's clamp")
-    }
-
-    /// **The third member of the screen class, found by enumerating it rather
-    /// than by a third review round.** A drag ends with the panel where it was
-    /// dropped and the pointer where it is; releasing across a display boundary
-    /// separates them. The recorded id is what `isUserAnchored(on:)` checks, so
-    /// the wrong one makes a deliberately placed pill stop counting as
-    /// user-anchored on its own display.
-    @Test("a drag records the screen the panel landed on, not the pointer's")
-    func dragRecordsTheLandingScreen() throws {
-      let h = Self.splitHost(pointer: { Self.shortSecondary }, containing: { _ in Self.screen })
-      defer { h.panelForTesting?.orderOut(nil) }
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-        position: .bottom)
-      let panel = try #require(h.panelForTesting)
-
-      panel.setFrameOrigin(NSPoint(x: 120, y: 85))
-      h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
-
-      #expect(
-        h.placementForTesting.isUserAnchored(on: ScreenID(rawValue: 1)),
-        """
-        the drag was recorded against the pointer's display, so the pill is not \
-        user-anchored on the one it is actually on
-        """)
-      #expect(
-        !h.placementForTesting.isUserAnchored(on: ScreenID(rawValue: 2)),
-        "the drag was recorded against a display the panel never touched")
-    }
-
-    /// A FRESH presentation still belongs where the POINTER is, which is the
-    /// shipped target resolution and must not be collateral damage of the fix
-    /// above. Without this, anchoring everything to the containing screen would
-    /// look correct and quietly stop new pills following the user.
-    ///
-    /// Asserted on Y, not X: both fixtures span the same horizontal range, so a
-    /// centre-X assertion cannot tell them apart and would pass either way.
-    @Test("a fresh presentation still follows the pointer's screen")
-    func freshPresentationFollowsThePointer() throws {
-      let h = Self.splitHost(pointer: { Self.shortSecondary }, containing: { _ in Self.screen })
-      defer { h.panelForTesting?.orderOut(nil) }
-
-      h.present(
-        Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
-        position: .top)
-
-      let panel = try #require(h.panelForTesting)
-      let expected = OverlayPlacementState.clampedOriginY(
-        requestedY: OverlayPlacementState.freshOriginY(for: .top, on: Self.shortSecondary),
-        height: 92, on: Self.shortSecondary)
-      #expect(
-        panel.frame.origin.y == expected,
-        "a fresh pill was placed on the containing screen instead of the pointer's")
-    }
+import AppKit
+import CoreGraphics
+import EnviousWisprCore
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2292 chunk C3. The retained window.
+///
+/// **Product Outcome.** When these fail the user sees the pill flicker as it is
+/// destroyed and rebuilt (#930), jump sideways after they dragged it (#2195), or
+/// a hidden window keeps swallowing clicks over an empty patch of screen.
+///
+/// These touch AppKit, so they build a real `NSPanel` — that is the point. The
+/// probe on 2026-08-21 established what a retained panel costs
+/// (`docs/audits/2026-08-21-overlay-probe-results.md`); this suite establishes
+/// that OUR host retains exactly one and places it correctly. Screens are faked
+/// so geometry is deterministic and a full-screen space is reachable, neither of
+/// which a test can arrange on a real display.
+///
+/// **Every case observes the panel through an `OverlayPanelCommandRecorder`
+/// rather than a `#if DEBUG` accessor on the host (#2377, P6-C2).** That is what
+/// lets this whole file — and its production counterpart — build and run in
+/// RELEASE: the recorder is a real `NSPanel` subclass injected through the same
+/// `OverlayPanelFactory` seam production code uses, not a compiled-out hatch.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayWindowHostTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static let screen = ScreenGeometry(
+    id: ScreenID(rawValue: 1),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
+
+  /// The same display with a full-screen space present. `visibleFrame` does NOT
+  /// shrink when another app goes full screen (#1341, measured 2026-07-17), so
+  /// the Bottom rule drops to the true screen edge instead.
+  private static let fullScreened = ScreenGeometry(
+    id: ScreenID(rawValue: 1),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860),
+    hasFullScreenSpace: true)
+
+  private static func makeHost(
+    _ geometry: @escaping @autoclosure () -> ScreenGeometry = screen,
+    panelFactory: OverlayPanelFactory = .live
+  ) -> OverlayWindowHost {
+    OverlayWindowHost(
+      screens: { OverlayScreenResolver { geometry() } }, panelFactory: panelFactory)
   }
-#endif
+
+  private static func host(panelFactory: OverlayPanelFactory = .live) -> OverlayWindowHost {
+    makeHost(panelFactory: panelFactory)
+  }
+
+  /// A view whose FRAME and FITTING size are independently settable.
+  ///
+  /// **The earlier fixture made every value coincide**, so no test could tell a
+  /// `.fixed` width from a fitting size from a frame fallback — three different
+  /// code paths producing one indistinguishable number. Cloud review named it;
+  /// a plain `NSView` also reports `fittingSize == .zero`, which is what made
+  /// the coincidence invisible.
+  private final class SizedView: NSView {
+    var fitting: NSSize = .zero
+    override var intrinsicContentSize: NSSize { fitting }
+  }
+
+  private static func view(
+    width: CGFloat, height: CGFloat, fitting: NSSize? = nil
+  ) -> SizedView {
+    let v = SizedView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+    v.fitting = fitting ?? .zero
+    return v
+  }
+
+  /// **The headline metric of the whole change.** The shipped panel destroys and
+  /// rebuilds itself on every panel-replacing transition, and four compensating
+  /// mechanisms exist only because of that.
+  @Test("one panel is constructed however many presentations arrive")
+  func onePanelForEveryPresentation() {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    for i in 0..<12 {
+      h.present(
+        Self.view(width: 185 + CGFloat(i), height: 44), width: .fixed(185 + CGFloat(i)),
+        fixedHeight: nil, isFresh: i == 0, position: .bottom)
+    }
+    h.hide()
+    h.present(
+      Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+
+    #expect(recorder.constructionCount == 1)
+  }
+
+  /// #2195 end to end through the host, not just through the placement value.
+  @Test("a continuing presentation keeps the pill where the user dragged it")
+  func continuingKeepsTheDraggedPosition() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+
+    // The user drags it well left of centre. `windowDidMove` is how the host
+    // learns; there is no rebuild for the fact to survive.
+    panel.setFrameOrigin(NSPoint(x: 120, y: 85))
+    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+
+    h.present(
+      Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: false,
+      position: .bottom)
+
+    #expect(panel.frame.origin.x == 120, "the pill snapped back to centre — this is #2195")
+  }
+
+  /// The paired case: a genuinely FRESH presentation must still centre, or the
+  /// guard above is satisfied by a host that never centres anything.
+  @Test("a fresh presentation is centred even after a drag")
+  func freshRecentresAfterADrag() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    panel.setFrameOrigin(NSPoint(x: 120, y: 85))
+    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+    h.hide()
+
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+
+    // Within a point, not exact: **AppKit aligns a window frame to whole
+    // points**, so a placement value of 663.5 lands at 663.0. The value type is
+    // right and the window is right; an exact float comparison against the
+    // unrounded computation is what was wrong. Half a point is tight enough that
+    // a pill left at 120 still fails this.
+    #expect(abs(panel.frame.origin.x - (Self.screen.visibleFrame.midX - 92.5)) <= 0.5)
+  }
+
+  /// **A programmatic move is not a drag**, and telling them apart is what makes
+  /// anchor promotion safe. The probe measured `NSEvent.pressedMouseButtons`
+  /// reading 0 even mid-drag, so the depth flag is the only working
+  /// discriminator and this is its guard.
+  ///
+  /// **Observed through the FRAME, not `placementForTesting`.** A programmatic
+  /// move wrongly promoted to a drag is invisible in isolation — the panel is
+  /// still exactly where the host put it — so the proof is a SECOND, continuing
+  /// presentation: an anchored pill preserves X; a merely-repositioned one
+  /// recentres. `continuingKeepsTheDraggedPosition` is this test's mirror image.
+  @Test("the host's own frame changes never count as a user drag")
+  func programmaticMovesAreNotDrags() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    // Every present/resize/reposition below moves the panel, and each fires
+    // `windowDidMove` for real.
+    h.resizeCurrentPresentation(to: CGSize(width: 240, height: 60))
+    h.repositionForActiveSpaceChange()
+    h.present(
+      Self.view(width: 300, height: 60), width: .fixed(300), fixedHeight: nil, isFresh: false,
+      position: .bottom)
+
+    let recentredX = Self.screen.visibleFrame.midX - 300 / 2
+    #expect(
+      abs(panel.frame.origin.x - recentredX) <= 0.5,
+      """
+      the host mistook its own frame change for the user dragging the pill, so the \
+      continuation preserved X instead of recentring
+      """)
+  }
+
+  @Test("a real drag does count")
+  func aRealDragCounts() throws {
+    // Paired with the case above: a host that never promotes would recentre
+    // here too.
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    panel.setFrameOrigin(NSPoint(x: 400, y: 300))
+    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+
+    // The same proof as `continuingKeepsTheDraggedPosition`: a continuation
+    // preserves X only when the drag was recorded as user-anchored.
+    h.present(
+      Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: false,
+      position: .bottom)
+
+    #expect(
+      panel.frame.origin.x == 400,
+      """
+      the drag was not recorded as user-anchored, so the continuation recentred instead of \
+      preserving X
+      """)
+  }
+
+  /// `orderOut`, never `close`. Closing is what forces the rebuild.
+  @Test("hiding orders the panel out and keeps it alive")
+  func hideOrdersOutWithoutClosing() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    #expect(panel.isVisible)
+
+    h.hide()
+
+    #expect(panel.isVisible == false, "a hidden panel still on screen swallows clicks")
+    #expect(recorder.panel === panel, "hiding released the panel — it must be retained")
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    #expect(recorder.constructionCount == 1, "showing after a hide rebuilt the panel")
+  }
+
+  /// **`hide()` must ORDER OUT, and a mutation control is what proved this test
+  /// was needed.** Substituting `close()` for `orderOut` left all eight cases
+  /// green: with `isReleasedWhenClosed = false` a closed panel is still alive,
+  /// still the same instance, still `isVisible == false`, and the construction
+  /// count is unchanged — every assertion the suite had. The distinction that
+  /// matters is not observable through any of them.
+  ///
+  /// `close()` posts `willCloseNotification`; `orderOut` does not. Observing the
+  /// notification needs no production seam and no text matching, so it holds
+  /// whatever the method is called. The C5 freeze assertion (zero `.close()`
+  /// calls in the overlay module) is a second, structural protection — but it
+  /// does not exist yet, and deferring to it would have left the central claim
+  /// of this change unguarded for two chunks.
+  @Test("hiding never closes the window")
+  func hideNeverCloses() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+
+    nonisolated(unsafe) var closed = false
+    let token = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification, object: panel, queue: nil
+    ) { _ in closed = true }
+    defer { NotificationCenter.default.removeObserver(token) }
+
+    h.hide()
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    h.hide()
+
+    #expect(
+      closed == false,
+      "the panel was CLOSED rather than ordered out — every rebuild this change removes comes from that"
+    )
+    // Command-log corroboration of the same fact, now that the recorder can
+    // observe it directly: `.close` must never appear.
+    #expect(
+      recorder.commands.contains { if case .close = $0 { true } else { false } } == false,
+      "the recorder saw a `.close` command — `hide()` must issue only `orderOut`")
+  }
+
+  /// **Three sizing paths, three DIFFERENT numbers**, so each is separable.
+  @Test("fixed, fitting and frame-fallback widths are told apart")
+  func sizingPathsAreDistinguishable() throws {
+    // fixed 300, fitting 211, frame 150 — no two alike.
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    let v = Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58))
+
+    h.present(v, width: .fixed(300), fixedHeight: nil, isFresh: true, position: .bottom)
+    let panel = try #require(recorder.panel)
+    #expect(panel.frame.width == 300, "a fixed width was not honoured")
+    #expect(panel.frame.height == 58, "height did not come from the fitting size")
+
+    h.present(
+      Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58)),
+      width: .measured, fixedHeight: nil, isFresh: true, position: .bottom)
+    #expect(panel.frame.width == 211, "a measured width did not come from the fitting size")
+
+    // Fitting size zero: the frame is the only remaining truth.
+    h.present(
+      Self.view(width: 150, height: 40), width: .measured, fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    #expect(panel.frame.width == 150, "the frame fallback did not apply")
+  }
+
+  /// A presentation that cannot be sized must not present. A zero-sized panel is
+  /// an invisible pill that reports success — the failure nothing would report.
+  @Test("a presentation that cannot be sized is refused, not shown at zero")
+  func unsizablePresentationIsRefused() {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    let empty = Self.view(width: 0, height: 0)
+    h.present(empty, width: .measured, fixedHeight: nil, isFresh: true, position: .bottom)
+
+    #expect(recorder.panel == nil, "an unsizable presentation created a zero-sized window")
+    #expect(recorder.constructionCount == 0)
+    // A retained panel makes `panel != nil` useless as a success signal, and the
+    // shipped import-status owner depends on exactly that check.
+    #expect(
+      h.present(empty, width: .measured, fixedHeight: nil, isFresh: true, position: .bottom)
+        == false,
+      "a refused presentation reported success — the slot owner would claim it")
+  }
+
+  /// A morph must actually swap the content. Nothing else in this suite would
+  /// notice a host that resized the panel and left the old view in it.
+  @Test("morphing replaces the panel's content view")
+  func morphReplacesContent() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+
+    let replacement = Self.view(width: 320, height: 120)
+    h.present(replacement, width: .fixed(320), fixedHeight: nil, isFresh: false, position: .bottom)
+
+    #expect(panel.contentView === replacement, "the panel kept the previous presentation's view")
+  }
+
+  /// **The copied panel configuration is pinned.** Removing the floating level,
+  /// all-Spaces behaviour, movability or the shadow would otherwise leave every
+  /// test green while changing what the user sees: a pill behind other windows,
+  /// one that vanishes on a Space swipe, or one that cannot be dragged.
+  @Test("the panel's shipped configuration is unchanged")
+  func panelConfigurationIsPinned() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+
+    #expect(panel.level == .floating)
+    #expect(panel.collectionBehavior == [.canJoinAllSpaces, .fullScreenAuxiliary])
+    #expect(panel.isMovableByWindowBackground)
+    #expect(panel.hasShadow)
+    #expect(panel.isOpaque == false)
+    #expect(panel.isReleasedWhenClosed == false, "a released panel cannot be retained")
+    #expect(panel.styleMask.contains(.borderless))
+    #expect(panel.styleMask.contains(.nonactivatingPanel))
+  }
+
+  /// Top continuity through the HOST, not just the placement value: a
+  /// content-sized outgoing pill re-anchors by its top edge, a fixed-height one
+  /// by its centre. Nothing at host level distinguished these.
+  @Test("Top continuity re-anchors by top edge when the outgoing pill was content-sized")
+  func topContinuityContentSized() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44, fitting: NSSize(width: 185, height: 44)),
+      width: .fixed(185), fixedHeight: nil, isFresh: true, position: .top)
+    let panel = try #require(recorder.panel)
+    let before = panel.frame
+
+    h.present(
+      Self.view(width: 185, height: 92, fitting: NSSize(width: 185, height: 92)),
+      width: .fixed(185), fixedHeight: nil, isFresh: false, position: .top)
+
+    #expect(abs(panel.frame.maxY - before.maxY) <= 0.5, "the top edge moved")
+  }
+
+  @Test("Top continuity re-anchors by centre when the outgoing pill had a fixed height")
+  func topContinuityFixedHeight() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
+      position: .top)
+    let panel = try #require(recorder.panel)
+    let before = panel.frame
+
+    h.present(
+      Self.view(width: 185, height: 44, fitting: NSSize(width: 185, height: 44)),
+      width: .fixed(185), fixedHeight: nil, isFresh: false, position: .top)
+
+    #expect(abs(panel.frame.midY - before.midY) <= 0.5, "the centre moved")
+  }
+
+  /// **Component-contract guard, NOT product evidence.** Asked directly whether
+  /// this pairing is reachable, cloud review answered no: no current production
+  /// path produces a measured width with a fixed height, since a faithful
+  /// wiring yields either `fitToContent -> (.measured, nil)` or fixed
+  /// dimensions, and the only reserved height belongs to the fixed-width
+  /// recording pill. It is kept because `present` deliberately exposes the two
+  /// axes independently, so the contract is real even where no caller uses it —
+  /// but it must never be cited as coverage of a shipped behaviour.
+  ///
+  /// **The one combination that separates the two sizing predicates.**
+  ///
+  /// `currentWasContentSized` keys on HEIGHT. The earlier predicate ORed the
+  /// axes — `width == .measured || fixedHeight == nil` — which agrees with the
+  /// correct one everywhere EXCEPT a measured width with a fixed height. Without
+  /// this case the fix is real and completely unguarded: a mutant restoring the
+  /// old predicate stays green.
+  ///
+  /// A measured-width, fixed-height pill is content-sized HORIZONTALLY and fixed
+  /// VERTICALLY, so Top continuity must re-anchor it by its CENTRE.
+  @Test("a measured width with a fixed height is not content-sized vertically")
+  func measuredWidthWithFixedHeightIsNotContentSized() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58)),
+      width: .measured, fixedHeight: 92, isFresh: true, position: .top)
+    let panel = try #require(recorder.panel)
+    #expect(panel.frame.width == 211)
+    #expect(panel.frame.height == 92)
+    let before = panel.frame
+
+    h.present(
+      Self.view(width: 185, height: 44, fitting: NSSize(width: 185, height: 44)),
+      width: .fixed(185), fixedHeight: nil, isFresh: false, position: .top)
+
+    #expect(
+      abs(panel.frame.midY - before.midY) <= 0.5,
+      "re-anchored by top edge — the outgoing pill's fixed HEIGHT makes it centre-anchored")
+  }
+
+  /// **Hiding must release the hosting view, and nothing observed that until a
+  /// mutant survived.** The shipped panel got this for free by being destroyed.
+  /// `RecordingOverlayView` runs a `.task` polling the audio level every 50 ms
+  /// and `OverlayCapsuleBackground` runs a `repeatForever` animation; a retained
+  /// panel that is merely ordered out keeps both running for the rest of the
+  /// session, invisibly and forever.
+  ///
+  /// The window is correctly hidden either way, so no visibility assertion can
+  /// see it — this had to be a direct observation of the content view.
+  @Test("hiding releases the hosting view so its work stops")
+  func hideReleasesTheHostingView() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    #expect(panel.contentView != nil)
+
+    h.hide()
+
+    #expect(
+      panel.contentView == nil,
+      "a hidden pill kept its view, so its 50ms polling loop runs for the rest of the session")
+  }
+
+  /// **The host observes Space changes itself, and nothing in the suite covered
+  /// this before it moved.** The panel used to own the observer and hand the
+  /// geometry back across the seam; every fact the callback needs — the anchor,
+  /// the screen, the window — already lives here.
+  ///
+  /// Posting the real `NSWorkspace` notification is the observation: it proves
+  /// the host is REGISTERED, which a direct call to
+  /// `repositionForActiveSpaceChange()` would not.
+  @Test("the host re-anchors a Bottom pill when the active Space changes")
+  func spaceChangeReachesTheHost() throws {
+    var geometry = Self.screen
+    let recorder = OverlayPanelCommandRecorder()
+    let h = OverlayWindowHost(
+      screens: { OverlayScreenResolver { geometry } }, panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    #expect(panel.frame.origin.y == 85)
+
+    // A full-screen space appears: `visibleFrame` does not shrink, so the pill
+    // must drop to the true screen edge (#1341).
+    geometry = Self.fullScreened
+    NSWorkspace.shared.notificationCenter.post(
+      name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
+    RunLoop.main.run(until: Date())  // settle: deliver a posted notification, no polling
+
+    #expect(
+      panel.frame.origin.y == 0,
+      "the Space-change notification never reached the host — it is not registered")
+
+    // **A SECOND swipe, and this is the assertion that matters.** The first one
+    // proves only that the host is listening. The host moves the window itself
+    // to re-anchor, and that move fires `windowDidMove` — so if the programmatic
+    // guard did not hold, the host would record its OWN reposition as the user
+    // dragging the pill and refuse to follow Spaces ever again. One swipe cannot
+    // see that; the pill would look correct and then silently stop.
+    geometry = Self.screen
+    NSWorkspace.shared.notificationCenter.post(
+      name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
+    RunLoop.main.run(until: Date())  // settle: deliver a posted notification, no polling
+
+    #expect(
+      panel.frame.origin.y == 85,
+      "the first automatic Space move was mistaken for a drag, so the pill stopped following Spaces"
+    )
+  }
+
+  /// A `.measured` width must come from the view, and no default may stand in
+  /// for it. Escape Recovery's real width is computed from text metrics, so a
+  /// literal there would look plausible and silently disagree with the pill.
+  @Test("a measured width is taken from the view, not from a default")
+  func measuredWidthComesFromTheView() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 271, height: 58), width: .measured, fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    #expect(panel.frame.width == 271)
+  }
+
+  /// The #1060 reserved interaction frame survives the migration. It is NOT
+  /// universal — only the non-preview recording pill asks for it — so the host
+  /// must honour a fixed height when given one and measure when not.
+  @Test("a fixed height is honoured and overrides the view's own")
+  func fixedHeightIsHonoured() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+    #expect(panel.frame.height == 92)
+  }
+
+  // MARK: - A continuation stays on ITS OWN display (#2292 C10)
+
+  /// A SHORT second display, and short is the whole point.
+  ///
+  /// The clamp is `min(requestedY, visibleFrame.maxY - height - margin)`, so
+  /// reading the wrong screen only MOVES the pill when the wrong screen's
+  /// ceiling is LOWER. Two displays of the same height give identical answers
+  /// and the defect is invisible; so does a taller second display, because a
+  /// looser clamp changes nothing. A short one is the case that bites, and the
+  /// first version of this test used a tall one and passed against the bug.
+  private static let shortSecondary = ScreenGeometry(
+    id: ScreenID(rawValue: 2),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 400),
+    visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 380))
+
+  /// A host whose POINTER screen and CONTAINING screen can disagree, which is
+  /// exactly the situation a moved pointer creates.
+  private static func splitHost(
+    pointer: @escaping () -> ScreenGeometry,
+    containing: @escaping (CGRect) -> ScreenGeometry?,
+    panelFactory: OverlayPanelFactory = .live
+  ) -> OverlayWindowHost {
+    OverlayWindowHost(
+      screens: { OverlayScreenResolver(containing: containing, current: pointer) },
+      panelFactory: panelFactory)
+  }
+
+  /// **The regression, stated as the user sees it.** Start dictating on the
+  /// main display, move the pointer to a shorter second display, and the
+  /// recording-to-processing transition yanks the pill downward on the display
+  /// it is still sitting on.
+  ///
+  /// The mechanism is a coordinate-space mix: the continuation inherits
+  /// `panel.frame`, which is in the ORIGINAL display's space, while the clamp
+  /// measured it against the POINTER's display. A Top pill sits at 845 on the
+  /// tall display; the short display's ceiling is 280, so the wrong anchor
+  /// drags it 565 points down a screen the pointer is not even on.
+  @Test("a continuation is clamped against the display it is on, not the pointer's")
+  func continuationKeepsItsOwnScreen() throws {
+    var pointer = Self.screen
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.splitHost(
+      pointer: { pointer }, containing: { _ in Self.screen }, panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
+      position: .top)
+    let first = try #require(recorder.panel).frame
+
+    // The pointer moves to the SHORT display. The panel has not moved.
+    pointer = Self.shortSecondary
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: false,
+      position: .top)
+    let after = try #require(recorder.panel).frame
+
+    #expect(
+      after.origin.y == first.origin.y,
+      "the pill was dragged down its own display by a clamp read off the pointer's screen")
+    #expect(after.origin.x == first.origin.x, "a continuation must preserve X (#2195)")
+  }
+
+  /// **The fallback is the disconnected-display case.** When nothing contains
+  /// the panel any more, the pointer's screen is the right answer: re-home the
+  /// pill onto a screen that exists rather than clamp it against one that does
+  /// not. Asserted so the `?? screen` is a decision rather than an accident.
+  @Test("a continuation with no containing screen falls back to the pointer's")
+  func continuationFallsBackWhenItsScreenIsGone() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.splitHost(
+      pointer: { Self.screen }, containing: { _ in nil }, panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
+      position: .top)
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: false,
+      position: .top)
+
+    let panel = try #require(recorder.panel)
+    #expect(
+      panel.frame.maxY <= Self.screen.visibleFrame.maxY - OverlayPlacementState.topClampMargin,
+      "the fallback produced a frame outside the only screen that exists")
+  }
+
+  /// **The twin C10 missed, found by the review gate and unguarded until now.**
+  /// A resize is a continuation by definition — the pill is on screen and Live
+  /// Preview is growing it — so it has exactly the same coordinate-space
+  /// problem as a transition, in a different method.
+  ///
+  /// This case exists because the mutation control for the fix came back
+  /// UNCAUGHT: the repair was right and nothing would have failed if it were
+  /// reverted, which is the state that let the defect live in two methods in
+  /// the first place.
+  @Test("a resize is clamped against the display the pill is on")
+  func resizeKeepsItsOwnScreen() throws {
+    var pointer = Self.screen
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.splitHost(
+      pointer: { pointer }, containing: { _ in Self.screen }, panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
+      position: .top)
+    let before = try #require(recorder.panel).frame
+
+    // Live Preview grows the pill while the pointer sits on the SHORT display.
+    pointer = Self.shortSecondary
+    h.resizeCurrentPresentation(to: CGSize(width: 185, height: 92))
+
+    let after = try #require(recorder.panel).frame
+    #expect(
+      after.origin.y == before.origin.y,
+      "the growing pill was dragged down its own display by the pointer's clamp")
+  }
+
+  /// **The third member of the screen class, found by enumerating it rather
+  /// than by a third review round.** A drag ends with the panel where it was
+  /// dropped and the pointer where it is; releasing across a display boundary
+  /// separates them. The recorded id is what `isUserAnchored(on:)` checks, so
+  /// the wrong one makes a deliberately placed pill stop counting as
+  /// user-anchored on its own display.
+  ///
+  /// **Observed through TWO continuations rather than `placementForTesting`.**
+  /// `isUserAnchored(on:)` has no receipt; what it decides is directly
+  /// observable as X-preservation-versus-recentring on the next presentation,
+  /// exactly as the drag tests above prove the same fact. `containingScreen` is
+  /// mutable so the SAME drag can be continued once resolved to the landing
+  /// screen (must preserve X) and once resolved to the pointer's display, which
+  /// the panel never touched (must recentre).
+  @Test("a drag records the screen the panel landed on, not the pointer's")
+  func dragRecordsTheLandingScreen() throws {
+    var containingScreen: ScreenGeometry? = Self.screen
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.splitHost(
+      pointer: { Self.shortSecondary }, containing: { _ in containingScreen },
+      panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
+      position: .bottom)
+    let panel = try #require(recorder.panel)
+
+    panel.setFrameOrigin(NSPoint(x: 120, y: 85))
+    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+
+    // Continued on the LANDING screen (id 1, where `containing` placed the
+    // panel): the drag is user-anchored there, so X is preserved.
+    h.present(
+      Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: false,
+      position: .bottom)
+    #expect(
+      panel.frame.origin.x == 120,
+      """
+      the drag was recorded against the pointer's display, so the pill is not user-anchored \
+      on the one it is actually on
+      """)
+
+    // The SAME drag, continued on the pointer's display (id 2, which the panel
+    // never touched): not user-anchored there, so X recentres instead of
+    // preserving the dragged value.
+    containingScreen = Self.shortSecondary
+    h.present(
+      Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: false,
+      position: .bottom)
+    let recentredX = Self.shortSecondary.visibleFrame.midX - 320 / 2
+    #expect(
+      panel.frame.origin.x == recentredX,
+      "the drag was recorded against a display the panel never touched")
+  }
+
+  /// A FRESH presentation still belongs where the POINTER is, which is the
+  /// shipped target resolution and must not be collateral damage of the fix
+  /// above. Without this, anchoring everything to the containing screen would
+  /// look correct and quietly stop new pills following the user.
+  ///
+  /// Asserted on Y, not X: both fixtures span the same horizontal range, so a
+  /// centre-X assertion cannot tell them apart and would pass either way.
+  @Test("a fresh presentation still follows the pointer's screen")
+  func freshPresentationFollowsThePointer() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.splitHost(
+      pointer: { Self.shortSecondary }, containing: { _ in Self.screen },
+      panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+
+    h.present(
+      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
+      position: .top)
+
+    let panel = try #require(recorder.panel)
+    let expected = OverlayPlacementState.clampedOriginY(
+      requestedY: OverlayPlacementState.freshOriginY(for: .top, on: Self.shortSecondary),
+      height: 92, on: Self.shortSecondary)
+    #expect(
+      panel.frame.origin.y == expected,
+      "a fresh pill was placed on the containing screen instead of the pointer's")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
@@ -233,6 +233,100 @@ struct OverlayWindowHostTests {
     #expect(recorder.constructionCount == 1, "showing after a hide rebuilt the panel")
   }
 
+  /// **The recorder's own coverage.** Every other test in this file reads
+  /// `recorder.panel`/`recorder.constructionCount`, which only exercise
+  /// `.constructed` and (indirectly, via `hideNeverCloses` below) `.close`.
+  /// Nothing directly asserted `setFrame`, `setContentView` or
+  /// `orderFrontRegardless` ever appear — a recorder that silently stopped
+  /// recording any one of those would leave every OTHER test in this file
+  /// green, because they all read the PANEL's own state, never the recorder's
+  /// command log. Codex found this gap in chunk review.
+  @Test("present, resize and hide issue the real panel commands in order")
+  func panelCommandOrderIsObservable() throws {
+    let recorder = OverlayPanelCommandRecorder()
+    let h = Self.host(panelFactory: recorder.makeFactory())
+    defer { recorder.panel?.orderOut(nil) }
+
+    let view = Self.view(width: 185, height: 44)
+    let presentStart = recorder.commands.count
+    #expect(
+      h.present(
+        view, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom))
+
+    let panel = try #require(recorder.panel)
+    let panelID = ObjectIdentifier(panel)
+    let presented = Array(recorder.commands[presentStart...])
+
+    // **`NSPanel`'s OWN designated initializer sets a default `contentView`
+    // internally, before `.constructed` is even appended** — measured live:
+    // `super.init(contentRect:styleMask:backing:defer:)` issues a
+    // `.setContentView` receipt of its own, ahead of construction finishing.
+    // That is a real AppKit fact this test is not about, so it locates
+    // `.constructed` rather than assuming position 0, and asserts only what
+    // HOST code issues after it — the three commands `present` itself drives.
+    guard
+      let constructedIndex = presented.firstIndex(where: {
+        if case .constructed = $0 { return true }
+        return false
+      })
+    else {
+      Issue.record("present never constructed a panel")
+      return
+    }
+    guard case .constructed(let constructedID) = presented[constructedIndex] else {
+      Issue.record("unreachable: index was located by matching .constructed")
+      return
+    }
+    let afterConstruction = Array(presented[(constructedIndex + 1)...])
+    try #require(
+      afterConstruction.count == 3,
+      """
+      expected exactly setFrame → setContentView → orderFrontRegardless after construction, \
+      got \(afterConstruction)
+      """)
+
+    guard case .setFrame(let frameID, let frame, let display, let animated) = afterConstruction[0],
+      case .setContentView(let contentID, let viewID) = afterConstruction[1],
+      case .orderFrontRegardless(let frontID) = afterConstruction[2]
+    else {
+      Issue.record("present did not issue frame → content → order-front after construction")
+      return
+    }
+
+    #expect(constructedID == panelID)
+    #expect(frameID == panelID)
+    #expect(frame.size == CGSize(width: 185, height: 44))
+    #expect(display == false)
+    #expect(animated == false)
+    #expect(contentID == panelID)
+    #expect(viewID == ObjectIdentifier(view))
+    #expect(frontID == panelID)
+
+    let resizeStart = recorder.commands.count
+    h.resizeCurrentPresentation(to: CGSize(width: 240, height: 60))
+    let resized = Array(recorder.commands[resizeStart...])
+    try #require(resized.count == 1)
+    guard
+      case .setFrame(let resizeID, let resizedFrame, let resizeDisplay, let resizeAnimated) =
+        resized[0]
+    else {
+      Issue.record("resize did not issue exactly one setFrame")
+      return
+    }
+    #expect(resizeID == panelID)
+    #expect(resizedFrame.size == CGSize(width: 240, height: 60))
+    #expect(resizeDisplay)
+    #expect(resizeAnimated == false)
+
+    let hideStart = recorder.commands.count
+    h.hide()
+    #expect(
+      Array(recorder.commands[hideStart...]) == [
+        .orderOut(panel: panelID),
+        .setContentView(panel: panelID, view: nil),
+      ])
+  }
+
   /// **`hide()` must ORDER OUT, and a mutation control is what proved this test
   /// was needed.** Substituting `close()` for `orderOut` left all eight cases
   /// green: with `isReleasedWhenClosed = false` a closed panel is still alive,
@@ -497,6 +591,7 @@ struct OverlayWindowHostTests {
 
     // A full-screen space appears: `visibleFrame` does not shrink, so the pill
     // must drop to the true screen edge (#1341).
+    let spaceChangeStart = recorder.commands.count
     geometry = Self.fullScreened
     NSWorkspace.shared.notificationCenter.post(
       name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
@@ -505,6 +600,25 @@ struct OverlayWindowHostTests {
     #expect(
       panel.frame.origin.y == 0,
       "the Space-change notification never reached the host — it is not registered")
+
+    // **The recorder's proof that the animated-`setFrame` depth guard is doing
+    // real work, not defending against a call AppKit never makes.**
+    // `repositionForActiveSpaceChange` issues `setFrame(_:display:animate:)`,
+    // exactly the overload the guard exists to keep from double-recording.
+    // Removing the guard is the control: this row must fail by finding TWO
+    // receipts instead of one if the animated overload also routes through
+    // the non-animated override internally.
+    let spaceChangeCommands = Array(recorder.commands[spaceChangeStart...])
+    let animatedFrameCommands = spaceChangeCommands.filter {
+      if case .setFrame(_, _, let display, let animated) = $0 { return display && animated }
+      return false
+    }
+    #expect(
+      animatedFrameCommands.count == 1,
+      """
+      expected exactly one animated setFrame receipt for the Space-change reposition, got \
+      \(spaceChangeCommands)
+      """)
 
     // **A SECOND swipe, and this is the assertion that matters.** The first one
     // proves only that the host is listening. The host moves the window itself

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
@@ -601,24 +601,27 @@ struct OverlayWindowHostTests {
       panel.frame.origin.y == 0,
       "the Space-change notification never reached the host — it is not registered")
 
-    // **The recorder's proof that the animated-`setFrame` depth guard is doing
-    // real work, not defending against a call AppKit never makes.**
-    // `repositionForActiveSpaceChange` issues `setFrame(_:display:animate:)`,
-    // exactly the overload the guard exists to keep from double-recording.
-    // Removing the guard is the control: this row must fail by finding TWO
-    // receipts instead of one if the animated overload also routes through
-    // the non-animated override internally.
+    // One Host animated move must yield exactly one `setFrame` receipt. Count ALL
+    // frame receipts first: filtering to `animated == true` would hide the extra
+    // non-animated receipt this normalization exists to suppress.
     let spaceChangeCommands = Array(recorder.commands[spaceChangeStart...])
-    let animatedFrameCommands = spaceChangeCommands.filter {
-      if case .setFrame(_, _, let display, let animated) = $0 { return display && animated }
+    let frameCommands = spaceChangeCommands.filter {
+      if case .setFrame = $0 { return true }
       return false
     }
-    #expect(
-      animatedFrameCommands.count == 1,
+    try #require(
+      frameCommands.count == 1,
       """
-      expected exactly one animated setFrame receipt for the Space-change reposition, got \
+      expected exactly one setFrame receipt for the Space-change reposition, got \
       \(spaceChangeCommands)
       """)
+
+    guard case .setFrame(_, _, let display, let animated) = frameCommands[0] else {
+      Issue.record("the Space-change command was not setFrame")
+      return
+    }
+    #expect(display)
+    #expect(animated)
 
     // **A SECOND swipe, and this is the assertion that matters.** The first one
     // proves only that the host is listening. The host moves the window itself

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -491,6 +491,13 @@ def adjudicate_ax_overlay(*, ax_available, preexisting_count, match_count_at_sto
     its content is on screen, which is exactly the case the plan's
     "first-AX-overlay" language exists to rule out.
 
+    **AX membership is not proof of the first COMPOSITED pixel either** —
+    stated so this function is never cited as more than it is. A real screen
+    recording is (`wispr_eyes.record()`); that proof belongs to C5, which
+    exists specifically because #2377 needed the pill's first composited
+    frame and this repo's own tooling already documents that no amount of
+    polling — CGWindow or AX — can answer that question.
+
     The value is always the harness's own first-observed timestamp for the
     identifier the panel carries. The app supplies identity; it does not
     supply time. `host_window_id` — the marker's own CGWindow number, already
@@ -845,50 +852,68 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     match_count_at_stop = 0
     gaps = []
     marker_result = (None, None)  # (window_id, block_tuple) — both None means "not yet"
+    keydown_ns = 0
+    host_window_id = None
+    presentation_block = None
 
-    keydown_ns = time.perf_counter_ns()
-    _si.modifier_down(binding.keycode)
-    last = time.perf_counter_ns()
-    deadline = last + int(timeout_s * 1e9)
-    try:
-        while time.perf_counter_ns() < deadline:
-            matches = ax_matching_windows(pid) if ax_available else []
-            seen = time.perf_counter_ns()
-            gaps.append((seen - last) / 1e6)
-            last = seen
-            if matches and first_seen_ns is None:
-                first_seen_ns = seen
-                match_count_at_stop = len(matches)
-            if marker_result[0] is None and marker_result[1] is None:
-                try:
-                    marker_text = marker_path.read_text()
-                except OSError:
-                    marker_text = ""
-                marker_result = recording_host_marker_from(marker_text, exhausted=False)
-            if marker_result[1] is not None:
-                # A definitive block. No amount of further AX polling changes
-                # a marker-level fault, so stop now rather than run out the
-                # clock on a verdict already decided.
-                break
-            if first_seen_ns is not None and marker_result[0] is not None:
-                break
-    finally:
-        # Released whatever happened above. A modifier left down is a stuck key
-        # for every app on the machine, and the failure path is exactly when it
-        # is least likely to be noticed.
-        _si.modifier_up(binding.keycode)
-
-    if marker_result[0] is None and marker_result[1] is None:
-        # Neither confirmed nor blocked when time ran out: force the FINAL
-        # call, which is the one point "only .other, no .recording yet" and
-        # "only .other, no .recording EVER" become the same fact.
+    # **Known-invalid preconditions are checked BEFORE any synthetic input**
+    # (cloud review P1, C1 repair round 2). A keypress cannot produce
+    # evidence `adjudicate_ax_overlay` will accept when the AX tree is
+    # unreadable or a match already exists — driving the key anyway wastes a
+    # real press, and a synthetic keypress on an already-doomed launch is not
+    # free: it is the exact input this instrument exists to measure the
+    # effect of.
+    if ax_available and not preexisting:
+        keydown_ns = time.perf_counter_ns()
+        _si.modifier_down(binding.keycode)
+        last = time.perf_counter_ns()
+        deadline = last + int(timeout_s * 1e9)
         try:
-            marker_text = marker_path.read_text()
-        except OSError:
-            marker_text = ""
-        marker_result = recording_host_marker_from(marker_text, exhausted=True)
+            while time.perf_counter_ns() < deadline:
+                matches = ax_matching_windows(pid)
+                seen = time.perf_counter_ns()
+                gaps.append((seen - last) / 1e6)
+                last = seen
+                # **The tested stopping rule, actually called** (cloud review
+                # P1, C1 repair round 2) — `ax_overlay_has_appeared` was
+                # tested but the live loop reimplemented its condition inline,
+                # so a mutant weakening the real rule left the whole suite
+                # green.
+                if ax_overlay_has_appeared(len(matches)) and first_seen_ns is None:
+                    first_seen_ns = seen
+                    match_count_at_stop = len(matches)
+                if marker_result[0] is None and marker_result[1] is None:
+                    try:
+                        marker_text = marker_path.read_text()
+                    except OSError:
+                        marker_text = ""
+                    marker_result = recording_host_marker_from(marker_text, exhausted=False)
+                if marker_result[1] is not None:
+                    # A definitive block. No amount of further AX polling
+                    # changes a marker-level fault, so stop now rather than
+                    # run out the clock on a verdict already decided.
+                    break
+                if first_seen_ns is not None and marker_result[0] is not None:
+                    break
+        finally:
+            # Released whatever happened above. A modifier left down is a
+            # stuck key for every app on the machine, and the failure path
+            # is exactly when it is least likely to be noticed.
+            _si.modifier_up(binding.keycode)
 
-    host_window_id, presentation_block = marker_result
+        if marker_result[0] is None and marker_result[1] is None:
+            # Neither confirmed nor blocked when time ran out: force the
+            # FINAL call, which is the one point "only .other, no .recording
+            # yet" and "only .other, no .recording EVER" become the same
+            # fact.
+            try:
+                marker_text = marker_path.read_text()
+            except OSError:
+                marker_text = ""
+            marker_result = recording_host_marker_from(marker_text, exhausted=True)
+
+        host_window_id, presentation_block = marker_result
+
     if presentation_block is not None:
         timing = OverlayTiming(verdict=presentation_block[0], detail=presentation_block[1],
                                window_id=host_window_id, keypress_ms=None)

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -395,6 +395,27 @@ def smoke_verdict(result):
     return SMOKE_PASS if result.verdict == OK else result.verdict
 
 
+def final_verdict_and_detail(result, timing):
+    """The SINGLE place that decides `smoke()`'s outcome once a launch's
+    marker adjudication AND a keypress measurement both exist.
+
+    `timing` is checked FIRST (cloud review P2, #2377 C1 repair): it is the
+    SPECIFIC diagnosis from the actual keypress measurement — AX
+    unavailable, a preexisting match, a wrong presentation, a timeout —
+    while `result` only sees the marker file's completeness AFTER the fact.
+    A precondition block like `BLOCKED_AX_UNAVAILABLE` writes no recording
+    marker at all, so `result` would independently and correctly report the
+    true-but-less-informative `BLOCKED_MISSING_MARKER` for the SAME run,
+    masking the real reason behind a verdict that reads like an app defect
+    rather than an unavailable precondition.
+    """
+    if timing["verdict"] != OK:
+        return timing["verdict"], timing["detail"]
+    if result.verdict != OK:
+        return result.verdict, result.detail
+    return smoke_verdict(result), result.detail
+
+
 # ------------------------------------------------------- the overlay endpoint
 
 def read_complete_markers(text):
@@ -1268,6 +1289,7 @@ def smoke(bundle_path, *, out_dir):
     timebase = None
     engine_ready_wait_ms = None
     engine_not_ready = False
+    screen_locked_before_press = None
     try:
         # Inside the reaped region, not before it. `mach_timebase()` loads a
         # native symbol and can raise; raising here with the app already launched
@@ -1285,16 +1307,33 @@ def smoke(bundle_path, *, out_dir):
             run_id=launched["run_id"], expected_pid=launched["pid"],
             expected_bundle=launched["requested"].bundle_id)
         engine_ready_wait_ms = (time.monotonic() - ready_start) * 1000.0
+
+        # Re-check the screen lock immediately before the press (cloud
+        # review P1, #2377 C1 repair). The launch and engine-readiness waits
+        # above can together run for up to ~60s — wide enough for the screen
+        # to lock AFTER the check at the top of this function, which the
+        # initial check cannot see. A press sent into a locked screen
+        # invalidates the run for the same reason that initial check exists;
+        # checked here, not inside `measure_keypress_to_overlay`, so it
+        # shares the SAME verdict and receipt field as the initial check
+        # rather than inventing a second meaning for the same fact.
+        pre_press_lock = screen_lock_state()
+        pre_press_blocked = screen_lock_block(pre_press_lock)
+        out["screen_locked_pre_press"] = pre_press_lock
+        press_permitted = engine_ready and not pre_press_blocked
+
         # Gated through `measure_after_engine_ready` rather than an inline
         # `if`/`else` around the call — the gate is then provable by calling
         # that function directly with a spy, not just by reading this
         # function's source layout (#2377, C1 repair).
         timing = measure_after_engine_ready(
-            engine_ready,
+            press_permitted,
             lambda: measure_keypress_to_overlay(
                 launched["pid"], launched["marker_path"]))
         if not engine_ready:
             engine_not_ready = True
+        elif pre_press_blocked:
+            screen_locked_before_press = pre_press_blocked
         else:
             marker_text = launched["marker_path"].read_text()
             # `resolved_identity` raises if the pid is gone, which is exactly what a
@@ -1333,20 +1372,14 @@ def smoke(bundle_path, *, out_dir):
             f"within the warm-up wait; a keypress sent now would race "
             f"ColdPressGuard (#879)")
         return out
+    if screen_locked_before_press:
+        out["verdict"] = BLOCKED_SCREEN_LOCKED
+        out["detail"] = screen_locked_before_press
+        return out
     if failure is not None:
         out["verdict"] = BLOCKED_LAUNCH
         return out
-    if result.verdict != OK:
-        out["verdict"] = result.verdict
-        return out
-    if timing["verdict"] != OK:
-        # The markers can be complete while the keypress interval has no
-        # identifiable endpoint. That is a block, never a pass with a missing
-        # field: the plan's third bound is stated on this number.
-        out["verdict"] = timing["verdict"]
-        out["detail"] = timing["detail"]
-        return out
-    out["verdict"] = smoke_verdict(result)
+    out["verdict"], out["detail"] = final_verdict_and_detail(result, timing)
     return out
 
 

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -89,7 +89,11 @@ LaunchSample = namedtuple(
     "LaunchSample", "run launch_ms root_ms order_front_ms host_window_id")
 LaunchResult = namedtuple("LaunchResult", "verdict detail sample")
 OverlayTiming = namedtuple("OverlayTiming", "verdict detail window_id keypress_ms")
-Pair = namedtuple("Pair", "order a b a_keypress_ms b_keypress_ms")
+# A keypress figure carries the run it belongs to. Untagged floats let a runner
+# associate the wrong measurement with a launch and still satisfy every other
+# check — the identity argument this whole instrument rests on, one level out.
+KeypressSample = namedtuple("KeypressSample", "run keypress_ms")
+Pair = namedtuple("Pair", "order a b a_keypress b_keypress")
 Budget = namedtuple(
     "Budget", "launch_median_regression_ms root_p95_ms keypress_p95_regression_ms")
 BenchmarkResult = namedtuple("BenchmarkResult", "verdict detail measured")
@@ -494,11 +498,25 @@ def adjudicate_benchmark(pairs, budget=PLAN_BUDGET, pair_count=PAIR_COUNT):
                        f"{len(set(runs))} distinct run ids across {pair_count * 2} "
                        "sides; every side must come from its own cold launch")
 
+    # Each keypress figure must name the launch it came from. The distinct-run
+    # check above validates the LAUNCH samples; without this, a runner that
+    # reused a prior keypress result or crossed the two sides still satisfies it
+    # and produces BENCHMARK_PASS from cross-associated evidence.
+    for i, p in enumerate(pairs):
+        for side, result, keypress in (("A", p.a, p.a_keypress),
+                                       ("B", p.b, p.b_keypress)):
+            if keypress.run != result.sample.run:
+                return blocked(
+                    BLOCKED_INCOMPLETE_PAIRS,
+                    f"pair {i} side {side}: the keypress figure names run "
+                    f"{keypress.run!r} and the launch is {result.sample.run!r}. "
+                    "Every timing must come from the launch it is reported with.")
+
     a_launch = [p.a.sample.launch_ms for p in pairs]
     b_launch = [p.b.sample.launch_ms for p in pairs]
     b_root = [p.b.sample.root_ms for p in pairs]
-    a_key = [p.a_keypress_ms for p in pairs]
-    b_key = [p.b_keypress_ms for p in pairs]
+    a_key = [p.a_keypress.keypress_ms for p in pairs]
+    b_key = [p.b_keypress.keypress_ms for p in pairs]
 
     launch_regression = median(b_launch) - median(a_launch)
     root_p95 = nearest_rank(b_root, 95)
@@ -946,12 +964,17 @@ def smoke(bundle_path, *, out_dir):
         out["detail"] = f"{type(exc).__name__}: {exc}"
         return out
 
-    timebase = mach_timebase()
     resolved = None
     timing = None
     result = None
     failure = None
+    timebase = None
     try:
+        # Inside the reaped region, not before it. `mach_timebase()` loads a
+        # native symbol and can raise; raising here with the app already launched
+        # and the cleanup not yet armed leaves an orphan and produces no receipt
+        # at all — the one run that most needs explaining.
+        timebase = mach_timebase()
         timing = measure_keypress_to_overlay(
             launched["pid"], launched["marker_path"])
         marker_text = launched["marker_path"].read_text()

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -970,7 +970,20 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     # real press, and a synthetic keypress on an already-doomed launch is not
     # free: it is the exact input this instrument exists to measure the
     # effect of.
-    if ax_available and not preexisting:
+    #
+    # **The screen-lock check is HERE, immediately before `modifier_down`,
+    # not only in `smoke()` (#2377, C1 repair).** `smoke()`'s own recheck
+    # runs before `_ptt.resolve()` above — which can spend up to ~5s in
+    # `defaults export` — and the AX queries just above it, so the screen
+    # can still lock inside that gap even though `smoke()` saw it unlocked.
+    # This is the LAST statement before the press, so no further gap can
+    # exist after it; `smoke()`'s own check remains as a cheap early exit
+    # that skips the ~5s of PTT/AX work entirely when the screen is ALREADY
+    # locked, rather than being made redundant by this one.
+    pre_press_lock = screen_lock_state()
+    pre_press_blocked = screen_lock_block(pre_press_lock)
+
+    if ax_available and not preexisting and not pre_press_blocked:
         keydown_ns = time.perf_counter_ns()
         _si.modifier_down(binding.keycode)
         last = time.perf_counter_ns()
@@ -1021,7 +1034,13 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
 
         host_window_id, presentation_block = marker_result
 
-    if presentation_block is not None:
+    if pre_press_blocked:
+        # Checked first: a screen that locked in the gap above never gets a
+        # press, whatever `presentation_block`/`adjudicate_ax_overlay` would
+        # otherwise have said about a poll loop that never ran.
+        timing = OverlayTiming(verdict=BLOCKED_SCREEN_LOCKED, detail=pre_press_blocked,
+                               window_id=None, keypress_ms=None)
+    elif presentation_block is not None:
         timing = OverlayTiming(verdict=presentation_block[0], detail=presentation_block[1],
                                window_id=host_window_id, keypress_ms=None)
     else:
@@ -1036,6 +1055,7 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     return {
         "verdict": timing.verdict,
         "detail": timing.detail,
+        "screen_locked": pre_press_lock,
         "keypress_ms": timing.keypress_ms,
         "window_id": timing.window_id,
         "host_window_id": host_window_id,

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -757,23 +757,39 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     }
 
 
-def screen_lock_state():
+def screen_lock_state(session_reader=None):
     """`True` locked, `False` unlocked, `None` could not tell.
 
-    Three-valued on purpose. Collapsing "could not tell" into "unlocked" is the
-    shape that turns a broken probe into a green: the caller would proceed on a
-    machine it cannot describe, which is precisely the state a measurement must
-    not be taken in.
+    A readable WindowServer session uses presence semantics for
+    `CGSSessionScreenIsLocked`: present and true means locked; absence means
+    unlocked. Import failure, reader failure, a missing session, an unusable
+    dictionary or an unexpected lock value remains unknown and fails closed.
     """
+    if session_reader is None:
+        try:
+            import Quartz
+            session_reader = Quartz.CGSessionCopyCurrentDictionary
+        except Exception:
+            return None
+
     try:
-        import Quartz
-        session = Quartz.CGSessionCopyCurrentDictionary()
+        session = session_reader()
     except Exception:
         return None
-    if session is None:
+
+    if session is None or not hasattr(session, "get") or not hasattr(session, "__contains__"):
         return None
-    value = session.get("CGSSessionScreenIsLocked")
-    return None if value is None else bool(value)
+
+    key = "CGSSessionScreenIsLocked"
+    if key not in session:
+        return False
+
+    value = session.get(key)
+    if value is True or value == 1:
+        return True
+    if value is False or value == 0:
+        return False
+    return None
 
 
 def screen_lock_block(state):

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -971,17 +971,16 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     # free: it is the exact input this instrument exists to measure the
     # effect of.
     #
-    # **The screen-lock check is HERE, immediately before `modifier_down`,
-    # not only in `smoke()` (#2377, C1 repair).** `smoke()`'s own recheck
-    # runs before `_ptt.resolve()` above — which can spend up to ~5s in
-    # `defaults export` — and the AX queries just above it, so the screen
-    # can still lock inside that gap even though `smoke()` saw it unlocked.
-    # This is the LAST statement before the press, so no further gap can
-    # exist after it; `smoke()`'s own check remains as a cheap early exit
-    # that skips the ~5s of PTT/AX work entirely when the screen is ALREADY
-    # locked, rather than being made redundant by this one.
+    # This is the final pre-input check. A session transition cannot be
+    # atomic with synthetic input, so the post-measure check below brackets
+    # the whole interval and prevents any locked-screen sample from being
+    # accepted. `smoke()`'s own recheck (run before this function is even
+    # called) remains as a cheap early exit that skips the ~5s of PTT/AX
+    # work entirely when the screen is ALREADY locked at readiness time.
     pre_press_lock = screen_lock_state()
     pre_press_blocked = screen_lock_block(pre_press_lock)
+    post_measure_lock = None
+    post_measure_blocked = None
 
     if ax_available and not preexisting and not pre_press_blocked:
         keydown_ns = time.perf_counter_ns()
@@ -1021,6 +1020,15 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
             # is exactly when it is least likely to be noticed.
             _si.modifier_up(binding.keycode)
 
+        # The OTHER boundary: the screen can lock DURING the poll loop above
+        # (up to `timeout_s`, not instantaneous), so a sample that started
+        # unlocked can still finish having been taken against a locked
+        # screen. Checked immediately after the modifier is released and
+        # normal polling completes — bracketing the whole measured interval
+        # is what closes the class; a pre-check alone only moves the gap.
+        post_measure_lock = screen_lock_state()
+        post_measure_blocked = screen_lock_block(post_measure_lock)
+
         if marker_result[0] is None and marker_result[1] is None:
             # Neither confirmed nor blocked when time ran out: force the
             # FINAL call, which is the one point "only .other, no .recording
@@ -1034,11 +1042,15 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
 
         host_window_id, presentation_block = marker_result
 
-    if pre_press_blocked:
-        # Checked first: a screen that locked in the gap above never gets a
-        # press, whatever `presentation_block`/`adjudicate_ax_overlay` would
-        # otherwise have said about a poll loop that never ran.
-        timing = OverlayTiming(verdict=BLOCKED_SCREEN_LOCKED, detail=pre_press_blocked,
+    if pre_press_blocked or post_measure_blocked:
+        # EITHER boundary blocks the sample — a lock caught only at one end
+        # would still accept a measurement taken while locked in the middle.
+        # `presentation_block`/`adjudicate_ax_overlay` never get a say over
+        # a locked-screen sample, whatever they would otherwise have
+        # concluded about a poll loop that ran against the wrong machine
+        # state.
+        lock_block = pre_press_blocked or post_measure_blocked
+        timing = OverlayTiming(verdict=BLOCKED_SCREEN_LOCKED, detail=lock_block,
                                window_id=None, keypress_ms=None)
     elif presentation_block is not None:
         timing = OverlayTiming(verdict=presentation_block[0], detail=presentation_block[1],
@@ -1055,7 +1067,8 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     return {
         "verdict": timing.verdict,
         "detail": timing.detail,
-        "screen_locked": pre_press_lock,
+        "screen_locked_pre_press": pre_press_lock,
+        "screen_locked_post_measurement": post_measure_lock,
         "keypress_ms": timing.keypress_ms,
         "window_id": timing.window_id,
         "host_window_id": host_window_id,

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -399,7 +399,7 @@ def final_verdict_and_detail(result, timing):
     """The SINGLE place that decides `smoke()`'s outcome once a launch's
     marker adjudication AND a keypress measurement both exist.
 
-    `timing` is checked FIRST (cloud review P2, #2377 C1 repair): it is the
+    `timing` is checked FIRST (#2377, C1 repair): it is the
     SPECIFIC diagnosis from the actual keypress measurement — AX
     unavailable, a preexisting match, a wrong presentation, a timeout —
     while `result` only sees the marker file's completeness AFTER the fact.
@@ -1308,10 +1308,10 @@ def smoke(bundle_path, *, out_dir):
             expected_bundle=launched["requested"].bundle_id)
         engine_ready_wait_ms = (time.monotonic() - ready_start) * 1000.0
 
-        # Re-check the screen lock immediately before the press (cloud
-        # review P1, #2377 C1 repair). The launch and engine-readiness waits
-        # above can together run for up to ~60s — wide enough for the screen
-        # to lock AFTER the check at the top of this function, which the
+        # Re-check the screen lock immediately before the press (#2377, C1
+        # repair). The launch and engine-readiness waits above can together
+        # run for up to ~60s — wide enough for the screen to lock AFTER the
+        # check at the top of this function, which the
         # initial check cannot see. A press sent into a locked screen
         # invalidates the run for the same reason that initial check exists;
         # checked here, not inside `measure_keypress_to_overlay`, so it

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -1,0 +1,930 @@
+"""First-render measurement instrument for #2377 Phase 6 (P6-C1).
+
+**This chunk proves the INSTRUMENT, not the latency outcome.** The 30-pair
+decision belongs to C4, after a final candidate exists; what ships here is the
+marker contract, the adjudicator, and a one-bundle smoke receipt.
+
+The whole design follows from one property: a benchmark that can report PASS on
+incomplete evidence is worse than no benchmark, because it buys the confidence
+without the cover. So no `FAIL` is reachable from missing evidence — the verdict
+set is `SMOKE_PASS`, `BENCHMARK_PASS`, `BENCHMARK_FAIL`, and `BLOCKED_<reason>`,
+and a `FAIL` is a claim about the CODE that requires complete evidence first.
+
+Identity is the sharp edge. Every dev bundle on this machine is named
+`EnviousWispr Local.app`, so a name, a bundle id and a version can all agree
+across two worktrees' builds. The executable's SHA-256 is therefore the
+authority, and the harness computes it from the launched pid's resolved
+executable path — never from a marker, because an app echoing back what the
+harness supplied proves nothing about which bytes ran.
+
+The pure half of this module imports nothing but the standard library, so the
+refusal suite beside it runs anywhere. Every PyObjC and app-driving import is
+made inside the function that needs it.
+
+Run the suite:  `python3 Tests/RuntimeUAT/measure_overlay_first_render_test.py`
+Run the smoke:  `python3 Tests/RuntimeUAT/measure_overlay_first_render.py --smoke
+                    --bundle "<path>/EnviousWispr Local.app"`
+"""
+
+import hashlib
+import json
+import os
+import pathlib
+import statistics
+import subprocess
+import sys
+import time
+import uuid
+from collections import namedtuple
+
+# The sibling harness modules are imported lazily, inside the functions that
+# drive the app, so the pure half of this module stays standard-library only.
+# The path insert itself imports nothing, so it belongs here rather than being
+# repeated - and repeated - inside each of them.
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+# --------------------------------------------------------------- the contract
+
+# The version is IN the schema token, so a future format is refused loudly by an
+# old harness rather than parsed leniently into a plausible number.
+SCHEMA_FAMILY = "EW_OVERLAY_FIRST_RENDER"
+SCHEMA = SCHEMA_FAMILY + "_V1"
+
+LAUNCH_ENTER = "launch.enter"
+LAUNCH_EXIT = "launch.exit"
+ROOT_START = "root.construct.start"
+ROOT_END = "root.construct.end"
+ORDER_FRONT = "host.order_front.complete"
+
+# In causal order. The whole chain is enforced, which is what forbids a root
+# built inside launch; there is deliberately no separate notion of "pairs".
+EVENTS = (LAUNCH_ENTER, LAUNCH_EXIT, ROOT_START, ROOT_END, ORDER_FRONT)
+
+MARKER_PATH_ENV = "EW_OVERLAY_FIRST_RENDER_MARKER_PATH"
+RUN_ID_ENV = "EW_OVERLAY_FIRST_RENDER_RUN_ID"
+
+# ---------------------------------------------------------------- the verdicts
+
+OK = "OK"
+SMOKE_PASS = "SMOKE_PASS"
+BENCHMARK_PASS = "BENCHMARK_PASS"
+BENCHMARK_FAIL = "BENCHMARK_FAIL"
+
+BLOCKED_MALFORMED_MARKER = "BLOCKED_MALFORMED_MARKER"
+BLOCKED_WRONG_APP = "BLOCKED_WRONG_APP"
+BLOCKED_MISSING_MARKER = "BLOCKED_MISSING_MARKER"
+BLOCKED_DUPLICATE_MARKER = "BLOCKED_DUPLICATE_MARKER"
+BLOCKED_PAIR_ORDER = "BLOCKED_PAIR_ORDER"
+BLOCKED_NON_MONOTONIC = "BLOCKED_NON_MONOTONIC"
+BLOCKED_INCOMPLETE_PAIRS = "BLOCKED_INCOMPLETE_PAIRS"
+BLOCKED_SCHEDULE = "BLOCKED_SCHEDULE"
+BLOCKED_OCCUPANCY = "BLOCKED_OCCUPANCY"
+BLOCKED_LAUNCH = "BLOCKED_LAUNCH"
+BLOCKED_NO_OVERLAY = "BLOCKED_NO_OVERLAY"
+
+Identity = namedtuple("Identity", "bundle_id executable_path sha256")
+Marker = namedtuple("Marker", "run pid bundle event ticks window index")
+LaunchSample = namedtuple(
+    "LaunchSample", "run launch_ms root_ms order_front_ms host_window_id")
+LaunchResult = namedtuple("LaunchResult", "verdict detail sample")
+OverlayTiming = namedtuple("OverlayTiming", "verdict detail window_id keypress_ms")
+Pair = namedtuple("Pair", "order a b a_keypress_ms b_keypress_ms")
+Budget = namedtuple(
+    "Budget", "launch_median_regression_ms root_p95_ms keypress_p95_regression_ms")
+BenchmarkResult = namedtuple("BenchmarkResult", "verdict detail measured")
+
+# The plan's binding launch budget. Named here so a change to it has one place to
+# land; the values are NOT this module's to choose.
+PLAN_BUDGET = Budget(launch_median_regression_ms=5.0,
+                     root_p95_ms=8.0,
+                     keypress_p95_regression_ms=16.7)
+
+PAIR_COUNT = 30
+
+
+class MarkerFormatError(Exception):
+    """A line carrying our schema family that we cannot read."""
+
+
+# ------------------------------------------------------------------ parsing
+
+def parse_marker_line(line, index=0):
+    """One TSV marker line to a `Marker`, or raise.
+
+    Fixed field order, each `key=value`. A positional format rather than JSON
+    because the app writes this on the launch path: one `write(2)` of a
+    pre-built string, no encoder, no allocation beyond the string itself.
+    """
+    fields = line.split("\t")
+    if len(fields) != 7:
+        raise MarkerFormatError(
+            f"expected 7 tab-separated fields, got {len(fields)}: {line!r}")
+    schema, run, pid, bundle, event, ticks, window = fields
+    if schema != SCHEMA:
+        raise MarkerFormatError(f"unknown schema {schema!r}, this harness reads {SCHEMA}")
+    parsed = {}
+    for key, field in (("run", run), ("pid", pid), ("bundle", bundle),
+                       ("event", event), ("ticks", ticks), ("window", window)):
+        prefix = key + "="
+        if not field.startswith(prefix):
+            raise MarkerFormatError(f"expected {prefix!r}, got {field!r}")
+        parsed[key] = field[len(prefix):]
+    if parsed["event"] not in EVENTS:
+        raise MarkerFormatError(f"unknown event {parsed['event']!r}")
+    for key in ("pid", "ticks", "window"):
+        if not parsed[key].isdigit():
+            raise MarkerFormatError(
+                f"{key} must be a non-negative integer, got {parsed[key]!r}")
+    # Only the host event names a window; every other event writes 0, and BOTH
+    # halves are enforced. A host marker with no usable window id is a MALFORMED
+    # marker rather than a missing overlay — the app reached the call site and
+    # could not say which window it ordered, which is a different fault sent to a
+    # different place. A non-host event carrying a window means the emitter is
+    # writing something this parser does not model, and a contract stated only in
+    # a comment is the shape that retires the check instead of failing it.
+    window_id = int(parsed["window"])
+    if parsed["event"] == ORDER_FRONT:
+        if window_id <= 0:
+            raise MarkerFormatError(
+                f"{ORDER_FRONT} must name a positive window id, got {window_id}")
+    elif window_id != 0:
+        raise MarkerFormatError(
+            f"{parsed['event']} must carry window 0, got {window_id}")
+    return Marker(run=parsed["run"], pid=int(parsed["pid"]), bundle=parsed["bundle"],
+                  event=parsed["event"], ticks=int(parsed["ticks"]),
+                  window=int(parsed["window"]), index=index)
+
+
+def read_markers(text):
+    """Every marker in `text`, in file order. Foreign lines are IGNORED.
+
+    A line that does not begin with our schema FAMILY belongs to something else
+    and is none of our business — refusing on it would make the instrument fail
+    whenever anything else wrote to the same file. A line that DOES carry the
+    family and cannot be read is a different fact and raises: that is our own
+    format, drifted.
+    """
+    out = []
+    for i, line in enumerate(text.splitlines()):
+        line = line.rstrip("\r")
+        if not line.startswith(SCHEMA_FAMILY):
+            continue
+        out.append(parse_marker_line(line, index=i))
+    return out
+
+
+# -------------------------------------------------------------- adjudication
+
+def ticks_to_ms(ticks, timebase):
+    numer, denom = timebase
+    return (ticks * numer / denom) / 1_000_000.0
+
+
+def adjudicate_launch(marker_text, *, expected_run, expected_pid,
+                      requested, resolved, timebase):
+    """One launch's markers to a verdict. Never raises, never guesses.
+
+    Check order is deliberate and each step is a different question:
+
+    1. Is this the app we asked for?  An identity mismatch makes every marker
+       below it irrelevant, so it is asked first.
+    2. Can we read our own format?
+    3. Whose launch wrote these lines?
+    4. Is every marker present, exactly once?
+    5. Are the pairs in order, and does the clock move forwards?
+    """
+    def blocked(reason, detail):
+        return LaunchResult(verdict=reason, detail=detail, sample=None)
+
+    if resolved.bundle_id != requested.bundle_id:
+        return blocked(BLOCKED_WRONG_APP,
+                       f"requested bundle {requested.bundle_id!r}, "
+                       f"the launched process resolves to {resolved.bundle_id!r}")
+    if resolved.executable_path != requested.executable_path:
+        return blocked(BLOCKED_WRONG_APP,
+                       f"requested executable {requested.executable_path!r}, "
+                       f"the launched pid resolves to {resolved.executable_path!r}")
+    if resolved.sha256 != requested.sha256:
+        # The case a bundle-id check cannot see, and the one that matters here.
+        return blocked(BLOCKED_WRONG_APP,
+                       f"executable hash {resolved.sha256} is not the requested "
+                       f"{requested.sha256} - same path, different bytes")
+
+    try:
+        markers = read_markers(marker_text)
+    except MarkerFormatError as exc:
+        return blocked(BLOCKED_MALFORMED_MARKER, str(exc))
+
+    for mk in markers:
+        if mk.run != expected_run:
+            return blocked(
+                BLOCKED_WRONG_APP,
+                f"a marker carries run {mk.run!r}, this launch is {expected_run!r}")
+        if mk.pid != expected_pid:
+            return blocked(
+                BLOCKED_WRONG_APP,
+                f"a marker carries pid {mk.pid}, this launch is {expected_pid}")
+        if mk.bundle != requested.bundle_id:
+            return blocked(BLOCKED_WRONG_APP,
+                           f"a marker names bundle {mk.bundle!r}, we requested "
+                           f"{requested.bundle_id!r}")
+
+    by_event = {}
+    for mk in markers:
+        by_event.setdefault(mk.event, []).append(mk)
+
+    missing = [e for e in EVENTS if not by_event.get(e)]
+    if missing:
+        return blocked(BLOCKED_MISSING_MARKER, "absent: " + ", ".join(missing))
+    doubled = [e for e in EVENTS if len(by_event[e]) > 1]
+    if doubled:
+        # Every event is a singleton within one launch. Two of anything means
+        # two launches wrote to one file, and the durations would be a mix.
+        return blocked(BLOCKED_DUPLICATE_MARKER,
+                       "seen more than once: " + ", ".join(
+                           f"{e} x{len(by_event[e])}" for e in doubled))
+
+    single = {e: by_event[e][0] for e in EVENTS}
+
+    # **The whole chain, not two pairs checked separately.** `EVENTS` is in
+    # causal order, and the link that only a full chain enforces is
+    # `launch.exit -> root.construct.start`: without it a launch that built the
+    # root SYNCHRONOUSLY, inside `applicationDidFinishLaunching`, satisfies both
+    # pairs and is accepted. That is the arrangement Phase 6 exists to move away
+    # from, so the instrument must not certify it.
+    for earlier, later in zip(EVENTS, EVENTS[1:]):
+        if single[later].index <= single[earlier].index:
+            return blocked(BLOCKED_PAIR_ORDER,
+                           f"{later} was written before {earlier}")
+        if single[later].ticks <= single[earlier].ticks:
+            return blocked(BLOCKED_NON_MONOTONIC,
+                           f"{later} at {single[later].ticks} ticks is not after "
+                           f"{earlier} at {single[earlier].ticks}")
+
+    sample = LaunchSample(
+        run=expected_run,
+        launch_ms=ticks_to_ms(
+            single[LAUNCH_EXIT].ticks - single[LAUNCH_ENTER].ticks, timebase),
+        root_ms=ticks_to_ms(
+            single[ROOT_END].ticks - single[ROOT_START].ticks, timebase),
+        order_front_ms=ticks_to_ms(
+            single[ORDER_FRONT].ticks - single[ROOT_START].ticks, timebase),
+        host_window_id=single[ORDER_FRONT].window)
+    return LaunchResult(verdict=OK, detail="", sample=sample)
+
+
+def smoke_verdict(result):
+    """One accepted launch is `SMOKE_PASS` and can never be a benchmark PASS.
+
+    The smoke run proves the instrument works end to end on one bundle. It says
+    nothing about latency, because a single launch has no baseline to be
+    compared against - so it gets its own verdict rather than borrowing one that
+    would read as a budget decision.
+    """
+    return SMOKE_PASS if result.verdict == OK else result.verdict
+
+
+# ------------------------------------------------------- the overlay endpoint
+
+def read_complete_markers(text):
+    """Markers from COMPLETE lines only, for a reader polling a file being written.
+
+    The emitter loops on a short `write(2)`, which is correct — a truncated line
+    would otherwise reach the harness as a malformed one, an instrument fault
+    wearing an app fault's clothes. But a poller can still read BETWEEN the two
+    halves of that loop and see an unfinished final line.
+
+    A line is finished when a newline follows it, so everything up to the last
+    newline is safe to parse and anything after it is not yet a line. Discarding
+    the tail costs one more poll; parsing it costs a false verdict about the app.
+    """
+    end = text.rfind("\n")
+    if end < 0:
+        return []
+    return read_markers(text[:end + 1])
+
+
+def launch_is_ready(text, *, expected_run, expected_pid, expected_bundle):
+    """Has THIS launch written its `launch.exit` marker yet?
+
+    An exact, complete marker matching this run, pid and bundle — not a substring
+    search for the event name. A substring matches a half-written line, a line
+    from another run that somehow reached this file, and the event name appearing
+    anywhere at all; and it answers "ready" the instant those bytes land, which
+    is before the app has finished saying anything.
+    """
+    try:
+        markers = read_complete_markers(text)
+    except MarkerFormatError:
+        # A malformed line is a real fault and belongs to the adjudicator, not to
+        # a readiness probe. Answering "not ready" fails CLOSED: the launch times
+        # out and says so, rather than proceeding on a file it cannot read.
+        return False
+    return any(mk.event == LAUNCH_EXIT and mk.run == expected_run
+               and mk.pid == expected_pid and mk.bundle == expected_bundle
+               for mk in markers)
+
+
+def named_window_has_appeared(host_window_id, first_seen):
+    """The live loop's stopping rule, extracted so a test can reach it.
+
+    **It lived inline and no test could touch it**, which meant the whole
+    identity binding could be reverted to "the host marker plus any window" and
+    every pure test still passed — the adjudicator was bound and the thing that
+    decides when to STOP CALLING it was not. That is the same defect one level
+    out from the one this rule exists to fix.
+    """
+    return host_window_id is not None and host_window_id in first_seen
+
+
+def host_window_from(marker_text):
+    """The window id the app says it ordered front, or `(None, reason)`.
+
+    Returns `(window_id, None)` once the host marker is present and usable,
+    `(None, None)` while it has not arrived, and `(None, BLOCKED_...)` when it
+    arrived and cannot be read.
+    """
+    try:
+        markers = read_complete_markers(marker_text)
+    except MarkerFormatError as exc:
+        return None, (BLOCKED_MALFORMED_MARKER, str(exc))
+    hosts = [mk for mk in markers if mk.event == ORDER_FRONT]
+    if not hosts:
+        return None, None
+    if len(hosts) > 1:
+        return None, (BLOCKED_DUPLICATE_MARKER,
+                      f"{len(hosts)} {ORDER_FRONT} markers in one launch")
+    return hosts[0].window, None
+
+
+def adjudicate_overlay_window(host_window_id, first_seen, keydown_ns, preexisting):
+    """Which window ended the keypress interval — NAMED by the app, timed by us.
+
+    **Identity is bound, not inferred.** An earlier version watched for "a new
+    window owned by this process" and stopped at the first one it saw. That
+    accepts this sequence, which no amount of settling delay fixes and which a
+    fixture supplying both windows at once cannot even express:
+
+        1. an unrelated window appears — settings, onboarding, a prompt
+        2. the app writes its host marker
+        3. the harness stops, holding only the unrelated window
+        4. the real pill reaches WindowServer a moment later
+        5. the unrelated window is reported as the overlay
+
+    Every step is plausible and the output is a normal-looking latency about the
+    wrong subject. So the app now names the window it ordered front, and this
+    waits for THAT id. Unrelated windows are recorded for the receipt and can
+    neither end the interval nor invalidate it.
+
+    The value is always the harness's own first-observed timestamp for the named
+    window. The app supplies identity; it does not supply time.
+    """
+    if host_window_id is None:
+        return OverlayTiming(
+            verdict=BLOCKED_NO_OVERLAY,
+            detail="the app never reported ordering a window front",
+            window_id=None, keypress_ms=None)
+    if host_window_id <= 0:
+        return OverlayTiming(
+            verdict=BLOCKED_MALFORMED_MARKER,
+            detail=f"the host marker named window {host_window_id}, which is not a window",
+            window_id=None, keypress_ms=None)
+    if host_window_id in preexisting:
+        # It was already on screen when the key went down, so its appearance is
+        # not an event this keypress caused and there is no interval to report.
+        return OverlayTiming(
+            verdict=BLOCKED_NO_OVERLAY,
+            detail=(f"window {host_window_id} already existed before the keypress, so "
+                    "nothing about its appearance is attributable to this press"),
+            window_id=host_window_id, keypress_ms=None)
+    if host_window_id not in first_seen:
+        return OverlayTiming(
+            verdict=BLOCKED_NO_OVERLAY,
+            detail=(f"the app ordered window {host_window_id} front, but it was never "
+                    "observed on screen before the deadline"),
+            window_id=host_window_id, keypress_ms=None)
+    return OverlayTiming(verdict=OK, detail="", window_id=host_window_id,
+                         keypress_ms=(first_seen[host_window_id] - keydown_ns) / 1e6)
+
+
+# -------------------------------------------------------------- statistics
+
+def median(values):
+    return statistics.median(values)
+
+
+def nearest_rank(values, percentile):
+    """The nearest-rank percentile: the ceil(p/100 * n)-th of the sorted values.
+
+    Nearest rank rather than interpolation, so every reported figure is a
+    duration that was actually OBSERVED. An interpolated p95 is a number no
+    launch produced, which is a poor thing to hold a budget against.
+
+    The rank is computed in INTEGER arithmetic. `math.ceil(0.95 * n)` is a float
+    expression and 0.95 has no exact binary representation, so it can land one
+    rank high for values of n where the true product is a whole number -
+    silently reporting the maximum as the p95.
+    """
+    if not values:
+        raise ValueError("nearest_rank of an empty sample")
+    ordered = sorted(values)
+    n = len(ordered)
+    rank = -(-int(percentile) * n // 100)          # ceil division, exact
+    rank = max(1, min(rank, n))
+    return ordered[rank - 1]
+
+
+def paired_schedule(pair_count=PAIR_COUNT):
+    """Alternating AB/BA, half each way.
+
+    A run drifts - caches warm, the machine heats, the page cache fills - and a
+    drift is monotone across the run. Alternating splits any such trend evenly
+    between the two bundles instead of handing all of it to whichever went
+    second.
+    """
+    if pair_count % 2:
+        raise ValueError("an alternating schedule needs an even pair count")
+    return ["AB" if i % 2 == 0 else "BA" for i in range(pair_count)]
+
+
+# -------------------------------------------------------- benchmark verdict
+
+def adjudicate_benchmark(pairs, budget=PLAN_BUDGET, pair_count=PAIR_COUNT):
+    """Thirty complete pairs to a budget verdict, or a block naming why not.
+
+    **No top-up.** A rejected sample blocks the whole run rather than being
+    replaced, because replacing it selects for launches that happened to produce
+    clean evidence - and the ones that do not are exactly the launches a latency
+    question is about.
+    """
+    def blocked(reason, detail):
+        return BenchmarkResult(verdict=reason, detail=detail, measured={})
+
+    if len(pairs) != pair_count:
+        return blocked(
+            BLOCKED_INCOMPLETE_PAIRS,
+            f"{len(pairs)} pairs, this benchmark requires exactly {pair_count}")
+
+    for i, p in enumerate(pairs):
+        for side, result in (("A", p.a), ("B", p.b)):
+            if result.verdict != OK:
+                return blocked(
+                    BLOCKED_INCOMPLETE_PAIRS,
+                    f"pair {i} side {side} is {result.verdict}: {result.detail}. "
+                    "The run is not topped up; re-run the whole schedule.")
+
+    # Balanced is NOT the requirement; ALTERNATING is. Fifteen AB followed by
+    # fifteen BA is perfectly balanced and hands the whole first half of any
+    # thermal or cache drift to one bundle, which is the bias the alternation
+    # exists to cancel.
+    orders = [p.order for p in pairs]
+    expected_orders = paired_schedule(pair_count)
+    if orders != expected_orders:
+        return blocked(BLOCKED_SCHEDULE,
+                       f"the order was {orders!r}; the schedule must alternate as "
+                       f"{expected_orders!r}")
+
+    # Every side must be its OWN cold launch. Without this, one result reused
+    # sixty times satisfies every check above and produces a zero-variance
+    # benchmark that looks superb.
+    runs = [result.sample.run for p in pairs for result in (p.a, p.b)]
+    if len(set(runs)) != pair_count * 2:
+        return blocked(BLOCKED_INCOMPLETE_PAIRS,
+                       f"{len(set(runs))} distinct run ids across {pair_count * 2} "
+                       "sides; every side must come from its own cold launch")
+
+    a_launch = [p.a.sample.launch_ms for p in pairs]
+    b_launch = [p.b.sample.launch_ms for p in pairs]
+    b_root = [p.b.sample.root_ms for p in pairs]
+    a_key = [p.a_keypress_ms for p in pairs]
+    b_key = [p.b_keypress_ms for p in pairs]
+
+    launch_regression = median(b_launch) - median(a_launch)
+    root_p95 = nearest_rank(b_root, 95)
+    keypress_regression = nearest_rank(b_key, 95) - nearest_rank(a_key, 95)
+
+    breaches = []
+    if launch_regression > budget.launch_median_regression_ms:
+        breaches.append(
+            f"launch median regressed {launch_regression:.3f} ms, budget "
+            f"{budget.launch_median_regression_ms} ms")
+    if root_p95 > budget.root_p95_ms:
+        breaches.append(
+            f"root construction p95 is {root_p95:.3f} ms, budget {budget.root_p95_ms} ms")
+    if keypress_regression > budget.keypress_p95_regression_ms:
+        breaches.append(
+            f"keypress-to-overlay p95 regressed {keypress_regression:.3f} ms, budget "
+            f"{budget.keypress_p95_regression_ms} ms")
+
+    measured = {
+        "launch_median_a_ms": median(a_launch),
+        "launch_median_b_ms": median(b_launch),
+        "launch_median_regression_ms": launch_regression,
+        "root_p95_b_ms": root_p95,
+        "keypress_p95_a_ms": nearest_rank(a_key, 95),
+        "keypress_p95_b_ms": nearest_rank(b_key, 95),
+        "keypress_p95_regression_ms": keypress_regression,
+    }
+    return BenchmarkResult(
+        verdict=BENCHMARK_FAIL if breaches else BENCHMARK_PASS,
+        detail="; ".join(breaches),
+        measured=measured)
+
+
+# ============================================================================
+# The live half. Everything below drives a real app; everything above is pure.
+# ============================================================================
+
+
+def sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def bundle_identity(bundle_path):
+    """The requested bundle's identity, read from disk BEFORE any launch."""
+    bundle = pathlib.Path(bundle_path).resolve()
+    executable = bundle / "Contents" / "MacOS" / "EnviousWispr"
+    if not executable.exists():
+        raise FileNotFoundError(f"no executable at {executable}")
+    return Identity(bundle_id=bundle_id_at(bundle / "Contents" / "Info.plist"),
+                    executable_path=str(executable), sha256=sha256_of(executable))
+
+
+def bundle_id_at(plist):
+    """`CFBundleIdentifier` from an Info.plist, or raise."""
+    result = subprocess.run(
+        ["/usr/libexec/PlistBuddy", "-c", "Print :CFBundleIdentifier", str(plist)],
+        capture_output=True, text=True, check=True)
+    value = result.stdout.strip()
+    # PlistBuddy prints its own failures to STDOUT — a missing file yields the
+    # sentence "File Doesn't Exist, Will Create: <path>" rather than an error —
+    # so every `if value:` guard downstream passes on a failure. Assert the
+    # SHAPE, not the truthiness.
+    if not value or " " in value:
+        raise ValueError(f"PlistBuddy returned {value!r} for {plist}")
+    return value
+
+
+def resolved_identity(pid):
+    """What the LAUNCHED process actually is, resolved entirely from its own pid.
+
+    **Takes no bundle id.** An earlier version accepted the REQUESTED one and
+    returned it unchanged, which made the resolved-versus-requested bundle
+    comparison tautologically true on every live run — a check that could only
+    ever pass, sitting in the identity guard this whole instrument rests on. The
+    bundle id is now read from the Info.plist of the bundle that actually
+    contains the running executable.
+
+    Reads `comm`, never `command`: `command` is the executable plus its
+    arguments with no delimiter, so recovering the path means guessing where the
+    arguments begin, and every guess is wrong for some legal path.
+    """
+    exe = subprocess.run(["/bin/ps", "-o", "comm=", "-p", str(pid)],
+                         capture_output=True, text=True).stdout.strip()
+    if not exe:
+        raise RuntimeError(f"pid {pid} is not running")
+    executable = pathlib.Path(exe)
+    # <bundle>.app/Contents/MacOS/<exe> -> <bundle>.app
+    bundle = executable.parent.parent.parent
+    if bundle.suffix != ".app":
+        raise RuntimeError(
+            f"pid {pid} runs {exe}, which is not inside a .app bundle")
+    return Identity(bundle_id=bundle_id_at(bundle / "Contents" / "Info.plist"),
+                    executable_path=exe, sha256=sha256_of(exe))
+
+
+def mach_timebase():
+    """`mach_timebase_info`, so raw ticks convert HERE rather than in the app.
+
+    The app emits ticks and does no arithmetic on the launch path, because the
+    arithmetic would be inside the interval it is measuring.
+    """
+    import ctypes
+    libc = ctypes.CDLL(None)
+
+    class Timebase(ctypes.Structure):
+        _fields_ = [("numer", ctypes.c_uint32), ("denom", ctypes.c_uint32)]
+
+    tb = Timebase()
+    if libc.mach_timebase_info(ctypes.byref(tb)) != 0:
+        raise RuntimeError("mach_timebase_info failed")
+    return (tb.numer, tb.denom)
+
+
+def running_instances():
+    """Every running EnviousWispr bundle as {pid: executable path}.
+
+    Delegates to the shipped helper rather than re-deriving the `comm`-not-
+    `command` reading, the basename requirement and the self-exclusion. Three
+    implementations of that have existed; a fourth is how they drift.
+    """
+    import wispr_eyes as _we
+    return _we.running_enviouswispr_instances()
+
+
+def onscreen_window_ids(pid):
+    import Quartz
+    info = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
+    return {w.get("kCGWindowNumber") for w in info
+            if w.get("kCGWindowOwnerPID") == pid}
+
+
+def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
+    """Key DOWN to the named overlay window's first appearance, timed here.
+
+    Both endpoints are `perf_counter_ns` reads in THIS process, because the
+    quantity is what a user waits for. Splitting it across two clocks in two
+    processes would measure two different things and subtract them.
+
+    **The key is held down across the poll, and released afterwards.**
+    `wispr_eyes.press_record_key` is a complete push-to-talk gesture — down, a
+    40 ms hold, up — so wrapping the timer around it puts that hold INSIDE the
+    interval. The pill appears during the hold, so every sample would be
+    dominated by the harness's own sleep. It would still have compared the two
+    bundles fairly, which is exactly why it would have survived: a constant
+    added to both sides leaves the REGRESSION right and the absolute number
+    meaningless, and the plan's keypress bound is stated in absolute
+    milliseconds. So this calls `simulate_input.modifier_down`/`modifier_up`
+    directly — those two functions ARE the owner of the event mechanism,
+    including the `CGEventSetIntegerValueField(kCGKeyboardEventKeycode)` line a
+    hand-rolled version omits, and `press_record_key` reaches them the same way.
+    Only its sequencing is not reused.
+
+    **The app names the subject; the harness times it.** Polling continues until
+    the specific window id from `host.order_front.complete` is seen on screen.
+    Every other new window is recorded for the receipt and ends nothing — see
+    `adjudicate_overlay_window` for why stopping at "the marker plus any window"
+    is not a smaller version of this but a different, wrong measurement.
+
+    Window identity comes from CGWindowList rather than the accessibility tree.
+    The plan says "first-AX-overlay"; this is the deliberate implementation of
+    that requirement, ruled on rather than assumed. A host-supplied window id
+    plus a harness-observed first appearance identifies the visible panel more
+    exactly than an AX sweep, and costs far less per poll — and polling
+    resolution is the floor of this measurement, so a slower probe reports a
+    worse number for a better reason. The observed resolution is in the receipt.
+    """
+    import ptt_binding as _ptt
+    import simulate_input as _si
+
+    # RESOLVE the binding; never assume it. A profile bound to something else,
+    # or to a non-modifier key, produces silence — and silence read as a product
+    # failure is the exact class `ptt_binding` refuses rather than guessing.
+    binding = _ptt.resolve()
+    if not binding.is_modifier_only:
+        raise _ptt.PTTBindingError(
+            f"the record key is bound to {binding.key_name!r} (keycode "
+            f"{binding.keycode}), which is not a standalone modifier. A plain key "
+            "is registered with Carbon, which does not deliver synthetic events.")
+
+    marker_path = pathlib.Path(marker_path)
+    preexisting = onscreen_window_ids(pid)
+    first_seen = {}
+    gaps = []
+    host_window_id = None
+    marker_failure = None
+
+    keydown_ns = time.perf_counter_ns()
+    _si.modifier_down(binding.keycode)
+    last = time.perf_counter_ns()
+    deadline = last + int(timeout_s * 1e9)
+    try:
+        while time.perf_counter_ns() < deadline:
+            now = onscreen_window_ids(pid)
+            seen = time.perf_counter_ns()
+            gaps.append((seen - last) / 1e6)
+            last = seen
+            for window in now - preexisting:
+                first_seen.setdefault(window, seen)
+            if host_window_id is None and marker_failure is None:
+                host_window_id, marker_failure = host_window_from(
+                    marker_path.read_text())
+                if marker_failure is not None:
+                    break
+            if named_window_has_appeared(host_window_id, first_seen):
+                break
+    finally:
+        # Released whatever happened above. A modifier left down is a stuck key
+        # for every app on the machine, and the failure path is exactly when it
+        # is least likely to be noticed.
+        _si.modifier_up(binding.keycode)
+
+    if marker_failure is not None:
+        timing = OverlayTiming(verdict=marker_failure[0], detail=marker_failure[1],
+                               window_id=None, keypress_ms=None)
+    else:
+        timing = adjudicate_overlay_window(
+            host_window_id, first_seen, keydown_ns, preexisting)
+
+    return {
+        "verdict": timing.verdict,
+        "detail": timing.detail,
+        "keypress_ms": timing.keypress_ms,
+        "window_id": timing.window_id,
+        "host_window_id": host_window_id,
+        # Kept so a receipt can show what else was on screen. These never end the
+        # interval; recording them is how an unexplained result stays explicable.
+        "other_windows_ms": {str(w): (t - keydown_ns) / 1e6
+                             for w, t in first_seen.items() if w != host_window_id},
+        "keycode": binding.keycode,
+        "poll_resolution_ms_median": median(gaps) if gaps else None,
+        "poll_resolution_ms_max": max(gaps) if gaps else None,
+        "polls": len(gaps),
+    }
+
+
+def hardware_identity():
+    """The machine, recorded with every run.
+
+    A latency figure is a measurement OF THIS MAC. This one is further from the
+    slowest supported machine than the last one was, so a bound cleared here is
+    LOOSER than a real user's floor - and a receipt that does not name its host
+    invites the opposite reading.
+    """
+    def sysctl(key):
+        return subprocess.run(["/usr/sbin/sysctl", "-n", key],
+                              capture_output=True, text=True).stdout.strip()
+    return {
+        "model": sysctl("hw.model"),
+        "cpu": sysctl("machdep.cpu.brand_string"),
+        "cores": sysctl("hw.ncpu"),
+        "memory_bytes": sysctl("hw.memsize"),
+        "os": subprocess.run(["/usr/bin/sw_vers", "-productVersion"],
+                             capture_output=True, text=True).stdout.strip(),
+    }
+
+
+def launch_with_markers(bundle_path, *, marker_dir, ready_timeout_s=30.0):
+    """One cold launch with markers armed, returning everything needed to judge it.
+
+    Launches the EXECUTABLE directly rather than through `open`, because `open`
+    does not pass an environment through and the emitter is armed entirely by
+    environment. The marker file is pre-created here: the app opens it WITHOUT
+    `O_CREAT`, so an app that finds no file writes nothing rather than creating
+    one somewhere unexpected.
+
+    **Readiness comes from the SUBJECT, never from a settle time.** The app
+    writes `launch.exit` when `applicationDidFinishLaunching` returns, which is
+    the exact event a sleep would be guessing at — and a guess is wrong in both
+    directions: too short and the press lands before the app can see it, too
+    long and every launch pays for the slowest machine anyone ran this on.
+    """
+    requested = bundle_identity(bundle_path)
+    run_id = str(uuid.uuid4()).upper()
+    marker_path = pathlib.Path(marker_dir) / f"markers-{run_id}.tsv"
+    marker_path.write_text("")
+
+    env = dict(os.environ)
+    env[MARKER_PATH_ENV] = str(marker_path)
+    env[RUN_ID_ENV] = run_id
+
+    proc = subprocess.Popen([requested.executable_path], env=env,
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    deadline = time.monotonic() + ready_timeout_s
+    ready = False
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"the app exited during launch with {proc.returncode}")
+        if launch_is_ready(marker_path.read_text(),
+                           expected_run=run_id, expected_pid=proc.pid,
+                           expected_bundle=requested.bundle_id):
+            ready = True
+            break
+        # deadline-fallback: the interval between reads of the app's own
+        # readiness marker, bounded by `ready_timeout_s` above. The signal is
+        # the marker; this only decides how often we look for it.
+        time.sleep(0.02)
+    if not ready:
+        proc.terminate()
+        raise RuntimeError(
+            f"no complete {LAUNCH_EXIT} marker for run {run_id} within "
+            f"{ready_timeout_s}s. Either the build carries no emitter (a Release "
+            f"build carries none by design), the marker environment did not reach "
+            f"it, or the file holds a line this parser cannot read.")
+    return {"requested": requested, "run_id": run_id, "pid": proc.pid,
+            "marker_path": marker_path, "process": proc}
+
+
+def smoke(bundle_path, *, out_dir):
+    """One bundle, one launch, one press: does the instrument produce a receipt?
+
+    Returns a JSON-serialisable dict whose `verdict` is `SMOKE_PASS` or a
+    `BLOCKED_` reason. It is never `BENCHMARK_PASS` — one bundle has nothing to
+    be compared against.
+    """
+    out = {"kind": "smoke", "bundle": str(bundle_path),
+           "hardware": hardware_identity()}
+
+    # Occupancy: REFUSE rather than choose. Every dev bundle on this machine is
+    # named the same, so picking one of two instances silently retargets the
+    # measurement at somebody else's build.
+    instances = running_instances()
+    if instances:
+        out["verdict"] = BLOCKED_OCCUPANCY
+        out["detail"] = ("EnviousWispr is already running and this measurement needs a "
+                         "cold launch it owns: " +
+                         ", ".join(f"pid {p} at {x}" for p, x in sorted(instances.items())))
+        return out
+
+    try:
+        launched = launch_with_markers(bundle_path, marker_dir=out_dir)
+    except Exception as exc:
+        out["verdict"] = BLOCKED_LAUNCH
+        out["detail"] = f"{type(exc).__name__}: {exc}"
+        return out
+
+    timebase = mach_timebase()
+    resolved = None
+    timing = None
+    result = None
+    failure = None
+    try:
+        timing = measure_keypress_to_overlay(
+            launched["pid"], launched["marker_path"])
+        marker_text = launched["marker_path"].read_text()
+        # `resolved_identity` raises if the pid is gone, which is exactly what a
+        # crash during the take looks like. A traceback here would leave NO
+        # receipt on disk for the one run that most needs explaining, so the
+        # failure becomes a verdict rather than an exception.
+        resolved = resolved_identity(launched["pid"])
+        result = adjudicate_launch(
+            marker_text,
+            expected_run=launched["run_id"],
+            expected_pid=launched["pid"],
+            requested=launched["requested"],
+            resolved=resolved,
+            timebase=timebase)
+    except Exception as exc:
+        failure = f"{type(exc).__name__}: {exc}"
+    finally:
+        launched["process"].terminate()
+        try:
+            # deadline-fallback: the signal is the process exiting; this bounds
+            # how long a wedged instance can hold the dev slot before we escalate.
+            launched["process"].wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            launched["process"].kill()
+
+    out.update({
+        "run_id": launched["run_id"],
+        "pid": launched["pid"],
+        "marker_path": str(launched["marker_path"]),
+        "requested_identity": launched["requested"]._asdict(),
+        "resolved_identity": resolved._asdict() if resolved else None,
+        "timebase": timebase,
+        "keypress": timing,
+        "detail": failure or (result.detail if result else ""),
+        "sample": result.sample._asdict() if result and result.sample else None,
+    })
+    if failure is not None:
+        out["verdict"] = BLOCKED_LAUNCH
+        return out
+    if result.verdict != OK:
+        out["verdict"] = result.verdict
+        return out
+    if timing["verdict"] != OK:
+        # The markers can be complete while the keypress interval has no
+        # identifiable endpoint. That is a block, never a pass with a missing
+        # field: the plan's third bound is stated on this number.
+        out["verdict"] = timing["verdict"]
+        out["detail"] = timing["detail"]
+        return out
+    out["verdict"] = smoke_verdict(result)
+    return out
+
+
+def main(argv):
+    import argparse
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--smoke", action="store_true",
+                    help="one bundle, one launch; proves the instrument, not the latency")
+    ap.add_argument("--bundle", help="path to an EnviousWispr .app")
+    ap.add_argument("--out-dir", default=None,
+                    help="where the receipt and marker file are written")
+    args = ap.parse_args(argv)
+
+    if not args.smoke:
+        ap.error("only --smoke is implemented in P6-C1; "
+                 "the 30-pair benchmark run belongs to C4, after a final candidate exists")
+    if not args.bundle:
+        ap.error("--smoke needs --bundle")
+
+    out_dir = pathlib.Path(args.out_dir or (pathlib.Path.cwd() / ".validation" /
+                                            "runs" / "2377-p6c1-smoke"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    receipt = smoke(args.bundle, out_dir=out_dir)
+    path = out_dir / "overlay-first-render-smoke.json"
+    path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    print(f"\nreceipt: {path}")
+    print(f"VERDICT: {receipt['verdict']}")
+    return 0 if receipt["verdict"] == SMOKE_PASS else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -759,6 +759,38 @@ def hardware_identity():
     }
 
 
+def reap(proc, *, timeout_s=10.0):
+    """Terminate a launched app and make sure it is actually gone.
+
+    **Every path that abandons a launch uses this one, and that is the point.**
+    A bare `terminate()` followed by a raise is a request, not an outcome: a
+    process slow to exit — or ignoring SIGTERM — outlives the exception, and the
+    NEXT cold launch then either blocks on occupancy or, worse, is measured
+    beside an orphan answering the same global hotkey and writing the same log.
+    Every dev bundle on this machine is named `EnviousWispr Local.app`, so an
+    orphan is not distinguishable by name from the instance under test.
+
+    Bounded, then escalated, then waited on again: a `kill()` that is never
+    reaped leaves a zombie, which `ps` still reports.
+    """
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        # deadline-fallback: the signal is the process exiting; this bounds how
+        # long a wedged instance can hold the shared dev-app slot.
+        proc.wait(timeout=timeout_s)
+        return
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    try:
+        # deadline-fallback: same signal, after SIGKILL, so the child is reaped
+        # rather than left as a zombie for the next occupancy probe to find.
+        proc.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def launch_with_markers(bundle_path, *, marker_dir, ready_timeout_s=30.0):
     """One cold launch with markers armed, returning everything needed to judge it.
 
@@ -800,7 +832,10 @@ def launch_with_markers(bundle_path, *, marker_dir, ready_timeout_s=30.0):
         # the marker; this only decides how often we look for it.
         time.sleep(0.02)
     if not ready:
-        proc.terminate()
+        # The same bounded cleanup the successful path uses. A Release bundle, or
+        # an emitter that cannot open its marker file, reaches here — and both are
+        # ordinary enough that leaving an orphan behind would be a routine cost.
+        reap(proc)
         raise RuntimeError(
             f"no complete {LAUNCH_EXIT} marker for run {run_id} within "
             f"{ready_timeout_s}s. Either the build carries no emitter (a Release "
@@ -862,13 +897,7 @@ def smoke(bundle_path, *, out_dir):
     except Exception as exc:
         failure = f"{type(exc).__name__}: {exc}"
     finally:
-        launched["process"].terminate()
-        try:
-            # deadline-fallback: the signal is the process exiting; this bounds
-            # how long a wedged instance can hold the dev slot before we escalate.
-            launched["process"].wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            launched["process"].kill()
+        reap(launched["process"])
 
     out.update({
         "run_id": launched["run_id"],

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -456,7 +456,7 @@ def engine_is_ready(text, *, expected_run, expected_pid, expected_bundle):
                for mk in markers)
 
 
-def await_engine_ready(marker_path, *, run_id, expected_pid, expected_bundle,
+def await_engine_ready(marker_path, *, proc, run_id, expected_pid, expected_bundle,
                        timeout_s=30.0, read_text=None):
     """Wait for `engine.ready` before any synthetic input is sent.
 
@@ -471,12 +471,24 @@ def await_engine_ready(marker_path, *, run_id, expected_pid, expected_bundle,
     the caller turns that into `BLOCKED_ENGINE_NOT_READY`, a receipt, not an
     exception with no receipt behind it.
 
+    **Watches `proc`, not just the marker file (#2377, C1 repair round 4,
+    Codex MEDIUM).** Without this, an app that crashes DURING warm-up burns
+    the whole `timeout_s` waiting for a marker that will never arrive, then
+    reports `BLOCKED_ENGINE_NOT_READY` — a plausible-sounding but wrong
+    diagnosis for what was actually a crash. Raising here instead reaches
+    `smoke()`'s existing `except Exception` handler, which reports
+    `BLOCKED_LAUNCH` — the same fate a crash during the ORIGINAL launch wait
+    already gets via `await_launch_ready`.
+
     `read_text` exists for the suite, which cannot launch a real app to make
     the read fail or to control what it returns.
     """
     read_text = read_text or (lambda: marker_path.read_text())
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"the app exited during engine warm-up with {proc.returncode}")
         try:
             text = read_text()
         except OSError:
@@ -1015,6 +1027,17 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     }
 
 
+def measure_after_engine_ready(engine_ready, measure):
+    """Gate a measurement behind a readiness fact — extracted so `smoke()`'s
+    "never press before the engine is ready" property is provable by CALLING
+    this with a spy, not merely by reading `smoke()`'s own source layout
+    (#2377, C1 repair round 4, Codex MEDIUM). `measure` is a zero-argument
+    thunk so the caller controls exactly what "the measurement" means without
+    this function needing to know.
+    """
+    return measure() if engine_ready else None
+
+
 def screen_lock_state(session_reader=None):
     """`True` locked, `False` unlocked, `None` could not tell.
 
@@ -1258,15 +1281,21 @@ def smoke(bundle_path, *, out_dir):
         # that race, not to measure the app's response to it.
         ready_start = time.monotonic()
         engine_ready = await_engine_ready(
-            launched["marker_path"], run_id=launched["run_id"],
-            expected_pid=launched["pid"],
+            launched["marker_path"], proc=launched["process"],
+            run_id=launched["run_id"], expected_pid=launched["pid"],
             expected_bundle=launched["requested"].bundle_id)
         engine_ready_wait_ms = (time.monotonic() - ready_start) * 1000.0
+        # Gated through `measure_after_engine_ready` rather than an inline
+        # `if`/`else` around the call — the gate is then provable by calling
+        # that function directly with a spy, not just by reading this
+        # function's source layout (#2377, C1 repair round 4, Codex MEDIUM).
+        timing = measure_after_engine_ready(
+            engine_ready,
+            lambda: measure_keypress_to_overlay(
+                launched["pid"], launched["marker_path"]))
         if not engine_ready:
             engine_not_ready = True
         else:
-            timing = measure_keypress_to_overlay(
-                launched["pid"], launched["marker_path"])
             marker_text = launched["marker_path"].read_text()
             # `resolved_identity` raises if the pid is gone, which is exactly what a
             # crash during the take looks like. A traceback here would leave NO

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -55,8 +55,8 @@ SCHEMA_FAMILY = "EW_OVERLAY_FIRST_RENDER"
 # keypress-triggered recording. A schema bump because a V1 harness reading a
 # V2 line, or a V2 harness reading a V1 line, must refuse loudly rather than
 # silently misparse the field count.
-# V3 adds the `engine.ready` event (#2377, C1 repair, Codex's smoke ruling):
-# an app launched with an engine that has not finished warming refuses a
+# V3 adds the `engine.ready` event (#2377, C1 repair): an app launched with
+# an engine that has not finished warming refuses a
 # synthetic keypress via `ColdPressGuard` (#879), a real product policy this
 # instrument's own input must not trip. A V2 harness has no such event in its
 # `EVENTS`/`KNOWN_EVENTS` set and would refuse the line rather than silently
@@ -471,8 +471,8 @@ def await_engine_ready(marker_path, *, proc, run_id, expected_pid, expected_bund
     the caller turns that into `BLOCKED_ENGINE_NOT_READY`, a receipt, not an
     exception with no receipt behind it.
 
-    **Watches `proc`, not just the marker file (#2377, C1 repair round 4,
-    Codex MEDIUM).** Without this, an app that crashes DURING warm-up burns
+    **Watches `proc`, not just the marker file (#2377, C1 repair).** Without
+    this, an app that crashes DURING warm-up burns
     the whole `timeout_s` waiting for a marker that will never arrive, then
     reports `BLOCKED_ENGINE_NOT_READY` — a plausible-sounding but wrong
     diagnosis for what was actually a crash. Raising here instead reaches
@@ -1031,7 +1031,7 @@ def measure_after_engine_ready(engine_ready, measure):
     """Gate a measurement behind a readiness fact — extracted so `smoke()`'s
     "never press before the engine is ready" property is provable by CALLING
     this with a spy, not merely by reading `smoke()`'s own source layout
-    (#2377, C1 repair round 4, Codex MEDIUM). `measure` is a zero-argument
+    (#2377, C1 repair). `measure` is a zero-argument
     thunk so the caller controls exactly what "the measurement" means without
     this function needing to know.
     """
@@ -1288,7 +1288,7 @@ def smoke(bundle_path, *, out_dir):
         # Gated through `measure_after_engine_ready` rather than an inline
         # `if`/`else` around the call — the gate is then provable by calling
         # that function directly with a spy, not just by reading this
-        # function's source layout (#2377, C1 repair round 4, Codex MEDIUM).
+        # function's source layout (#2377, C1 repair).
         timing = measure_after_engine_ready(
             engine_ready,
             lambda: measure_keypress_to_overlay(

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -55,17 +55,32 @@ SCHEMA_FAMILY = "EW_OVERLAY_FIRST_RENDER"
 # keypress-triggered recording. A schema bump because a V1 harness reading a
 # V2 line, or a V2 harness reading a V1 line, must refuse loudly rather than
 # silently misparse the field count.
-SCHEMA = SCHEMA_FAMILY + "_V2"
+# V3 adds the `engine.ready` event (#2377, C1 repair, Codex's smoke ruling):
+# an app launched with an engine that has not finished warming refuses a
+# synthetic keypress via `ColdPressGuard` (#879), a real product policy this
+# instrument's own input must not trip. A V2 harness has no such event in its
+# `EVENTS`/`KNOWN_EVENTS` set and would refuse the line rather than silently
+# treat it as launch/root evidence it is not.
+SCHEMA = SCHEMA_FAMILY + "_V3"
 
 LAUNCH_ENTER = "launch.enter"
 LAUNCH_EXIT = "launch.exit"
 ROOT_START = "root.construct.start"
 ROOT_END = "root.construct.end"
 ORDER_FRONT = "host.order_front.complete"
+ENGINE_READY = "engine.ready"
 
 # In causal order. The whole chain is enforced, which is what forbids a root
 # built inside launch; there is deliberately no separate notion of "pairs".
+# `ENGINE_READY` is deliberately NOT a member: engine warm-up and first render
+# run on two independent schedules, and folding one into the other's ordering
+# check would make an instrument change what it exists only to observe.
 EVENTS = (LAUNCH_ENTER, LAUNCH_EXIT, ROOT_START, ROOT_END, ORDER_FRONT)
+
+# Every event the PARSER accepts — `EVENTS` plus `ENGINE_READY`. Kept separate
+# from `EVENTS` so adding a recognized event never silently widens the launch
+# causal chain `adjudicate_launch` enforces.
+KNOWN_EVENTS = EVENTS + (ENGINE_READY,)
 
 # Which presentation an `ORDER_FRONT` marker belongs to. `NONE` is the only
 # legal intent for every other event; `RECORDING` is the presentation the
@@ -113,6 +128,12 @@ BLOCKED_AX_UNAVAILABLE = "BLOCKED_AX_UNAVAILABLE"
 # appearance. Never averaged or picked from — refused, like every other
 # ambiguity this instrument treats as evidence it cannot trust.
 BLOCKED_AMBIGUOUS_OVERLAY = "BLOCKED_AMBIGUOUS_OVERLAY"
+# No complete `engine.ready` marker for this run/pid/bundle within the wait.
+# Sending a synthetic keypress anyway would race `ColdPressGuard` (#879),
+# which correctly refuses a press on a still-warming engine — a real product
+# policy, not a first-render fault, so it gets its own verdict rather than
+# reusing `BLOCKED_WRONG_PRESENTATION` or `BLOCKED_LAUNCH`.
+BLOCKED_ENGINE_NOT_READY = "BLOCKED_ENGINE_NOT_READY"
 
 Identity = namedtuple("Identity", "bundle_id executable_path sha256")
 Marker = namedtuple("Marker", "run pid bundle event ticks window intent index")
@@ -166,7 +187,7 @@ def parse_marker_line(line, index=0):
         if not field.startswith(prefix):
             raise MarkerFormatError(f"expected {prefix!r}, got {field!r}")
         parsed[key] = field[len(prefix):]
-    if parsed["event"] not in EVENTS:
+    if parsed["event"] not in KNOWN_EVENTS:
         raise MarkerFormatError(f"unknown event {parsed['event']!r}")
     if parsed["intent"] not in INTENTS:
         raise MarkerFormatError(f"unknown intent {parsed['intent']!r}")
@@ -413,6 +434,59 @@ def launch_is_ready(text, *, expected_run, expected_pid, expected_bundle):
     return any(mk.event == LAUNCH_EXIT and mk.run == expected_run
                and mk.pid == expected_pid and mk.bundle == expected_bundle
                for mk in markers)
+
+
+def engine_is_ready(text, *, expected_run, expected_pid, expected_bundle):
+    """Has THIS launch written its `engine.ready` marker yet?
+
+    Same exact-match discipline as `launch_is_ready`, for a different fact:
+    the app writes `launch.exit` when `applicationDidFinishLaunching`
+    returns, well before the selected engine has finished warming. Sending a
+    synthetic keypress in that window races `ColdPressGuard` (#879), which
+    correctly refuses the press and blocks the run for a reason that has
+    nothing to do with first render — the fact this instrument exists to
+    measure.
+    """
+    try:
+        markers = read_complete_markers(text)
+    except MarkerFormatError:
+        return False
+    return any(mk.event == ENGINE_READY and mk.run == expected_run
+               and mk.pid == expected_pid and mk.bundle == expected_bundle
+               for mk in markers)
+
+
+def await_engine_ready(marker_path, *, run_id, expected_pid, expected_bundle,
+                       timeout_s=30.0, read_text=None):
+    """Wait for `engine.ready` before any synthetic input is sent.
+
+    **A separate clock from the keypress-to-overlay interval it gates.** This
+    function returns before `measure_keypress_to_overlay` ever reads
+    `perf_counter_ns`, so warm-up wait time cannot fold into the number the
+    plan states as PILL latency — the same reasoning `hold()`'s doc comment
+    gives for keeping marker I/O cost out of the interval it would bias.
+
+    Never a fixed sleep: the signal is the app's own marker, exactly like
+    `await_launch_ready`. Returns `False` on timeout rather than raising —
+    the caller turns that into `BLOCKED_ENGINE_NOT_READY`, a receipt, not an
+    exception with no receipt behind it.
+
+    `read_text` exists for the suite, which cannot launch a real app to make
+    the read fail or to control what it returns.
+    """
+    read_text = read_text or (lambda: marker_path.read_text())
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            text = read_text()
+        except OSError:
+            text = ""
+        if engine_is_ready(text, expected_run=run_id, expected_pid=expected_pid,
+                           expected_bundle=expected_bundle):
+            return True
+        # deadline-fallback: the interval between reads of the app's own marker.
+        time.sleep(0.02)
+    return False
 
 
 def ax_overlay_has_appeared(match_count):
@@ -1169,27 +1243,43 @@ def smoke(bundle_path, *, out_dir):
     result = None
     failure = None
     timebase = None
+    engine_ready_wait_ms = None
+    engine_not_ready = False
     try:
         # Inside the reaped region, not before it. `mach_timebase()` loads a
         # native symbol and can raise; raising here with the app already launched
         # and the cleanup not yet armed leaves an orphan and produces no receipt
         # at all — the one run that most needs explaining.
         timebase = mach_timebase()
-        timing = measure_keypress_to_overlay(
-            launched["pid"], launched["marker_path"])
-        marker_text = launched["marker_path"].read_text()
-        # `resolved_identity` raises if the pid is gone, which is exactly what a
-        # crash during the take looks like. A traceback here would leave NO
-        # receipt on disk for the one run that most needs explaining, so the
-        # failure becomes a verdict rather than an exception.
-        resolved = resolved_identity(launched["pid"])
-        result = adjudicate_launch(
-            marker_text,
-            expected_run=launched["run_id"],
+        # Gated BEFORE any synthetic input, on its OWN clock — never the one
+        # `measure_keypress_to_overlay` starts below. A press sent while the
+        # engine is still warming races `ColdPressGuard` (#879), which
+        # correctly refuses it; this instrument's job is to avoid causing
+        # that race, not to measure the app's response to it.
+        ready_start = time.monotonic()
+        engine_ready = await_engine_ready(
+            launched["marker_path"], run_id=launched["run_id"],
             expected_pid=launched["pid"],
-            requested=launched["requested"],
-            resolved=resolved,
-            timebase=timebase)
+            expected_bundle=launched["requested"].bundle_id)
+        engine_ready_wait_ms = (time.monotonic() - ready_start) * 1000.0
+        if not engine_ready:
+            engine_not_ready = True
+        else:
+            timing = measure_keypress_to_overlay(
+                launched["pid"], launched["marker_path"])
+            marker_text = launched["marker_path"].read_text()
+            # `resolved_identity` raises if the pid is gone, which is exactly what a
+            # crash during the take looks like. A traceback here would leave NO
+            # receipt on disk for the one run that most needs explaining, so the
+            # failure becomes a verdict rather than an exception.
+            resolved = resolved_identity(launched["pid"])
+            result = adjudicate_launch(
+                marker_text,
+                expected_run=launched["run_id"],
+                expected_pid=launched["pid"],
+                requested=launched["requested"],
+                resolved=resolved,
+                timebase=timebase)
     except Exception as exc:
         failure = f"{type(exc).__name__}: {exc}"
     finally:
@@ -1202,10 +1292,18 @@ def smoke(bundle_path, *, out_dir):
         "requested_identity": launched["requested"]._asdict(),
         "resolved_identity": resolved._asdict() if resolved else None,
         "timebase": timebase,
+        "engine_ready_wait_ms": engine_ready_wait_ms,
         "keypress": timing,
         "detail": failure or (result.detail if result else ""),
         "sample": result.sample._asdict() if result and result.sample else None,
     })
+    if engine_not_ready:
+        out["verdict"] = BLOCKED_ENGINE_NOT_READY
+        out["detail"] = (
+            f"no complete {ENGINE_READY} marker for run {launched['run_id']} "
+            f"within the warm-up wait; a keypress sent now would race "
+            f"ColdPressGuard (#879)")
+        return out
     if failure is not None:
         out["verdict"] = BLOCKED_LAUNCH
         return out

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -48,7 +48,14 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 # The version is IN the schema token, so a future format is refused loudly by an
 # old harness rather than parsed leniently into a plausible number.
 SCHEMA_FAMILY = "EW_OVERLAY_FIRST_RENDER"
-SCHEMA = SCHEMA_FAMILY + "_V1"
+# V2 adds the `intent` field (#2377, C1 repair, cloud review P1): the shared
+# retained panel makes every presentation look identical to a marker, so an
+# unrelated one — the crash-recovery card WisprBootstrapper can show on ANY
+# launch — could win the race and bind the marker instead of the
+# keypress-triggered recording. A schema bump because a V1 harness reading a
+# V2 line, or a V2 harness reading a V1 line, must refuse loudly rather than
+# silently misparse the field count.
+SCHEMA = SCHEMA_FAMILY + "_V2"
 
 LAUNCH_ENTER = "launch.enter"
 LAUNCH_EXIT = "launch.exit"
@@ -60,8 +67,21 @@ ORDER_FRONT = "host.order_front.complete"
 # built inside launch; there is deliberately no separate notion of "pairs".
 EVENTS = (LAUNCH_ENTER, LAUNCH_EXIT, ROOT_START, ROOT_END, ORDER_FRONT)
 
+# Which presentation an `ORDER_FRONT` marker belongs to. `NONE` is the only
+# legal intent for every other event; `RECORDING` is the presentation the
+# benchmark measures; `OTHER` is anything else sharing the retained panel.
+# Must match `OverlayFirstRenderMarkers.Intent` in Swift exactly — nothing
+# links the two spellings but `test_the_swift_emitter_and_this_parser_agree_on_the_schema`.
+INTENT_NONE = "none"
+INTENT_RECORDING = "recording"
+INTENT_OTHER = "other"
+INTENTS = (INTENT_NONE, INTENT_RECORDING, INTENT_OTHER)
+
 MARKER_PATH_ENV = "EW_OVERLAY_FIRST_RENDER_MARKER_PATH"
 RUN_ID_ENV = "EW_OVERLAY_FIRST_RENDER_RUN_ID"
+
+# Must match `OverlayFirstRenderMarkers.axPanelIdentifier` in Swift exactly.
+AX_PANEL_IDENTIFIER = "EW_OVERLAY_FIRST_RENDER_PANEL"
 
 # ---------------------------------------------------------------- the verdicts
 
@@ -82,9 +102,20 @@ BLOCKED_OCCUPANCY = "BLOCKED_OCCUPANCY"
 BLOCKED_LAUNCH = "BLOCKED_LAUNCH"
 BLOCKED_NO_OVERLAY = "BLOCKED_NO_OVERLAY"
 BLOCKED_SCREEN_LOCKED = "BLOCKED_SCREEN_LOCKED"
+# An unrelated presentation (intent=other) reached the shared panel before the
+# keypress-triggered recording did, so the FIRST order-front — and the root
+# construction it may have caused — belongs to the wrong presentation.
+BLOCKED_WRONG_PRESENTATION = "BLOCKED_WRONG_PRESENTATION"
+# The AX tree could not be read: permission not granted, or the app's own
+# AXRole did not resolve to AXApplication.
+BLOCKED_AX_UNAVAILABLE = "BLOCKED_AX_UNAVAILABLE"
+# More than one AX window bore our identifier at the moment of first
+# appearance. Never averaged or picked from — refused, like every other
+# ambiguity this instrument treats as evidence it cannot trust.
+BLOCKED_AMBIGUOUS_OVERLAY = "BLOCKED_AMBIGUOUS_OVERLAY"
 
 Identity = namedtuple("Identity", "bundle_id executable_path sha256")
-Marker = namedtuple("Marker", "run pid bundle event ticks window index")
+Marker = namedtuple("Marker", "run pid bundle event ticks window intent index")
 LaunchSample = namedtuple(
     "LaunchSample", "run launch_ms root_ms order_front_ms host_window_id")
 LaunchResult = namedtuple("LaunchResult", "verdict detail sample")
@@ -121,21 +152,24 @@ def parse_marker_line(line, index=0):
     pre-built string, no encoder, no allocation beyond the string itself.
     """
     fields = line.split("\t")
-    if len(fields) != 7:
+    if len(fields) != 8:
         raise MarkerFormatError(
-            f"expected 7 tab-separated fields, got {len(fields)}: {line!r}")
-    schema, run, pid, bundle, event, ticks, window = fields
+            f"expected 8 tab-separated fields, got {len(fields)}: {line!r}")
+    schema, run, pid, bundle, event, ticks, window, intent = fields
     if schema != SCHEMA:
         raise MarkerFormatError(f"unknown schema {schema!r}, this harness reads {SCHEMA}")
     parsed = {}
     for key, field in (("run", run), ("pid", pid), ("bundle", bundle),
-                       ("event", event), ("ticks", ticks), ("window", window)):
+                       ("event", event), ("ticks", ticks), ("window", window),
+                       ("intent", intent)):
         prefix = key + "="
         if not field.startswith(prefix):
             raise MarkerFormatError(f"expected {prefix!r}, got {field!r}")
         parsed[key] = field[len(prefix):]
     if parsed["event"] not in EVENTS:
         raise MarkerFormatError(f"unknown event {parsed['event']!r}")
+    if parsed["intent"] not in INTENTS:
+        raise MarkerFormatError(f"unknown intent {parsed['intent']!r}")
     for key in ("pid", "ticks", "window"):
         if not parsed[key].isdigit():
             raise MarkerFormatError(
@@ -147,17 +181,29 @@ def parse_marker_line(line, index=0):
     # different place. A non-host event carrying a window means the emitter is
     # writing something this parser does not model, and a contract stated only in
     # a comment is the shape that retires the check instead of failing it.
+    #
+    # The SAME split applies to intent: only the host event may concern a
+    # presentation, so it is the one event that must NOT carry `.none` — every
+    # other event must, since carrying anything else is the emitter writing a
+    # concept this parser does not model for that event.
     window_id = int(parsed["window"])
     if parsed["event"] == ORDER_FRONT:
         if window_id <= 0:
             raise MarkerFormatError(
                 f"{ORDER_FRONT} must name a positive window id, got {window_id}")
-    elif window_id != 0:
-        raise MarkerFormatError(
-            f"{parsed['event']} must carry window 0, got {window_id}")
+        if parsed["intent"] == INTENT_NONE:
+            raise MarkerFormatError(f"{ORDER_FRONT} must not carry intent={INTENT_NONE!r}")
+    else:
+        if window_id != 0:
+            raise MarkerFormatError(
+                f"{parsed['event']} must carry window 0, got {window_id}")
+        if parsed["intent"] != INTENT_NONE:
+            raise MarkerFormatError(
+                f"{parsed['event']} must carry intent={INTENT_NONE!r}, got "
+                f"{parsed['intent']!r}")
     return Marker(run=parsed["run"], pid=int(parsed["pid"]), bundle=parsed["bundle"],
                   event=parsed["event"], ticks=int(parsed["ticks"]),
-                  window=int(parsed["window"]), index=index)
+                  window=int(parsed["window"]), intent=parsed["intent"], index=index)
 
 
 def read_markers(text):
@@ -238,18 +284,57 @@ def adjudicate_launch(marker_text, *, expected_run, expected_pid,
     for mk in markers:
         by_event.setdefault(mk.event, []).append(mk)
 
-    missing = [e for e in EVENTS if not by_event.get(e)]
+    # `ORDER_FRONT` is no longer a plain singleton: the shared retained panel
+    # can legitimately write ONE marker per intent (`.recording`, `.other`),
+    # so its own missing/duplicate/identity checks are per-INTENT rather than
+    # per-event, on top of the ordinary per-event checks every other member of
+    # `EVENTS` still gets.
+    non_order_events = [e for e in EVENTS if e != ORDER_FRONT]
+
+    missing = [e for e in non_order_events if not by_event.get(e)]
+
+    order_fronts = by_event.get(ORDER_FRONT, [])
+    by_intent = {}
+    for mk in order_fronts:
+        by_intent.setdefault(mk.intent, []).append(mk)
+    # A `.recording` marker is what makes this launch usable at all — the
+    # benchmark's whole subject is that presentation. An `.other`-only launch
+    # is missing it exactly as if `ORDER_FRONT` were absent entirely.
+    if not by_intent.get(INTENT_RECORDING):
+        missing = missing + [ORDER_FRONT]
+
     if missing:
         return blocked(BLOCKED_MISSING_MARKER, "absent: " + ", ".join(missing))
-    doubled = [e for e in EVENTS if len(by_event[e]) > 1]
-    if doubled:
-        # Every event is a singleton within one launch. Two of anything means
-        # two launches wrote to one file, and the durations would be a mix.
-        return blocked(BLOCKED_DUPLICATE_MARKER,
-                       "seen more than once: " + ", ".join(
-                           f"{e} x{len(by_event[e])}" for e in doubled))
 
-    single = {e: by_event[e][0] for e in EVENTS}
+    # Every key in `non_order_events` is now guaranteed present — `missing`
+    # would have caught and returned on anything absent above — so indexing
+    # `by_event` directly here cannot raise.
+    doubled = [e for e in non_order_events if len(by_event[e]) > 1]
+    doubled_order_front = [intent for intent, group in by_intent.items() if len(group) > 1]
+    if doubled or doubled_order_front:
+        # Every event is a singleton within one launch, and now so is every
+        # INTENT of `ORDER_FRONT`. Two of anything means two launches — or two
+        # presentations of the same intent — wrote to one file, and the
+        # durations would be a mix.
+        parts = [f"{e} x{len(by_event[e])}" for e in doubled]
+        parts += [f"{ORDER_FRONT}(intent={intent}) x{len(by_intent[intent])}"
+                 for intent in doubled_order_front]
+        return blocked(BLOCKED_DUPLICATE_MARKER, "seen more than once: " + ", ".join(parts))
+
+    # Reached only once a `.recording` marker is confirmed present and alone.
+    recording_marker = by_intent[INTENT_RECORDING][0]
+    other_marker = by_intent.get(INTENT_OTHER, [None])[0]
+    if other_marker is not None and other_marker.index < recording_marker.index:
+        # The unrelated presentation reached the panel FIRST, so root
+        # construction — if this is the first-ever presentation — belongs to
+        # IT, not to the recording whose timing the benchmark actually wants.
+        return blocked(
+            BLOCKED_WRONG_PRESENTATION,
+            f"an unrelated presentation (window {other_marker.window}) reached the panel "
+            f"before the recording did (window {recording_marker.window})")
+
+    single = {e: by_event[e][0] for e in non_order_events}
+    single[ORDER_FRONT] = recording_marker
 
     # **The whole chain, not two pairs checked separately.** `EVENTS` is in
     # causal order, and the link that only a full chain enforces is
@@ -330,86 +415,119 @@ def launch_is_ready(text, *, expected_run, expected_pid, expected_bundle):
                for mk in markers)
 
 
-def named_window_has_appeared(host_window_id, first_seen):
-    """The live loop's stopping rule, extracted so a test can reach it.
+def ax_overlay_has_appeared(match_count):
+    """The live loop's stopping rule for the AX endpoint, extracted so a test
+    can reach it directly.
 
-    **It lived inline and no test could touch it**, which meant the whole
-    identity binding could be reverted to "the host marker plus any window" and
-    every pure test still passed — the adjudicator was bound and the thing that
-    decides when to STOP CALLING it was not. That is the same defect one level
-    out from the one this rule exists to fix.
+    Fires on the FIRST match, deliberately. Waiting to see whether a second one
+    also appears would inflate the very quantity being measured; ambiguity from
+    more than one match is judged AFTER the fact by the adjudicator, from the
+    count recorded at the moment of the first one.
     """
-    return host_window_id is not None and host_window_id in first_seen
+    return match_count > 0
 
 
-def host_window_from(marker_text):
-    """The window id the app says it ordered front, or `(None, reason)`.
+def recording_host_marker_from(marker_text, *, exhausted=False):
+    """The RECORDING-intent host marker's window id, or a block, or "not yet".
 
-    Returns `(window_id, None)` once the host marker is present and usable,
-    `(None, None)` while it has not arrived, and `(None, BLOCKED_...)` when it
-    arrived and cannot be read.
+    Three answers, and `exhausted` decides which of two readings an `.other`-
+    only file gets:
+
+    - `(window_id, None)` — a usable `.recording` marker exists, and no
+      `.other` marker reached the panel before it.
+    - `(None, (verdict, detail))` — a DEFINITIVE block: malformed content, a
+      duplicate marker of one intent, an `.other` marker that beat a
+      `.recording` marker that HAS arrived, or — only once `exhausted` is
+      True — an `.other` marker (or nothing at all) with no `.recording`
+      marker ever arriving.
+    - `(None, None)` — not enough information yet. Only possible when
+      `exhausted` is False: an `.other` marker alone does not yet mean the
+      recording never came, because it might still land within the deadline.
+
+    `exhausted=True` is for the ONE call made once polling has stopped (an AX
+    match fired, or the deadline passed) — the point at which "no `.recording`
+    marker yet" and "no `.recording` marker ever" become the same fact.
     """
     try:
         markers = read_complete_markers(marker_text)
     except MarkerFormatError as exc:
         return None, (BLOCKED_MALFORMED_MARKER, str(exc))
     hosts = [mk for mk in markers if mk.event == ORDER_FRONT]
-    if not hosts:
+    by_intent = {}
+    for mk in hosts:
+        by_intent.setdefault(mk.intent, []).append(mk)
+    for intent, group in by_intent.items():
+        if len(group) > 1:
+            return None, (BLOCKED_DUPLICATE_MARKER,
+                          f"{len(group)} {ORDER_FRONT} markers with intent={intent!r}")
+    recording = by_intent.get(INTENT_RECORDING, [None])[0]
+    other = by_intent.get(INTENT_OTHER, [None])[0]
+    if recording is not None:
+        if other is not None and other.index < recording.index:
+            return None, (BLOCKED_WRONG_PRESENTATION,
+                          f"an unrelated presentation (window {other.window}) reached the "
+                          f"panel before the recording did (window {recording.window})")
+        return recording.window, None
+    if not exhausted:
         return None, None
-    if len(hosts) > 1:
-        return None, (BLOCKED_DUPLICATE_MARKER,
-                      f"{len(hosts)} {ORDER_FRONT} markers in one launch")
-    return hosts[0].window, None
+    if other is not None:
+        return None, (BLOCKED_WRONG_PRESENTATION,
+                      f"only an unrelated presentation (window {other.window}) reached the "
+                      "panel; the keypress-triggered recording never did")
+    return None, (BLOCKED_MISSING_MARKER,
+                  f"the app never reported ordering a window front with intent="
+                  f"{INTENT_RECORDING!r}")
 
 
-def adjudicate_overlay_window(host_window_id, first_seen, keydown_ns, preexisting):
-    """Which window ended the keypress interval — NAMED by the app, timed by us.
+def adjudicate_ax_overlay(*, ax_available, preexisting_count, match_count_at_stop,
+                          first_seen_ns, keydown_ns, host_window_id):
+    """Which AX appearance ended the keypress interval — NAMED by the app's
+    identifier, timed by us.
 
-    **Identity is bound, not inferred.** An earlier version watched for "a new
-    window owned by this process" and stopped at the first one it saw. That
-    accepts this sequence, which no amount of settling delay fixes and which a
-    fixture supplying both windows at once cannot even express:
+    **CGWindow-list membership can precede compositing; AX membership is the
+    plan's own binding endpoint** (cloud review P1, #2377). Registration with
+    WindowServer is not the same fact as SwiftUI content having been drawn —
+    an app-owned window ID can appear in `CGWindowListCopyWindowInfo` before
+    its content is on screen, which is exactly the case the plan's
+    "first-AX-overlay" language exists to rule out.
 
-        1. an unrelated window appears — settings, onboarding, a prompt
-        2. the app writes its host marker
-        3. the harness stops, holding only the unrelated window
-        4. the real pill reaches WindowServer a moment later
-        5. the unrelated window is reported as the overlay
-
-    Every step is plausible and the output is a normal-looking latency about the
-    wrong subject. So the app now names the window it ordered front, and this
-    waits for THAT id. Unrelated windows are recorded for the receipt and can
-    neither end the interval nor invalidate it.
-
-    The value is always the harness's own first-observed timestamp for the named
-    window. The app supplies identity; it does not supply time.
+    The value is always the harness's own first-observed timestamp for the
+    identifier the panel carries. The app supplies identity; it does not
+    supply time. `host_window_id` — the marker's own CGWindow number, already
+    validated by `recording_host_marker_from` — is carried through as a
+    receipt and identity cross-check, never as part of the stopwatch.
     """
-    if host_window_id is None:
+    if not ax_available:
         return OverlayTiming(
-            verdict=BLOCKED_NO_OVERLAY,
-            detail="the app never reported ordering a window front",
-            window_id=None, keypress_ms=None)
-    if host_window_id <= 0:
-        return OverlayTiming(
-            verdict=BLOCKED_MALFORMED_MARKER,
-            detail=f"the host marker named window {host_window_id}, which is not a window",
-            window_id=None, keypress_ms=None)
-    if host_window_id in preexisting:
-        # It was already on screen when the key went down, so its appearance is
-        # not an event this keypress caused and there is no interval to report.
-        return OverlayTiming(
-            verdict=BLOCKED_NO_OVERLAY,
-            detail=(f"window {host_window_id} already existed before the keypress, so "
-                    "nothing about its appearance is attributable to this press"),
+            verdict=BLOCKED_AX_UNAVAILABLE,
+            detail="the AX tree could not be read: permission not granted, or the app's "
+                   "AXRole did not resolve to AXApplication",
             window_id=host_window_id, keypress_ms=None)
-    if host_window_id not in first_seen:
+    if preexisting_count > 0:
+        # Already present at key-down, so its appearance is not an event this
+        # keypress caused and there is no interval to report.
         return OverlayTiming(
             verdict=BLOCKED_NO_OVERLAY,
-            detail=(f"the app ordered window {host_window_id} front, but it was never "
-                    "observed on screen before the deadline"),
+            detail=(f"{preexisting_count} AX window(s) already bore our identifier before "
+                    "the keypress, so nothing about their appearance is attributable to "
+                    "this press"),
+            window_id=host_window_id, keypress_ms=None)
+    if first_seen_ns is None:
+        return OverlayTiming(
+            verdict=BLOCKED_NO_OVERLAY,
+            detail="no AX window bearing our identifier was observed before the deadline",
+            window_id=host_window_id, keypress_ms=None)
+    if match_count_at_stop != 1:
+        # Never averaged or picked from — refused, the same way every other
+        # ambiguity this instrument meets is refused rather than resolved by
+        # guessing.
+        return OverlayTiming(
+            verdict=BLOCKED_AMBIGUOUS_OVERLAY,
+            detail=f"{match_count_at_stop} AX windows bore our identifier at the moment of "
+                   "first appearance",
             window_id=host_window_id, keypress_ms=None)
     return OverlayTiming(verdict=OK, detail="", window_id=host_window_id,
-                         keypress_ms=(first_seen[host_window_id] - keydown_ns) / 1e6)
+                         keypress_ms=(first_seen_ns - keydown_ns) / 1e6)
 
 
 # -------------------------------------------------------------- statistics
@@ -645,12 +763,29 @@ def running_instances():
     return _we.running_enviouswispr_instances()
 
 
-def onscreen_window_ids(pid):
-    import Quartz
-    info = Quartz.CGWindowListCopyWindowInfo(
-        Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
-    return {w.get("kCGWindowNumber") for w in info
-            if w.get("kCGWindowOwnerPID") == pid}
+def ax_accessibility_available(pid):
+    """True when the AX tree is readable for this pid.
+
+    Mirrors `ui_helpers.validate_test_environment`'s own check: `AXRole`
+    resolving to `AXApplication` is what distinguishes a real, permitted read
+    from the silent `None` `AXUIElementCopyAttributeValue` returns for every
+    failure mode alike (no permission, wrong pid, app not responding).
+    """
+    import ui_helpers as _ui
+    app = _ui.get_ax_app(pid)
+    return _ui.get_attr(app, "AXRole") == "AXApplication"
+
+
+def ax_matching_windows(pid):
+    """Every AX window under this app bearing our panel's identifier.
+
+    A LIST, not a count and not a single element — the caller decides what
+    zero or more than one means; this function's only job is not to guess.
+    """
+    import ui_helpers as _ui
+    app = _ui.get_ax_app(pid)
+    windows = _ui.get_attr(app, "AXWindows") or []
+    return [w for w in windows if _ui.get_attr(w, "AXIdentifier") == AX_PANEL_IDENTIFIER]
 
 
 def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
@@ -674,19 +809,20 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     hand-rolled version omits, and `press_record_key` reaches them the same way.
     Only its sequencing is not reused.
 
-    **The app names the subject; the harness times it.** Polling continues until
-    the specific window id from `host.order_front.complete` is seen on screen.
-    Every other new window is recorded for the receipt and ends nothing — see
-    `adjudicate_overlay_window` for why stopping at "the marker plus any window"
-    is not a smaller version of this but a different, wrong measurement.
+    **AX membership, not CGWindow-list membership (cloud review P1, #2377).**
+    CGWindow-list registration can precede SwiftUI content actually being
+    composited — the plan's own "first-AX-overlay" language exists to rule
+    that reading out. Polling continues until an `AXWindow` bearing our
+    panel's identifier exists under the app; `recording_host_marker_from`
+    supplies the CAUSALITY check (that the recording, not some other
+    presentation, is what reached the panel), which AX identity alone cannot
+    express.
 
-    Window identity comes from CGWindowList rather than the accessibility tree.
-    The plan says "first-AX-overlay"; this is the deliberate implementation of
-    that requirement, ruled on rather than assumed. A host-supplied window id
-    plus a harness-observed first appearance identifies the visible panel more
-    exactly than an AX sweep, and costs far less per poll — and polling
-    resolution is the floor of this measurement, so a slower probe reports a
-    worse number for a better reason. The observed resolution is in the receipt.
+    **The marker read is decoupled from the AX poll's stop condition.** The
+    loop stops as soon as EITHER side has a definitive answer — an AX match
+    plus a confirmed recording marker, or a marker-level block that no amount
+    of further waiting would change. Re-reading the marker file only when the
+    last read was inconclusive avoids re-parsing on every single poll.
     """
     import ptt_binding as _ptt
     import simulate_input as _si
@@ -702,11 +838,13 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
             "is registered with Carbon, which does not deliver synthetic events.")
 
     marker_path = pathlib.Path(marker_path)
-    preexisting = onscreen_window_ids(pid)
-    first_seen = {}
+    ax_available = ax_accessibility_available(pid)
+    preexisting = ax_matching_windows(pid) if ax_available else []
+
+    first_seen_ns = None
+    match_count_at_stop = 0
     gaps = []
-    host_window_id = None
-    marker_failure = None
+    marker_result = (None, None)  # (window_id, block_tuple) — both None means "not yet"
 
     keydown_ns = time.perf_counter_ns()
     _si.modifier_down(binding.keycode)
@@ -714,18 +852,25 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     deadline = last + int(timeout_s * 1e9)
     try:
         while time.perf_counter_ns() < deadline:
-            now = onscreen_window_ids(pid)
+            matches = ax_matching_windows(pid) if ax_available else []
             seen = time.perf_counter_ns()
             gaps.append((seen - last) / 1e6)
             last = seen
-            for window in now - preexisting:
-                first_seen.setdefault(window, seen)
-            if host_window_id is None and marker_failure is None:
-                host_window_id, marker_failure = host_window_from(
-                    marker_path.read_text())
-                if marker_failure is not None:
-                    break
-            if named_window_has_appeared(host_window_id, first_seen):
+            if matches and first_seen_ns is None:
+                first_seen_ns = seen
+                match_count_at_stop = len(matches)
+            if marker_result[0] is None and marker_result[1] is None:
+                try:
+                    marker_text = marker_path.read_text()
+                except OSError:
+                    marker_text = ""
+                marker_result = recording_host_marker_from(marker_text, exhausted=False)
+            if marker_result[1] is not None:
+                # A definitive block. No amount of further AX polling changes
+                # a marker-level fault, so stop now rather than run out the
+                # clock on a verdict already decided.
+                break
+            if first_seen_ns is not None and marker_result[0] is not None:
                 break
     finally:
         # Released whatever happened above. A modifier left down is a stuck key
@@ -733,12 +878,28 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
         # is least likely to be noticed.
         _si.modifier_up(binding.keycode)
 
-    if marker_failure is not None:
-        timing = OverlayTiming(verdict=marker_failure[0], detail=marker_failure[1],
-                               window_id=None, keypress_ms=None)
+    if marker_result[0] is None and marker_result[1] is None:
+        # Neither confirmed nor blocked when time ran out: force the FINAL
+        # call, which is the one point "only .other, no .recording yet" and
+        # "only .other, no .recording EVER" become the same fact.
+        try:
+            marker_text = marker_path.read_text()
+        except OSError:
+            marker_text = ""
+        marker_result = recording_host_marker_from(marker_text, exhausted=True)
+
+    host_window_id, presentation_block = marker_result
+    if presentation_block is not None:
+        timing = OverlayTiming(verdict=presentation_block[0], detail=presentation_block[1],
+                               window_id=host_window_id, keypress_ms=None)
     else:
-        timing = adjudicate_overlay_window(
-            host_window_id, first_seen, keydown_ns, preexisting)
+        timing = adjudicate_ax_overlay(
+            ax_available=ax_available,
+            preexisting_count=len(preexisting),
+            match_count_at_stop=match_count_at_stop,
+            first_seen_ns=first_seen_ns,
+            keydown_ns=keydown_ns,
+            host_window_id=host_window_id)
 
     return {
         "verdict": timing.verdict,
@@ -746,10 +907,8 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
         "keypress_ms": timing.keypress_ms,
         "window_id": timing.window_id,
         "host_window_id": host_window_id,
-        # Kept so a receipt can show what else was on screen. These never end the
-        # interval; recording them is how an unexplained result stays explicable.
-        "other_windows_ms": {str(w): (t - keydown_ns) / 1e6
-                             for w, t in first_seen.items() if w != host_window_id},
+        "ax_available": ax_available,
+        "match_count_at_stop": match_count_at_stop,
         "keycode": binding.keycode,
         "poll_resolution_ms_median": median(gaps) if gaps else None,
         "poll_resolution_ms_max": max(gaps) if gaps else None,

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -81,6 +81,7 @@ BLOCKED_SCHEDULE = "BLOCKED_SCHEDULE"
 BLOCKED_OCCUPANCY = "BLOCKED_OCCUPANCY"
 BLOCKED_LAUNCH = "BLOCKED_LAUNCH"
 BLOCKED_NO_OVERLAY = "BLOCKED_NO_OVERLAY"
+BLOCKED_SCREEN_LOCKED = "BLOCKED_SCREEN_LOCKED"
 
 Identity = namedtuple("Identity", "bundle_id executable_path sha256")
 Marker = namedtuple("Marker", "run pid bundle event ticks window index")
@@ -738,6 +739,39 @@ def measure_keypress_to_overlay(pid, marker_path, *, timeout_s=5.0):
     }
 
 
+def screen_lock_state():
+    """`True` locked, `False` unlocked, `None` could not tell.
+
+    Three-valued on purpose. Collapsing "could not tell" into "unlocked" is the
+    shape that turns a broken probe into a green: the caller would proceed on a
+    machine it cannot describe, which is precisely the state a measurement must
+    not be taken in.
+    """
+    try:
+        import Quartz
+        session = Quartz.CGSessionCopyCurrentDictionary()
+    except Exception:
+        return None
+    if session is None:
+        return None
+    value = session.get("CGSSessionScreenIsLocked")
+    return None if value is None else bool(value)
+
+
+def screen_lock_block(state):
+    """A verdict for a lock state, or `None` to proceed."""
+    if state is True:
+        return ("the screen is locked, so `loginwindow` owns the active Space and no "
+                "app window is reachable. A latency figure taken here is a measurement "
+                "of a different machine state, and this repo has already shipped one "
+                "green whose screenshots were all the login window. Unlock and re-run.")
+    if state is None:
+        return ("could not read the login session, so whether the screen is locked is "
+                "unknown. An instrument that cannot describe the machine must not "
+                "measure it.")
+    return None
+
+
 def hardware_identity():
     """The machine, recorded with every run.
 
@@ -791,6 +825,56 @@ def reap(proc, *, timeout_s=10.0):
         pass
 
 
+def await_launch_ready(proc, marker_path, *, run_id, expected_bundle,
+                       ready_timeout_s=30.0, read_text=None):
+    """Wait for the app's own readiness marker, and reap it on EVERY failure.
+
+    **Separated from the launch so the guard can be tested at all**, and because
+    the guard is the whole point: `proc` is alive from the moment `Popen`
+    returns, so any exit from here that is not a success must leave nothing
+    behind. Two of the three ways out are exceptional and one of those is not
+    obvious — reading the marker file can raise on its own, if the output
+    directory is cleaned up underneath the run or the filesystem returns an
+    error. That escapes to `smoke()`, which turns it into `BLOCKED_LAUNCH` and
+    returns a tidy-looking receipt while the app keeps running.
+
+    An orphan is the expensive failure here rather than a cosmetic one: it
+    blocks the next cold launch on occupancy, or worse is not noticed and
+    answers the same global hotkey during someone else's measurement. Every dev
+    bundle on this machine carries the same name, so it cannot be told apart
+    from the instance under test.
+
+    `BaseException` rather than `Exception`, deliberately: a Ctrl-C in the middle
+    of a run is the case most likely to leave a stray app behind and the least
+    likely to be cleaned up by hand afterwards.
+
+    `read_text` exists for the suite, which cannot launch a real app to make the
+    read fail.
+    """
+    read_text = read_text or (lambda: marker_path.read_text())
+    try:
+        deadline = time.monotonic() + ready_timeout_s
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    f"the app exited during launch with {proc.returncode}")
+            if launch_is_ready(read_text(), expected_run=run_id,
+                               expected_pid=proc.pid, expected_bundle=expected_bundle):
+                return
+            # deadline-fallback: the interval between reads of the app's own
+            # readiness marker, bounded by `ready_timeout_s` above. The signal is
+            # the marker; this only decides how often we look for it.
+            time.sleep(0.02)
+        raise RuntimeError(
+            f"no complete {LAUNCH_EXIT} marker for run {run_id} within "
+            f"{ready_timeout_s}s. Either the build carries no emitter (a Release "
+            f"build carries none by design), the marker environment did not reach "
+            f"it, or the file holds a line this parser cannot read.")
+    except BaseException:
+        reap(proc)
+        raise
+
+
 def launch_with_markers(bundle_path, *, marker_dir, ready_timeout_s=30.0):
     """One cold launch with markers armed, returning everything needed to judge it.
 
@@ -817,30 +901,9 @@ def launch_with_markers(bundle_path, *, marker_dir, ready_timeout_s=30.0):
 
     proc = subprocess.Popen([requested.executable_path], env=env,
                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    deadline = time.monotonic() + ready_timeout_s
-    ready = False
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            raise RuntimeError(f"the app exited during launch with {proc.returncode}")
-        if launch_is_ready(marker_path.read_text(),
-                           expected_run=run_id, expected_pid=proc.pid,
-                           expected_bundle=requested.bundle_id):
-            ready = True
-            break
-        # deadline-fallback: the interval between reads of the app's own
-        # readiness marker, bounded by `ready_timeout_s` above. The signal is
-        # the marker; this only decides how often we look for it.
-        time.sleep(0.02)
-    if not ready:
-        # The same bounded cleanup the successful path uses. A Release bundle, or
-        # an emitter that cannot open its marker file, reaches here — and both are
-        # ordinary enough that leaving an orphan behind would be a routine cost.
-        reap(proc)
-        raise RuntimeError(
-            f"no complete {LAUNCH_EXIT} marker for run {run_id} within "
-            f"{ready_timeout_s}s. Either the build carries no emitter (a Release "
-            f"build carries none by design), the marker environment did not reach "
-            f"it, or the file holds a line this parser cannot read.")
+    await_launch_ready(proc, marker_path, run_id=run_id,
+                       expected_bundle=requested.bundle_id,
+                       ready_timeout_s=ready_timeout_s)
     return {"requested": requested, "run_id": run_id, "pid": proc.pid,
             "marker_path": marker_path, "process": proc}
 
@@ -854,6 +917,16 @@ def smoke(bundle_path, *, out_dir):
     """
     out = {"kind": "smoke", "bundle": str(bundle_path),
            "hardware": hardware_identity()}
+
+    # The screen lock is checked BEFORE occupancy, because it costs nothing and
+    # invalidates the run whatever the slot looks like.
+    lock = screen_lock_state()
+    blocked_reason = screen_lock_block(lock)
+    out["screen_locked"] = lock
+    if blocked_reason:
+        out["verdict"] = BLOCKED_SCREEN_LOCKED
+        out["detail"] = blocked_reason
+        return out
 
     # Occupancy: REFUSE rather than choose. Every dev bundle on this machine is
     # named the same, so picking one of two instances silently retargets the

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -604,6 +604,64 @@ def test_known_invalid_ax_preconditions_never_touch_the_record_key():
         m.screen_lock_state = saved_lock_state
 
 
+def test_screen_lock_brackets_the_whole_measured_interval():
+    """A pre-press check alone cannot see the screen lock DURING the AX poll
+    (up to `timeout_s`, not instantaneous) — only bracketing both ends of
+    the interval closes that (#2377, C1 repair). `screen_lock_state`
+    returns `[False, True]`: unlocked when the pre-press check runs, locked
+    by the time the post-measure check runs after polling completes. The
+    press still happens — the pre-press check correctly saw it as safe —
+    but the sample must still be blocked.
+    """
+    import types
+
+    class SpyInput(types.ModuleType):
+        def __init__(self, name):
+            super().__init__(name)
+            self.down_calls = []
+            self.up_calls = []
+
+        def modifier_down(self, keycode):
+            self.down_calls.append(keycode)
+
+        def modifier_up(self, keycode):
+            self.up_calls.append(keycode)
+
+    fake_ptt = types.ModuleType("ptt_binding")
+    fake_ptt.resolve = lambda: types.SimpleNamespace(
+        is_modifier_only=True, key_name="fn (globe)", keycode=63)
+    spy = SpyInput("simulate_input")
+
+    saved_modules = {name: sys.modules.get(name) for name in ("simulate_input", "ptt_binding")}
+    saved_ax_available = m.ax_accessibility_available
+    saved_ax_matching = m.ax_matching_windows
+    saved_lock_state = m.screen_lock_state
+    sys.modules["simulate_input"] = spy
+    sys.modules["ptt_binding"] = fake_ptt
+    lock_sequence = iter([False, True])
+    m.screen_lock_state = lambda: next(lock_sequence, True)
+    try:
+        m.ax_accessibility_available = lambda pid: True
+        m.ax_matching_windows = lambda pid: []
+        result = m.measure_keypress_to_overlay(4242, "/nonexistent-marker-path", timeout_s=0.05)
+        expect("the pre-press check passed, so the press still occurs once",
+               spy.down_calls, [63])
+        expect("and releases once", spy.up_calls, [63])
+        expect("but the post-measure check blocks the sample",
+               result["verdict"], m.BLOCKED_SCREEN_LOCKED)
+        expect("no keypress figure for a sample taken against a locked screen",
+               result["keypress_ms"], None)
+    finally:
+        for name, mod in saved_modules.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+        m.ax_accessibility_available = saved_ax_available
+        m.ax_matching_windows = saved_ax_matching
+        m.screen_lock_state = saved_lock_state
+
+
 # -------------------------------------------------- 9. thirty pairs, exactly
 
 
@@ -1574,6 +1632,7 @@ TESTS = [
     test_recording_host_marker_is_read_from_the_marker_text,
     test_wrong_presentation_binding_is_refused,
     test_known_invalid_ax_preconditions_never_touch_the_record_key,
+    test_screen_lock_brackets_the_whole_measured_interval,
     test_29_pairs_block_and_30_pairs_pass,
     test_one_invalid_sample_blocks_without_top_up,
     test_benchmark_fails_on_a_real_regression,

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -1172,6 +1172,37 @@ def test_smoke_routes_its_keypress_measurement_through_the_readiness_gate():
             "smoke() gates the keypress measurement BEFORE awaiting "
             "readiness — the readiness result it gates on would be stale")
 
+    # `final_verdict_and_detail` must actually be the live adjudicator, not
+    # just a correctly-behaving function nobody calls (round-two finding on
+    # this same review): restoring the old inline result-first ordering
+    # would leave the isolated priority test green.
+    required_final_adjudication = (
+        'out["verdict"], out["detail"] = '
+        "final_verdict_and_detail(result, timing)")
+    if required_final_adjudication not in body:
+        FAILURES.append(
+            "smoke() bypasses the timing-first final verdict adjudicator")
+
+    # The screen-lock recheck must both CAPTURE the block and RETURN its
+    # promised verdict — two separate live blocks, so each is bound on its
+    # own rather than inferred from the other.
+    required_screen_capture = "\n".join((
+        "        elif pre_press_blocked:",
+        "            screen_locked_before_press = pre_press_blocked",
+    ))
+    required_screen_verdict = "\n".join((
+        "    if screen_locked_before_press:",
+        "        out[\"verdict\"] = BLOCKED_SCREEN_LOCKED",
+        "        out[\"detail\"] = screen_locked_before_press",
+        "        return out",
+    ))
+    for required, message in (
+        (required_screen_capture, "smoke() discards the pre-press lock block"),
+        (required_screen_verdict, "smoke() does not return the pre-press lock verdict"),
+    ):
+        if required not in body:
+            FAILURES.append(message)
+
     # CONTROL: the same check, run against a synthetic source where the live
     # call is replaced by a direct measurement, must actually fail — proof
     # this row is not vacuously true. Never touches the real file.
@@ -1190,8 +1221,8 @@ def test_smoke_routes_its_keypress_measurement_through_the_readiness_gate():
 
 
 def test_final_verdict_prefers_the_specific_keypress_diagnosis():
-    """`timing`'s verdict must win over `result`'s (cloud review P2, #2377
-    C1 repair). When AX is unavailable, `measure_keypress_to_overlay`
+    """`timing`'s verdict must win over `result`'s (#2377, C1 repair). When
+    AX is unavailable, `measure_keypress_to_overlay`
     writes no recording marker, so `adjudicate_launch` independently and
     correctly reports the true-but-less-informative `BLOCKED_MISSING_MARKER`
     for the SAME run — reporting THAT instead of the actual

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -1,0 +1,661 @@
+"""Two-way control for the first-render measurement harness (#2377, P6-C1).
+
+Written BEFORE the harness it tests, and run before it to prove the suite can
+fail: a refusal set whose branches have never executed is indistinguishable from
+one that does not work, and this phase's whole argument rests on the instrument
+refusing rather than reporting.
+
+Every refusal below sits beside an ACCEPTED twin differing in exactly one field,
+so a parser that stopped adjudicating anything cannot read as clean. The twins
+are the point; the rejections alone would pass against a function that blocks
+unconditionally.
+
+Run: `python3 Tests/RuntimeUAT/measure_overlay_first_render_test.py`
+"""
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+import measure_overlay_first_render as m  # noqa: E402
+
+# ---------------------------------------------------------------- fixtures
+
+RUN = "6F1A2B3C-0000-4000-8000-000000000001"
+PID = 4242
+BUNDLE = "com.enviouswispr.app.dev"
+EXE = "/Users/x/EnviousWispr Local.app/Contents/MacOS/EnviousWispr"
+SHA = "a" * 64
+
+# 1/1 timebase: one tick is one nanosecond, so the arithmetic in a failure
+# message is readable by whoever has to adjudicate it.
+TIMEBASE = (1, 1)
+
+REQUESTED = m.Identity(bundle_id=BUNDLE, executable_path=EXE, sha256=SHA)
+RESOLVED = m.Identity(bundle_id=BUNDLE, executable_path=EXE, sha256=SHA)
+
+# ticks chosen so the durations are whole milliseconds under a 1/1 timebase:
+# launch 3 ms, root 2 ms.
+GOOD_TICKS = {
+    "launch.enter": 1_000_000,
+    "launch.exit": 4_000_000,
+    "root.construct.start": 10_000_000,
+    "root.construct.end": 12_000_000,
+    "host.order_front.complete": 13_000_000,
+}
+
+ORDER = [
+    "launch.enter",
+    "launch.exit",
+    "root.construct.start",
+    "root.construct.end",
+    "host.order_front.complete",
+]
+
+
+# Only the host event names a window; every other event writes 0.
+HOST_WINDOW = 4242
+
+
+def line(event, *, ticks=None, run=RUN, pid=PID, bundle=BUNDLE, schema=m.SCHEMA,
+         window=None):
+    t = GOOD_TICKS[event] if ticks is None else ticks
+    if window is None:
+        window = HOST_WINDOW if event == "host.order_front.complete" else 0
+    return (f"{schema}\trun={run}\tpid={pid}\tbundle={bundle}"
+            f"\tevent={event}\tticks={t}\twindow={window}")
+
+
+def text(events=None, **kw):
+    return "\n".join(line(e, **kw) for e in (ORDER if events is None else events)) + "\n"
+
+
+def adjudicate(marker_text, *, requested=REQUESTED, resolved=RESOLVED,
+               expected_run=RUN, expected_pid=PID):
+    return m.adjudicate_launch(
+        marker_text,
+        expected_run=expected_run,
+        expected_pid=expected_pid,
+        requested=requested,
+        resolved=resolved,
+        timebase=TIMEBASE)
+
+
+FAILURES = []
+
+
+def expect(name, got, want):
+    if got != want:
+        FAILURES.append(f"{name}: expected {want!r}, got {got!r}")
+
+
+def expect_verdict(name, marker_text, want, **kw):
+    expect(name, adjudicate(marker_text, **kw).verdict, want)
+
+
+# ------------------------------------------------------- 1. the accepted case
+
+def test_valid_marker_set_accepts():
+    r = adjudicate(text())
+    expect("a complete, consistent marker set is accepted", r.verdict, m.OK)
+    if r.sample is None:
+        FAILURES.append("an accepted set must carry a sample")
+        return
+    expect("launch duration", r.sample.launch_ms, 3.0)
+    expect("root construction duration", r.sample.root_ms, 2.0)
+    expect("the sample carries the window the host named",
+           r.sample.host_window_id, HOST_WINDOW)
+    expect("smoke verdict on an accepted set", m.smoke_verdict(r), m.SMOKE_PASS)
+
+
+# ---------------------------------------------- 2. every marker is REQUIRED
+
+def test_missing_each_required_marker_blocks():
+    for event in ORDER:
+        remaining = [e for e in ORDER if e != event]
+        expect_verdict(
+            f"a set missing {event} blocks", text(remaining), m.BLOCKED_MISSING_MARKER)
+    # TWIN: the same set with the marker restored is accepted, so the refusal
+    # above is about the absence and not about the fixture.
+    expect_verdict("restoring every marker accepts", text(), m.OK)
+
+
+# ------------------------------------------- 3. pair ORDER, not merely presence
+
+def test_partial_or_reversed_marker_pair_blocks():
+    reversed_launch = ["launch.exit", "launch.enter",
+                       "root.construct.start", "root.construct.end",
+                       "host.order_front.complete"]
+    expect_verdict("an exit line before its enter blocks",
+                   text(reversed_launch), m.BLOCKED_PAIR_ORDER)
+    reversed_root = ["launch.enter", "launch.exit",
+                     "root.construct.end", "root.construct.start",
+                     "host.order_front.complete"]
+    expect_verdict("a root end before its start blocks",
+                   text(reversed_root), m.BLOCKED_PAIR_ORDER)
+    # TWIN: identical lines in the shipped order.
+    expect_verdict("the same lines in order accept", text(), m.OK)
+
+
+# --------------------------------------------------- 4. singletons are single
+
+def test_duplicate_singleton_marker_blocks():
+    doubled = ORDER + ["host.order_front.complete"]
+    expect_verdict("a second host-order line blocks",
+                   text(doubled), m.BLOCKED_DUPLICATE_MARKER)
+    doubled_pair = ["launch.enter", "launch.enter", "launch.exit",
+                    "root.construct.start", "root.construct.end",
+                    "host.order_front.complete"]
+    expect_verdict("a second launch-enter blocks",
+                   text(doubled_pair), m.BLOCKED_DUPLICATE_MARKER)
+    expect_verdict("one of each accepts", text(), m.OK)
+
+
+# ------------------------------------------------------- 5. the schema itself
+
+def test_unknown_schema_or_malformed_line_blocks():
+    expect_verdict("a future schema version blocks",
+                   text(schema="EW_OVERLAY_FIRST_RENDER_V2"), m.BLOCKED_MALFORMED_MARKER)
+    expect_verdict("a line with a missing field blocks",
+                   text() + f"{m.SCHEMA}\trun={RUN}\tpid={PID}\n",
+                   m.BLOCKED_MALFORMED_MARKER)
+    expect_verdict("a host marker naming window 0 blocks",
+                   text()[: text().rindex("\twindow=")] + "\twindow=0\n",
+                   m.BLOCKED_MALFORMED_MARKER)
+    expect_verdict("a non-numeric window id blocks",
+                   text().replace(f"window={HOST_WINDOW}", "window=main"),
+                   m.BLOCKED_MALFORMED_MARKER)
+    # The window contract runs BOTH ways: only the host event names a window.
+    # A non-host event carrying one means the emitter writes something this
+    # parser does not model, and a contract stated only in a comment is the
+    # shape that retires a check instead of failing it.
+    expect_verdict("a launch event carrying a window blocks",
+                   text().replace("event=launch.enter\tticks=1000000\twindow=0",
+                                  "event=launch.enter\tticks=1000000\twindow=42"),
+                   m.BLOCKED_MALFORMED_MARKER)
+    # TWIN: the same events with window=0, which is the shipped form.
+    expect_verdict("non-host events carrying window 0 accept", text(), m.OK)
+    expect_verdict("a non-numeric tick count blocks",
+                   text().replace("ticks=1000000", "ticks=soon"),
+                   m.BLOCKED_MALFORMED_MARKER)
+    expect_verdict("an unknown event name blocks",
+                   text().replace("event=launch.enter", "event=launch.begin"),
+                   m.BLOCKED_MALFORMED_MARKER)
+    # An EMPTY file is missing evidence, never a pass, and never a crash.
+    expect_verdict("an empty marker file blocks", "", m.BLOCKED_MISSING_MARKER)
+    # TWIN: unrelated noise around a complete set is tolerated, because the
+    # schema prefix is what selects our lines. Blocking on it would make the
+    # instrument refuse whenever anything else wrote to the file.
+    expect_verdict("a foreign line beside a complete set accepts",
+                   "some other tool wrote this\n" + text(), m.OK)
+
+
+# ----------------------------------------------------------- 6. WHOSE launch
+
+def test_wrong_run_pid_or_bundle_blocks():
+    expect_verdict("a marker from another run blocks",
+                   text(run="6F1A2B3C-0000-4000-8000-000000000002"), m.BLOCKED_WRONG_APP)
+    expect_verdict("a marker from another pid blocks",
+                   text(pid=9999), m.BLOCKED_WRONG_APP)
+    expect_verdict("a marker naming another bundle blocks",
+                   text(bundle="com.enviouswispr.app"), m.BLOCKED_WRONG_APP)
+    other = m.Identity(bundle_id="com.enviouswispr.app",
+                       executable_path=EXE, sha256=SHA)
+    expect_verdict("a resolved bundle differing from the requested one blocks",
+                   text(), m.BLOCKED_WRONG_APP, resolved=other)
+    elsewhere = m.Identity(bundle_id=BUNDLE,
+                           executable_path="/somewhere/else/EnviousWispr", sha256=SHA)
+    expect_verdict("a resolved executable PATH differing from the requested one blocks",
+                   text(), m.BLOCKED_WRONG_APP, resolved=elsewhere)
+    expect_verdict("the matching identity accepts", text(), m.OK)
+
+
+# ------------------------ 7. the version can agree while the BYTES do not
+
+def test_same_bundle_version_but_different_executable_hash_blocks():
+    # Same bundle id, same path, ONE NIBBLE of the hash different. This is the
+    # case a bundle-id check cannot see, and it is the one that matters: two
+    # worktrees' dev builds are both `EnviousWispr Local.app`.
+    nibble = m.Identity(bundle_id=BUNDLE, executable_path=EXE, sha256="b" + "a" * 63)
+    expect_verdict("one changed hash nibble blocks",
+                   text(), m.BLOCKED_WRONG_APP, resolved=nibble)
+    expect_verdict("restoring the hash accepts", text(), m.OK)
+
+
+# ------------------------------------------------------------- 8. time's arrow
+
+def test_non_monotonic_ticks_block():
+    # Lines in the right ORDER, ticks going backwards. Distinct from case 3:
+    # there the file was out of order, here the clock is.
+    backwards = text().replace("ticks=4000000", "ticks=999999")
+    expect_verdict("an exit earlier than its enter blocks",
+                   backwards, m.BLOCKED_NON_MONOTONIC)
+    equal = text().replace("ticks=4000000", "ticks=1000000")
+    expect_verdict("a zero-length launch blocks", equal, m.BLOCKED_NON_MONOTONIC)
+    expect_verdict("increasing ticks accept", text(), m.OK)
+
+
+# -------------- 8b. the WHOLE chain, which is what forbids a synchronous root
+
+def test_root_construction_inside_launch_blocks():
+    """Phase 6 moves root construction OUT of launch. The instrument must not
+    certify the arrangement being moved away from.
+
+    Two pairs checked separately accept a synchronous build: `enter < exit` holds
+    and `start < end` holds, and nothing asks whether the root was built BEFORE
+    launch returned. Only the full chain does.
+    """
+    synchronous = ["launch.enter", "root.construct.start", "root.construct.end",
+                   "launch.exit", "host.order_front.complete"]
+    expect_verdict("a root built inside launch blocks on file order",
+                   text(synchronous), m.BLOCKED_PAIR_ORDER)
+    # The same claim in TICKS rather than file order: lines in the shipped order,
+    # but root construction starting before launch returned.
+    early = text().replace("ticks=10000000", "ticks=2000000")
+    expect_verdict("a root whose ticks start before launch returned blocks",
+                   early, m.BLOCKED_NON_MONOTONIC)
+    # And the host cannot order a panel front before the root finished existing.
+    before_root = text().replace("ticks=13000000", "ticks=11000000")
+    expect_verdict("a host order-front before root construction ended blocks",
+                   before_root, m.BLOCKED_NON_MONOTONIC)
+    # TWIN: the correctly ordered set, unchanged, is accepted.
+    expect_verdict("the deferred arrangement accepts", text(), m.OK)
+
+
+# ------------------- 8c. WHICH window ended the interval, named by the app
+
+def test_overlay_endpoint_waits_for_the_window_the_app_named():
+    """The app names the subject; the harness times it.
+
+    Watching for "a new window owned by this process" and stopping at the first
+    one accepts a sequence that no settling delay fixes: an unrelated window
+    appears, the host marker is written, the harness stops holding only that
+    window, and the real pill reaches WindowServer a moment later. Every step is
+    plausible and the output is a normal-looking latency about the wrong window.
+
+    These rows are written as SEQUENCES rather than as a set of candidates
+    supplied at once, because the previous version of this test handed the
+    adjudicator both windows simultaneously — and a fixture that cannot express
+    the ordering cannot fail on it. That is what let the defect survive a review
+    round.
+    """
+    t0 = 1_000_000_000
+    ms = lambda n: t0 + n * 1_000_000  # noqa: E731
+
+    # The sequence the old code got wrong: unrelated at +3, the named window at
+    # +12. The named window's time is what is reported.
+    unrelated_first = m.adjudicate_overlay_window(
+        99, {7: ms(3), 99: ms(12)}, t0, preexisting=set())
+    expect("an unrelated window arriving first does not win",
+           unrelated_first.verdict, m.OK)
+    expect("the named window is reported", unrelated_first.window_id, 99)
+    expect("with ITS first-observed time, not the unrelated one's",
+           unrelated_first.keypress_ms, 12.0)
+
+    # TWIN: the same call with only the unrelated window present. Nothing to
+    # report, and it must not fall back to the window it does have.
+    only_unrelated = m.adjudicate_overlay_window(
+        99, {7: ms(3)}, t0, preexisting=set())
+    expect("only an unrelated window blocks", only_unrelated.verdict,
+           m.BLOCKED_NO_OVERLAY)
+    expect("and carries no number", only_unrelated.keypress_ms, None)
+
+    # A window already on screen at key-down did not appear because of this
+    # press, so there is no interval to attribute to it.
+    preexisting = m.adjudicate_overlay_window(
+        99, {99: ms(12)}, t0, preexisting={99})
+    expect("a window that existed before the keypress blocks",
+           preexisting.verdict, m.BLOCKED_NO_OVERLAY)
+    expect("and carries no number", preexisting.keypress_ms, None)
+
+    # The app said it ordered a window front and that window never showed up.
+    never = m.adjudicate_overlay_window(99, {7: ms(3)}, t0, preexisting=set())
+    expect("a named window that never appears blocks", never.verdict,
+           m.BLOCKED_NO_OVERLAY)
+
+    # No host marker at all: a different fact from a window that did not appear,
+    # and it must not be reported as a latency of any kind.
+    silent = m.adjudicate_overlay_window(None, {99: ms(12)}, t0, preexisting=set())
+    expect("no host marker blocks", silent.verdict, m.BLOCKED_NO_OVERLAY)
+
+    # A host marker that reached the call site and could not name a window is a
+    # MALFORMED marker, not a missing overlay - different fault, different place.
+    zero = m.adjudicate_overlay_window(0, {99: ms(12)}, t0, preexisting=set())
+    expect("a host marker naming window 0 is malformed, not absent",
+           zero.verdict, m.BLOCKED_MALFORMED_MARKER)
+
+    # TWIN for the whole group: the ordinary case still passes.
+    ordinary = m.adjudicate_overlay_window(99, {99: ms(9)}, t0, preexisting=set())
+    expect("the ordinary case accepts", ordinary.verdict, m.OK)
+    expect("with the harness's own timestamp", ordinary.keypress_ms, 9.0)
+
+
+def test_the_live_stopping_rule_waits_for_the_named_window():
+    """The rule that decides when to STOP polling, tested directly.
+
+    Every other row here tests the adjudicator, which runs once the loop has
+    already stopped. That leaves the stop condition itself untested — so the
+    whole identity binding could be reverted to "the host marker plus any
+    window" and every other row would still pass. This is the row that fails
+    when it is.
+    """
+    ms = lambda n: 1_000_000_000 + n * 1_000_000  # noqa: E731
+    expect("an unrelated window does not stop polling",
+           m.named_window_has_appeared(99, {7: ms(3)}), False)
+    expect("the named window stops polling",
+           m.named_window_has_appeared(99, {7: ms(3), 99: ms(12)}), True)
+    expect("nothing stops polling before the app has named a window",
+           m.named_window_has_appeared(None, {7: ms(3), 99: ms(12)}), False)
+    expect("and an empty screen does not stop it either",
+           m.named_window_has_appeared(99, {}), False)
+
+
+def test_a_half_written_line_is_not_a_marker():
+    """The emitter loops on a short write, so a poller can read mid-line.
+
+    A line is finished when a newline follows it. Reading the tail costs a false
+    verdict about the app; discarding it costs one more poll.
+    """
+    complete = text()
+    partial = complete[: complete.rindex("\n")]  # same bytes, no trailing newline
+
+    expect("a complete launch.exit is ready",
+           m.launch_is_ready(complete, expected_run=RUN, expected_pid=PID,
+                             expected_bundle=BUNDLE), True)
+    # The launch line itself, truncated mid-write.
+    launch_only = line("launch.enter") + "\n" + line("launch.exit")
+    expect("a launch.exit with no newline yet is NOT ready",
+           m.launch_is_ready(launch_only, expected_run=RUN, expected_pid=PID,
+                             expected_bundle=BUNDLE), False)
+    expect("the same line, finished, is ready",
+           m.launch_is_ready(launch_only + "\n", expected_run=RUN, expected_pid=PID,
+                             expected_bundle=BUNDLE), True)
+    # Readiness is about THIS launch, not about the event name appearing.
+    expect("another run's launch.exit is not this launch's readiness",
+           m.launch_is_ready(complete, expected_run="SOMEONE-ELSE", expected_pid=PID,
+                             expected_bundle=BUNDLE), False)
+    expect("nor another pid's",
+           m.launch_is_ready(complete, expected_run=RUN, expected_pid=9999,
+                             expected_bundle=BUNDLE), False)
+
+    # The host half of the same problem.
+    window, failure = m.host_window_from(partial)
+    expect("a half-written host line is 'not yet', not a verdict", window, None)
+    expect("and not a failure either", failure, None)
+    window, failure = m.host_window_from(complete)
+    expect("the finished line names the window", window, HOST_WINDOW)
+    # A malformed line that IS finished is a real failure and must not be
+    # swallowed by the same truncation rule that hides an unfinished one.
+    malformed = complete.replace(f"window={HOST_WINDOW}", "window=main")
+    expect("a finished malformed host line blocks",
+           m.host_window_from(malformed)[1][0], m.BLOCKED_MALFORMED_MARKER)
+
+
+def test_host_window_is_read_from_the_marker_text():
+    """`host_window_from` is what the live loop polls with, so it gets its own
+    rows: an absent marker is 'not yet', never a verdict."""
+    window, failure = m.host_window_from(text())
+    expect("a complete file names the window", window, HOST_WINDOW)
+    expect("and reports no failure", failure, None)
+
+    partial = text([e for e in ORDER if e != "host.order_front.complete"])
+    window, failure = m.host_window_from(partial)
+    expect("a file without the host marker is not yet, not a verdict", window, None)
+    expect("and still no failure", failure, None)
+
+    doubled = m.host_window_from(text(ORDER + ["host.order_front.complete"]))
+    expect("two host markers are refused, not averaged",
+           doubled[1][0], m.BLOCKED_DUPLICATE_MARKER)
+
+
+# -------------------------------------------------- 9. thirty pairs, exactly
+
+
+def ok_result(launch_ms, root_ms, run):
+    """One accepted launch. `run` is REQUIRED — every side of every pair is its
+    own cold launch, and a shared default is how a fixture quietly stops
+    expressing that."""
+    return m.LaunchResult(
+        verdict=m.OK, detail="",
+        sample=m.LaunchSample(run=run, launch_ms=launch_ms, root_ms=root_ms,
+                              order_front_ms=root_ms + 1.0,
+                              host_window_id=HOST_WINDOW))
+
+
+def pairs(n, *, a_launch=10.0, b_launch=10.0, a_root=2.0, b_root=2.0,
+          a_key=100.0, b_key=100.0, bad_index=None, shared_run=False):
+    out = []
+    for i in range(n):
+        a_run = RUN if shared_run else f"RUN-A-{i:04d}"
+        b_run = RUN if shared_run else f"RUN-B-{i:04d}"
+        a = ok_result(a_launch, a_root, a_run)
+        b = ok_result(b_launch, b_root, b_run)
+        if bad_index == i:
+            b = m.LaunchResult(verdict=m.BLOCKED_MISSING_MARKER,
+                               detail="host.order_front.complete", sample=None)
+        out.append(m.Pair(order=("AB" if i % 2 == 0 else "BA"),
+                          a=a, b=b, a_keypress_ms=a_key, b_keypress_ms=b_key))
+    return out
+
+
+BUDGET = m.Budget(launch_median_regression_ms=5.0,
+                  root_p95_ms=8.0,
+                  keypress_p95_regression_ms=16.7)
+
+
+def test_29_pairs_block_and_30_pairs_pass():
+    expect("29 pairs block",
+           m.adjudicate_benchmark(pairs(29), BUDGET).verdict, m.BLOCKED_INCOMPLETE_PAIRS)
+    expect("31 pairs block",
+           m.adjudicate_benchmark(pairs(31), BUDGET).verdict, m.BLOCKED_INCOMPLETE_PAIRS)
+    expect("30 pairs within budget pass",
+           m.adjudicate_benchmark(pairs(30), BUDGET).verdict, m.BENCHMARK_PASS)
+
+
+def test_one_invalid_sample_blocks_without_top_up():
+    # 30 pairs, one of them carrying a blocked launch. The count is right and
+    # the evidence is not, and a harness that topped up would select for
+    # favourable runs.
+    r = m.adjudicate_benchmark(pairs(30, bad_index=7), BUDGET)
+    expect("one blocked launch among thirty blocks the whole run",
+           r.verdict, m.BLOCKED_INCOMPLETE_PAIRS)
+    if m.BLOCKED_MISSING_MARKER not in r.detail:
+        FAILURES.append(
+            f"the block must name the underlying refusal, got {r.detail!r}")
+    expect("thirty clean pairs pass",
+           m.adjudicate_benchmark(pairs(30), BUDGET).verdict, m.BENCHMARK_PASS)
+
+
+def test_benchmark_fails_on_a_real_regression():
+    # FAIL is a verdict about the CODE and is reachable only when the evidence
+    # is complete. Without this row every red result would be a BLOCK, and the
+    # budget would bind nothing.
+    over = m.adjudicate_benchmark(pairs(30, b_launch=16.0), BUDGET)
+    expect("a 6 ms launch median regression fails", over.verdict, m.BENCHMARK_FAIL)
+    under = m.adjudicate_benchmark(pairs(30, b_launch=14.0), BUDGET)
+    expect("a 4 ms launch median regression passes", under.verdict, m.BENCHMARK_PASS)
+    root_over = m.adjudicate_benchmark(pairs(30, b_root=9.0), BUDGET)
+    expect("root construction above 8 ms p95 fails", root_over.verdict, m.BENCHMARK_FAIL)
+    root_under = m.adjudicate_benchmark(pairs(30, b_root=7.0), BUDGET)
+    expect("root construction below 8 ms p95 passes", root_under.verdict, m.BENCHMARK_PASS)
+    key_over = m.adjudicate_benchmark(pairs(30, b_key=120.0), BUDGET)
+    expect("a 20 ms keypress regression fails", key_over.verdict, m.BENCHMARK_FAIL)
+    key_under = m.adjudicate_benchmark(pairs(30, b_key=115.0), BUDGET)
+    expect("a 15 ms keypress regression passes", key_under.verdict, m.BENCHMARK_PASS)
+
+
+# ---------------------------------------------------------- 10. the schedule
+
+def test_schedule_is_15_ab_and_15_ba():
+    s = m.paired_schedule(30)
+    expect("the schedule has one entry per pair", len(s), 30)
+    expect("fifteen pairs run A first", s.count("AB"), 15)
+    expect("fifteen pairs run B first", s.count("BA"), 15)
+    # Alternating, so a thermal or cache drift across the run cannot land on
+    # one bundle: any monotone trend is split evenly between the two.
+    expect("the orders alternate", s[:4], ["AB", "BA", "AB", "BA"])
+    # A schedule that is not 15/15 is refused rather than silently run.
+    expect("an unbalanced schedule blocks",
+           m.adjudicate_benchmark(
+               [p._replace(order="AB") for p in pairs(30)], BUDGET).verdict,
+           m.BLOCKED_SCHEDULE)
+    # BALANCED IS NOT THE REQUIREMENT. Fifteen AB then fifteen BA counts 15/15
+    # and hands the whole first half of any thermal or cache drift to one
+    # bundle — the exact bias alternation exists to cancel.
+    grouped = [p._replace(order=("AB" if i < 15 else "BA"))
+               for i, p in enumerate(pairs(30))]
+    expect("a balanced but GROUPED schedule blocks",
+           m.adjudicate_benchmark(grouped, BUDGET).verdict, m.BLOCKED_SCHEDULE)
+    expect("the alternating schedule passes",
+           m.adjudicate_benchmark(pairs(30), BUDGET).verdict, m.BENCHMARK_PASS)
+
+
+def test_every_side_must_be_its_own_cold_launch():
+    """One launch reused sixty times satisfies every other check and produces a
+    zero-variance benchmark that looks superb. The run id is what distinguishes
+    thirty cold launches from one launch counted thirty times."""
+    expect("sixty sides sharing one run id block",
+           m.adjudicate_benchmark(pairs(30, shared_run=True), BUDGET).verdict,
+           m.BLOCKED_INCOMPLETE_PAIRS)
+    expect("sixty distinct runs pass",
+           m.adjudicate_benchmark(pairs(30), BUDGET).verdict, m.BENCHMARK_PASS)
+
+
+# -------------------------------------------------------- 11. the statistics
+
+def test_median_uses_statistics_median():
+    import statistics
+    for values in ([1.0], [1.0, 2.0], [3.0, 1.0, 2.0], [4.0, 1.0, 3.0, 2.0]):
+        expect(f"median{values}", m.median(values), statistics.median(values))
+
+
+def test_p95_uses_nearest_rank():
+    # Nearest rank: ceil(0.95 * n)-th value of the sorted list, 1-indexed.
+    # With 20 values that is the 19th, NOT an interpolation between the 19th
+    # and 20th — the two differ, and only one of them is a value that was
+    # actually observed.
+    values = [float(i) for i in range(1, 21)]
+    expect("p95 of 1..20 is the 19th value", m.nearest_rank(values, 95), 19.0)
+    expect("p95 of a single value is that value", m.nearest_rank([7.0], 95), 7.0)
+    expect("p50 of 1..20 is the 10th value", m.nearest_rank(values, 50), 10.0)
+    expect("p95 of 1..30 is the 29th value",
+           m.nearest_rank([float(i) for i in range(1, 31)], 95), 29.0)
+    # Order of the input must not matter.
+    expect("p95 is order-independent",
+           m.nearest_rank(list(reversed(values)), 95), 19.0)
+
+
+# ------------------------------------------- 12. the OTHER implementation
+
+EMITTER = (pathlib.Path(__file__).resolve().parents[2]
+           / "Sources" / "EnviousWisprAppKit" / "App" / "Debug"
+           / "OverlayFirstRenderMarkers.swift")
+
+
+def test_the_swift_emitter_and_this_parser_agree_on_the_schema():
+    """The schema has TWO implementations and nothing else links them.
+
+    The app builds marker lines in Swift; this module parses them in Python. A
+    rename on either side leaves the other compiling and passing its own tests,
+    and the failure surfaces as `BLOCKED_MALFORMED_MARKER` on a benchmark night
+    — reading as a broken app rather than as a drifted contract.
+
+    So assert the agreement HERE, where it is one file read, rather than
+    discovering it from a live launch. Not a substitute for the live smoke: this
+    proves the two spellings match, never that the app reaches the call sites.
+    """
+    if not EMITTER.exists():
+        FAILURES.append(f"the emitter is not at {EMITTER}; this test's path is stale")
+        return
+    swift = EMITTER.read_text()
+    if f'"{m.SCHEMA}' not in swift:
+        FAILURES.append(
+            f"the emitter does not write {m.SCHEMA!r}; the schema token has drifted")
+    for event in m.EVENTS:
+        if f'"{event}"' not in swift:
+            FAILURES.append(f"the emitter has no case spelled {event!r}")
+    for key in ("run=", "pid=", "bundle=", "event=", "ticks=", "window="):
+        if key not in swift:
+            FAILURES.append(f"the emitter does not write the {key!r} field")
+    # The environment names are the emitter's arming contract, and the harness
+    # sets them. A rename on one side is a silent no-op on the other.
+    for env in (m.MARKER_PATH_ENV, m.RUN_ID_ENV):
+        if env not in swift:
+            FAILURES.append(f"the emitter does not read {env}")
+    # PAIRED REJECTION: a name this parser does NOT know must be absent, or the
+    # checks above would pass against an emitter that writes something else too.
+    if "launch.begin" in swift:
+        FAILURES.append("the emitter writes an event this parser cannot read")
+
+
+def test_the_host_marker_is_emitted_with_a_real_window_number():
+    """The window id is the newest field and the one that carries the fix.
+
+    A host marker that always wrote 0 would parse, block every run as malformed,
+    and read as a broken app. So bind the CALL SITE's source of the value, not
+    just the field's spelling: `OverlayWindowHost` must pass
+    `panel.windowNumber`, and it must do so on the `emitFirst` path.
+    """
+    host = (pathlib.Path(__file__).resolve().parents[2] / "Sources"
+            / "EnviousWisprAppKit" / "App" / "Overlay" / "OverlayWindowHost.swift")
+    if not host.exists():
+        FAILURES.append(f"the host is not at {host}; this test's path is stale")
+        return
+    swift = host.read_text()
+    if "window: panel.windowNumber" not in swift:
+        FAILURES.append(
+            "the host does not pass panel.windowNumber to the marker; the harness "
+            "would have no window to wait for")
+    if "emitFirst" not in swift:
+        FAILURES.append(
+            "the host no longer emits the order-front marker once per process")
+
+
+# ------------------------------------------------------------------- runner
+
+TESTS = [
+    test_valid_marker_set_accepts,
+    test_missing_each_required_marker_blocks,
+    test_partial_or_reversed_marker_pair_blocks,
+    test_duplicate_singleton_marker_blocks,
+    test_unknown_schema_or_malformed_line_blocks,
+    test_wrong_run_pid_or_bundle_blocks,
+    test_same_bundle_version_but_different_executable_hash_blocks,
+    test_non_monotonic_ticks_block,
+    test_root_construction_inside_launch_blocks,
+    test_overlay_endpoint_waits_for_the_window_the_app_named,
+    test_the_live_stopping_rule_waits_for_the_named_window,
+    test_a_half_written_line_is_not_a_marker,
+    test_host_window_is_read_from_the_marker_text,
+    test_29_pairs_block_and_30_pairs_pass,
+    test_one_invalid_sample_blocks_without_top_up,
+    test_benchmark_fails_on_a_real_regression,
+    test_schedule_is_15_ab_and_15_ba,
+    test_every_side_must_be_its_own_cold_launch,
+    test_the_swift_emitter_and_this_parser_agree_on_the_schema,
+    test_the_host_marker_is_emitted_with_a_real_window_number,
+    test_median_uses_statistics_median,
+    test_p95_uses_nearest_rank,
+]
+
+
+def main():
+    for t in TESTS:
+        before = len(FAILURES)
+        try:
+            t()
+        except Exception as exc:  # a raising adjudicator is itself a failure
+            FAILURES.append(f"{t.__name__}: raised {type(exc).__name__}: {exc}")
+        if len(FAILURES) == before:
+            print(f"ok   {t.__name__}")
+        else:
+            print(f"FAIL {t.__name__}")
+    for f in FAILURES:
+        print(f"  - {f}")
+    print(f"{len(TESTS)} tests, {len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -1144,16 +1144,29 @@ def test_smoke_routes_its_keypress_measurement_through_the_readiness_gate():
             'proc=launched["process"] — a crash during warm-up would wait '
             "out the full timeout instead of being detected")
 
+    # `press_permitted` must be derived from BOTH facts — engine readiness
+    # AND a screen-lock recheck taken AFTER the readiness wait (cloud review
+    # P1, #2377 C1 repair): the launch and readiness waits can together run
+    # long enough for the screen to lock after the function's initial check,
+    # which that initial check cannot see.
+    if "pre_press_lock = screen_lock_state()" not in body:
+        FAILURES.append("smoke() does not re-check the screen lock before the press")
+    required_permit = "press_permitted = engine_ready and not pre_press_blocked"
+    if required_permit not in body:
+        FAILURES.append(
+            "smoke() does not derive press_permitted from BOTH engine "
+            "readiness and the pre-press screen-lock recheck")
+
     required_gate = "\n".join((
         "        timing = measure_after_engine_ready(",
-        "            engine_ready,",
+        "            press_permitted,",
         "            lambda: measure_keypress_to_overlay(",
     ))
     gate_idx = body.find(required_gate)
     if gate_idx < 0:
         FAILURES.append(
-            "smoke() does not route its keypress measurement through the "
-            "engine-readiness gate")
+            "smoke() does not route its keypress measurement through "
+            "press_permitted")
     elif gate_idx < ready_idx:
         FAILURES.append(
             "smoke() gates the keypress measurement BEFORE awaiting "
@@ -1174,6 +1187,41 @@ def test_smoke_routes_its_keypress_measurement_through_the_readiness_gate():
         FAILURES.append(
             "the caller-contract check does not fail on a bypassed source — "
             "it cannot be trusted to catch a real regression")
+
+
+def test_final_verdict_prefers_the_specific_keypress_diagnosis():
+    """`timing`'s verdict must win over `result`'s (cloud review P2, #2377
+    C1 repair). When AX is unavailable, `measure_keypress_to_overlay`
+    writes no recording marker, so `adjudicate_launch` independently and
+    correctly reports the true-but-less-informative `BLOCKED_MISSING_MARKER`
+    for the SAME run — reporting THAT instead of the actual
+    `BLOCKED_AX_UNAVAILABLE` would mask an unavailable precondition behind
+    a verdict that reads like an app defect.
+    """
+    blocked_result = m.LaunchResult(
+        verdict=m.BLOCKED_MISSING_MARKER, detail="host.order_front.complete",
+        sample=None)
+    ax_unavailable_timing = {"verdict": m.BLOCKED_AX_UNAVAILABLE,
+                             "detail": "AX permission not granted"}
+    verdict, detail = m.final_verdict_and_detail(blocked_result, ax_unavailable_timing)
+    expect("the specific AX diagnosis wins over the generic marker block",
+           verdict, m.BLOCKED_AX_UNAVAILABLE)
+    expect("and carries its own detail, not the marker block's",
+           detail, "AX permission not granted")
+
+    # TWIN: when `timing` is OK, `result`'s own verdict is reported —
+    # proving the reordering above is about PRIORITY, not about `result`
+    # never being consulted at all.
+    ok_timing = {"verdict": m.OK, "detail": "", "keypress_ms": 12.0}
+    verdict, detail = m.final_verdict_and_detail(blocked_result, ok_timing)
+    expect("result's own verdict is reported once timing is OK",
+           verdict, m.BLOCKED_MISSING_MARKER)
+    expect("with result's own detail", detail, "host.order_front.complete")
+
+    # TWIN: both OK yields the smoke verdict, not a bare OK.
+    ok_result = m.LaunchResult(verdict=m.OK, detail="", sample=None)
+    verdict, detail = m.final_verdict_and_detail(ok_result, ok_timing)
+    expect("both OK yields SMOKE_PASS, not a bare OK", verdict, m.SMOKE_PASS)
 
 
 # ------------------------------------------- 13. nobody is left behind
@@ -1465,6 +1513,7 @@ TESTS = [
     test_await_engine_ready_raises_on_a_crash_rather_than_waiting_out_the_timeout,
     test_measure_after_engine_ready_gates_the_keypress_by_call_count,
     test_smoke_routes_its_keypress_measurement_through_the_readiness_gate,
+    test_final_verdict_prefers_the_specific_keypress_diagnosis,
     test_an_abandoned_launch_is_actually_reaped,
     test_every_exceptional_exit_from_the_readiness_wait_reaps,
     test_a_locked_screen_blocks_before_a_launch_is_spent,

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -611,6 +611,27 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
         FAILURES.append(
             "the host no longer emits the order-front marker once per process")
 
+    # The root markers must be HELD, not emitted where they are captured.
+    # Emitting at the capture site puts the marker's own write inside the
+    # keypress interval in the baseline bundle and outside it in the prewarmed
+    # one, so the benchmark credits the change for removing instrumentation cost
+    # that is not production work. Nothing about the marker FORMAT changes when
+    # this regresses, so no other row here would notice.
+    director = (pathlib.Path(__file__).resolve().parents[2] / "Sources"
+                / "EnviousWisprAppKit" / "App" / "Overlay" / "OverlayDirector.swift")
+    if not director.exists():
+        FAILURES.append(f"the director is not at {director}; this test's path is stale")
+        return
+    d = director.read_text()
+    if "OverlayFirstRenderMarkers.hold(" not in d:
+        FAILURES.append(
+            "the director does not HOLD its root captures; emitting them at the "
+            "capture site biases the keypress comparison toward the prewarmed bundle")
+    if "OverlayFirstRenderMarkers.emit(" in d:
+        FAILURES.append(
+            "the director emits directly, which is the biased form this test exists "
+            "to refuse")
+
 
 # ------------------------------------------------------------------- runner
 

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -59,12 +59,16 @@ HOST_WINDOW = 4242
 
 
 def line(event, *, ticks=None, run=RUN, pid=PID, bundle=BUNDLE, schema=m.SCHEMA,
-         window=None):
+         window=None, intent=None):
     t = GOOD_TICKS[event] if ticks is None else ticks
     if window is None:
         window = HOST_WINDOW if event == "host.order_front.complete" else 0
+    if intent is None:
+        # A single valid host marker is implicitly THE recording — matches
+        # what every existing row already meant before intent existed.
+        intent = m.INTENT_RECORDING if event == "host.order_front.complete" else m.INTENT_NONE
     return (f"{schema}\trun={run}\tpid={pid}\tbundle={bundle}"
-            f"\tevent={event}\tticks={t}\twindow={window}")
+            f"\tevent={event}\tticks={t}\twindow={window}\tintent={intent}")
 
 
 def text(events=None, **kw):
@@ -156,7 +160,7 @@ def test_duplicate_singleton_marker_blocks():
 
 def test_unknown_schema_or_malformed_line_blocks():
     expect_verdict("a future schema version blocks",
-                   text(schema="EW_OVERLAY_FIRST_RENDER_V2"), m.BLOCKED_MALFORMED_MARKER)
+                   text(schema="EW_OVERLAY_FIRST_RENDER_V3"), m.BLOCKED_MALFORMED_MARKER)
     expect_verdict("a line with a missing field blocks",
                    text() + f"{m.SCHEMA}\trun={RUN}\tpid={PID}\n",
                    m.BLOCKED_MALFORMED_MARKER)
@@ -265,90 +269,70 @@ def test_root_construction_inside_launch_blocks():
 
 # ------------------- 8c. WHICH window ended the interval, named by the app
 
-def test_overlay_endpoint_waits_for_the_window_the_app_named():
-    """The app names the subject; the harness times it.
+def test_ax_overlay_endpoint_waits_for_our_identified_window():
+    """The app names the subject via a fixed AX identifier; the harness times it.
 
-    Watching for "a new window owned by this process" and stopping at the first
-    one accepts a sequence that no settling delay fixes: an unrelated window
-    appears, the host marker is written, the harness stops holding only that
-    window, and the real pill reaches WindowServer a moment later. Every step is
-    plausible and the output is a normal-looking latency about the wrong window.
-
-    These rows are written as SEQUENCES rather than as a set of candidates
-    supplied at once, because the previous version of this test handed the
-    adjudicator both windows simultaneously — and a fixture that cannot express
-    the ordering cannot fail on it. That is what let the defect survive a review
-    round.
+    **AX membership, not CGWindow-list membership (cloud review P1, #2377).**
+    CGWindow-list registration can precede SwiftUI content actually being
+    composited, so the plan's own "first-AX-overlay" language is the binding
+    requirement, not an implementation detail. The adjudicator is pure — no
+    polling, no live process — so every branch is one row here.
     """
     t0 = 1_000_000_000
-    ms = lambda n: t0 + n * 1_000_000  # noqa: E731
 
-    # The sequence the old code got wrong: unrelated at +3, the named window at
-    # +12. The named window's time is what is reported.
-    unrelated_first = m.adjudicate_overlay_window(
-        99, {7: ms(3), 99: ms(12)}, t0, preexisting=set())
-    expect("an unrelated window arriving first does not win",
-           unrelated_first.verdict, m.OK)
-    expect("the named window is reported", unrelated_first.window_id, 99)
-    expect("with ITS first-observed time, not the unrelated one's",
-           unrelated_first.keypress_ms, 12.0)
-
-    # TWIN: the same call with only the unrelated window present. Nothing to
-    # report, and it must not fall back to the window it does have.
-    only_unrelated = m.adjudicate_overlay_window(
-        99, {7: ms(3)}, t0, preexisting=set())
-    expect("only an unrelated window blocks", only_unrelated.verdict,
-           m.BLOCKED_NO_OVERLAY)
-    expect("and carries no number", only_unrelated.keypress_ms, None)
-
-    # A window already on screen at key-down did not appear because of this
-    # press, so there is no interval to attribute to it.
-    preexisting = m.adjudicate_overlay_window(
-        99, {99: ms(12)}, t0, preexisting={99})
-    expect("a window that existed before the keypress blocks",
-           preexisting.verdict, m.BLOCKED_NO_OVERLAY)
-    expect("and carries no number", preexisting.keypress_ms, None)
-
-    # The app said it ordered a window front and that window never showed up.
-    never = m.adjudicate_overlay_window(99, {7: ms(3)}, t0, preexisting=set())
-    expect("a named window that never appears blocks", never.verdict,
-           m.BLOCKED_NO_OVERLAY)
-
-    # No host marker at all: a different fact from a window that did not appear,
-    # and it must not be reported as a latency of any kind.
-    silent = m.adjudicate_overlay_window(None, {99: ms(12)}, t0, preexisting=set())
-    expect("no host marker blocks", silent.verdict, m.BLOCKED_NO_OVERLAY)
-
-    # A host marker that reached the call site and could not name a window is a
-    # MALFORMED marker, not a missing overlay - different fault, different place.
-    zero = m.adjudicate_overlay_window(0, {99: ms(12)}, t0, preexisting=set())
-    expect("a host marker naming window 0 is malformed, not absent",
-           zero.verdict, m.BLOCKED_MALFORMED_MARKER)
-
-    # TWIN for the whole group: the ordinary case still passes.
-    ordinary = m.adjudicate_overlay_window(99, {99: ms(9)}, t0, preexisting=set())
+    ordinary = m.adjudicate_ax_overlay(
+        ax_available=True, preexisting_count=0, match_count_at_stop=1,
+        first_seen_ns=t0 + 9_000_000, keydown_ns=t0, host_window_id=HOST_WINDOW)
     expect("the ordinary case accepts", ordinary.verdict, m.OK)
     expect("with the harness's own timestamp", ordinary.keypress_ms, 9.0)
+    expect("the marker's window id is carried as a receipt, not the stopwatch",
+           ordinary.window_id, HOST_WINDOW)
+
+    unavailable = m.adjudicate_ax_overlay(
+        ax_available=False, preexisting_count=0, match_count_at_stop=0,
+        first_seen_ns=None, keydown_ns=t0, host_window_id=None)
+    expect("AX permission unavailable blocks", unavailable.verdict,
+           m.BLOCKED_AX_UNAVAILABLE)
+
+    # Already present at key-down: not an event this keypress caused.
+    already_there = m.adjudicate_ax_overlay(
+        ax_available=True, preexisting_count=1, match_count_at_stop=1,
+        first_seen_ns=t0 + 9_000_000, keydown_ns=t0, host_window_id=HOST_WINDOW)
+    expect("a match that existed before the keypress blocks",
+           already_there.verdict, m.BLOCKED_NO_OVERLAY)
+    expect("and carries no timing", already_there.keypress_ms, None)
+
+    never = m.adjudicate_ax_overlay(
+        ax_available=True, preexisting_count=0, match_count_at_stop=0,
+        first_seen_ns=None, keydown_ns=t0, host_window_id=HOST_WINDOW)
+    expect("no match before the deadline blocks", never.verdict, m.BLOCKED_NO_OVERLAY)
+
+    # More than one match at the moment of first appearance is refused, never
+    # averaged or picked from.
+    ambiguous = m.adjudicate_ax_overlay(
+        ax_available=True, preexisting_count=0, match_count_at_stop=2,
+        first_seen_ns=t0 + 9_000_000, keydown_ns=t0, host_window_id=HOST_WINDOW)
+    expect("more than one matching AX window blocks",
+           ambiguous.verdict, m.BLOCKED_AMBIGUOUS_OVERLAY)
+
+    # TWIN for the whole group: the ordinary case above (exactly one match,
+    # nothing preexisting, AX available) accepts.
 
 
-def test_the_live_stopping_rule_waits_for_the_named_window():
+def test_the_ax_stopping_rule_fires_on_the_first_match():
     """The rule that decides when to STOP polling, tested directly.
 
     Every other row here tests the adjudicator, which runs once the loop has
-    already stopped. That leaves the stop condition itself untested — so the
-    whole identity binding could be reverted to "the host marker plus any
-    window" and every other row would still pass. This is the row that fails
-    when it is.
+    already stopped. That leaves the stop condition itself untested — a
+    regression to "wait for two matches" or "never stop" would leave every
+    adjudicator row still passing. This is the row that fails when it is.
     """
-    ms = lambda n: 1_000_000_000 + n * 1_000_000  # noqa: E731
-    expect("an unrelated window does not stop polling",
-           m.named_window_has_appeared(99, {7: ms(3)}), False)
-    expect("the named window stops polling",
-           m.named_window_has_appeared(99, {7: ms(3), 99: ms(12)}), True)
-    expect("nothing stops polling before the app has named a window",
-           m.named_window_has_appeared(None, {7: ms(3), 99: ms(12)}), False)
-    expect("and an empty screen does not stop it either",
-           m.named_window_has_appeared(99, {}), False)
+    expect("no match does not stop polling", m.ax_overlay_has_appeared(0), False)
+    expect("one match stops polling", m.ax_overlay_has_appeared(1), True)
+    expect(
+        "more than one match ALSO stops polling — ambiguity is judged AFTER "
+        "stopping, by the adjudicator, never by waiting to see if it resolves",
+        m.ax_overlay_has_appeared(2), True)
 
 
 def test_a_half_written_line_is_not_a_marker():
@@ -380,33 +364,120 @@ def test_a_half_written_line_is_not_a_marker():
                              expected_bundle=BUNDLE), False)
 
     # The host half of the same problem.
-    window, failure = m.host_window_from(partial)
+    window, failure = m.recording_host_marker_from(partial, exhausted=False)
     expect("a half-written host line is 'not yet', not a verdict", window, None)
     expect("and not a failure either", failure, None)
-    window, failure = m.host_window_from(complete)
+    window, failure = m.recording_host_marker_from(complete, exhausted=False)
     expect("the finished line names the window", window, HOST_WINDOW)
     # A malformed line that IS finished is a real failure and must not be
     # swallowed by the same truncation rule that hides an unfinished one.
     malformed = complete.replace(f"window={HOST_WINDOW}", "window=main")
     expect("a finished malformed host line blocks",
-           m.host_window_from(malformed)[1][0], m.BLOCKED_MALFORMED_MARKER)
+           m.recording_host_marker_from(malformed, exhausted=False)[1][0],
+           m.BLOCKED_MALFORMED_MARKER)
 
 
-def test_host_window_is_read_from_the_marker_text():
-    """`host_window_from` is what the live loop polls with, so it gets its own
-    rows: an absent marker is 'not yet', never a verdict."""
-    window, failure = m.host_window_from(text())
+def test_recording_host_marker_is_read_from_the_marker_text():
+    """`recording_host_marker_from` is what the live loop polls with, so it
+    gets its own rows: an absent marker is 'not yet', never a verdict."""
+    window, failure = m.recording_host_marker_from(text(), exhausted=False)
     expect("a complete file names the window", window, HOST_WINDOW)
     expect("and reports no failure", failure, None)
 
     partial = text([e for e in ORDER if e != "host.order_front.complete"])
-    window, failure = m.host_window_from(partial)
+    window, failure = m.recording_host_marker_from(partial, exhausted=False)
     expect("a file without the host marker is not yet, not a verdict", window, None)
     expect("and still no failure", failure, None)
 
-    doubled = m.host_window_from(text(ORDER + ["host.order_front.complete"]))
-    expect("two host markers are refused, not averaged",
+    doubled = m.recording_host_marker_from(
+        text(ORDER + ["host.order_front.complete"]), exhausted=False)
+    expect("two host markers of the same intent are refused, not averaged",
            doubled[1][0], m.BLOCKED_DUPLICATE_MARKER)
+
+
+def test_wrong_presentation_binding_is_refused():
+    """A shared retained panel means ANY presentation can win the marker race.
+
+    Grounded in a real path, not a hypothetical: `WisprBootstrapper
+    .applicationDidFinishLaunching` starts an async crash-recovery scan on
+    EVERY launch (`Task { await recoveryCoordinator.scanAndRecover() }`),
+    which presents "behind the blocking recovering pill" through the SAME
+    retained panel the keypress-triggered recording uses. Without intent,
+    whichever wins the presentation race silently binds the marker.
+    """
+    def markers(*host_lines):
+        return "\n".join([
+            line("launch.enter"), line("launch.exit"),
+            line("root.construct.start"), line("root.construct.end"),
+        ] + list(host_lines)) + "\n"
+
+    other_then_recording = markers(
+        line("host.order_front.complete", window=7, intent=m.INTENT_OTHER,
+             ticks=13_000_000),
+        line("host.order_front.complete", window=99, intent=m.INTENT_RECORDING,
+             ticks=14_000_000))
+    window, failure = m.recording_host_marker_from(other_then_recording, exhausted=False)
+    expect("an unrelated presentation before the recording blocks", window, None)
+    if failure is None:
+        FAILURES.append("other-before-recording did not block at all")
+    else:
+        expect("with the specific wrong-presentation verdict",
+               failure[0], m.BLOCKED_WRONG_PRESENTATION)
+
+    recording_then_other = markers(
+        line("host.order_front.complete", window=99, intent=m.INTENT_RECORDING,
+             ticks=13_000_000),
+        line("host.order_front.complete", window=7, intent=m.INTENT_OTHER,
+             ticks=14_000_000))
+    window, failure = m.recording_host_marker_from(recording_then_other, exhausted=False)
+    expect("a LATER unrelated presentation does not invalidate the recording",
+           window, 99)
+    expect("and reports no failure", failure, None)
+
+    other_only = markers(
+        line("host.order_front.complete", window=7, intent=m.INTENT_OTHER))
+    window, failure = m.recording_host_marker_from(other_only, exhausted=False)
+    expect("an other-only file is not yet decidable mid-poll", window, None)
+    expect("the recording MIGHT still arrive, so no block yet", failure, None)
+    window, failure = m.recording_host_marker_from(other_only, exhausted=True)
+    expect("but IS decidable once polling has stopped", window, None)
+    if failure is None:
+        FAILURES.append("an exhausted other-only file did not block")
+    else:
+        expect("with the wrong-presentation verdict, since something DID present",
+               failure[0], m.BLOCKED_WRONG_PRESENTATION)
+
+    # Missing/illegal intent is malformed, exercised through the REAL parser
+    # rather than by constructing a `Marker` by hand.
+    illegal_intent = text().replace("intent=recording", "intent=urgent")
+    expect_verdict("an illegal intent value is malformed",
+                   illegal_intent, m.BLOCKED_MALFORMED_MARKER)
+    missing_intent_field = text().replace("\tintent=recording", "")
+    expect_verdict("a missing intent field is malformed",
+                   missing_intent_field, m.BLOCKED_MALFORMED_MARKER)
+
+    # The mutation control: if the Director's classifier were broken so the
+    # UNRELATED presentation were ALSO tagged `.recording` — indistinguishable
+    # from the real one — the FIRST control above stops being able to catch
+    # it. Both markers now read intent=recording, which is a DUPLICATE, not a
+    # wrong-presentation case; the verdict CLASS changes, which is what proves
+    # this suite is sensitive to the classifier rather than only to marker
+    # shape.
+    if_misclassified = markers(
+        line("host.order_front.complete", window=7, intent=m.INTENT_RECORDING,
+             ticks=13_000_000),
+        line("host.order_front.complete", window=99, intent=m.INTENT_RECORDING,
+             ticks=14_000_000))
+    window, failure = m.recording_host_marker_from(if_misclassified, exhausted=False)
+    expect("misclassifying BOTH as recording still blocks", window, None)
+    if failure is None:
+        FAILURES.append("two same-intent markers did not block at all")
+    else:
+        expect(
+            "but as duplicate-marker, not wrong-presentation — the first "
+            "control's specific verdict would no longer distinguish this case "
+            "from a real misclassification",
+            failure[0], m.BLOCKED_DUPLICATE_MARKER)
 
 
 # -------------------------------------------------- 9. thirty pairs, exactly
@@ -557,6 +628,9 @@ def test_p95_uses_nearest_rank():
 EMITTER = (pathlib.Path(__file__).resolve().parents[2]
            / "Sources" / "EnviousWisprAppKit" / "App" / "Debug"
            / "OverlayFirstRenderMarkers.swift")
+HOST = (pathlib.Path(__file__).resolve().parents[2]
+        / "Sources" / "EnviousWisprAppKit" / "App" / "Overlay"
+        / "OverlayWindowHost.swift")
 
 
 def test_the_swift_emitter_and_this_parser_agree_on_the_schema():
@@ -581,7 +655,7 @@ def test_the_swift_emitter_and_this_parser_agree_on_the_schema():
     for event in m.EVENTS:
         if f'"{event}"' not in swift:
             FAILURES.append(f"the emitter has no case spelled {event!r}")
-    for key in ("run=", "pid=", "bundle=", "event=", "ticks=", "window="):
+    for key in ("run=", "pid=", "bundle=", "event=", "ticks=", "window=", "intent="):
         if key not in swift:
             FAILURES.append(f"the emitter does not write the {key!r} field")
     # The environment names are the emitter's arming contract, and the harness
@@ -593,6 +667,29 @@ def test_the_swift_emitter_and_this_parser_agree_on_the_schema():
     # checks above would pass against an emitter that writes something else too.
     if "launch.begin" in swift:
         FAILURES.append("the emitter writes an event this parser cannot read")
+
+    # The intent values, spelled `case <name>` in the Swift enum — the same
+    # PAIRED-REJECTION shape as the events above: an intent this parser does
+    # NOT know must be absent, checked as one row so the acceptance checks
+    # cannot pass against an emitter that also writes something else.
+    for intent in m.INTENTS:
+        if f"case {intent}" not in swift:
+            FAILURES.append(f"the emitter has no Intent case spelled {intent!r}")
+    if "case urgent" in swift:
+        FAILURES.append("the emitter writes an intent this parser cannot read")
+
+    # The AX identifier the harness polls for must be the exact string set on
+    # the panel, or the C1-repair endpoint swap silently measures nothing.
+    if f'"{m.AX_PANEL_IDENTIFIER}"' not in swift:
+        FAILURES.append(
+            f"the emitter does not define {m.AX_PANEL_IDENTIFIER!r}; the AX identity "
+            "the harness polls for has drifted")
+
+    host = HOST.read_text() if HOST.exists() else ""
+    if "setAccessibilityIdentifier" not in host:
+        FAILURES.append(
+            "the host does not set an AX identifier on the panel; the AX endpoint has "
+            "nothing to poll for")
 
 
 def test_the_host_marker_is_emitted_with_a_real_window_number():
@@ -915,10 +1012,11 @@ TESTS = [
     test_same_bundle_version_but_different_executable_hash_blocks,
     test_non_monotonic_ticks_block,
     test_root_construction_inside_launch_blocks,
-    test_overlay_endpoint_waits_for_the_window_the_app_named,
-    test_the_live_stopping_rule_waits_for_the_named_window,
+    test_ax_overlay_endpoint_waits_for_our_identified_window,
+    test_the_ax_stopping_rule_fires_on_the_first_match,
     test_a_half_written_line_is_not_a_marker,
-    test_host_window_is_read_from_the_marker_text,
+    test_recording_host_marker_is_read_from_the_marker_text,
+    test_wrong_presentation_binding_is_refused,
     test_29_pairs_block_and_30_pairs_pass,
     test_one_invalid_sample_blocks_without_top_up,
     test_benchmark_fails_on_a_real_regression,

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -936,10 +936,10 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
     boot = BOOTSTRAPPER.read_text()
     for label, anchor, backend, driver in (
         ("WhisperKit preloadAction",
-         "preloadAction: { [weak whisperKitKernelDriver, asrManager] in",
+         "preloadAction: { [weak whisperKitKernelDriver] in",
          "whisperKit", "whisperKitKernelDriver"),
         ("parakeet launch Task",
-         "Task { [weak kernelDriver, asrManager] in",
+         "Task { [weak kernelDriver] in",
          "parakeet", "kernelDriver"),
     ):
         start = boot.find(anchor)

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -159,8 +159,14 @@ def test_duplicate_singleton_marker_blocks():
 # ------------------------------------------------------- 5. the schema itself
 
 def test_unknown_schema_or_malformed_line_blocks():
+    # Derived from `m.SCHEMA`, not hardcoded — a hardcoded "next version"
+    # string is exactly the kind of row that silently stops testing what its
+    # name claims the moment `SCHEMA` bumps again (cloud review P1, C1
+    # repair round 2: this row already went stale once, when V1 became V2).
+    current_suffix = m.SCHEMA[len(m.SCHEMA_FAMILY) + 2:]  # "_V2" -> "2"
+    future_schema = f"{m.SCHEMA_FAMILY}_V{int(current_suffix) + 1}"
     expect_verdict("a future schema version blocks",
-                   text(schema="EW_OVERLAY_FIRST_RENDER_V3"), m.BLOCKED_MALFORMED_MARKER)
+                   text(schema=future_schema), m.BLOCKED_MALFORMED_MARKER)
     expect_verdict("a line with a missing field blocks",
                    text() + f"{m.SCHEMA}\trun={RUN}\tpid={PID}\n",
                    m.BLOCKED_MALFORMED_MARKER)
@@ -334,6 +340,21 @@ def test_the_ax_stopping_rule_fires_on_the_first_match():
         "stopping, by the adjudicator, never by waiting to see if it resolves",
         m.ax_overlay_has_appeared(2), True)
 
+    # **The tested rule must be the BOUND rule, not a reimplementation
+    # sitting beside it** (cloud review P1, C1 repair round 2). Every
+    # assertion above tests `ax_overlay_has_appeared` directly; none of them
+    # can see whether the LIVE poll loop actually calls it, versus
+    # reimplementing its condition inline — which is exactly what the first
+    # draft of this repair did, silently, with every row above still green.
+    harness_source = pathlib.Path(__file__).with_name("measure_overlay_first_render.py")
+    if not harness_source.exists():
+        FAILURES.append(f"the harness is not at {harness_source}; this test's path is stale")
+        return
+    if "ax_overlay_has_appeared(len(matches))" not in harness_source.read_text():
+        FAILURES.append(
+            "the live poll loop does not call ax_overlay_has_appeared(len(matches)) — "
+            "the stopping rule tested above is not the one the loop actually uses")
+
 
 def test_a_half_written_line_is_not_a_marker():
     """The emitter loops on a short write, so a poller can read mid-line.
@@ -478,6 +499,79 @@ def test_wrong_presentation_binding_is_refused():
             "control's specific verdict would no longer distinguish this case "
             "from a real misclassification",
             failure[0], m.BLOCKED_DUPLICATE_MARKER)
+
+
+def test_known_invalid_ax_preconditions_never_touch_the_record_key():
+    """A synthetic keypress on a launch already known to be unusable is not
+    free (cloud review P1, C1 repair round 2): it is the exact input this
+    instrument exists to measure the effect of, so AX-unavailable and
+    a-match-already-exists must refuse BEFORE any input, not after.
+
+    `simulate_input`/`ptt_binding` are imported LAZILY inside
+    `measure_keypress_to_overlay`, so a fake registered in `sys.modules`
+    before the call is what `import ... as _si` finds instead of the real
+    one. `ax_accessibility_available`/`ax_matching_windows` are called
+    unqualified at module scope, so replacing the attribute on `m` itself
+    is enough — no `sys.modules` trick needed for those two.
+    """
+    import types
+
+    class SpyInput(types.ModuleType):
+        def __init__(self, name):
+            super().__init__(name)
+            self.down_calls = []
+            self.up_calls = []
+
+        def modifier_down(self, keycode):
+            self.down_calls.append(keycode)
+
+        def modifier_up(self, keycode):
+            self.up_calls.append(keycode)
+
+    fake_ptt = types.ModuleType("ptt_binding")
+    fake_ptt.resolve = lambda: types.SimpleNamespace(
+        is_modifier_only=True, key_name="fn (globe)", keycode=63)
+    spy = SpyInput("simulate_input")
+
+    saved_modules = {name: sys.modules.get(name) for name in ("simulate_input", "ptt_binding")}
+    saved_ax_available = m.ax_accessibility_available
+    saved_ax_matching = m.ax_matching_windows
+    sys.modules["simulate_input"] = spy
+    sys.modules["ptt_binding"] = fake_ptt
+    try:
+        m.ax_accessibility_available = lambda pid: False
+        m.ax_matching_windows = lambda pid: []
+        result = m.measure_keypress_to_overlay(4242, "/nonexistent-marker-path")
+        expect("AX-unavailable never presses the record key", spy.down_calls, [])
+        expect("and never releases it either", spy.up_calls, [])
+        expect("while still reporting the right verdict",
+               result["verdict"], m.BLOCKED_AX_UNAVAILABLE)
+
+        m.ax_accessibility_available = lambda pid: True
+        m.ax_matching_windows = lambda pid: [object()]
+        result = m.measure_keypress_to_overlay(4242, "/nonexistent-marker-path")
+        expect("a preexisting match never presses the record key either",
+               spy.down_calls, [])
+        expect("nor releases it", spy.up_calls, [])
+        expect("while still reporting the right verdict",
+               result["verdict"], m.BLOCKED_NO_OVERLAY)
+
+        # TWIN: with both preconditions satisfied, the record key IS pressed
+        # and released exactly once — the refusal above is about the
+        # preconditions, not about this function never pressing a key at all.
+        m.ax_accessibility_available = lambda pid: True
+        m.ax_matching_windows = lambda pid: []
+        result = m.measure_keypress_to_overlay(4242, "/nonexistent-marker-path", timeout_s=0.05)
+        expect("a clean precondition set presses the record key once", spy.down_calls, [63])
+        expect("and releases it once", spy.up_calls, [63])
+    finally:
+        for name, mod in saved_modules.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+        m.ax_accessibility_available = saved_ax_available
+        m.ax_matching_windows = saved_ax_matching
 
 
 # -------------------------------------------------- 9. thirty pairs, exactly
@@ -631,6 +725,9 @@ EMITTER = (pathlib.Path(__file__).resolve().parents[2]
 HOST = (pathlib.Path(__file__).resolve().parents[2]
         / "Sources" / "EnviousWisprAppKit" / "App" / "Overlay"
         / "OverlayWindowHost.swift")
+DIRECTOR = (pathlib.Path(__file__).resolve().parents[2]
+            / "Sources" / "EnviousWisprAppKit" / "App" / "Overlay"
+            / "OverlayDirector.swift")
 
 
 def test_the_swift_emitter_and_this_parser_agree_on_the_schema():
@@ -700,12 +797,10 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
     just the field's spelling: `OverlayWindowHost` must pass
     `panel.windowNumber`, and it must do so on the `emitFirst` path.
     """
-    host = (pathlib.Path(__file__).resolve().parents[2] / "Sources"
-            / "EnviousWisprAppKit" / "App" / "Overlay" / "OverlayWindowHost.swift")
-    if not host.exists():
-        FAILURES.append(f"the host is not at {host}; this test's path is stale")
+    if not HOST.exists():
+        FAILURES.append(f"the host is not at {HOST}; this test's path is stale")
         return
-    swift = host.read_text()
+    swift = HOST.read_text()
     if "window: panel.windowNumber" not in swift:
         FAILURES.append(
             "the host does not pass panel.windowNumber to the marker; the harness "
@@ -714,18 +809,36 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
         FAILURES.append(
             "the host no longer emits the order-front marker once per process")
 
+    # **The AX identifier must be set AFTER `orderFrontRegardless()`, never at
+    # construction (cloud review P1, C1 repair round 2).**
+    # `accessibilityWindows` enumerates every application window regardless of
+    # visibility, so setting the identifier in `ensurePanel()` would let the
+    # harness's AX poll match a panel that has no content and was never
+    # ordered front — a timestamp for an event the user cannot see. Source
+    # order is the only thing that can catch this class of regression; the
+    # marker format does not change when it does.
+    order_front_index = swift.find("orderFrontRegardless()")
+    identifier_index = swift.find("setAccessibilityIdentifier(")
+    if order_front_index < 0 or identifier_index < 0:
+        FAILURES.append(
+            "could not find both orderFrontRegardless() and setAccessibilityIdentifier( "
+            "in the host source to check their order")
+    elif identifier_index < order_front_index:
+        FAILURES.append(
+            "setAccessibilityIdentifier( appears BEFORE orderFrontRegardless() in the "
+            "host — the AX identifier would be visible to a poll before the panel has "
+            "any content or is on screen")
+
     # The root markers must be HELD, not emitted where they are captured.
     # Emitting at the capture site puts the marker's own write inside the
     # keypress interval in the baseline bundle and outside it in the prewarmed
     # one, so the benchmark credits the change for removing instrumentation cost
     # that is not production work. Nothing about the marker FORMAT changes when
     # this regresses, so no other row here would notice.
-    director = (pathlib.Path(__file__).resolve().parents[2] / "Sources"
-                / "EnviousWisprAppKit" / "App" / "Overlay" / "OverlayDirector.swift")
-    if not director.exists():
-        FAILURES.append(f"the director is not at {director}; this test's path is stale")
+    if not DIRECTOR.exists():
+        FAILURES.append(f"the director is not at {DIRECTOR}; this test's path is stale")
         return
-    d = director.read_text()
+    d = DIRECTOR.read_text()
     if "OverlayFirstRenderMarkers.hold(" not in d:
         FAILURES.append(
             "the director does not HOLD its root captures; emitting them at the "
@@ -734,6 +847,22 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
         FAILURES.append(
             "the director emits directly, which is the biased form this test exists "
             "to refuse")
+
+    # **The production intent classifier must be BOUND, not just present**
+    # (cloud review P1, C1 repair round 2). Every Python row above proves the
+    # ADJUDICATOR reads intent correctly from fabricated marker text; none of
+    # them can see whether the Director actually asks `isRecording` before
+    # tagging a presentation. Flipping the real classifier to always say
+    # `.recording` would leave all 28 Python rows green, because they never
+    # read this file. This is the same defect class the marker's own window
+    # number was written to fix, one call site over.
+    if ("OverlayFirstRenderMarkers.withPresentationIntent(" not in d
+            or "Self.isRecording(presentation) ? .recording : .other" not in d):
+        FAILURES.append(
+            "the director does not wrap host.present with "
+            "withPresentationIntent(Self.isRecording(presentation) ? .recording : .other) "
+            "— the intent tag is no longer bound to the real classifier, so a broken "
+            "classifier would leave every marker-shape test green")
 
     # Holding is not enough on its own: an empty array allocates its buffer on
     # the FIRST append, which in the baseline bundle happens inside the keypress
@@ -1017,6 +1146,7 @@ TESTS = [
     test_a_half_written_line_is_not_a_marker,
     test_recording_host_marker_is_read_from_the_marker_text,
     test_wrong_presentation_binding_is_refused,
+    test_known_invalid_ax_preconditions_never_touch_the_record_key,
     test_29_pairs_block_and_30_pairs_pass,
     test_one_invalid_sample_blocks_without_top_up,
     test_benchmark_fails_on_a_real_regression,

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -652,7 +652,8 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
 class FakeProc:
     """Enough of `subprocess.Popen` to exercise the reaper's three outcomes."""
 
-    def __init__(self, *, exits_on=None, already_gone=False):
+    def __init__(self, *, exits_on=None, already_gone=False, pid=4242):
+        self.pid = pid
         # exits_on: which wait() call succeeds — 1 after TERM, 2 after KILL,
         # None for a process that ignores both.
         self.exits_on = exits_on
@@ -711,6 +712,87 @@ def test_an_abandoned_launch_is_actually_reaped():
     expect("nor killed", gone.killed, False)
 
 
+def test_every_exceptional_exit_from_the_readiness_wait_reaps():
+    """`proc` is alive from the moment `Popen` returns, so nothing may leave here
+    without it.
+
+    Three ways out: ready (keep it), timeout (reap), and an exception from
+    reading the marker file itself (reap). The third is the one that escaped —
+    it is not a failure of the app, so nothing about it looks like a launch
+    problem, and `smoke()` turns it into a tidy `BLOCKED_LAUNCH` receipt while
+    the app keeps running.
+    """
+    good = (line("launch.enter") + "\n" + line("launch.exit") + "\n")
+
+    # READY: the process is kept, not reaped.
+    alive = FakeProc(exits_on=1)
+    m.await_launch_ready(alive, pathlib.Path("/unused"), run_id=RUN,
+                         expected_bundle=BUNDLE, ready_timeout_s=1.0,
+                         read_text=lambda: good)
+    expect("a ready launch is not terminated", alive.terminated, False)
+
+    # TIMEOUT: never ready, so reaped and reported.
+    timed_out = FakeProc(exits_on=1)
+    try:
+        m.await_launch_ready(timed_out, pathlib.Path("/unused"), run_id=RUN,
+                             expected_bundle=BUNDLE, ready_timeout_s=0.05,
+                             read_text=lambda: "")
+        FAILURES.append("a launch that never became ready must raise")
+    except RuntimeError:
+        pass
+    expect("a timed-out launch is reaped", timed_out.terminated, True)
+
+    # THE ESCAPED CASE: reading the marker file raises.
+    def explode():
+        raise OSError("the output directory went away underneath the run")
+
+    io_error = FakeProc(exits_on=1)
+    try:
+        m.await_launch_ready(io_error, pathlib.Path("/unused"), run_id=RUN,
+                             expected_bundle=BUNDLE, ready_timeout_s=1.0,
+                             read_text=explode)
+        FAILURES.append("an unreadable marker file must not be swallowed")
+    except OSError:
+        pass
+    expect("a launch whose marker read raises is still reaped",
+           io_error.terminated, True)
+
+    # And an interrupt, which is the case least likely to be cleaned up by hand.
+    def interrupt():
+        raise KeyboardInterrupt()
+
+    interrupted = FakeProc(exits_on=1)
+    try:
+        m.await_launch_ready(interrupted, pathlib.Path("/unused"), run_id=RUN,
+                             expected_bundle=BUNDLE, ready_timeout_s=1.0,
+                             read_text=interrupt)
+        FAILURES.append("an interrupt must propagate")
+    except KeyboardInterrupt:
+        pass
+    expect("an interrupted launch is reaped", interrupted.terminated, True)
+
+
+def test_a_locked_screen_blocks_before_a_launch_is_spent():
+    """A locked screen is a different machine, not a slower one.
+
+    `loginwindow` owns the active Space, no app window is reachable, and this
+    repo has already shipped one green whose screenshots were all the login
+    window. The check runs before occupancy because it costs nothing and
+    invalidates the run whatever the slot looks like.
+    """
+    expect("a locked screen blocks", m.screen_lock_block(True) is not None, True)
+    expect("an unlocked screen proceeds", m.screen_lock_block(False), None)
+    # THE THIRD VALUE. Collapsing "could not tell" into "unlocked" would let the
+    # run proceed on a machine it cannot describe — the exact shape that turns a
+    # broken probe into a green.
+    expect("an unreadable session blocks too",
+           m.screen_lock_block(None) is not None, True)
+    # The two refusals must not read the same, or a reader cannot tell a locked
+    # screen from a probe that failed.
+    if m.screen_lock_block(True) == m.screen_lock_block(None):
+        FAILURES.append("locked and unknown must give distinguishable reasons")
+
+
 # ------------------------------------------------------------------- runner
 
 TESTS = [
@@ -735,6 +817,8 @@ TESTS = [
     test_the_swift_emitter_and_this_parser_agree_on_the_schema,
     test_the_host_marker_is_emitted_with_a_real_window_number,
     test_an_abandoned_launch_is_actually_reaped,
+    test_every_exceptional_exit_from_the_readiness_wait_reaps,
+    test_a_locked_screen_blocks_before_a_launch_is_spent,
     test_median_uses_statistics_median,
     test_p95_uses_nearest_rank,
 ]

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -817,17 +817,46 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
     # ordered front — a timestamp for an event the user cannot see. Source
     # order is the only thing that can catch this class of regression; the
     # marker format does not change when it does.
-    order_front_index = swift.find("orderFrontRegardless()")
-    identifier_index = swift.find("setAccessibilityIdentifier(")
-    if order_front_index < 0 or identifier_index < 0:
+    #
+    # **Scoped to `present()`'s own body, and matched against the FULL call**
+    # (round 2 of this control): a global `.find()` for the bare substrings
+    # matches this very comment, which mentions both names — so a regression
+    # that moved the REAL call into `ensurePanel()` while leaving the comment
+    # here would still read as passing. Isolating the function and requiring
+    # the complete call text is what makes the control test the call site,
+    # not the prose describing it.
+    identifier_call = (
+        "panel.setAccessibilityIdentifier("
+        "OverlayFirstRenderMarkers.axPanelIdentifier)"
+    )
+    # **Anchored to the CLASS, not just a bare function name** — Codex's first
+    # draft of this control searched for `resizeCurrentPresentation(` from
+    # the top of the file, which matches the `OverlayWindowHosting` PROTOCOL's
+    # own requirement (identically indented, and textually first) before ever
+    # reaching the real implementation — the exact same "found the wrong twin"
+    # shape this repo has hit before. Starting from `final class
+    # OverlayWindowHost` skips the protocol declaration entirely.
+    class_start = swift.find("final class OverlayWindowHost")
+    present_start = swift.find("\n  func present(", class_start) if class_start >= 0 else -1
+    present_end = (
+        swift.find("\n  func resizeCurrentPresentation(", class_start)
+        if class_start >= 0 else -1)
+    if class_start < 0 or present_start < 0 or present_end < 0:
+        FAILURES.append("could not isolate OverlayWindowHost.present() by source markers")
+    elif swift.count(identifier_call) != 1:
         FAILURES.append(
-            "could not find both orderFrontRegardless() and setAccessibilityIdentifier( "
-            "in the host source to check their order")
-    elif identifier_index < order_front_index:
-        FAILURES.append(
-            "setAccessibilityIdentifier( appears BEFORE orderFrontRegardless() in the "
-            "host — the AX identifier would be visible to a poll before the panel has "
-            "any content or is on screen")
+            "the AX identifier must be assigned exactly once in OverlayWindowHost, via "
+            f"the exact call {identifier_call!r}")
+    else:
+        order_front_index = swift.find(
+            "panel.orderFrontRegardless()", present_start, present_end)
+        identifier_index = swift.find(identifier_call, present_start, present_end)
+        if order_front_index < 0 or identifier_index < 0:
+            FAILURES.append(
+                "present() must assign the AX identifier after orderFrontRegardless()")
+        elif identifier_index < order_front_index:
+            FAILURES.append(
+                "present() assigns the AX identifier before orderFrontRegardless()")
 
     # The root markers must be HELD, not emitted where they are captured.
     # Emitting at the capture site puts the marker's own write inside the

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -632,6 +632,20 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
             "the director emits directly, which is the biased form this test exists "
             "to refuse")
 
+    # Holding is not enough on its own: an empty array allocates its buffer on
+    # the FIRST append, which in the baseline bundle happens inside the keypress
+    # interval and in the prewarmed one does not. The reservation has to happen
+    # in `prepare()`, which runs before either interval.
+    emitter = EMITTER.read_text()
+    if "pending.reserveCapacity" not in emitter:
+        FAILURES.append(
+            "prepare() does not reserve the held-capture storage; the first hold "
+            "would allocate inside the keypress interval in one bundle only")
+    if "removeAll(keepingCapacity: true)" not in emitter:
+        FAILURES.append(
+            "the flush frees the capacity it just used, inside the interval it was "
+            "reserved to stay out of")
+
 
 # ------------------------------------------------------------------- runner
 

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -540,8 +540,16 @@ def test_known_invalid_ax_preconditions_never_touch_the_record_key():
     saved_modules = {name: sys.modules.get(name) for name in ("simulate_input", "ptt_binding")}
     saved_ax_available = m.ax_accessibility_available
     saved_ax_matching = m.ax_matching_windows
+    saved_lock_state = m.screen_lock_state
     sys.modules["simulate_input"] = spy
     sys.modules["ptt_binding"] = fake_ptt
+    # Locked out (`False` = unlocked) for every case below except the one
+    # that tests it — real PTT resolution and AX queries are already mocked
+    # here, so the screen lock must be too, or this test's own verdict
+    # depends on whether the machine running it happens to be locked.
+    # `screen_lock_block` itself stays real: it is pure and deterministic
+    # given `screen_lock_state`'s True/False/None.
+    m.screen_lock_state = lambda: False
     try:
         m.ax_accessibility_available = lambda pid: False
         m.ax_matching_windows = lambda pid: []
@@ -560,9 +568,26 @@ def test_known_invalid_ax_preconditions_never_touch_the_record_key():
         expect("while still reporting the right verdict",
                result["verdict"], m.BLOCKED_NO_OVERLAY)
 
-        # TWIN: with both preconditions satisfied, the record key IS pressed
-        # and released exactly once — the refusal above is about the
-        # preconditions, not about this function never pressing a key at all.
+        # A screen that locked in the gap between smoke()'s own recheck and
+        # this function's PTT/AX resolution work must ALSO refuse before any
+        # input — this is the LAST possible gate, immediately before
+        # `modifier_down` (#2377, C1 repair): AX is available and no match
+        # preexists, so without this check the press would go through.
+        m.ax_accessibility_available = lambda pid: True
+        m.ax_matching_windows = lambda pid: []
+        m.screen_lock_state = lambda: True
+        result = m.measure_keypress_to_overlay(4242, "/nonexistent-marker-path")
+        expect("a screen locked right before the press never presses the record key",
+               spy.down_calls, [])
+        expect("nor releases it", spy.up_calls, [])
+        expect("while still reporting the right verdict",
+               result["verdict"], m.BLOCKED_SCREEN_LOCKED)
+        m.screen_lock_state = lambda: False
+
+        # TWIN: with all three preconditions satisfied, the record key IS
+        # pressed and released exactly once — the refusals above are about
+        # the preconditions, not about this function never pressing a key
+        # at all.
         m.ax_accessibility_available = lambda pid: True
         m.ax_matching_windows = lambda pid: []
         result = m.measure_keypress_to_overlay(4242, "/nonexistent-marker-path", timeout_s=0.05)
@@ -576,6 +601,7 @@ def test_known_invalid_ax_preconditions_never_touch_the_record_key():
                 sys.modules[name] = mod
         m.ax_accessibility_available = saved_ax_available
         m.ax_matching_windows = saved_ax_matching
+        m.screen_lock_state = saved_lock_state
 
 
 # -------------------------------------------------- 9. thirty pairs, exactly

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -921,25 +921,44 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
             "the flush frees the capacity it just used, inside the interval it was "
             "reserved to stay out of")
 
-    # `emitEngineReadyOnce()` must be BOUND to a real readiness re-read at
-    # both launch warm-up paths, not just present somewhere in the file.
-    # Only one path runs for a given launch (keyed on selected backend), so
-    # both must carry the guard-then-emit pair.
+    # `emitEngineReadyOnce()` must be BOUND to a COMPLETE readiness guard at
+    # EACH launch warm-up path separately (#2377, C1 repair round 4, Codex
+    # HIGH) — checking the two facts "two emit calls exist" and "the string
+    # engineReadiness == .ready appears somewhere" independently would pass
+    # a mutant that moves one emit call OUTSIDE its own guard, since both
+    # facts would still be true elsewhere in the file. Each call site is
+    # scoped by its own unique capture-list text, so this cannot cross-match
+    # the other path's guard — the measured gap between the two capture
+    # lists is over 13,000 characters, far past this window.
     if not BOOTSTRAPPER.exists():
         FAILURES.append(f"the bootstrapper is not at {BOOTSTRAPPER}; this test's path is stale")
         return
     boot = BOOTSTRAPPER.read_text()
-    guarded_emit_count = boot.count(
-        "OverlayFirstRenderMarkers.emitEngineReadyOnce()")
-    if guarded_emit_count != 2:
-        FAILURES.append(
-            f"expected emitEngineReadyOnce() at exactly 2 call sites (parakeet "
-            f"launch Task, WhisperKit preloadAction), found {guarded_emit_count}")
-    if "engineReadiness == .ready" not in boot:
-        FAILURES.append(
-            "no launch warm-up path re-reads engineReadiness == .ready before "
-            "emitting; emitting unconditionally would report readiness for a "
-            "warm-up that actually failed")
+    for label, anchor, backend, driver in (
+        ("WhisperKit preloadAction",
+         "preloadAction: { [weak whisperKitKernelDriver, asrManager] in",
+         "whisperKit", "whisperKitKernelDriver"),
+        ("parakeet launch Task",
+         "Task { [weak kernelDriver, asrManager] in",
+         "parakeet", "kernelDriver"),
+    ):
+        start = boot.find(anchor)
+        if start < 0:
+            FAILURES.append(f"could not locate the {label} call site by its capture list")
+            continue
+        window = boot[start:start + 1000]
+        required = (
+            f"settings.selectedBackend == .{backend}",
+            f"asrManager.activeBackendType == .{backend}",
+            f"{driver}?.engineReadiness == .ready",
+            "OverlayFirstRenderMarkers.emitEngineReadyOnce()",
+        )
+        missing = [r for r in required if r not in window]
+        if missing:
+            FAILURES.append(
+                f"the {label} path's readiness guard is missing: {missing!r} — "
+                "moving emitEngineReadyOnce() outside its own selected/active/"
+                "engineReadiness guard must be caught here")
 
 
 # --------------------------------------- 12b. the engine-readiness gate
@@ -1024,13 +1043,14 @@ def test_await_engine_ready_waits_for_the_marker_and_times_out_without_it():
     """
     calls = {"n": 0}
     ready_marker = line("engine.ready", ticks=500_000) + "\n"
+    running = FakeProc()
 
     def eventually_ready():
         calls["n"] += 1
         return ready_marker if calls["n"] >= 3 else ""
 
     ready = m.await_engine_ready(
-        "/nonexistent-marker-path", run_id=RUN, expected_pid=PID,
+        "/nonexistent-marker-path", proc=running, run_id=RUN, expected_pid=PID,
         expected_bundle=BUNDLE, timeout_s=5.0, read_text=eventually_ready)
     expect("readiness is detected once the marker appears", ready, True)
     expect("it took more than one read to get there", calls["n"] >= 3, True)
@@ -1039,78 +1059,51 @@ def test_await_engine_ready_waits_for_the_marker_and_times_out_without_it():
     # wait times out and reports False rather than hanging or raising.
     wrong_run_marker = line("engine.ready", ticks=500_000, run="SOME-OTHER-RUN") + "\n"
     never_ready = m.await_engine_ready(
-        "/nonexistent-marker-path", run_id=RUN, expected_pid=PID,
+        "/nonexistent-marker-path", proc=FakeProc(), run_id=RUN, expected_pid=PID,
         expected_bundle=BUNDLE, timeout_s=0.05, read_text=lambda: wrong_run_marker)
     expect("a marker for a different run never satisfies readiness", never_ready, False)
 
 
-def _smoke_body(source):
-    """`smoke()`'s own body text, isolated by its full definition signature —
-    never a bare function name, which would match a call site instead (the
-    same "found the wrong twin" class the AX-identifier order check hit
-    before it anchored on `final class OverlayWindowHost`).
+def test_await_engine_ready_raises_on_a_crash_rather_than_waiting_out_the_timeout():
+    """A crash DURING warm-up must not burn the full timeout waiting for a
+    marker that will never arrive, then report the plausible-sounding but
+    wrong `BLOCKED_ENGINE_NOT_READY` (#2377, C1 repair round 4, Codex
+    MEDIUM). Watching `proc.poll()` is what tells the two apart.
     """
-    start = source.find("\ndef smoke(bundle_path")
-    end = source.find("\ndef main(argv)", start) if start >= 0 else -1
-    if start < 0 or end < 0:
-        return None
-    return source[start:end]
+    crashed = FakeProc(already_gone=True)
+    try:
+        m.await_engine_ready(
+            "/nonexistent-marker-path", proc=crashed, run_id=RUN, expected_pid=PID,
+            expected_bundle=BUNDLE, timeout_s=5.0, read_text=lambda: "")
+        FAILURES.append(
+            "await_engine_ready did not raise when the process had already exited")
+    except RuntimeError:
+        pass
 
 
-def test_smoke_gates_the_synthetic_keypress_behind_engine_readiness():
-    """`smoke()` must wait for `engine.ready` and take the READY branch
-    before ever calling `measure_keypress_to_overlay` — never the reverse.
-    A keypress sent first races `ColdPressGuard` (#879) for a warming
-    engine, which is the exact false alarm (`BLOCKED_WRONG_PRESENTATION` for
-    a reason that is not first render) Codex's smoke ruling exists to
-    remove. Source position is the only thing that can catch a regression
-    here: reordering the two calls changes no marker FORMAT, so nothing
-    else in this suite would notice.
+def test_measure_after_engine_ready_gates_the_keypress_by_call_count():
+    """The "never press before the engine is ready" property, proved by
+    EXECUTION rather than by reading `smoke()`'s source layout (#2377, C1
+    repair round 4, Codex MEDIUM) — the prior version of this test could
+    only see where the two calls sat in the file, which survives a
+    regression that keeps the right shape but breaks the actual gating
+    (e.g. a mutant `measure() if True else None`, still textually inside an
+    `if`).
     """
-    real_source = pathlib.Path(m.__file__).read_text()
-    body = _smoke_body(real_source)
-    if body is None:
-        FAILURES.append("could not isolate smoke()'s body by source markers")
-        return
-    ready_idx = body.find("await_engine_ready(")
-    else_idx = body.find("else:", ready_idx) if ready_idx >= 0 else -1
-    press_idx = body.find("measure_keypress_to_overlay(", else_idx) if else_idx >= 0 else -1
-    if ready_idx < 0:
-        FAILURES.append("smoke() does not call await_engine_ready")
-    elif else_idx < 0:
-        FAILURES.append(
-            "smoke() does not branch on the readiness result before pressing")
-    elif press_idx < 0:
-        FAILURES.append(
-            "smoke() does not call measure_keypress_to_overlay inside the "
-            "readiness-true branch")
+    calls = {"n": 0}
+    sentinel = object()
 
-    # TWO-WAY CONTROL: the same scoping-and-order logic, run against a
-    # synthetic source with the calls in the WRONG order, must actually
-    # report a failure — proof the check is not vacuously true. Never
-    # touches the real file.
-    reversed_fake = (
-        "\ndef smoke(bundle_path, *, out_dir):\n"
-        "    timing = measure_keypress_to_overlay(pid, marker_path)\n"
-        "    if not engine_ready:\n"
-        "        pass\n"
-        "    else:\n"
-        "        ready = await_engine_ready(marker_path, run_id=run_id)\n"
-        "\ndef main(argv):\n")
-    fake_body = _smoke_body(reversed_fake)
-    if fake_body is None:
-        FAILURES.append("the control fixture's own source markers do not isolate")
-        return
-    fake_ready_idx = fake_body.find("await_engine_ready(")
-    fake_else_idx = (
-        fake_body.find("else:", fake_ready_idx) if fake_ready_idx >= 0 else -1)
-    fake_press_idx = (
-        fake_body.find("measure_keypress_to_overlay(", fake_else_idx)
-        if fake_else_idx >= 0 else -1)
-    if fake_ready_idx >= 0 and fake_else_idx >= 0 and fake_press_idx >= 0:
-        FAILURES.append(
-            "the order check does not fail on a deliberately reversed source — "
-            "it cannot be trusted to catch a real regression")
+    def spy():
+        calls["n"] += 1
+        return sentinel
+
+    not_ready_result = m.measure_after_engine_ready(False, spy)
+    expect("a not-ready engine returns no measurement", not_ready_result, None)
+    expect("and the measurement thunk is never called", calls["n"], 0)
+
+    ready_result = m.measure_after_engine_ready(True, spy)
+    expect("a ready engine returns the measurement", ready_result, sentinel)
+    expect("calling the thunk exactly once", calls["n"], 1)
 
 
 # ------------------------------------------- 13. nobody is left behind
@@ -1127,6 +1120,12 @@ class FakeProc:
         self.waits = 0
         self.terminated = False
         self.killed = False
+        # Real `Popen.returncode` is `None` while running; `poll()`/`wait()`
+        # set it as a side effect once the process exits. `already_gone`
+        # models a process that was already dead when first observed, so it
+        # is set once here rather than dynamically — enough for the crash
+        # rows this fixture exercises, never a general `wait()` simulation.
+        self.returncode = 0 if already_gone else None
 
     def poll(self):
         return 0 if self.already_gone else None
@@ -1393,7 +1392,8 @@ TESTS = [
     test_engine_ready_marker_position_never_affects_launch_adjudication,
     test_engine_is_ready_matches_exactly_this_launch,
     test_await_engine_ready_waits_for_the_marker_and_times_out_without_it,
-    test_smoke_gates_the_synthetic_keypress_behind_engine_readiness,
+    test_await_engine_ready_raises_on_a_crash_rather_than_waiting_out_the_timeout,
+    test_measure_after_engine_ready_gates_the_keypress_by_call_count,
     test_an_abandoned_launch_is_actually_reaped,
     test_every_exceptional_exit_from_the_readiness_wait_reaps,
     test_a_locked_screen_blocks_before_a_launch_is_spent,

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -882,6 +882,7 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
         FAILURES.append(f"the director is not at {DIRECTOR}; this test's path is stale")
         return
     d = DIRECTOR.read_text()
+    emitter = EMITTER.read_text()
     if "OverlayFirstRenderMarkers.hold(" not in d:
         FAILURES.append(
             "the director does not HOLD its root captures; emitting them at the "
@@ -890,6 +891,25 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
         FAILURES.append(
             "the director emits directly, which is the biased form this test exists "
             "to refuse")
+
+    # `hold` must take exactly ONE Capture, never variadic (#2377, C1
+    # repair): a variadic parameter allocates a temporary `[Capture]` at
+    # its CALL SITE before the function body runs, the same asymmetric
+    # cost `reserveCapacity` below exists to avoid one level up. Bound at
+    # BOTH ends — the signature itself, and each of the two call sites
+    # appearing exactly once with a single argument — so a revert of
+    # either half is caught, including the less-obvious one-element-array
+    # regression that keeps the call sites looking unchanged.
+    if "public static func hold(_ capture: Capture)" not in emitter:
+        FAILURES.append("hold must accept exactly one Capture")
+    if "func hold(_ captures: Capture...)" in emitter:
+        FAILURES.append("hold regressed to a call-site-allocating variadic")
+    if d.count("OverlayFirstRenderMarkers.hold(constructStart)") != 1:
+        FAILURES.append("root construction must hold constructStart once")
+    if d.count("OverlayFirstRenderMarkers.hold(constructEnd)") != 1:
+        FAILURES.append("root construction must hold constructEnd once")
+    if "hold(constructStart, constructEnd)" in d:
+        FAILURES.append("root markers regressed to one variadic call")
 
     # **The production intent classifier must be BOUND, not just present**
     # (cloud review P1, C1 repair round 2). Every Python row above proves the
@@ -911,7 +931,6 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
     # the FIRST append, which in the baseline bundle happens inside the keypress
     # interval and in the prewarmed one does not. The reservation has to happen
     # in `prepare()`, which runs before either interval.
-    emitter = EMITTER.read_text()
     if "pending.reserveCapacity" not in emitter:
         FAILURES.append(
             "prepare() does not reserve the held-capture storage; the first hold "

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -647,6 +647,70 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
             "reserved to stay out of")
 
 
+# ------------------------------------------- 13. nobody is left behind
+
+class FakeProc:
+    """Enough of `subprocess.Popen` to exercise the reaper's three outcomes."""
+
+    def __init__(self, *, exits_on=None, already_gone=False):
+        # exits_on: which wait() call succeeds — 1 after TERM, 2 after KILL,
+        # None for a process that ignores both.
+        self.exits_on = exits_on
+        self.already_gone = already_gone
+        self.waits = 0
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return 0 if self.already_gone else None
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+    def wait(self, timeout=None):
+        self.waits += 1
+        if self.exits_on is not None and self.waits >= self.exits_on:
+            return 0
+        import subprocess
+        raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout)
+
+
+def test_an_abandoned_launch_is_actually_reaped():
+    """A bare terminate-and-raise is a REQUEST, not an outcome.
+
+    A process slow to exit, or ignoring SIGTERM, outlives the exception — and
+    the next cold launch is then either blocked on occupancy or measured beside
+    an orphan answering the same global hotkey and writing the same log. Every
+    dev bundle here is named `EnviousWispr Local.app`, so an orphan is not
+    distinguishable by name from the instance under test.
+    """
+    polite = FakeProc(exits_on=1)
+    m.reap(polite, timeout_s=0.01)
+    expect("a process that exits on TERM is not killed", polite.killed, False)
+    expect("and it is waited on", polite.waits, 1)
+
+    stubborn = FakeProc(exits_on=2)
+    m.reap(stubborn, timeout_s=0.01)
+    expect("a process that ignores TERM is killed", stubborn.killed, True)
+    expect("and waited on again, so it is reaped rather than left a zombie",
+           stubborn.waits, 2)
+
+    wedged = FakeProc(exits_on=None)
+    m.reap(wedged, timeout_s=0.01)
+    expect("a wedged process is still killed", wedged.killed, True)
+    expect("and the reaper returns rather than hanging the run", wedged.waits, 2)
+
+    # TWIN: a process that has already exited is not signalled at all. Without
+    # this the reaper would TERM a pid that may since have been recycled.
+    gone = FakeProc(already_gone=True)
+    m.reap(gone, timeout_s=0.01)
+    expect("an already-exited process is not signalled", gone.terminated, False)
+    expect("nor killed", gone.killed, False)
+
+
 # ------------------------------------------------------------------- runner
 
 TESTS = [
@@ -670,6 +734,7 @@ TESTS = [
     test_every_side_must_be_its_own_cold_launch,
     test_the_swift_emitter_and_this_parser_agree_on_the_schema,
     test_the_host_marker_is_emitted_with_a_real_window_number,
+    test_an_abandoned_launch_is_actually_reaped,
     test_median_uses_statistics_median,
     test_p95_uses_nearest_rank,
 ]

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -434,8 +434,14 @@ def pairs(n, *, a_launch=10.0, b_launch=10.0, a_root=2.0, b_root=2.0,
         if bad_index == i:
             b = m.LaunchResult(verdict=m.BLOCKED_MISSING_MARKER,
                                detail="host.order_front.complete", sample=None)
-        out.append(m.Pair(order=("AB" if i % 2 == 0 else "BA"),
-                          a=a, b=b, a_keypress_ms=a_key, b_keypress_ms=b_key))
+        # The keypress figure names the launch it came from, so a crossed or
+        # reused measurement cannot pass the run check on the launch alone.
+        out.append(m.Pair(
+            order=("AB" if i % 2 == 0 else "BA"), a=a, b=b,
+            a_keypress=m.KeypressSample(run=a.sample.run if a.sample else a_run,
+                                        keypress_ms=a_key),
+            b_keypress=m.KeypressSample(run=b.sample.run if b.sample else b_run,
+                                        keypress_ms=b_key)))
     return out
 
 
@@ -793,6 +799,44 @@ def test_a_locked_screen_blocks_before_a_launch_is_spent():
         FAILURES.append("locked and unknown must give distinguishable reasons")
 
 
+def test_a_keypress_figure_must_name_the_launch_it_came_from():
+    """Tagging the LAUNCHES is not enough; the timings need identity too.
+
+    The distinct-run check validates `p.a`/`p.b`. A runner that reused a prior
+    keypress result, or associated the two sides' timings the wrong way round,
+    satisfies it completely — the launches are all distinct and only the numbers
+    are wrong. `BENCHMARK_PASS` from cross-associated evidence is the worst
+    outcome this instrument has, because every other check reads clean.
+    """
+    good = pairs(30)
+    expect("matched timings pass",
+           m.adjudicate_benchmark(good, BUDGET).verdict, m.BENCHMARK_PASS)
+
+    # One side's keypress figure carries a run that is not its launch's.
+    crossed = list(good)
+    crossed[11] = crossed[11]._replace(
+        b_keypress=m.KeypressSample(run="RUN-FROM-SOMEWHERE-ELSE",
+                                    keypress_ms=100.0))
+    r = m.adjudicate_benchmark(crossed, BUDGET)
+    expect("a keypress figure from another run blocks",
+           r.verdict, m.BLOCKED_INCOMPLETE_PAIRS)
+    if "RUN-FROM-SOMEWHERE-ELSE" not in r.detail:
+        FAILURES.append(f"the block must name the mismatched run: {r.detail!r}")
+
+    # THE SWAP, which is the case a per-side check catches and a set check does
+    # not: both runs are present and legitimate, on the wrong sides.
+    swapped = list(good)
+    p12 = swapped[12]
+    swapped[12] = p12._replace(a_keypress=p12.b_keypress,
+                               b_keypress=p12.a_keypress)
+    expect("two legitimate timings on the wrong sides block",
+           m.adjudicate_benchmark(swapped, BUDGET).verdict,
+           m.BLOCKED_INCOMPLETE_PAIRS)
+
+    expect("and the untouched set still passes",
+           m.adjudicate_benchmark(pairs(30), BUDGET).verdict, m.BENCHMARK_PASS)
+
+
 # ------------------------------------------------------------------- runner
 
 TESTS = [
@@ -819,6 +863,7 @@ TESTS = [
     test_an_abandoned_launch_is_actually_reaped,
     test_every_exceptional_exit_from_the_readiness_wait_reaps,
     test_a_locked_screen_blocks_before_a_launch_is_spent,
+    test_a_keypress_figure_must_name_the_launch_it_came_from,
     test_median_uses_statistics_median,
     test_p95_uses_nearest_rank,
 ]

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -43,6 +43,10 @@ GOOD_TICKS = {
     "root.construct.start": 10_000_000,
     "root.construct.end": 12_000_000,
     "host.order_front.complete": 13_000_000,
+    # Deliberately BEFORE `launch.enter`'s own tick — proves position and
+    # ticks are irrelevant to `engine.ready`, which sits outside `EVENTS`'s
+    # causal chain entirely (#2377, C1 repair, Codex's smoke ruling).
+    "engine.ready": 500_000,
 }
 
 ORDER = [
@@ -728,6 +732,8 @@ HOST = (pathlib.Path(__file__).resolve().parents[2]
 DIRECTOR = (pathlib.Path(__file__).resolve().parents[2]
             / "Sources" / "EnviousWisprAppKit" / "App" / "Overlay"
             / "OverlayDirector.swift")
+BOOTSTRAPPER = (pathlib.Path(__file__).resolve().parents[2]
+                / "Sources" / "EnviousWisprAppKit" / "App" / "WisprBootstrapper.swift")
 
 
 def test_the_swift_emitter_and_this_parser_agree_on_the_schema():
@@ -752,6 +758,14 @@ def test_the_swift_emitter_and_this_parser_agree_on_the_schema():
     for event in m.EVENTS:
         if f'"{event}"' not in swift:
             FAILURES.append(f"the emitter has no case spelled {event!r}")
+    # `engine.ready` is a KNOWN event but deliberately not part of `EVENTS`'s
+    # causal chain — checked separately so it never silently joins that list.
+    if f'"{m.ENGINE_READY}"' not in swift:
+        FAILURES.append(f"the emitter has no case spelled {m.ENGINE_READY!r}")
+    if m.ENGINE_READY in m.EVENTS:
+        FAILURES.append(
+            f"{m.ENGINE_READY!r} joined the launch/root causal chain (EVENTS) — "
+            "engine warm-up and first render run on independent schedules")
     for key in ("run=", "pid=", "bundle=", "event=", "ticks=", "window=", "intent="):
         if key not in swift:
             FAILURES.append(f"the emitter does not write the {key!r} field")
@@ -906,6 +920,197 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
         FAILURES.append(
             "the flush frees the capacity it just used, inside the interval it was "
             "reserved to stay out of")
+
+    # `emitEngineReadyOnce()` must be BOUND to a real readiness re-read at
+    # both launch warm-up paths, not just present somewhere in the file.
+    # Only one path runs for a given launch (keyed on selected backend), so
+    # both must carry the guard-then-emit pair.
+    if not BOOTSTRAPPER.exists():
+        FAILURES.append(f"the bootstrapper is not at {BOOTSTRAPPER}; this test's path is stale")
+        return
+    boot = BOOTSTRAPPER.read_text()
+    guarded_emit_count = boot.count(
+        "OverlayFirstRenderMarkers.emitEngineReadyOnce()")
+    if guarded_emit_count != 2:
+        FAILURES.append(
+            f"expected emitEngineReadyOnce() at exactly 2 call sites (parakeet "
+            f"launch Task, WhisperKit preloadAction), found {guarded_emit_count}")
+    if "engineReadiness == .ready" not in boot:
+        FAILURES.append(
+            "no launch warm-up path re-reads engineReadiness == .ready before "
+            "emitting; emitting unconditionally would report readiness for a "
+            "warm-up that actually failed")
+
+
+# --------------------------------------- 12b. the engine-readiness gate
+
+def test_engine_ready_is_a_known_event_outside_the_launch_causal_chain():
+    """`engine.ready` must parse, but must never join `EVENTS` — the launch/
+    root causal chain `adjudicate_launch` enforces. Mechanical guard for the
+    property Codex's smoke ruling states in prose: engine warm-up and first
+    render run on two independent schedules.
+    """
+    expect("engine.ready is not part of the launch causal chain",
+           m.ENGINE_READY in m.EVENTS, False)
+    expect("engine.ready is a known, parseable event",
+           m.ENGINE_READY in m.KNOWN_EVENTS, True)
+
+
+def test_parse_marker_line_accepts_a_well_formed_engine_ready_marker():
+    parsed = m.parse_marker_line(line("engine.ready", ticks=500_000))
+    expect("event", parsed.event, "engine.ready")
+    expect("window is 0, like every non-host event", parsed.window, 0)
+    expect("intent is none, like every non-host event", parsed.intent, m.INTENT_NONE)
+
+
+def test_engine_ready_marker_position_never_affects_launch_adjudication():
+    """Whether `engine.ready` is written first, last, or anywhere else in the
+    file, and whatever tick it carries, a launch's OK verdict is unaffected —
+    proof that it sits outside the enforced causal chain. `GOOD_TICKS` gives
+    it an earlier tick than `launch.enter`'s own, which would trip
+    `BLOCKED_NON_MONOTONIC` or `BLOCKED_PAIR_ORDER` were it a chain member.
+    """
+    expect_verdict("engine.ready written before the whole launch chain still accepts",
+                   text(["engine.ready"] + ORDER), m.OK)
+    expect_verdict("engine.ready written after the whole launch chain still accepts",
+                   text(ORDER + ["engine.ready"]), m.OK)
+
+
+def test_engine_is_ready_matches_exactly_this_launch():
+    """Missing, wrong-run, wrong-pid, wrong-bundle, and partial readiness
+    markers are all `False` — the exact set Codex's smoke ruling names as
+    the precondition that must gate a synthetic keypress. `engine_is_ready`
+    is what `smoke()` calls before it, so a `False` here is what keeps the
+    press from ever being sent (proved structurally below).
+    """
+    marker = line("engine.ready", ticks=500_000)
+    good = marker + "\n"
+    expect("a matching complete marker is ready",
+           m.engine_is_ready(good, expected_run=RUN, expected_pid=PID,
+                             expected_bundle=BUNDLE),
+           True)
+    expect("no marker at all is not ready",
+           m.engine_is_ready("", expected_run=RUN, expected_pid=PID,
+                             expected_bundle=BUNDLE),
+           False)
+    expect("a wrong run is not ready",
+           m.engine_is_ready(good, expected_run="OTHER-RUN-0000", expected_pid=PID,
+                             expected_bundle=BUNDLE),
+           False)
+    expect("a wrong pid is not ready",
+           m.engine_is_ready(good, expected_run=RUN, expected_pid=PID + 1,
+                             expected_bundle=BUNDLE),
+           False)
+    expect("a wrong bundle is not ready",
+           m.engine_is_ready(good, expected_run=RUN, expected_pid=PID,
+                             expected_bundle="com.other.app"),
+           False)
+    # TWIN: a half-written line (no trailing newline yet) is not complete,
+    # mirroring `read_complete_markers`'s own truncation discipline.
+    expect("a half-written line is not ready",
+           m.engine_is_ready(marker, expected_run=RUN, expected_pid=PID,
+                             expected_bundle=BUNDLE),
+           False)
+    # Fails CLOSED on our own drifted format, not an exception with no verdict.
+    expect("a malformed line of our own schema is not ready, not an exception",
+           m.engine_is_ready(f"{m.SCHEMA}\tbroken\n", expected_run=RUN,
+                             expected_pid=PID, expected_bundle=BUNDLE),
+           False)
+
+
+def test_await_engine_ready_waits_for_the_marker_and_times_out_without_it():
+    """A separate clock from the keypress interval, and never a fixed sleep —
+    the signal is the app's own marker, exactly like `await_launch_ready`.
+    """
+    calls = {"n": 0}
+    ready_marker = line("engine.ready", ticks=500_000) + "\n"
+
+    def eventually_ready():
+        calls["n"] += 1
+        return ready_marker if calls["n"] >= 3 else ""
+
+    ready = m.await_engine_ready(
+        "/nonexistent-marker-path", run_id=RUN, expected_pid=PID,
+        expected_bundle=BUNDLE, timeout_s=5.0, read_text=eventually_ready)
+    expect("readiness is detected once the marker appears", ready, True)
+    expect("it took more than one read to get there", calls["n"] >= 3, True)
+
+    # TWIN: a marker for the WRONG run never satisfies readiness, and the
+    # wait times out and reports False rather than hanging or raising.
+    wrong_run_marker = line("engine.ready", ticks=500_000, run="SOME-OTHER-RUN") + "\n"
+    never_ready = m.await_engine_ready(
+        "/nonexistent-marker-path", run_id=RUN, expected_pid=PID,
+        expected_bundle=BUNDLE, timeout_s=0.05, read_text=lambda: wrong_run_marker)
+    expect("a marker for a different run never satisfies readiness", never_ready, False)
+
+
+def _smoke_body(source):
+    """`smoke()`'s own body text, isolated by its full definition signature —
+    never a bare function name, which would match a call site instead (the
+    same "found the wrong twin" class the AX-identifier order check hit
+    before it anchored on `final class OverlayWindowHost`).
+    """
+    start = source.find("\ndef smoke(bundle_path")
+    end = source.find("\ndef main(argv)", start) if start >= 0 else -1
+    if start < 0 or end < 0:
+        return None
+    return source[start:end]
+
+
+def test_smoke_gates_the_synthetic_keypress_behind_engine_readiness():
+    """`smoke()` must wait for `engine.ready` and take the READY branch
+    before ever calling `measure_keypress_to_overlay` — never the reverse.
+    A keypress sent first races `ColdPressGuard` (#879) for a warming
+    engine, which is the exact false alarm (`BLOCKED_WRONG_PRESENTATION` for
+    a reason that is not first render) Codex's smoke ruling exists to
+    remove. Source position is the only thing that can catch a regression
+    here: reordering the two calls changes no marker FORMAT, so nothing
+    else in this suite would notice.
+    """
+    real_source = pathlib.Path(m.__file__).read_text()
+    body = _smoke_body(real_source)
+    if body is None:
+        FAILURES.append("could not isolate smoke()'s body by source markers")
+        return
+    ready_idx = body.find("await_engine_ready(")
+    else_idx = body.find("else:", ready_idx) if ready_idx >= 0 else -1
+    press_idx = body.find("measure_keypress_to_overlay(", else_idx) if else_idx >= 0 else -1
+    if ready_idx < 0:
+        FAILURES.append("smoke() does not call await_engine_ready")
+    elif else_idx < 0:
+        FAILURES.append(
+            "smoke() does not branch on the readiness result before pressing")
+    elif press_idx < 0:
+        FAILURES.append(
+            "smoke() does not call measure_keypress_to_overlay inside the "
+            "readiness-true branch")
+
+    # TWO-WAY CONTROL: the same scoping-and-order logic, run against a
+    # synthetic source with the calls in the WRONG order, must actually
+    # report a failure — proof the check is not vacuously true. Never
+    # touches the real file.
+    reversed_fake = (
+        "\ndef smoke(bundle_path, *, out_dir):\n"
+        "    timing = measure_keypress_to_overlay(pid, marker_path)\n"
+        "    if not engine_ready:\n"
+        "        pass\n"
+        "    else:\n"
+        "        ready = await_engine_ready(marker_path, run_id=run_id)\n"
+        "\ndef main(argv):\n")
+    fake_body = _smoke_body(reversed_fake)
+    if fake_body is None:
+        FAILURES.append("the control fixture's own source markers do not isolate")
+        return
+    fake_ready_idx = fake_body.find("await_engine_ready(")
+    fake_else_idx = (
+        fake_body.find("else:", fake_ready_idx) if fake_ready_idx >= 0 else -1)
+    fake_press_idx = (
+        fake_body.find("measure_keypress_to_overlay(", fake_else_idx)
+        if fake_else_idx >= 0 else -1)
+    if fake_ready_idx >= 0 and fake_else_idx >= 0 and fake_press_idx >= 0:
+        FAILURES.append(
+            "the order check does not fail on a deliberately reversed source — "
+            "it cannot be trusted to catch a real regression")
 
 
 # ------------------------------------------- 13. nobody is left behind
@@ -1183,6 +1388,12 @@ TESTS = [
     test_every_side_must_be_its_own_cold_launch,
     test_the_swift_emitter_and_this_parser_agree_on_the_schema,
     test_the_host_marker_is_emitted_with_a_real_window_number,
+    test_engine_ready_is_a_known_event_outside_the_launch_causal_chain,
+    test_parse_marker_line_accepts_a_well_formed_engine_ready_marker,
+    test_engine_ready_marker_position_never_affects_launch_adjudication,
+    test_engine_is_ready_matches_exactly_this_launch,
+    test_await_engine_ready_waits_for_the_marker_and_times_out_without_it,
+    test_smoke_gates_the_synthetic_keypress_behind_engine_readiness,
     test_an_abandoned_launch_is_actually_reaped,
     test_every_exceptional_exit_from_the_readiness_wait_reaps,
     test_a_locked_screen_blocks_before_a_launch_is_spent,

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -799,6 +799,72 @@ def test_a_locked_screen_blocks_before_a_launch_is_spent():
         FAILURES.append("locked and unknown must give distinguishable reasons")
 
 
+def test_the_real_screen_lock_probe_distinguishes_absence_from_failure():
+    """`screen_lock_block` above tests the POLICY on synthetic True/False/None.
+
+    This tests the PROBE that produces those values. A live machine measurement
+    (2026-08-26, this repo's own dev Mac, screen independently confirmed unlocked
+    via `osascript` frontmost-process resolution and a non-overlay app window
+    list) found `CGSSessionScreenIsLocked` absent from a perfectly valid session
+    dict — not present-and-false, absent. Apple does not document the key as a
+    standard session property, so presence-semantics (absent means unlocked) is
+    the correct reading, not a broken probe. What must still fail closed is a
+    session the probe genuinely could not read.
+    """
+    valid_session = {
+        "kCGSessionUserIDKey": 501,
+        "kCGSessionOnConsoleKey": True,
+    }
+
+    expect(
+        "a valid session with no lock key is unlocked",
+        m.screen_lock_state(lambda: valid_session),
+        False,
+    )
+
+    expect(
+        "a present true lock key is locked",
+        m.screen_lock_state(
+            lambda: {**valid_session, "CGSSessionScreenIsLocked": True}),
+        True,
+    )
+
+    expect(
+        "a present false lock key is unlocked",
+        m.screen_lock_state(
+            lambda: {**valid_session, "CGSSessionScreenIsLocked": False}),
+        False,
+    )
+
+    expect(
+        "no session remains unknown",
+        m.screen_lock_state(lambda: None),
+        None,
+    )
+
+    def failed_reader():
+        raise RuntimeError("WindowServer probe failed")
+
+    expect(
+        "a failed session read remains unknown",
+        m.screen_lock_state(failed_reader),
+        None,
+    )
+
+    expect(
+        "an unusable session object remains unknown",
+        m.screen_lock_state(lambda: object()),
+        None,
+    )
+
+    expect(
+        "an unexpected lock value remains unknown",
+        m.screen_lock_state(
+            lambda: {**valid_session, "CGSSessionScreenIsLocked": "yes"}),
+        None,
+    )
+
+
 def test_a_keypress_figure_must_name_the_launch_it_came_from():
     """Tagging the LAUNCHES is not enough; the timings need identity too.
 
@@ -863,6 +929,7 @@ TESTS = [
     test_an_abandoned_launch_is_actually_reaped,
     test_every_exceptional_exit_from_the_readiness_wait_reaps,
     test_a_locked_screen_blocks_before_a_launch_is_spent,
+    test_the_real_screen_lock_probe_distinguishes_absence_from_failure,
     test_a_keypress_figure_must_name_the_launch_it_came_from,
     test_median_uses_statistics_median,
     test_p95_uses_nearest_rank,

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -45,7 +45,7 @@ GOOD_TICKS = {
     "host.order_front.complete": 13_000_000,
     # Deliberately BEFORE `launch.enter`'s own tick — proves position and
     # ticks are irrelevant to `engine.ready`, which sits outside `EVENTS`'s
-    # causal chain entirely (#2377, C1 repair, Codex's smoke ruling).
+    # causal chain entirely (#2377, C1 repair).
     "engine.ready": 500_000,
 }
 
@@ -921,15 +921,15 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
             "the flush frees the capacity it just used, inside the interval it was "
             "reserved to stay out of")
 
-    # `emitEngineReadyOnce()` must be BOUND to a COMPLETE readiness guard at
-    # EACH launch warm-up path separately (#2377, C1 repair round 4, Codex
-    # HIGH) — checking the two facts "two emit calls exist" and "the string
-    # engineReadiness == .ready appears somewhere" independently would pass
-    # a mutant that moves one emit call OUTSIDE its own guard, since both
-    # facts would still be true elsewhere in the file. Each call site is
-    # scoped by its own unique capture-list text, so this cannot cross-match
-    # the other path's guard — the measured gap between the two capture
-    # lists is over 13,000 characters, far past this window.
+    # `emitEngineReadyOnce()` must be emitted FROM INSIDE a complete
+    # selected/active/readiness guard at EACH launch warm-up path
+    # separately (#2377, C1 repair) — checking that four required
+    # substrings all appear somewhere in a scoped window passes a mutant
+    # that moves the emit call immediately ABOVE its own `if`: all four
+    # strings are still present in the window, just no longer nested
+    # inside the brace. Matching one
+    # CONTIGUOUS block — the exact `if ... { emit }` text — is what proves
+    # containment, not mere co-occurrence.
     if not BOOTSTRAPPER.exists():
         FAILURES.append(f"the bootstrapper is not at {BOOTSTRAPPER}; this test's path is stale")
         return
@@ -947,18 +947,18 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
             FAILURES.append(f"could not locate the {label} call site by its capture list")
             continue
         window = boot[start:start + 1000]
-        required = (
-            f"settings.selectedBackend == .{backend}",
-            f"asrManager.activeBackendType == .{backend}",
-            f"{driver}?.engineReadiness == .ready",
-            "OverlayFirstRenderMarkers.emitEngineReadyOnce()",
-        )
-        missing = [r for r in required if r not in window]
-        if missing:
+        required_block = "\n".join((
+            f"          if settings.selectedBackend == .{backend},",
+            f"            asrManager.activeBackendType == .{backend},",
+            f"            {driver}?.engineReadiness == .ready",
+            "          {",
+            "            OverlayFirstRenderMarkers.emitEngineReadyOnce()",
+            "          }",
+        ))
+        if required_block not in window:
             FAILURES.append(
-                f"the {label} path's readiness guard is missing: {missing!r} — "
-                "moving emitEngineReadyOnce() outside its own selected/active/"
-                "engineReadiness guard must be caught here")
+                f"the {label} path does not emit inside its complete "
+                "selected/active/readiness guard")
 
 
 # --------------------------------------- 12b. the engine-readiness gate
@@ -966,8 +966,8 @@ def test_the_host_marker_is_emitted_with_a_real_window_number():
 def test_engine_ready_is_a_known_event_outside_the_launch_causal_chain():
     """`engine.ready` must parse, but must never join `EVENTS` — the launch/
     root causal chain `adjudicate_launch` enforces. Mechanical guard for the
-    property Codex's smoke ruling states in prose: engine warm-up and first
-    render run on two independent schedules.
+    fact `EVENTS`'s own comment states: engine warm-up and first render run
+    on two independent schedules.
     """
     expect("engine.ready is not part of the launch causal chain",
            m.ENGINE_READY in m.EVENTS, False)
@@ -997,10 +997,10 @@ def test_engine_ready_marker_position_never_affects_launch_adjudication():
 
 def test_engine_is_ready_matches_exactly_this_launch():
     """Missing, wrong-run, wrong-pid, wrong-bundle, and partial readiness
-    markers are all `False` — the exact set Codex's smoke ruling names as
-    the precondition that must gate a synthetic keypress. `engine_is_ready`
-    is what `smoke()` calls before it, so a `False` here is what keeps the
-    press from ever being sent (proved structurally below).
+    markers are all `False` — the precondition that must gate a synthetic
+    keypress. `engine_is_ready` is what `smoke()` calls before it, so a
+    `False` here is what keeps the press from ever being sent (proved by
+    execution below, via `measure_after_engine_ready`).
     """
     marker = line("engine.ready", ticks=500_000)
     good = marker + "\n"
@@ -1067,8 +1067,8 @@ def test_await_engine_ready_waits_for_the_marker_and_times_out_without_it():
 def test_await_engine_ready_raises_on_a_crash_rather_than_waiting_out_the_timeout():
     """A crash DURING warm-up must not burn the full timeout waiting for a
     marker that will never arrive, then report the plausible-sounding but
-    wrong `BLOCKED_ENGINE_NOT_READY` (#2377, C1 repair round 4, Codex
-    MEDIUM). Watching `proc.poll()` is what tells the two apart.
+    wrong `BLOCKED_ENGINE_NOT_READY` (#2377, C1 repair). Watching
+    `proc.poll()` is what tells the two apart.
     """
     crashed = FakeProc(already_gone=True)
     try:
@@ -1084,11 +1084,10 @@ def test_await_engine_ready_raises_on_a_crash_rather_than_waiting_out_the_timeou
 def test_measure_after_engine_ready_gates_the_keypress_by_call_count():
     """The "never press before the engine is ready" property, proved by
     EXECUTION rather than by reading `smoke()`'s source layout (#2377, C1
-    repair round 4, Codex MEDIUM) — the prior version of this test could
-    only see where the two calls sat in the file, which survives a
-    regression that keeps the right shape but breaks the actual gating
-    (e.g. a mutant `measure() if True else None`, still textually inside an
-    `if`).
+    repair) — a check that only sees where two calls sit in the file
+    survives a regression that keeps the right shape but breaks the actual
+    gating (e.g. a mutant `measure() if True else None`, still textually
+    inside an `if`).
     """
     calls = {"n": 0}
     sentinel = object()
@@ -1104,6 +1103,77 @@ def test_measure_after_engine_ready_gates_the_keypress_by_call_count():
     ready_result = m.measure_after_engine_ready(True, spy)
     expect("a ready engine returns the measurement", ready_result, sentinel)
     expect("calling the thunk exactly once", calls["n"], 1)
+
+
+def _smoke_body(source):
+    """`smoke()`'s own body text, isolated by its full definition signature —
+    never a bare function name, which would match a call site instead (the
+    same "found the wrong twin" class the AX-identifier order check hit
+    before it anchored on `final class OverlayWindowHost`).
+    """
+    start = source.find("\ndef smoke(bundle_path")
+    end = source.find("\ndef main(argv)", start) if start >= 0 else -1
+    if start < 0 or end < 0:
+        return None
+    return source[start:end]
+
+
+def test_smoke_routes_its_keypress_measurement_through_the_readiness_gate():
+    """A CALLER-CONTRACT row (#2377, C1 repair): the
+    previous test proved `measure_after_engine_ready` behaves correctly in
+    isolation, which says nothing about whether `smoke()` still CALLS it —
+    replacing the live call with a direct `measure_keypress_to_overlay()`
+    would leave that test green. This binds the exact live shape instead.
+    """
+    real_source = pathlib.Path(m.__file__).read_text()
+    body = _smoke_body(real_source)
+    if body is None:
+        FAILURES.append("could not isolate smoke()'s body by source markers")
+        return
+
+    ready_idx = body.find("await_engine_ready(")
+    if ready_idx < 0:
+        FAILURES.append("smoke() does not call await_engine_ready")
+        return
+    # Bound to THIS call, not merely present anywhere in the function — the
+    # keyword must appear before the call's own closing paren is reached.
+    call_end = body.find(")", ready_idx)
+    if 'proc=launched["process"]' not in body[ready_idx:call_end + 1]:
+        FAILURES.append(
+            "smoke()'s await_engine_ready call does not pass "
+            'proc=launched["process"] — a crash during warm-up would wait '
+            "out the full timeout instead of being detected")
+
+    required_gate = "\n".join((
+        "        timing = measure_after_engine_ready(",
+        "            engine_ready,",
+        "            lambda: measure_keypress_to_overlay(",
+    ))
+    gate_idx = body.find(required_gate)
+    if gate_idx < 0:
+        FAILURES.append(
+            "smoke() does not route its keypress measurement through the "
+            "engine-readiness gate")
+    elif gate_idx < ready_idx:
+        FAILURES.append(
+            "smoke() gates the keypress measurement BEFORE awaiting "
+            "readiness — the readiness result it gates on would be stale")
+
+    # CONTROL: the same check, run against a synthetic source where the live
+    # call is replaced by a direct measurement, must actually fail — proof
+    # this row is not vacuously true. Never touches the real file.
+    bypassed_fake = (
+        "\ndef smoke(bundle_path, *, out_dir):\n"
+        "    ready = await_engine_ready(marker_path, proc=proc, run_id=run_id)\n"
+        "    timing = measure_keypress_to_overlay(pid, marker_path)\n"
+        "\ndef main(argv):\n")
+    fake_body = _smoke_body(bypassed_fake)
+    if fake_body is None:
+        FAILURES.append("the control fixture's own source markers do not isolate")
+    elif required_gate in fake_body:
+        FAILURES.append(
+            "the caller-contract check does not fail on a bypassed source — "
+            "it cannot be trusted to catch a real regression")
 
 
 # ------------------------------------------- 13. nobody is left behind
@@ -1394,6 +1464,7 @@ TESTS = [
     test_await_engine_ready_waits_for_the_marker_and_times_out_without_it,
     test_await_engine_ready_raises_on_a_crash_rather_than_waiting_out_the_timeout,
     test_measure_after_engine_ready_gates_the_keypress_by_call_count,
+    test_smoke_routes_its_keypress_measurement_through_the_readiness_gate,
     test_an_abandoned_launch_is_actually_reaped,
     test_every_exceptional_exit_from_the_readiness_wait_reaps,
     test_a_locked_screen_blocks_before_a_launch_is_spent,


### PR DESCRIPTION
Part of #2377. Phase 6 chunk 1: **the instrument, before the change it will judge.**

Ships alone and changes no behaviour. The 30-pair benchmark compares two bundles, so an
instrumentation commit landing with the behaviour change leaves nothing to be the baseline.

## What this is

DEBUG-only structured markers at three boundaries — the launch forwarding call,
`NSHostingView` construction, host order-front completion — plus
`Tests/RuntimeUAT/measure_overlay_first_render.py` and its 22-row refusal suite.

Production diff is 39 added lines across three files, every one inside `#if DEBUG`.
No deletions. `WisprBootstrapper.swift` untouched.

**The whole design follows from one property:** a benchmark that can report PASS on
incomplete evidence is worse than no benchmark, because it buys the confidence without the
cover. No `FAIL` is reachable from missing evidence — the verdict set is `SMOKE_PASS`,
`BENCHMARK_PASS`, `BENCHMARK_FAIL`, and eleven distinct `BLOCKED_` reasons.

**Identity is the sharp edge.** Every dev bundle on this machine is named
`EnviousWispr Local.app`, so name, bundle id and version can all agree across two worktrees'
builds. The executable's SHA-256 is the authority, computed by the harness from the launched
pid's resolved executable — never carried in a marker, because an app echoing back what the
harness supplied proves nothing about which bytes ran.

## RED before green

The suite was written before the module and run before it existed:
`ModuleNotFoundError: No module named 'measure_overlay_first_render'`, exit 1. Every refusal
sits beside an accepted twin differing in exactly one field.

## Four review rounds, and the two findings worth keeping

**The instrument must not be sensitive to the change it measures.** The marker sink is a
lazy static, so the first `emit` pays for the environment read and the `open`. Today root
construction is lazy and that cost lands after launch closes, so it costs nothing. **Phase 6
exists to move root construction earlier** — at which point its emit becomes the first one
and the setup lands inside the launch measurement, inflating exactly the number the move is
judged on, in the direction that makes the change look worse than it is. `prepare()` arms the
sink in `applicationWillFinishLaunching`, after that callback's own production work so #739's
Sparkle correlation keeps the earliest slot.

**The pure function was bound and its caller was not — twice, which is why it is here rather
than in a comment.** The keypress endpoint adjudicator was thoroughly tested while the loop's
stop condition sat inline, so reverting the whole identity binding to "the host marker plus
any window" passed every test. Extracted as `named_window_has_appeared` with its own rows.
The first version of that control also handed the adjudicator both windows at once, so the
ordering the defect needs could not occur — **a fixture that cannot express a failure cannot
fail on it.**

Three more, each a real defect the reviewer found: two pairs checked separately accepted a
root built *inside* launch, which is the arrangement this phase exists to move away from; the
resolved-versus-requested bundle comparison was tautological because the harness passed its
own answer in; and a balanced-but-grouped schedule, or one launch reused sixty times, passed
every check.

## Two I found in my own harness before review saw them

**The 40 ms hold was inside the measured interval.** `press_record_key` is a complete
push-to-talk gesture — down, hold, up — and wrapping the timer around it puts that hold inside
the keypress measurement. It would still have compared the two bundles fairly, which is
exactly why it would have survived: a constant added to both sides leaves the *regression*
right and the absolute number meaningless, and the plan's keypress bound is stated in
absolute milliseconds.

**A failure mid-run threw away the receipt** instead of writing one that explains itself —
on the one run that most needs explaining.

## The app names the subject; the harness owns the timestamp

The host marker carries `panel.windowNumber`, and polling waits for that exact window.
Stopping at the first new window owned by the process accepts a settings or onboarding window
arriving before the pill reaches WindowServer, and reports a plausible latency about the wrong
subject. Other windows are recorded in the receipt and can neither end nor invalidate the
interval.

## Receipts

**Live smoke, first attempt, cold launch of the built bundle: `SMOKE_PASS`.**

| | reading |
|---|---|
| `applicationDidFinishLaunching` | 16.28 ms |
| root construction | 0.35 ms |
| key down to overlay on screen | 51.83 ms |
| poll resolution | 0.45 ms median, 7.99 ms max, 62 polls |

All five markers present, window `74383` named by the app and observed by the harness,
identity confirmed by hash, clean teardown. **These are baseline readings on an M5 Max, which
is further from the slowest supported machine (macOS 14, M1, 8 GB) than a real user's floor.**

| lane | executed | own bundles | verdict |
|---|---|---|---|
| Debug | 7050 | 6844 + 206 | PASS |
| Release | 6398 | 6192 + 206 | PASS |

Both reconcile against their own per-bundle sums. Zero `Fatal error`, zero `Crash:`. No Swift
test file is added or modified, so these are the baseline's counts rather than a delta.

Release symbol absence, two-way controlled: `EW_OVERLAY_FIRST_RENDER` 0 in Release against 3
in Debug, `OverlayFirstRenderMarkers` 0 against 2, `host.order_front.complete` 0 against 1 —
with the control string `EnviousWispr` at 623 in Release, which is what separates "absent"
from "I grepped the wrong file".

**Not run:** the mutation battery binding each refusal. Filed as #2434 with 27 rows, including
the reviewer's required mutant of the stop condition, each carrying its desk checks and what
the pre-fix code accepted. No mutant runs in the founder's waking hours.

## What C1 deliberately does not do

No gate, no coalescing, no prewarm, no marker read at runtime, no behaviour keyed on marker
availability, no change to `builtRootView` / `deferFirstRender` / `RenderOutcome.deferred`,
and no 30-pair run. The benchmark decision belongs to C4, after a final candidate exists.

**STOP-SAFE.** With the marker environment absent this is a strict no-op: no file opened,
nothing written, on any launch.

---

## Review history, added after the fact

Six cloud rounds on top of four local chunk rounds. **Every finding was real; none was
a false alarm.** Recorded because the pattern matters more than the count.

| round | finding |
|---|---|
| 1 | the root marker's own `write(2)` sat inside the keypress interval in the baseline bundle and outside it in the prewarmed one — the benchmark would have credited the change for removing instrumentation cost |
| 2 | holding the captures left the ARRAY: an empty `pending` allocates on first append, same asymmetry one level down |
| 3 | the readiness-timeout path terminated and raised without waiting or escalating, leaving a possible orphan to block or contaminate the next launch |
| 4 | an exception from reading the marker file escaped before any reap — not a failure of the app, so it looks like nothing |
| 5 | keypress figures were untagged floats: a reused or cross-associated timing passes the distinct-run check completely, because the LAUNCHES are all fine and only the numbers are wrong |
| 5 | `mach_timebase()` could raise between a successful launch and the cleanup being armed |
| — | **clean on `750252ae`** |

**Three of those are one property: THE INSTRUMENT MUST NOT BE SENSITIVE TO THE CHANGE IT
MEASURES.** Each fix was correct and each exposed a subtler instance — the sink's lazy
open, then the write, then the array's first allocation. That is the expected shape when
the quantity under test is a fraction of a millisecond, and it is the argument for this
chunk shipping ALONE rather than beside the behaviour change.

**Two are one property one level out: EVERY MEASUREMENT MUST NAME WHAT IT IS A
MEASUREMENT OF.** The executable is bound by hash, the overlay by window id, the launch
by run id — and the keypress figure was the one number still floating free.

A peer session separately caught that **the screen was locked** while this was queued for
its final live run. That row had no guard and would not have refused: the record key is an
event tap rather than Carbon so a synthetic press arrives while locked, and the overlay
panel is `.canJoinAllSpaces` so `CGWindowListCopyWindowInfo` lists it. All five markers
would have been written and the identity check would have passed — a complete,
self-consistent receipt taken on a machine where `loginwindow` owns the active Space,
filed as the baseline every later chunk is judged against. `screen_lock_state()` is
three-valued and blocks on both locked and unknown.

## Outstanding before merge

**One live `--smoke` on this head, which needs an unlocked screen.** Two earlier smokes
passed (`SMOKE_PASS`, all five markers, window named and matched) but the branch has moved
six findings since. The guard has been exercised against the real locked machine —
`BLOCKED_SCREEN_LOCKED`, no marker file, no process spawned — so what is proven today is
that the instrument refuses correctly, not that this head measures correctly.

Recorded as owed rather than assumed.
