### PR TITLE
feat(appearance): show the recording pills instead of describing them (#2435)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
@@ -19,6 +19,13 @@ struct OverlayCapsuleBackground: View {
   }
 
   var cornerStyle: CornerStyle = .capsule
+
+  /// Whether the hairline breathes at all (#2435).
+  ///
+  /// **A still pill is a REQUIREMENT where this background is a picture rather
+  /// than a live overlay**, and the Appearance picker draws three of them at
+  /// once. Defaults to `true`, so all eight existing call sites are unchanged.
+  var animatesGlow: Bool = true
   @State private var glowOpacity: Double = 0.3
 
   /// #2201: the preview pill's rainbow hairline holds still instead of breathing
@@ -32,7 +39,13 @@ struct OverlayCapsuleBackground: View {
   ///
   /// Mid-way between the loop's own 0.3 and 0.65 endpoints, so the line is no
   /// dimmer on average than the one it replaces.
-  private static let steadyPreviewGlow: Double = 0.5
+  ///
+  /// **#2435 widened it to every hairline that is not breathing, which is why it
+  /// is no longer named for the preview.** A capsule drawn as a still picture in
+  /// Settings would otherwise sit at `glowOpacity`'s initial 0.3 — the DIM
+  /// ENDPOINT of a loop that is not running, which nobody chose and which shows
+  /// the user a duller pill than the one they will get.
+  private static let steadyGlowOpacity: Double = 0.5
 
   private var shape: AnyShape {
     switch cornerStyle {
@@ -90,7 +103,11 @@ struct OverlayCapsuleBackground: View {
           endPoint: .trailing
         )
         .frame(height: 1)
-        .opacity(cornerStyle == .rounded ? Self.steadyPreviewGlow : glowOpacity)
+        // Breathing is the ONLY case that reads the animated value. Everything
+        // else — the reading well, and any capsule asked to hold still — takes
+        // the chosen steady one.
+        .opacity(
+          animatesGlow && cornerStyle == .capsule ? glowOpacity : Self.steadyGlowOpacity)
         .padding(.horizontal, 20)
         .offset(y: -1)
       }
@@ -99,7 +116,7 @@ struct OverlayCapsuleBackground: View {
         // preview would keep it re-rendering whether or not anything read
         // `glowOpacity`, and the point of this chunk is that the preview pill
         // stops moving on its own.
-        guard cornerStyle == .capsule else { return }
+        guard animatesGlow, cornerStyle == .capsule else { return }
         withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
           glowOpacity = 0.65
         }

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RainbowLevelMeter.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RainbowLevelMeter.swift
@@ -70,6 +70,28 @@ struct RainbowLevelMeter: View {
   /// scalars.
   @State private var history: [CGFloat]
 
+  /// **A SEEDED METER IS A PICTURE AND STOPS ACCUMULATING (#2435).** Non-empty
+  /// `initialHistory` is the caller declaring that it owns what this meter shows,
+  /// so tick changes are ignored and the rendered bars are exactly what was
+  /// handed in, on the first frame and every frame after it.
+  ///
+  /// **Two review rounds were spent trying to make an accumulating meter hold
+  /// still, and both fixes only moved the artifact.** A FULL seed hit capacity on
+  /// the first poll, dropped its oldest sample and shifted every bar. Seeding one
+  /// SHORT moved it: `bars` right-aligns a short history and pads the old end,
+  /// so the first frame carried a leading silence bar that the poll then pushed
+  /// out — the same one-bar shift, arriving from the other side. The root was
+  /// never the seed's length; it was that the meter kept accumulating into a
+  /// picture somebody else had already decided.
+  ///
+  /// Production passes nothing, gets `[]`, and accumulates exactly as it always
+  /// has — the branch cannot reach a live pill.
+  private var isSeeded: Bool { !initialHistory.isEmpty }
+
+  /// The history this meter was handed, if any. Held as well as seeded into
+  /// `@State` because the seeded-ness is what decides whether ticks are read.
+  private let initialHistory: [CGFloat]
+
   /// Seeds `history` so a meter that will never poll still shows a real shape
   /// (#2435).
   ///
@@ -99,6 +121,7 @@ struct RainbowLevelMeter: View {
     self.barWidth = barWidth
     self.spacing = spacing
     self.onHistoryChange = onHistoryChange
+    self.initialHistory = initialHistory
     _history = State(initialValue: initialHistory)
   }
 
@@ -202,6 +225,9 @@ struct RainbowLevelMeter: View {
     }
     .frame(width: Self.width(barWidth: barWidth, spacing: spacing), height: height)
     .onChange(of: tick) { _, _ in
+      // A seeded meter is a PICTURE: the caller owns what it shows, so a poll
+      // that exists only to synchronise scalars must not shift the bars.
+      guard !isSeeded else { return }
       let next = Self.pushed(history, level: CGFloat(audioLevel))
       history = next
       onHistoryChange(next)

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RainbowLevelMeter.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RainbowLevelMeter.swift
@@ -68,7 +68,39 @@ struct RainbowLevelMeter: View {
   /// therefore only LOOKED like a record of anything. Real audio hands us one
   /// scalar per tick, so the only honest way to get that picture is to keep the
   /// scalars.
-  @State private var history: [CGFloat] = []
+  @State private var history: [CGFloat]
+
+  /// Seeds `history` so a meter that will never poll still shows a real shape
+  /// (#2435).
+  ///
+  /// **Without it a still pill draws ONE sample and twenty-three bars at the
+  /// silence floor**, because `history` starts empty and only `onChange(of: tick)`
+  /// ever appends. The Appearance picker draws exactly that pill, and the Level
+  /// Rail's entire identity is this meter, so the picker would misrepresent the
+  /// design it is asking the user to choose.
+  ///
+  /// Seeded through an initializer rather than `onAppear`, which runs after the
+  /// first layout and would show the flat meter for a frame before filling it —
+  /// the same defect `initialPreview:` exists to avoid one view up.
+  ///
+  /// Production passes nothing and gets `[]`, which is exactly today's behaviour.
+  init(
+    audioLevel: Float,
+    tick: Int,
+    height: CGFloat = 16,
+    barWidth: CGFloat = 2,
+    spacing: CGFloat = 1.5,
+    onHistoryChange: @escaping ([CGFloat]) -> Void = { _ in },
+    initialHistory: [CGFloat] = []
+  ) {
+    self.audioLevel = audioLevel
+    self.tick = tick
+    self.height = height
+    self.barWidth = barWidth
+    self.spacing = spacing
+    self.onHistoryChange = onHistoryChange
+    _history = State(initialValue: initialHistory)
+  }
 
   /// About 1.2 seconds of history at the parent's 50 ms poll — long enough to read
   /// as a shape, short enough that it is recognisably what you just said.

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -328,6 +328,19 @@ struct RecordingOverlayView: View {
   /// CONSTRUCTS its own background** and a caller has no other way to reach it.
   /// Defaults to `true`, so the one production caller is unchanged.
   let animatesGlow: Bool
+  /// **THE POLL WRITES FOUR PIECES OF `@State`, AND A PILL THAT NEVER POLLS NEEDS
+  /// EVERY ONE OF THEM SEEDED (#2435).** Three cloud-review rounds each found a
+  /// different member of this set — the reading well's words, the meter's history,
+  /// then the level and the clock — so the set is now ENUMERATED here rather than
+  /// described, and `RecordingPillPreviewWiringTests` reads the poll body to
+  /// enforce it. A fifth one added later fails that guard until it is seeded.
+  ///
+  /// | poll writes | seed | why |
+  /// |---|---|---|
+  /// | `audioLevel` | `initialAudioLevel` | the rainbow mark's height |
+  /// | `elapsed` | `initialElapsed` | the clock |
+  /// | `preview` | `initialPreview` | the reading well's words |
+  /// | `audioTick` | NONE, deliberately | a counter, not a picture. It exists so the meter appends on every poll INCLUDING silent ones; seeding it to anything but 0 would suppress the meter's first append, and the meter takes its own `initialHistory` instead. |
   @State private var audioLevel: Float = 0
 
   /// Counts polls, not level changes. #2216: the meter's history needs a sample
@@ -360,7 +373,9 @@ struct RecordingOverlayView: View {
     initialPreview: LivePreviewDisplay = .off,
     cadence: RecordingPollCadence = .live,
     animatesGlow: Bool = true,
-    initialLevelHistory: [CGFloat] = []
+    initialLevelHistory: [CGFloat] = [],
+    initialAudioLevel: Float = 0,
+    initialElapsed: TimeInterval = 0
   ) {
     self.audioLevelProvider = audioLevelProvider
     self.recordingElapsedProvider = recordingElapsedProvider
@@ -373,6 +388,8 @@ struct RecordingOverlayView: View {
     self.animatesGlow = animatesGlow
     self.initialLevelHistory = initialLevelHistory
     _preview = State(initialValue: initialPreview)
+    _audioLevel = State(initialValue: initialAudioLevel)
+    _elapsed = State(initialValue: initialElapsed)
   }
 
   /// #2202: the preview pill's header — timer hard left, live meter beside it,

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -315,6 +315,13 @@ struct RecordingOverlayView: View {
   /// How long the poll waits between reads. Production never passes this.
   let cadence: RecordingPollCadence
 
+  /// Seeds the level meter's history, for a pill drawn as a PICTURE (#2435).
+  ///
+  /// **Threaded through for the same reason as `animatesGlow`: this view
+  /// constructs the meter**, at both of its layouts, so a caller has no other way
+  /// to reach it. Empty by default, which is today's behaviour exactly.
+  let initialLevelHistory: [CGFloat]
+
   /// Whether the capsule's rainbow hairline breathes (#2435).
   ///
   /// **Threaded through rather than set at the call site, because this view
@@ -352,7 +359,8 @@ struct RecordingOverlayView: View {
     noticeText: String?,
     initialPreview: LivePreviewDisplay = .off,
     cadence: RecordingPollCadence = .live,
-    animatesGlow: Bool = true
+    animatesGlow: Bool = true,
+    initialLevelHistory: [CGFloat] = []
   ) {
     self.audioLevelProvider = audioLevelProvider
     self.recordingElapsedProvider = recordingElapsedProvider
@@ -363,6 +371,7 @@ struct RecordingOverlayView: View {
     self.noticeText = noticeText
     self.cadence = cadence
     self.animatesGlow = animatesGlow
+    self.initialLevelHistory = initialLevelHistory
     _preview = State(initialValue: initialPreview)
   }
 
@@ -394,7 +403,8 @@ struct RecordingOverlayView: View {
         .font(.system(size: 13, weight: .semibold, design: .monospaced))
         .foregroundStyle(PreviewPillPalette.timer)
 
-      RainbowLevelMeter(audioLevel: audioLevel, tick: audioTick)
+      RainbowLevelMeter(
+        audioLevel: audioLevel, tick: audioTick, initialHistory: initialLevelHistory)
 
       Spacer(minLength: 8)
 
@@ -460,7 +470,8 @@ struct RecordingOverlayView: View {
           // than the clock is what the eye lands on. No lips mark: the rail IS
           // the audio-reactive element, and two of them would compete.
           RainbowLevelMeter(
-            audioLevel: audioLevel, tick: audioTick, height: 24, barWidth: 3, spacing: 2)
+            audioLevel: audioLevel, tick: audioTick, height: 24, barWidth: 3, spacing: 2,
+            initialHistory: initialLevelHistory)
 
           // **The hands-free badge, and without it this design was the one that
           // never said the microphone stays open** (#2376 Phase 4, cloud review

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -243,6 +243,28 @@ struct RecordingPollCadence: Sendable {
   static let live = RecordingPollCadence {
     try? await Task.sleep(for: .milliseconds(50))
   }
+
+  /// Parks until the enclosing task is cancelled, so a pill rendered as a
+  /// PICTURE reads its providers once and never again (#2435).
+  ///
+  /// **It does NOT mean "no poll".** The loop performs one provider read before
+  /// it ever calls `wait`, and that read is what synchronises the first frame
+  /// with whatever the providers say. What this removes is every read AFTER it.
+  ///
+  /// **A stream rather than a long sleep, because a duration is a schedule and
+  /// this is a park.** Any finite sleep is a number a reader has to judge, and a
+  /// settings window left open longer than it would repoll once for no reason.
+  /// The continuation is created per call, so two pills parked on this share no
+  /// state, and `finish()` is safe before the loop starts: the stream is already
+  /// finished and `for await` returns immediately.
+  static let still = RecordingPollCadence {
+    let (stream, continuation) = AsyncStream<Void>.makeStream()
+    await withTaskCancellationHandler {
+      for await _ in stream { break }
+    } onCancel: {
+      continuation.finish()
+    }
+  }
 }
 
 /// Compact recording indicator overlay.
@@ -292,6 +314,13 @@ struct RecordingOverlayView: View {
 
   /// How long the poll waits between reads. Production never passes this.
   let cadence: RecordingPollCadence
+
+  /// Whether the capsule's rainbow hairline breathes (#2435).
+  ///
+  /// **Threaded through rather than set at the call site, because this view
+  /// CONSTRUCTS its own background** and a caller has no other way to reach it.
+  /// Defaults to `true`, so the one production caller is unchanged.
+  let animatesGlow: Bool
   @State private var audioLevel: Float = 0
 
   /// Counts polls, not level changes. #2216: the meter's history needs a sample
@@ -322,7 +351,8 @@ struct RecordingOverlayView: View {
     isLocked: Bool,
     noticeText: String?,
     initialPreview: LivePreviewDisplay = .off,
-    cadence: RecordingPollCadence = .live
+    cadence: RecordingPollCadence = .live,
+    animatesGlow: Bool = true
   ) {
     self.audioLevelProvider = audioLevelProvider
     self.recordingElapsedProvider = recordingElapsedProvider
@@ -332,6 +362,7 @@ struct RecordingOverlayView: View {
     self.isLocked = isLocked
     self.noticeText = noticeText
     self.cadence = cadence
+    self.animatesGlow = animatesGlow
     _preview = State(initialValue: initialPreview)
   }
 
@@ -568,7 +599,8 @@ struct RecordingOverlayView: View {
     // measurement is taken on the padded stack, so moving this either side of it
     // measures a different view than the one that was proven.
     .fixedSize(horizontal: false, vertical: chrome.isContentSizedVertically)
-    .background(OverlayCapsuleBackground(cornerStyle: chrome.cornerStyle))
+    .background(
+      OverlayCapsuleBackground(cornerStyle: chrome.cornerStyle, animatesGlow: animatesGlow))
     // #1988: report the capsule's real height so the panel can follow it. Measured
     // on the capsule rather than computed from a line count, because only the text
     // engine knows how many lines a sentence wraps to at this width in this script.

--- a/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
@@ -9,6 +9,17 @@ import SwiftUI
 /// each with a miniature window preview, so the choice reads at a glance. The
 /// cards flow in an adaptive grid: three across when the detail pane is wide,
 /// reflowing to two then one as the window narrows.
+///
+/// **The cards are a ROW rather than a column, and carry no description (#2435,
+/// founder).** They cost 191 points of height each and the page below them is now
+/// three pill pictures; laid out horizontally they cost 90. The picture is the
+/// explanation for Light and Dark.
+///
+/// **What that trades away, so nobody restores it by accident: the `System`
+/// card's split thumbnail cannot say that it FOLLOWS the Mac.** Keeping a short
+/// caption and renaming `System` to `Auto` were both offered and both declined
+/// in favour of the shorter page (founder, 2026-08-26). The card's meaning now
+/// rests on its title. This is the accepted trade, not an oversight.
 struct AppearanceSettingsView: View {
   @Environment(SettingsManager.self) private var settings
 
@@ -19,14 +30,10 @@ struct AppearanceSettingsView: View {
 
     SettingsContentView {
       // No section eyebrow or restated description here: the page-header card
-      // already introduces the page and each card describes its own mode. Say it
-      // once, then show the choices (founder, 2026-07-03).
-      //
-      // **#2376: that header no longer tells the whole truth and was revised with
-      // this change.** It read "Choose how EnviousWispr looks in light and dark",
-      // which was complete while theme and pill position were the only settings
-      // here; a pill-design picker on the same page makes it a description of one
-      // section rather than of the page.
+      // already introduces the page (founder, 2026-07-03). #2376 revised that
+      // header when the pill picker arrived, and #2435 shortened it again when the
+      // cards below stopped describing themselves — the subtitle in
+      // `SettingsSection` is the one sentence this page gets.
       LazyVGrid(columns: columns, spacing: 12) {
         ForEach(AppearancePreference.allCases, id: \.self) { preference in
           AppearanceCard(
@@ -39,11 +46,13 @@ struct AppearanceSettingsView: View {
       }
 
       // #1341: where the recording pill and status notices open on screen.
+      // #2435: the description went with the picker's. The two segments say
+      // "Top" and "Bottom" and the panel is called Pill Position, so a sentence
+      // repeating that is text for its own sake, and the pill panel below carries
+      // the one next-recording note the page needs.
       BrandedPanel(
         icon: "rectangle.portrait.and.arrow.right",
-        header: "Recording Indicator Position",
-        description:
-          "Choose where the recording pill and status notices appear. Changes apply the next time one appears."
+        header: "Pill Position"
       ) {
         BrandedSegmentedPicker(
           options: [
@@ -62,45 +71,54 @@ struct AppearanceSettingsView: View {
 
 // MARK: - Appearance card
 
-/// One selectable appearance option: mini window preview, icon + title, and a
-/// short description. The selected card carries an accent border and a filled
-/// accent check badge.
+/// One selectable appearance option: mini window preview beside its icon and
+/// title. The selected card carries an accent border and a filled accent check
+/// badge.
 private struct AppearanceCard: View {
   let preference: AppearancePreference
   let isSelected: Bool
   let onSelect: () -> Void
 
+  /// The thumbnail's authored size, kept as the size it is DRAWN at and then
+  /// scaled whole (#2435).
+  ///
+  /// **Scaled rather than re-laid-out, because `MiniWindow`'s parts are fixed
+  /// points** — a 15 point title bar and a 44 point sidebar. Handing it a 108
+  /// point frame would make the sidebar 41% of the window instead of 22%, so the
+  /// preview would stop looking like this app.
+  private static let thumbnailSize = CGSize(width: 200, height: 116)
+  private static let thumbnailScale: CGFloat = 0.54
+
   var body: some View {
     Button(action: onSelect) {
-      VStack(alignment: .leading, spacing: 0) {
-        ZStack(alignment: .topTrailing) {
-          AppearancePreviewThumbnail(preference: preference)
-            .frame(height: 116)
+      HStack(spacing: 12) {
+        AppearancePreviewThumbnail(preference: preference)
+          .frame(width: Self.thumbnailSize.width, height: Self.thumbnailSize.height)
+          .scaleEffect(Self.thumbnailScale)
+          .frame(
+            width: Self.thumbnailSize.width * Self.thumbnailScale,
+            height: Self.thumbnailSize.height * Self.thumbnailScale)
 
-          if isSelected {
-            Image(systemName: "checkmark.circle.fill")
-              .font(.system(size: 20, weight: .semibold))
-              .foregroundStyle(Color.white, Color.stAccent)
-              .padding(10)
-          }
-        }
+        Image(systemName: iconName)
+          .font(.system(size: 16, weight: .medium))
+          .foregroundStyle(isSelected ? .stAccent : .stTextSecondary)
+          .frame(width: 22, alignment: .center)
+        Text(title)
+          .font(.stRowTitle)
+          .foregroundStyle(isSelected ? .stAccent : .stTextPrimary)
 
-        VStack(alignment: .leading, spacing: 4) {
-          HStack(spacing: 8) {
-            Image(systemName: iconName)
-              .font(.system(size: 16, weight: .medium))
-              .foregroundStyle(isSelected ? .stAccent : .stTextSecondary)
-              .frame(width: 22, alignment: .center)
-            Text(title)
-              .font(.stRowTitle)
-              .foregroundStyle(isSelected ? .stAccent : .stTextPrimary)
-          }
-          Text(description)
-            .settingsReadingCopy()
-            .frame(maxWidth: .infinity, minHeight: 40, alignment: .topLeading)
+        Spacer(minLength: 0)
+
+        if isSelected {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(Color.white, Color.stAccent)
         }
-        .padding(14)
       }
+      .padding(12)
+      // Before `.buttonStyle(.plain)`: the `Spacer` above is otherwise dead space
+      // rather than part of the hit target.
+      .contentShape(Rectangle())
       .background(Color.stSectionBg)
       .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
       .overlay(
@@ -131,17 +149,6 @@ private struct AppearanceCard: View {
     case .system: return "System"
     case .light: return "Light"
     case .dark: return "Dark"
-    }
-  }
-
-  private var description: String {
-    switch preference {
-    case .system:
-      return "Automatically switches between Light and Dark based on your system settings."
-    case .light:
-      return "A clean, bright interface for daytime and well-lit environments."
-    case .dark:
-      return "A low-light interface that's easy on the eyes."
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
@@ -23,7 +23,11 @@ import SwiftUI
 struct AppearanceSettingsView: View {
   @Environment(SettingsManager.self) private var settings
 
-  private let columns = [GridItem(.adaptive(minimum: 210, maximum: .infinity), spacing: 12)]
+  /// 270, not the 210 this grid used while the cards were vertical (#2435). A
+  /// selected `System` row is 108 of thumbnail, 22 of icon, its title, an 18
+  /// point check, four gaps and the padding. At 210 the title or the check
+  /// compresses at narrow multi-column widths, silently.
+  private let columns = [GridItem(.adaptive(minimum: 270, maximum: .infinity), spacing: 12)]
 
   var body: some View {
     @Bindable var settings = settings

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -1,7 +1,15 @@
 import EnviousWisprCore
 import SwiftUI
 
-/// Choose the recording pill's design, per capability group (#2376 Phase 4, C7).
+/// Choose the recording pill's design, per capability group (#2376 Phase 4, C7;
+/// redrawn as pictures in #2435).
+///
+/// **The picker SHOWS each design instead of describing it (#2435).** A user
+/// could not previously see what any option looked like without starting a
+/// recording and cancelling it. Every option is now the real pill, rendered by
+/// the same view the overlay uses, and the words it used to print move into the
+/// accessibility label — which is the only channel a macOS user cannot silence
+/// (VoiceOver Utility can turn hints and custom content off).
 ///
 /// **Two groups, and the one that does not apply is GREYED WITH ITS REASON
 /// rather than hidden.** Hiding it would leave a user who turns Live Preview on
@@ -21,35 +29,85 @@ import SwiftUI
 /// places saying why is how they come to disagree. Here the requirement is the
 /// reason WITH the greyed group, so it is rendered once in that group's header
 /// and nowhere else.
+///
+/// **The two group titles name a CONDITION, not the current state, and that is
+/// what makes them true** (founder, 2026-08-26). Read as a status claim,
+/// "Live Preview on" would be false at `.engineUnsupported` and
+/// `.modelBeingRemoved`, where the setting is on and the pills are still out of
+/// reach. Read as "the pills you get when Live Preview is on", it holds in all
+/// four cases. Two things carry the CURRENT state instead, and both are
+/// requirements rather than decoration: exactly one group shows the filled active
+/// dot, and the other one prints `reason(for:groupHoldsWords:)`, which already
+/// distinguishes every case. `AppearancePillPickerTests` asserts both.
 struct RecordingPillAppearancePanel: View {
 
   @Environment(PillAppearanceModel.self) private var model
 
-  private let columns = [GridItem(.adaptive(minimum: 210, maximum: .infinity), spacing: 12)]
-
   var body: some View {
     BrandedPanel(
       icon: "waveform.badge.mic",
-      header: "Recording Pill",
-      description:
-        "Choose how the pill looks while you are dictating. Changes apply the next time you record."
+      header: "Recording Pill"
     ) {
-      VStack(alignment: .leading, spacing: 18) {
-        group(holdingWords: false)
-        group(holdingWords: true)
+      // **`ViewThatFits` rather than a width breakpoint**, because the number
+      // would have to be re-derived every time a design's width moved, and the
+      // designs already declare their own widths. Side by side while both groups
+      // fit; stacked otherwise, with every pill still drawn at TRUE SIZE. The
+      // alternative measured badly: the settings window opens at 820 points wide,
+      // where fitting both groups side by side needs a shared 0.47 scale factor
+      // and the reading well's words become unreadable.
+      ViewThatFits(in: .horizontal) {
+        HStack(alignment: .top, spacing: 12) {
+          group(holdingWords: false)
+          group(holdingWords: true)
+        }
+        VStack(alignment: .leading, spacing: 12) {
+          group(holdingWords: false)
+          group(holdingWords: true)
+        }
       }
+    } footnote: {
+      // ONE quiet line for the whole page's pill settings (founder, 2026-08-26),
+      // replacing the sentence this panel and the position panel each carried.
+      Text("Changes apply the next time you record.")
+        .settingsReadingCopy()
     }
   }
 
-  private var hasWords: Bool { model.wordsCapability.hasWords }
+  /// Whether a group describes the situation the user is actually in.
+  ///
+  /// **A function rather than a computed property inside `body`, because it is
+  /// the authority the active dot and the reason line BOTH read**, and because
+  /// the rendered accessibility tree is not readable from a test (recorded in
+  /// `RenderedPillHarness`). A test can hold this to "exactly one group is
+  /// active, in every capability state" without hosting anything.
+  static func isActive(_ capability: PillWordsCapability, groupHoldsWords: Bool) -> Bool {
+    groupHoldsWords == capability.hasWords
+  }
 
   @ViewBuilder
   private func group(holdingWords: Bool) -> some View {
-    let isActive = holdingWords == hasWords
-    VStack(alignment: .leading, spacing: 8) {
-      Text(holdingWords ? "Shows your words as you speak" : "Without live words")
-        .font(.stRowTitle)
-        .foregroundStyle(isActive ? .stTextPrimary : .stTextSecondary)
+    let isActive = Self.isActive(model.wordsCapability, groupHoldsWords: holdingWords)
+    let title = holdingWords ? "Live Preview on" : "Live Preview off"
+
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 7) {
+        // The dot is the CURRENT state; the title beside it is the condition.
+        Circle()
+          .fill(isActive ? Color.green : Color.clear)
+          .overlay(
+            Circle().strokeBorder(
+              isActive ? Color.clear : Color.stTextTertiary, lineWidth: 1)
+          )
+          .frame(width: 8, height: 8)
+          // Announced through the title's own label instead, so a screen reader
+          // hears one phrase rather than an unnamed shape beside a heading.
+          .accessibilityHidden(true)
+
+        Text(title)
+          .font(.stRowTitle)
+          .foregroundStyle(isActive ? .stTextPrimary : .stTextSecondary)
+          .accessibilityLabel(isActive ? "\(title). In use." : title)
+      }
 
       // The reason, rendered ONLY on the inactive group and only once.
       if !isActive,
@@ -59,18 +117,26 @@ struct RecordingPillAppearancePanel: View {
           .settingsReadingCopy()
       }
 
-      LazyVGrid(columns: columns, spacing: 12) {
-        ForEach(model.designs(holdingWords: holdingWords), id: \.self) { design in
-          RecordingPillDesignCard(
-            design: design,
-            isSelected: model.selection(holdingWords: holdingWords) == design,
-            isEnabled: model.offers(design, holdingWords: holdingWords) && isActive,
-            onSelect: { model.choose(design, holdingWords: holdingWords) })
-        }
+      ViewThatFits(in: .horizontal) {
+        HStack(alignment: .top, spacing: 12) { tiles(holdingWords: holdingWords) }
+        VStack(alignment: .leading, spacing: 12) { tiles(holdingWords: holdingWords) }
       }
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
     // One animation on the container, never per `ForEach` child.
     .animation(.easeInOut(duration: 0.15), value: isActive)
+  }
+
+  @ViewBuilder
+  private func tiles(holdingWords: Bool) -> some View {
+    let isActive = Self.isActive(model.wordsCapability, groupHoldsWords: holdingWords)
+    ForEach(model.designs(holdingWords: holdingWords), id: \.self) { design in
+      RecordingPillPreviewTile(
+        design: design,
+        isSelected: model.selection(holdingWords: holdingWords) == design,
+        isEnabled: model.offers(design, holdingWords: holdingWords) && isActive,
+        onSelect: { model.choose(design, holdingWords: holdingWords) })
+    }
   }
 
   /// Why the inactive group is inactive, in that user's terms.
@@ -78,64 +144,88 @@ struct RecordingPillAppearancePanel: View {
   /// **Two refusals, two sentences, and that is the whole reason the capability
   /// carries a reason at all.** One sentence for both would tell a user whose
   /// engine cannot run on this Mac to turn on a setting that would not help them.
+  ///
+  /// **Shortened to a phrase each (#2435)** — the page is now pictures, and a
+  /// paragraph under a greyed group is the text this change exists to remove. Each
+  /// phrase still names its own cause, which is the property that matters: it is
+  /// the only surface that distinguishes `previewOff` from `engineUnsupported`
+  /// from `modelBeingRemoved`.
   static func reason(for capability: PillWordsCapability, groupHoldsWords: Bool) -> String? {
     if groupHoldsWords {
       switch capability {
       case .available: return nil
-      case .previewOff:
-        return
-          "These need Live Preview, which is currently off. Turn it on in Live Preview settings."
-      case .engineUnsupported:
-        return "These need Live Preview, which the engine you have selected cannot run on this Mac."
-      case .modelBeingRemoved:
-        return "These need Live Preview, which is unavailable while the model you removed finishes clearing."
+      case .previewOff: return "Turn on Live Preview to use these."
+      case .engineUnsupported: return "Your engine cannot show words on this Mac."
+      case .modelBeingRemoved: return "Unavailable while a removed model finishes clearing."
       }
     }
     // The wordless group is inactive exactly when words ARE available.
-    return capability.hasWords
-      ? "Live Preview is on, so the pill shows your words. These become available if you turn it off."
-      : nil
+    return capability.hasWords ? "Live Preview is on, so the pill shows your words." : nil
   }
 }
 
-/// One selectable pill design.
+// MARK: - One design, drawn
+
+/// One selectable pill design, shown as the pill itself (#2435).
 ///
-/// A new card rather than a generalised `AppearanceCard`: that one is private to
-/// the light/dark grid this phase must leave untouched, and widening it would
-/// mean editing the very control the page already ships.
-private struct RecordingPillDesignCard: View {
+/// `internal` rather than `private` so its accessibility string has a name a test
+/// can call. The rendered accessibility TREE is not readable from a hosted view
+/// (measured, and recorded in `RenderedPillHarness`), so the label is proven
+/// through the function that produces it and confirmed by a VoiceOver pass.
+struct RecordingPillPreviewTile: View {
   let design: RecordingPillDesign
   let isSelected: Bool
   let isEnabled: Bool
   let onSelect: () -> Void
 
+  /// **The name AND the description, both in the LABEL.** Once the tile carries
+  /// no visible text the drawing IS the content, and WCAG 1.1.1 asks for a text
+  /// alternative serving an EQUIVALENT purpose — a bare "Capsule" names the
+  /// option and says nothing about the thing every sighted user can now see.
+  ///
+  /// **Not a hint, and not `accessibilityCustomContent`, and that is a standards
+  /// answer rather than a preference.** VoiceOver Utility's Verbosity pane lets a
+  /// user set hints and extra content to "Do Nothing", so both can be silenced by
+  /// the reader. The label is the only channel guaranteed to be announced, so it
+  /// is where a text alternative that must arrive has to live.
+  ///
+  /// The cost is a longer announcement on every focus, which is accepted: the
+  /// summaries are one short sentence each, which bounds it.
+  static func accessibilityLabel(for design: RecordingPillDesign) -> String {
+    "\(design.displayName). \(design.summary)"
+  }
+
+  /// What the pill inside the tile is shown SAYING.
+  ///
+  /// **Keyed off `canHoldWords`, so the panel names no design.** A design added
+  /// later gets the right sample with no edit here.
+  ///
+  /// `internal` because a size test has to drive the same input through an
+  /// independent measurement of the leaf; using a different sentence there would
+  /// compare two different pictures and call the difference a defect.
+  static func sampleDisplay(for design: RecordingPillDesign) -> LivePreviewDisplay {
+    design.canHoldWords ? .text("the quarterly numbers came in") : .off
+  }
+
   var body: some View {
     Button(action: onSelect) {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 8) {
-          Image(systemName: iconName)
-            .font(.system(size: 16, weight: .medium))
-            .foregroundStyle(isSelected && isEnabled ? .stAccent : .stTextSecondary)
-            .frame(width: 22, alignment: .center)
-          Text(design.displayName)
-            .font(.stRowTitle)
-            .foregroundStyle(isSelected && isEnabled ? .stAccent : .stTextPrimary)
-          Spacer(minLength: 0)
-          if isSelected {
-            Image(systemName: "checkmark.circle.fill")
-              .font(.system(size: 15, weight: .semibold))
-              .foregroundStyle(isEnabled ? Color.stAccent : Color.stTextSecondary)
-          }
+      ZStack(alignment: .topTrailing) {
+        RecordingPillPreview(design: design)
+          .padding(.horizontal, 16)
+          .padding(.vertical, 16)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        if isSelected {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundStyle(Color.white, isEnabled ? Color.stAccent : Color.stTextSecondary)
+            .padding(9)
         }
-        Text(design.summary)
-          .settingsReadingCopy()
-          .frame(maxWidth: .infinity, minHeight: 40, alignment: .topLeading)
       }
-      .padding(14)
-      // Before `.buttonStyle(.plain)`, so the whole card is the hit target rather
-      // than the label's glyphs.
+      // Before `.buttonStyle(.plain)`, so the whole tile is the hit target rather
+      // than the pill's own glyphs.
       .contentShape(Rectangle())
-      .background(Color.stSectionBg)
+      .background(Color.stPageBg)
       .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
       .overlay(
         RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
@@ -148,20 +238,76 @@ private struct RecordingPillDesignCard: View {
     .disabled(!isEnabled)
     .opacity(isEnabled ? 1 : 0.45)
     // **Addressed by role and title, never by an accessibility identifier**
-    // (swift-patterns). A greyed card must REPORT as disabled rather than merely
+    // (swift-patterns). A greyed tile must REPORT as disabled rather than merely
     // look it: the mistake `EngineCard` records for itself is a control that is
     // visible and inaudible.
     .accessibilityElement(children: .combine)
-    .accessibilityLabel(design.displayName)
+    .accessibilityLabel(Self.accessibilityLabel(for: design))
     .accessibilityValue(isSelected ? "Selected" : "")
     .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
   }
+}
 
-  private var iconName: String {
-    switch design {
-    case .classic: return "capsule"
-    case .readingWell: return "text.alignleft"
-    case .levelRail: return "waveform"
+/// The real recording pill, standing still (#2435).
+///
+/// **`RecordingOverlayView`, never a drawing of it.** `RecordingPillChrome`
+/// exists so ONE table describes each design; a second renderer in Settings would
+/// disagree with the overlay the first time a design changed, and would disagree
+/// silently, because nothing compares a settings picture to a running pill.
+///
+/// **The sample state is FIXED and stated, because an unspecified sample is an
+/// unspecified picture.** Lock state and preview state both change the pixels, so
+/// leaving either to chance would make the tile a picture of some pill rather
+/// than of this design.
+private struct RecordingPillPreview: View {
+  let design: RecordingPillDesign
+
+  /// Mid level, so the meter and the rainbow mark are visibly alive rather than
+  /// sitting on the silence floor.
+  private static let sampleLevel: Float = 0.42
+
+  /// A two digit clock, which is the widest ordinary case.
+  private static let sampleElapsed: TimeInterval = 12
+
+  var body: some View {
+    let display = RecordingPillPreviewTile.sampleDisplay(for: design)
+    RecordingOverlayView(
+      audioLevelProvider: { Self.sampleLevel },
+      recordingElapsedProvider: { Self.sampleElapsed },
+      livePreviewProvider: { display },
+      onContentHeightChange: { _ in },
+      chrome: design.chrome,
+      // Hands free is not what is being chosen here, and the locked variants
+      // differ per design, so a picker showing ONE mode is the honest one.
+      isLocked: false,
+      // #1060's banner is a runtime event, not an appearance.
+      noticeText: nil,
+      // **Seeded, or the reading well renders empty on its first frame and
+      // visibly fills in.** `preview` is `@State`, so this parameter is the only
+      // way to make the first frame the right one.
+      initialPreview: display,
+      // One read to synchronise, then nothing. Three live pills on a settings
+      // page would read their providers sixty times a second between them.
+      cadence: .still,
+      // A settings page is not the place for a permanent two second pulse, and
+      // there would be one per capsule tile.
+      animatesGlow: false
+    )
+    // **A PICTURE does not move, including on the way in.** The leaf animates
+    // `audioLevel`, and its first poll moves that from 0 to the sample — so a
+    // tile would fade its meter up every time the grid created the row, which a
+    // `LazyVGrid` does on scroll as well as on appear. Rejecting inherited
+    // animations is the only reach a caller has: the `.animation` modifiers are
+    // inside the leaf.
+    .transaction { transaction in
+      transaction.disablesAnimations = true
     }
+    // **The design's OWN declared width, uniformly — no per design table here.**
+    // It is the interaction window rather than the pill: `OverlayRootView`
+    // applies it outside the leaf, so the capsule paints at its own content size
+    // and centres inside. Passing it matters for the reading well, whose text
+    // wraps to the width it is given; for the other two it reserves transparent
+    // space either side and changes no pixel of the pill.
+    .frame(width: design.width)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -283,26 +283,25 @@ struct RecordingPillPreviewTile: View {
   /// identity is that meter, so the picker would misrepresent the design it is
   /// asking the user to choose. Found by cloud review on #2439.
   ///
-  /// **It is deliberately ONE SHORT of `RainbowLevelMeter.barCount`, and the
-  /// coupling is the point rather than an accident.** `.still` polls once, that
-  /// poll increments the tick, and the meter appends on a tick change — so a
-  /// FULL seed would immediately drop its oldest sample and shift every bar,
-  /// leaving the rendered meter one bar different from the array written here.
-  /// Cloud review caught that as a consequence of the seed itself, on the round
-  /// after the seed landed. Seeding one short lets the single poll COMPLETE the
-  /// history instead: `pushed` drops only past capacity, so nothing shifts and
-  /// the rail draws exactly this shape with `sampleLevel` newest.
+  /// **Exactly `RainbowLevelMeter.barCount` samples, and it is the whole
+  /// picture.** A seeded meter ignores tick changes, so these bars are what
+  /// renders on the first frame and on every frame after it — no dependence on
+  /// how many times the pill polls or on how `bars` pads a short history.
   ///
-  /// That also removes the need to end this array at `sampleLevel` by hand — the
-  /// poll supplies it, from the same provider that drives the rainbow mark, so
-  /// the newest bar and the mark cannot disagree.
+  /// Two earlier attempts tuned the LENGTH instead and each only moved the
+  /// artifact by one bar; the owner of that reasoning is now
+  /// `RainbowLevelMeter.isSeeded`, which is where it belongs.
+  ///
+  /// It ENDS at `sampleLevel`, because the newest bar and the rainbow mark are
+  /// driven by the same instant and a picker drawing them disagreeing would be
+  /// showing a pill that cannot occur.
   ///
   /// `internal`, like `sampleDisplay`, because "what the sample pill shows" has
   /// one owner and a test has to be able to read it.
   static let sampleLevelHistory: [CGFloat] = [
     0.06, 0.11, 0.24, 0.38, 0.52, 0.61, 0.55, 0.40,
     0.22, 0.13, 0.09, 0.18, 0.34, 0.49, 0.66, 0.73,
-    0.64, 0.47, 0.29, 0.16, 0.10, 0.21, 0.35,
+    0.64, 0.47, 0.29, 0.16, 0.10, 0.21, 0.35, CGFloat(sampleLevel),
   ]
 
   var body: some View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -349,7 +349,14 @@ private struct RecordingPillPreview: View {
       animatesGlow: false,
       // The meter is the Level Rail's whole identity, and a pill that never polls
       // has no history to build. See `sampleLevelHistory`.
-      initialLevelHistory: RecordingPillPreviewTile.sampleLevelHistory
+      initialLevelHistory: RecordingPillPreviewTile.sampleLevelHistory,
+      // **The last two of the poll's four pieces of state.** Without them the
+      // first frame draws the rainbow mark at silence and a 0:00 clock, then
+      // snaps to the sample once the single poll lands. The leaf's own doc
+      // comment enumerates the set; the wiring guard reads the poll body and
+      // requires a seed for each.
+      initialAudioLevel: RecordingPillPreviewTile.sampleLevel,
+      initialElapsed: RecordingPillPreviewTile.sampleElapsed
     )
     // **A PICTURE does not move, including on the way in.** The leaf animates
     // `audioLevel`, and its first poll moves that from 0 to the sample, so a tile

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -68,7 +68,17 @@ struct RecordingPillAppearancePanel: View {
     } footnote: {
       // ONE quiet line for the whole page's pill settings (founder, 2026-08-26),
       // replacing the sentence this panel and the position panel each carried.
-      Text("Changes apply the next time you record.")
+      //
+      // **It NAMES both settings, because it sits inside the Recording Pill
+      // panel** and an unqualified "Changes" reads there as design changes only,
+      // leaving the position panel above silently uncovered.
+      //
+      // "the next time the pill appears", not "the next time you record": the
+      // position setting also places status notices, which the deleted copy said
+      // outright ("Changes apply the next time one appears"). A notice can arrive
+      // without a recording, so scoping this line to recording would be wrong for
+      // half of what it now covers.
+      Text("Design and position changes apply the next time the pill appears.")
         .settingsReadingCopy()
     }
   }
@@ -294,11 +304,10 @@ private struct RecordingPillPreview: View {
       animatesGlow: false
     )
     // **A PICTURE does not move, including on the way in.** The leaf animates
-    // `audioLevel`, and its first poll moves that from 0 to the sample — so a
-    // tile would fade its meter up every time the grid created the row, which a
-    // `LazyVGrid` does on scroll as well as on appear. Rejecting inherited
-    // animations is the only reach a caller has: the `.animation` modifiers are
-    // inside the leaf.
+    // `audioLevel`, and its first poll moves that from 0 to the sample, so a tile
+    // would fade its meter up every time `ViewThatFits` changes candidates or the
+    // settings page recreates it. Rejecting inherited animations is the only
+    // reach a caller has: the `.animation` modifiers are inside the leaf.
     .transaction { transaction in
       transaction.disablesAnimations = true
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -48,43 +48,36 @@ struct RecordingPillAppearancePanel: View {
       icon: "waveform.badge.mic",
       header: "Recording Pill"
     ) {
-      // **`ViewThatFits` rather than a width breakpoint**, because the number
-      // would have to be re-derived every time a design's width moved, and the
-      // designs already declare their own widths. Side by side while both groups
-      // fit; stacked otherwise, with every pill still drawn at TRUE SIZE. The
-      // alternative measured badly: the settings window opens at 820 points wide,
-      // where fitting both groups side by side needs a shared 0.47 scale factor
-      // and the reading well's words become unreadable.
-      ViewThatFits(in: .horizontal) {
-        HStack(alignment: .top, spacing: 12) {
-          group(holdingWords: false)
-          group(holdingWords: true)
-        }
-        VStack(alignment: .leading, spacing: 12) {
-          group(holdingWords: false)
-          group(holdingWords: true)
-        }
-        // **The last resort SCROLLS, because the alternative is a pill cut in
-        // half** (#2439 cloud review, P2). Stacking does not rescue a window
-        // narrower than one tile: the reading well asks for its design's full
-        // width plus the tile's padding, and the tile clips its own content, so
-        // below that the pill is silently truncated rather than merely cramped.
-        //
-        // Scrolling rather than scaling is the founder's constraint holding: a
-        // preview shrunk to fit is the illegible thumbnail this whole change
-        // exists to remove, and a user who can see two thirds of a pill and drag
-        // for the rest has lost nothing about what it looks like.
-        //
-        // It must be LAST. A `ScrollView` reports a small minimum and therefore
-        // always fits, so any earlier position would make it the only candidate
-        // `ViewThatFits` ever chooses.
-        ScrollView(.horizontal) {
-          VStack(alignment: .leading, spacing: 12) {
-            group(holdingWords: false)
-            group(holdingWords: true)
-          }
-        }
+      // **The two groups always STACK, and each one reflows its own tiles.**
+      //
+      // A `ViewThatFits` chose the groups' side-by-side arrangement here and was
+      // REMOVED after rendering it: nested inside the page's vertical
+      // `ScrollView` it does not reliably receive a bounded horizontal proposal,
+      // so it cannot judge whether a candidate fits and keeps its first one. At a
+      // 530 point content width that clipped both wordless pills; at 1010 it
+      // stacked two groups with room to sit side by side. A container that
+      // guesses wrong CLIPS here rather than cramping, because every pill is a
+      // fixed width by design.
+      //
+      // `LazyVGrid` is the container this page already proves receives a bounded
+      // width — the theme cards above use one — so the reflow is decided by
+      // arithmetic rather than by a proposal that may not arrive.
+      VStack(alignment: .leading, spacing: 18) {
+        group(holdingWords: false)
+        group(holdingWords: true)
       }
+      // **The page REFUSES to be narrower than its widest pill, rather than
+      // clipping one.** Rendered at a 380 point content width the reading well
+      // was cut off: a grid column cannot shrink below its content, and the tile
+      // clips its own, so there is no width at which a too-narrow layout degrades
+      // gracefully. A minimum propagates up to the window, so the window stops
+      // resizing instead — which is the honest behaviour for a page whose whole
+      // subject is fixed-size pictures.
+      //
+      // DERIVED, never a literal: a design added later widens it with no edit
+      // here, and a literal would be a second authority for a number the tile
+      // already owns.
+      .frame(minWidth: Self.widestTile(holdingWords: true), alignment: .leading)
     } footnote: {
       // ONE quiet line for the whole page's pill settings (founder, 2026-08-26),
       // replacing the sentence this panel and the position panel each carried.
@@ -112,6 +105,17 @@ struct RecordingPillAppearancePanel: View {
   /// active, in every capability state" without hosting anything.
   static func isActive(_ capability: PillWordsCapability, groupHoldsWords: Bool) -> Bool {
     groupHoldsWords == capability.hasWords
+  }
+
+  /// The widest tile a group will contain, which is what its grid column has to
+  /// be able to hold.
+  ///
+  /// Read off `PillCatalog` and the tile, so a design added later widens the
+  /// column with no edit here.
+  static func widestTile(holdingWords: Bool) -> CGFloat {
+    PillCatalog.designs(holdingWords: holdingWords)
+      .map(RecordingPillPreviewTile.width(for:))
+      .max() ?? 0
   }
 
   @ViewBuilder
@@ -147,13 +151,29 @@ struct RecordingPillAppearancePanel: View {
           .settingsReadingCopy()
       }
 
-      ViewThatFits(in: .horizontal) {
-        HStack(alignment: .top, spacing: 12) { tiles(holdingWords: holdingWords) }
-        VStack(alignment: .leading, spacing: 12) { tiles(holdingWords: holdingWords) }
+      // **One column per tile that fits, sized by the WIDEST tile in this group.**
+      // A narrower minimum would let a column form that the reading well cannot
+      // sit in, and the tile clips its own content, so the pill would be cut
+      // rather than cramped. Taken from the tile itself, never a literal here.
+      LazyVGrid(
+        columns: [
+          GridItem(
+            .adaptive(minimum: Self.widestTile(holdingWords: holdingWords), maximum: .infinity),
+            spacing: 12)
+        ],
+        alignment: .leading,
+        spacing: 12
+      ) {
+        tiles(holdingWords: holdingWords)
       }
     }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    // One animation on the container, never per `ForEach` child.
+    // **NO `maxWidth: .infinity` HERE, and it stays absent deliberately.** It was
+    // removed while this panel still chose its layout with `ViewThatFits`, which
+    // asks each candidate for its IDEAL size: a greedy child answers that it will
+    // take whatever it is given, so every candidate fit at every width and the
+    // fallbacks were dead code. That container is gone, but a greedy group would
+    // now stretch every column to the panel's full width instead, which is the
+    // same wrong picture by another route.
     .animation(.easeInOut(duration: 0.15), value: isActive)
   }
 
@@ -225,6 +245,17 @@ struct RecordingPillPreviewTile: View {
     "\(design.displayName). \(design.summary)"
   }
 
+  /// The pill's own inset inside the tile, on each side.
+  static let horizontalInset: CGFloat = 16
+
+  /// **What one tile occupies, derived rather than restated.** The panel's grid
+  /// needs this to size a column that can hold the widest design; a literal there
+  /// would be a second authority for the same number, free to disagree the day a
+  /// design's width moves.
+  static func width(for design: RecordingPillDesign) -> CGFloat {
+    design.width + horizontalInset * 2
+  }
+
   /// What the pill inside the tile is shown SAYING.
   ///
   /// **Keyed off `canHoldWords`, so the panel names no design.** A design added
@@ -272,9 +303,12 @@ struct RecordingPillPreviewTile: View {
     Button(action: onSelect) {
       ZStack(alignment: .topTrailing) {
         RecordingPillPreview(design: design)
-          .padding(.horizontal, 16)
+          .padding(.horizontal, Self.horizontalInset)
           .padding(.vertical, 16)
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          // Height only, so tiles sharing a grid row are the same size. A greedy
+          // WIDTH would make the tile report that it fits anywhere, which is what
+          // stops any container above it from reflowing correctly.
+          .frame(maxHeight: .infinity)
 
         if isSelected {
           Image(systemName: "checkmark.circle.fill")
@@ -360,9 +394,9 @@ private struct RecordingPillPreview: View {
     )
     // **A PICTURE does not move, including on the way in.** The leaf animates
     // `audioLevel`, and its first poll moves that from 0 to the sample, so a tile
-    // would fade its meter up every time `ViewThatFits` changes candidates or the
-    // settings page recreates it. Rejecting inherited animations is the only
-    // reach a caller has: the `.animation` modifiers are inside the leaf.
+    // would fade its meter up every time the grid recreates a row or the settings
+    // page rebuilds. Rejecting inherited animations is the only reach a caller
+    // has: the `.animation` modifiers are inside the leaf.
     .transaction { transaction in
       transaction.disablesAnimations = true
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -275,7 +275,7 @@ struct RecordingPillPreviewTile: View {
   /// A two digit clock, which is the widest ordinary case.
   static let sampleElapsed: TimeInterval = 12
 
-  /// Twenty-four samples of a plausible sentence, oldest first (#2435).
+  /// A plausible sentence's worth of level samples, oldest first (#2435).
   ///
   /// **A still pill has no history to build, so this IS the meter.** With one
   /// poll and nothing after it the rail would draw a single bar at the sample
@@ -283,20 +283,26 @@ struct RecordingPillPreviewTile: View {
   /// identity is that meter, so the picker would misrepresent the design it is
   /// asking the user to choose. Found by cloud review on #2439.
   ///
-  /// A shorter array pads with silence at the OLD end, which is what a real
-  /// recording looks like a second in, so a future `barCount` change degrades
-  /// rather than breaks.
+  /// **It is deliberately ONE SHORT of `RainbowLevelMeter.barCount`, and the
+  /// coupling is the point rather than an accident.** `.still` polls once, that
+  /// poll increments the tick, and the meter appends on a tick change — so a
+  /// FULL seed would immediately drop its oldest sample and shift every bar,
+  /// leaving the rendered meter one bar different from the array written here.
+  /// Cloud review caught that as a consequence of the seed itself, on the round
+  /// after the seed landed. Seeding one short lets the single poll COMPLETE the
+  /// history instead: `pushed` drops only past capacity, so nothing shifts and
+  /// the rail draws exactly this shape with `sampleLevel` newest.
   ///
-  /// It ENDS at `sampleLevel`, because the newest bar and the rainbow mark are
-  /// driven by the same instant, and a picker drawing them disagreeing would be
-  /// showing a pill that cannot occur.
+  /// That also removes the need to end this array at `sampleLevel` by hand — the
+  /// poll supplies it, from the same provider that drives the rainbow mark, so
+  /// the newest bar and the mark cannot disagree.
   ///
   /// `internal`, like `sampleDisplay`, because "what the sample pill shows" has
   /// one owner and a test has to be able to read it.
   static let sampleLevelHistory: [CGFloat] = [
     0.06, 0.11, 0.24, 0.38, 0.52, 0.61, 0.55, 0.40,
     0.22, 0.13, 0.09, 0.18, 0.34, 0.49, 0.66, 0.73,
-    0.64, 0.47, 0.29, 0.16, 0.10, 0.21, 0.35, CGFloat(sampleLevel),
+    0.64, 0.47, 0.29, 0.16, 0.10, 0.21, 0.35,
   ]
 
   var body: some View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -64,6 +64,26 @@ struct RecordingPillAppearancePanel: View {
           group(holdingWords: false)
           group(holdingWords: true)
         }
+        // **The last resort SCROLLS, because the alternative is a pill cut in
+        // half** (#2439 cloud review, P2). Stacking does not rescue a window
+        // narrower than one tile: the reading well asks for its design's full
+        // width plus the tile's padding, and the tile clips its own content, so
+        // below that the pill is silently truncated rather than merely cramped.
+        //
+        // Scrolling rather than scaling is the founder's constraint holding: a
+        // preview shrunk to fit is the illegible thumbnail this whole change
+        // exists to remove, and a user who can see two thirds of a pill and drag
+        // for the rest has lost nothing about what it looks like.
+        //
+        // It must be LAST. A `ScrollView` reports a small minimum and therefore
+        // always fits, so any earlier position would make it the only candidate
+        // `ViewThatFits` ever chooses.
+        ScrollView(.horizontal) {
+          VStack(alignment: .leading, spacing: 12) {
+            group(holdingWords: false)
+            group(holdingWords: true)
+          }
+        }
       }
     } footnote: {
       // ONE quiet line for the whole page's pill settings (founder, 2026-08-26),
@@ -217,6 +237,37 @@ struct RecordingPillPreviewTile: View {
     design.canHoldWords ? .text("the quarterly numbers came in") : .off
   }
 
+  /// Mid level, so the meter and the rainbow mark are visibly alive rather than
+  /// sitting on the silence floor.
+  static let sampleLevel: Float = 0.42
+
+  /// A two digit clock, which is the widest ordinary case.
+  static let sampleElapsed: TimeInterval = 12
+
+  /// Twenty-four samples of a plausible sentence, oldest first (#2435).
+  ///
+  /// **A still pill has no history to build, so this IS the meter.** With one
+  /// poll and nothing after it the rail would draw a single bar at the sample
+  /// level and twenty-three at the silence floor — and the Level Rail's whole
+  /// identity is that meter, so the picker would misrepresent the design it is
+  /// asking the user to choose. Found by cloud review on #2439.
+  ///
+  /// A shorter array pads with silence at the OLD end, which is what a real
+  /// recording looks like a second in, so a future `barCount` change degrades
+  /// rather than breaks.
+  ///
+  /// It ENDS at `sampleLevel`, because the newest bar and the rainbow mark are
+  /// driven by the same instant, and a picker drawing them disagreeing would be
+  /// showing a pill that cannot occur.
+  ///
+  /// `internal`, like `sampleDisplay`, because "what the sample pill shows" has
+  /// one owner and a test has to be able to read it.
+  static let sampleLevelHistory: [CGFloat] = [
+    0.06, 0.11, 0.24, 0.38, 0.52, 0.61, 0.55, 0.40,
+    0.22, 0.13, 0.09, 0.18, 0.34, 0.49, 0.66, 0.73,
+    0.64, 0.47, 0.29, 0.16, 0.10, 0.21, 0.35, CGFloat(sampleLevel),
+  ]
+
   var body: some View {
     Button(action: onSelect) {
       ZStack(alignment: .topTrailing) {
@@ -272,18 +323,12 @@ struct RecordingPillPreviewTile: View {
 private struct RecordingPillPreview: View {
   let design: RecordingPillDesign
 
-  /// Mid level, so the meter and the rainbow mark are visibly alive rather than
-  /// sitting on the silence floor.
-  private static let sampleLevel: Float = 0.42
-
-  /// A two digit clock, which is the widest ordinary case.
-  private static let sampleElapsed: TimeInterval = 12
-
+  ///
   var body: some View {
     let display = RecordingPillPreviewTile.sampleDisplay(for: design)
     RecordingOverlayView(
-      audioLevelProvider: { Self.sampleLevel },
-      recordingElapsedProvider: { Self.sampleElapsed },
+      audioLevelProvider: { RecordingPillPreviewTile.sampleLevel },
+      recordingElapsedProvider: { RecordingPillPreviewTile.sampleElapsed },
       livePreviewProvider: { display },
       onContentHeightChange: { _ in },
       chrome: design.chrome,
@@ -301,7 +346,10 @@ private struct RecordingPillPreview: View {
       cadence: .still,
       // A settings page is not the place for a permanent two second pulse, and
       // there would be one per capsule tile.
-      animatesGlow: false
+      animatesGlow: false,
+      // The meter is the Level Rail's whole identity, and a pill that never polls
+      // has no history to build. See `sampleLevelHistory`.
+      initialLevelHistory: RecordingPillPreviewTile.sampleLevelHistory
     )
     // **A PICTURE does not move, including on the way in.** The leaf animates
     // `audioLevel`, and its first poll moves that from 0 to the sample, so a tile

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -87,7 +87,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .whatsNew: return "The latest improvements and fixes in this release."
     // #2376: widened from "in light and dark" when the recording-pill picker
     // joined this page. The old line described one section rather than the page.
-    case .appearance: return "Choose how EnviousWispr looks, and which pill you see while dictating."
+    case .appearance: return "How the app looks, and the pill you see while dictating."
     case .speechEngine: return "The speech engine that turns your voice into text."
     case .livePreview: return "See your words on screen while you are still speaking."
     case .audio: return "Choose your input source and readiness behavior."

--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -221,4 +221,50 @@ struct AppearancePillPickerTests {
     let names = RecordingPillDesign.allCases.map(\.displayName)
     #expect(Set(names).count == names.count, "two designs share a card title: \(names)")
   }
+
+  // MARK: - The current state stays unmistakable (#2435)
+
+  /// **Product Outcome, and the reason the approved group titles are honest.**
+  ///
+  /// "Live Preview off" and "Live Preview on" name a CONDITION — the pills you get
+  /// when the setting is that way. Read instead as a claim about the CURRENT
+  /// state they would be false at `engineUnsupported` and `modelBeingRemoved`,
+  /// where the setting is on and the pills are still out of reach. What makes the
+  /// condition reading the one a user actually gets is that exactly one group
+  /// shows the filled dot and the other prints its own reason. Both are therefore
+  /// requirements, and this is the row that holds them.
+  ///
+  /// **It links the two surfaces rather than re-deriving either.** The dot reads
+  /// `isActive`; the greyed line reads `reason(for:groupHoldsWords:)`. That they
+  /// each behave correctly is asserted above; that they AGREE, in every
+  /// capability state, is what this asserts and nothing else does.
+  @Test(
+    "exactly one group is marked in use, and it is the one with nothing to explain",
+    arguments: PillWordsCapability.allCases)
+  func theDotAndTheReasonAgree(capability: PillWordsCapability) throws {
+    let active = [true, false].filter {
+      RecordingPillAppearancePanel.isActive(capability, groupHoldsWords: $0)
+    }
+
+    #expect(
+      active.count == 1,
+      """
+      \(capability) marks \(active.count) groups in use. The dot is the only thing on \
+      the page carrying the CURRENT state, so zero leaves a user unable to tell which \
+      pills they have and two tells them both.
+      """)
+    let live = try #require(active.first)
+
+    #expect(
+      RecordingPillAppearancePanel.reason(for: capability, groupHoldsWords: live) == nil,
+      "\(capability) marks a group in use and still explains why it is not")
+    #expect(
+      RecordingPillAppearancePanel.reason(for: capability, groupHoldsWords: !live)?.isEmpty
+        == false,
+      """
+      \(capability) greys a group without saying why. The title says only which \
+      CONDITION that group belongs to, so with no reason beside it there is nothing on \
+      the page that names what is actually wrong.
+      """)
+  }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/AppearanceRenderHarness.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearanceRenderHarness.swift
@@ -1,0 +1,108 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprServices
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// Renders the real Appearance page to PNG so a human can LOOK at it (#2435).
+///
+/// **Harness Contract. It asserts almost nothing and is not a test of the
+/// product** — it is an instrument, and it exists because this page's whole
+/// subject is PAINT, which every other instrument here is blind to.
+/// `NSHostingView.fittingSize` measures layout; `RenderedPillHarness` records
+/// that it cannot see icon, colour, corner shape or `scaleEffect`. A flat level
+/// meter, a pill drawn at the wrong size, a clipped theme title and a capsule
+/// frozen at the wrong opacity are all invisible to every size assertion in this
+/// target — and three of those four actually happened on this change.
+///
+/// **It is NOT a substitute for Live UAT and must never be cited as one.** It
+/// renders SwiftUI views in a test process: no window server chrome, no real
+/// scroll interaction, no accessibility tree, no running app. What it does give,
+/// on a machine where the screen is LOCKED and no input can be driven, is a true
+/// picture of what the layout code produces at a given width — which is the half
+/// of a design review that does not need a person clicking.
+///
+/// **Gated OFF by default**, so CI never renders and no absolute geometry is ever
+/// frozen. Run it deliberately:
+///
+///     TEST_RUNNER_EW_RENDER_APPEARANCE=1 scripts/xcode-test.sh \
+///       --filter EnviousWisprTests/AppearanceRenderHarness
+///
+/// PNGs land in `build/appearance-render/`. A skipped receipt is not a passed
+/// receipt: when this row is skipped it has proven nothing at all.
+@MainActor
+@Suite(.tags(.harnessContract))
+struct AppearanceRenderHarness {
+
+  init() { _ = NSApplication.shared }
+
+  private static func model(_ capability: PillWordsCapability) -> (SettingsManager, PillAppearanceModel) {
+    let name = "ew.appearanceRender." + UUID().uuidString
+    let suite = UserDefaults(suiteName: name)!
+    suite.removePersistentDomain(forName: name)
+    let settings = SettingsManager(defaults: suite)
+    return (settings, PillAppearanceModel(settings: settings, capability: { capability }))
+  }
+
+  /// Render one width to a PNG and return the size it actually took.
+  ///
+  /// **The width is the CONTENT area, not the window.** The settings window's
+  /// 820pt default leaves ~530 inside after the sidebar and insets; the wide case
+  /// is what ~1300 leaves. Passing a window width here would measure a page that
+  /// does not exist.
+  @discardableResult
+  private static func render(
+    _ label: String, contentWidth: CGFloat, capability: PillWordsCapability = .available
+  ) throws -> CGSize {
+    let (settings, pill) = model(capability)
+    let page = AppearanceSettingsView()
+      .environment(settings)
+      .environment(pill)
+      .frame(width: contentWidth)
+
+    let host = NSHostingView(rootView: AnyView(page))
+    let ideal = host.fittingSize
+    let size = CGSize(width: contentWidth, height: max(ideal.height, 400))
+    host.frame = NSRect(origin: .zero, size: size)
+
+    let window = NSWindow(
+      contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    let rep = try #require(
+      host.bitmapImageRepForCachingDisplay(in: host.bounds),
+      "the host produced no bitmap rep, so this render proved nothing")
+    host.cacheDisplay(in: host.bounds, to: rep)
+
+    let png = try #require(
+      rep.representation(using: .png, properties: [:]),
+      "the bitmap did not encode to PNG")
+
+    let dir = RepoRoot.url.appending(path: "build/appearance-render")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let url = dir.appending(path: "appearance-\(label).png")
+    try png.write(to: url)
+
+    print("RENDERED \(label): \(Int(size.width))x\(Int(size.height)) -> \(url.path)")
+    return size
+  }
+
+  @Test(
+    "render the Appearance page at the widths a user actually gets",
+    .enabled(if: ProcessInfo.processInfo.environment["EW_RENDER_APPEARANCE"] == "1"))
+  func renderTheAppearancePage() throws {
+    // 530: the content area at the shipped 820pt default window.
+    // 1010: roughly what a ~1300pt window leaves, where both groups sit side by side.
+    // 380: deliberately narrower than one reading-well tile, which is the only
+    //      case that can show whether the horizontal scroll fallback is chosen.
+    try Self.render("default-530", contentWidth: 530)
+    try Self.render("wide-1010", contentWidth: 1010)
+    try Self.render("narrow-380", contentWidth: 380)
+    // The greyed group, which no other render reaches.
+    try Self.render("preview-off-530", contentWidth: 530, capability: .previewOff)
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -239,14 +239,27 @@ struct RecordingPillTileTests {
   /// `RecordingPillPreviewWiringTests`.
   @Test("the sample waveform fills the meter and ends where the mark is")
   func theSampleWaveformIsWellFormed() {
-    let history = RecordingPillPreviewTile.sampleLevelHistory
+    // **The subject is what the meter DRAWS, not the array as written.** `.still`
+    // polls once, that poll appends, and asserting the raw seed would be asserting
+    // a value nothing renders — which is exactly the defect cloud review found in
+    // the round that introduced the seed.
+    let history = RainbowLevelMeter.pushed(
+      RecordingPillPreviewTile.sampleLevelHistory,
+      level: CGFloat(RecordingPillPreviewTile.sampleLevel))
 
+    #expect(
+      RecordingPillPreviewTile.sampleLevelHistory.count == RainbowLevelMeter.barCount - 1,
+      """
+      the seed has \(RecordingPillPreviewTile.sampleLevelHistory.count) samples for \
+      \(RainbowLevelMeter.barCount) bars. It must be exactly one short: the single still \
+      poll completes it, and a FULL seed drops its oldest and shifts every bar.
+      """)
     #expect(
       history.count == RainbowLevelMeter.barCount,
       """
-      the sample waveform has \(history.count) samples for \(RainbowLevelMeter.barCount) \
-      bars. Short pads the OLD end with silence, which is survivable; long silently \
-      drops the oldest, which is not what this array is claiming to be.
+      after the one still poll the meter holds \(history.count) samples for \
+      \(RainbowLevelMeter.barCount) bars, so the rendered waveform is not the shape \
+      written here.
       """)
     #expect(
       history.allSatisfy { $0 >= 0 && $0 <= 1 },

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -239,27 +239,19 @@ struct RecordingPillTileTests {
   /// `RecordingPillPreviewWiringTests`.
   @Test("the sample waveform fills the meter and ends where the mark is")
   func theSampleWaveformIsWellFormed() {
-    // **The subject is what the meter DRAWS, not the array as written.** `.still`
-    // polls once, that poll appends, and asserting the raw seed would be asserting
-    // a value nothing renders — which is exactly the defect cloud review found in
-    // the round that introduced the seed.
-    let history = RainbowLevelMeter.pushed(
-      RecordingPillPreviewTile.sampleLevelHistory,
-      level: CGFloat(RecordingPillPreviewTile.sampleLevel))
+    // **The seed IS the picture now**, because a seeded meter ignores ticks. Two
+    // earlier versions of this row chased the seed's LENGTH instead and each one
+    // only moved a one-bar shift; the property that matters is that the rendered
+    // bars are exactly this, which `theSeededMeterIgnoresTicks` proves for the
+    // mechanism and this row proves for the shape.
+    let history = RecordingPillPreviewTile.sampleLevelHistory
 
-    #expect(
-      RecordingPillPreviewTile.sampleLevelHistory.count == RainbowLevelMeter.barCount - 1,
-      """
-      the seed has \(RecordingPillPreviewTile.sampleLevelHistory.count) samples for \
-      \(RainbowLevelMeter.barCount) bars. It must be exactly one short: the single still \
-      poll completes it, and a FULL seed drops its oldest and shifts every bar.
-      """)
     #expect(
       history.count == RainbowLevelMeter.barCount,
       """
-      after the one still poll the meter holds \(history.count) samples for \
-      \(RainbowLevelMeter.barCount) bars, so the rendered waveform is not the shape \
-      written here.
+      the seed has \(history.count) samples for \(RainbowLevelMeter.barCount) bars. \
+      `bars` right-aligns a short history and pads the OLD end with silence, so anything \
+      but an exact fill draws a leading silence bar nobody chose.
       """)
     #expect(
       history.allSatisfy { $0 >= 0 && $0 <= 1 },
@@ -279,6 +271,68 @@ struct RecordingPillTileTests {
     #expect(
       Set(history).count > 1,
       "every sample in the authored waveform is identical, so the meter draws a flat bar")
+  }
+
+  /// **The mechanism behind the shape row above: a seeded meter does not
+  /// accumulate.**
+  ///
+  /// Driven through the meter's own `onHistoryChange` seam, which exists for
+  /// exactly this — an outcome observer that reports what was pushed. A seeded
+  /// meter must never push, so the observer must never fire, however many ticks
+  /// arrive. The unseeded control is what makes that non-vacuous: without it a
+  /// meter that had simply stopped working would pass.
+  @Test("a seeded meter ignores ticks, and an unseeded one does not")
+  func theSeededMeterIgnoresTicks() {
+    final class Pushes: @unchecked Sendable {
+      var histories: [[CGFloat]] = []
+    }
+
+    // **The tick must actually CHANGE, or neither arm pushes and the row is
+    // vacuous in both directions.** `onChange` fires on a change, so a meter
+    // mounted at a fixed tick never appends whatever its seed. The rootView is
+    // replaced to advance it, which is what a real poll does.
+    func drive(seed: [CGFloat]) -> Pushes {
+      let pushes = Pushes()
+      func meter(tick: Int) -> AnyView {
+        AnyView(
+          RainbowLevelMeter(
+            audioLevel: 0.42, tick: tick,
+            onHistoryChange: { pushes.histories.append($0) },
+            initialHistory: seed))
+      }
+
+      let host = NSHostingView(rootView: meter(tick: 0))
+      let frame = NSRect(x: 0, y: 0, width: 200, height: 60)
+      let window = NSWindow(
+        contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+      window.contentView = host
+      host.frame = frame
+      host.layoutSubtreeIfNeeded()
+      window.displayIfNeeded()
+
+      host.rootView = meter(tick: 1)
+      host.layoutSubtreeIfNeeded()
+      window.displayIfNeeded()
+      return pushes
+    }
+
+    // THE CONTROL, and without it a meter that had simply stopped appending
+    // would satisfy the assertion below.
+    let unseeded = drive(seed: [])
+    #expect(
+      !unseeded.histories.isEmpty,
+      """
+      control: an UNSEEDED meter did not append on a tick change, so this row cannot \
+      distinguish a seeded meter holding still from a meter that no longer works.
+      """)
+
+    let seeded = drive(seed: RecordingPillPreviewTile.sampleLevelHistory)
+    #expect(
+      seeded.histories.isEmpty,
+      """
+      a seeded meter pushed \(seeded.histories.count) time(s), so the picker's waveform \
+      is not the array the picker chose. Every push shifts the bars.
+      """)
   }
 
   @Test("no two tiles announce the same thing")

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -1,0 +1,191 @@
+import AppKit
+import EnviousWisprCore
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// The Appearance picker draws each pill instead of describing it (#2435).
+///
+/// **Product Outcome.** When these fail, a user picking a recording pill is
+/// looking at the wrong picture, an empty box, or a preview that says nothing to
+/// a screen reader — and picks by guessing, which is the failure the whole change
+/// exists to remove.
+///
+/// **Every size assertion here is a RELATION between two measurements taken in
+/// one process, never a frozen point value.** The 2026-08-25 lesson from #2376
+/// Phase 4 is that an absolute rendered size is a reading of one Mac's font
+/// metrics: the suite went Debug-green and CI-red on exactly that. Differences
+/// and orderings survive a different machine; numbers do not.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingPillTileTests {
+
+  init() { _ = NSApplication.shared }
+
+  /// The tile as the settings page builds it, measured unconstrained so it
+  /// reports what it ideally wants.
+  private static func tileSize(_ design: RecordingPillDesign) -> CGSize {
+    let tile = RecordingPillPreviewTile(
+      design: design, isSelected: false, isEnabled: true, onSelect: {})
+    let host = NSHostingView(rootView: AnyView(tile))
+    let frame = NSRect(x: 0, y: 0, width: 1200, height: 600)
+    let window = NSWindow(
+      contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.frame = frame
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    return host.fittingSize
+  }
+
+  /// **The oracle the tile did not write.** `RenderedPillHarness` measures the
+  /// recording leaf directly, through the leaf's own height callback, with no
+  /// tile involved. The sample display comes from the tile so both sides are
+  /// looking at the same picture — that is the INPUT, not the thing under test.
+  private static func leafHeight(_ design: RecordingPillDesign) throws -> CGFloat {
+    try RenderedPillHarness.recordingContentHeight(
+      design: design,
+      display: RecordingPillPreviewTile.sampleDisplay(for: design),
+      width: design.width)
+  }
+
+  // MARK: - The tile renders the real pill
+
+  /// **The strong one: the tile's height tracks the LEAF's height exactly.**
+  ///
+  /// Stated as a difference so the tile's own padding cancels out of both sides.
+  /// A tile that drew a placeholder, an empty box, or another design's chrome
+  /// would have a height unrelated to what the leaf reports for itself, and no
+  /// absolute constant is involved on either side.
+  @Test(
+    "each tile is as tall as the pill inside it",
+    arguments: [RecordingPillDesign.levelRail, RecordingPillDesign.readingWell])
+  func tileHeightTracksTheLeaf(design: RecordingPillDesign) throws {
+    let baseline = RecordingPillDesign.classic
+
+    let tileDelta = Self.tileSize(design).height - Self.tileSize(baseline).height
+    let leafDelta = try Self.leafHeight(design) - Self.leafHeight(baseline)
+
+    #expect(
+      abs(tileDelta - leafDelta) < 0.5,
+      """
+      the \(design) tile is \(tileDelta)pt taller than the \(baseline) tile while the \
+      PILLS differ by \(leafDelta)pt. The tile is not sized by the pill it contains, so \
+      it is drawing something else.
+      """)
+  }
+
+  /// **The two wordless designs are the same height, because they are the same
+  /// chrome.** A tile that routed one of them through the reading well's layout
+  /// would differ here, and the difference is what no static mock could catch.
+  @Test("the two wordless pills give tiles of equal height")
+  func wordlessTilesAgree() {
+    let capsule = Self.tileSize(.classic).height
+    let rail = Self.tileSize(.levelRail).height
+
+    #expect(capsule > 0 && rail > 0, "measured \(capsule)/\(rail): nothing rendered, which is not a pass")
+    #expect(
+      abs(capsule - rail) < 0.5,
+      "the capsule tile is \(capsule)pt and the level rail tile is \(rail)pt, so one of them is not the pill it claims")
+  }
+
+  /// **The first frame is already right, and this is the only row that can see
+  /// it.**
+  ///
+  /// The reading well's words come from `initialPreview:`. Without that seed the
+  /// well renders `.off` on its first layout pass, which is an EmptyView — the
+  /// tile would then be SHORTER than a capsule tile rather than taller, and would
+  /// visibly fill in a frame later. No size freeze would catch it; this ordering
+  /// does, and it fails in the informative direction.
+  @Test("the reading well tile already holds words on its first layout pass")
+  func theReadingWellIsSeeded() {
+    let well = Self.tileSize(.readingWell).height
+    let capsule = Self.tileSize(.classic).height
+
+    #expect(
+      well > capsule,
+      """
+      the reading well tile is \(well)pt against a \(capsule)pt capsule tile. A seeded \
+      well is TALLER; an unseeded one collapses to its header strip and fills in later. \
+      `initialPreview:` is not reaching the leaf.
+      """)
+  }
+
+  /// Each design asks for its own width, so no two tiles are interchangeable.
+  @Test("no two tiles are the same width")
+  func tileWidthsAreDistinct() {
+    let widths = RecordingPillDesign.allCases.map { Self.tileSize($0).width }
+    #expect(widths.allSatisfy { $0 > 0 }, "measured \(widths): nothing rendered")
+    #expect(
+      Set(widths).count == widths.count,
+      "two tiles measured the same width \(widths), so the picker shows one design twice")
+  }
+
+  // MARK: - What a screen reader gets
+
+  /// **The words that left the screen have to arrive somewhere, and the LABEL is
+  /// the only channel a macOS user cannot switch off.**
+  ///
+  /// VoiceOver Utility's Verbosity pane sets hints and extra content to "Do
+  /// Nothing", so a design that put the description in either could go silent on
+  /// a real reader's machine. WCAG 1.1.1 asks for a text alternative serving an
+  /// EQUIVALENT purpose, and once the tile is only a picture, the option's name
+  /// alone does not serve it.
+  ///
+  /// **What this row does NOT prove, stated rather than discovered later:** the
+  /// selected VALUE, the `.isSelected` TRAIT and DISABLED reporting are carried
+  /// by modifiers on the tile, and a hosted SwiftUI view's accessibility tree is
+  /// not readable from a test — measured 2026-08-25 and recorded in
+  /// `RenderedPillHarness`. Those three are unchanged from the control this tile
+  /// replaces and are confirmed by the VoiceOver pass in Live UAT.
+  @Test("every tile announces its name and what it looks like", arguments: RecordingPillDesign.allCases)
+  func theLabelCarriesNameAndDescription(design: RecordingPillDesign) {
+    let label = RecordingPillPreviewTile.accessibilityLabel(for: design)
+
+    #expect(
+      label.contains(design.displayName),
+      "the \(design) tile announces \"\(label)\", which does not name the option")
+    #expect(
+      label.contains(design.summary),
+      """
+      the \(design) tile announces \"\(label)\", which drops the description. That \
+      description is no longer on screen, so a reader who cannot see the picture now \
+      gets nothing about what this option looks like.
+      """)
+  }
+
+  @Test("no two tiles announce the same thing")
+  func labelsAreDistinct() {
+    let labels = RecordingPillDesign.allCases.map {
+      RecordingPillPreviewTile.accessibilityLabel(for: $0)
+    }
+    #expect(
+      Set(labels).count == labels.count,
+      "two tiles announce identically: \(labels)")
+  }
+
+  /// House style, swept over the surface that is now the ONLY place these strings
+  /// are read (GR-NO-DASHES).
+  @Test("no announced string carries a dash", arguments: RecordingPillDesign.allCases)
+  func labelsCarryNoDashes(design: RecordingPillDesign) {
+    let label = RecordingPillPreviewTile.accessibilityLabel(for: design)
+    #expect(!label.contains("\u{2014}"), "em dash in: \(label)")
+    #expect(!label.contains("\u{2013}"), "en dash in: \(label)")
+  }
+
+  /// The sample sentence is a real one, and the wordless designs get no words —
+  /// which is what makes their tiles pictures of a capsule rather than of a well.
+  @Test("only a design that can hold words is shown holding any", arguments: RecordingPillDesign.allCases)
+  func onlyWordCapableDesignsAreShownWords(design: RecordingPillDesign) {
+    switch RecordingPillPreviewTile.sampleDisplay(for: design) {
+    case .text(let sentence):
+      #expect(design.canHoldWords, "\(design) cannot hold words and is drawn holding \"\(sentence)\"")
+      #expect(!sentence.isEmpty, "\(design) is drawn holding an empty sentence")
+    case .off:
+      #expect(!design.canHoldWords, "\(design) can hold words and is drawn empty, so its tile understates it")
+    default:
+      Issue.record("\(design) is sampled in a transient state, which is not an appearance")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -219,9 +219,14 @@ struct RecordingPillTileTests {
       \(RecordingPillPreviewTile.sampleLevel). Both render the same instant, so a picker \
       showing them disagreeing is drawing a pill that cannot occur.
       """)
+    // **This is about an AUTHORED constant, not about a recording**, and the
+    // distinction matters if anyone copies the assertion: a genuinely SILENT take
+    // renders all-zeros for honest reasons and would fail it. Here the array is
+    // written by hand and a flat one would mean somebody replaced a waveform with
+    // a placeholder. Raised by a peer session against its own prewarm work.
     #expect(
       Set(history).count > 1,
-      "every sample is identical, so the meter draws a flat bar rather than a waveform")
+      "every sample in the authored waveform is identical, so the meter draws a flat bar")
   }
 
   @Test("no two tiles announce the same thing")
@@ -326,6 +331,97 @@ struct RecordingPillPreviewWiringTests {
     call.arguments.first { $0.label?.text == label }?.expression
   }
 
+  static let leaf = "Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift"
+
+  private final class StructFinder: SyntaxVisitor {
+    let wanted: String
+    private(set) var found: StructDeclSyntax?
+    init(_ wanted: String) {
+      self.wanted = wanted
+      super.init(viewMode: .sourceAccurate)
+    }
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+      if node.name.text == wanted { found = node }
+      return .visitChildren
+    }
+  }
+
+  private static func structDecl(named: String, in tree: SourceFileSyntax) -> StructDeclSyntax? {
+    let f = StructFinder(named)
+    f.walk(tree)
+    return f.found
+  }
+
+  /// Names of the `@State` properties declared DIRECTLY on this struct.
+  private static func stateProperties(of decl: StructDeclSyntax) -> Set<String> {
+    var names: Set<String> = []
+    for member in decl.memberBlock.members {
+      guard let variable = member.decl.as(VariableDeclSyntax.self) else { continue }
+      let isState = variable.attributes.contains { attribute in
+        attribute.as(AttributeSyntax.self)?
+          .attributeName.as(IdentifierTypeSyntax.self)?.name.text == "State"
+      }
+      guard isState else { continue }
+      for binding in variable.bindings {
+        if let pattern = binding.pattern.as(IdentifierPatternSyntax.self) {
+          names.insert(pattern.identifier.text)
+        }
+      }
+    }
+    return names
+  }
+
+  /// **Assignments the view makes to its own names, with initializers EXCLUDED.**
+  /// An init writes `_name = State(initialValue:)`, which is the seed itself, so
+  /// counting it would make every property look poll-written.
+  private final class AssignmentFinder: SyntaxVisitor {
+    private(set) var names: Set<String> = []
+    private var initDepth = 0
+
+    override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+      initDepth += 1
+      return .visitChildren
+    }
+    override func visitPost(_ node: InitializerDeclSyntax) { initDepth -= 1 }
+
+    /// **`SequenceExprSyntax`, not `InfixOperatorExprSyntax`.** An unfolded parse
+    /// represents `a = b` as a flat sequence — reference, operator, value — and
+    /// the folded infix form never appears. Reaching for the infix node returned
+    /// an EMPTY set, which the `audioTick` control below caught rather than
+    /// letting it pass as "the poll writes nothing".
+    override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+      guard initDepth == 0 else { return .visitChildren }
+      let elements = Array(node.elements)
+      guard elements.count >= 3,
+        let target = elements[0].as(DeclReferenceExprSyntax.self)
+      else { return .visitChildren }
+
+      let isAssignment =
+        elements[1].is(AssignmentExprSyntax.self)
+        || (elements[1].as(BinaryOperatorExprSyntax.self)?.operator.text.hasSuffix("=") ?? false)
+      if isAssignment { names.insert(target.baseName.text) }
+      return .visitChildren
+    }
+  }
+
+  private static func namesAssignedOutsideInit(of decl: StructDeclSyntax) -> Set<String> {
+    let f = AssignmentFinder(viewMode: .sourceAccurate)
+    f.walk(decl)
+    return f.names
+  }
+
+  /// Every parameter label on this struct's initializers.
+  private static func initParameterNames(of decl: StructDeclSyntax) -> Set<String> {
+    var names: Set<String> = []
+    for member in decl.memberBlock.members {
+      guard let initializer = member.decl.as(InitializerDeclSyntax.self) else { continue }
+      for parameter in initializer.signature.parameterClause.parameters {
+        names.insert((parameter.secondName ?? parameter.firstName).text)
+      }
+    }
+    return names
+  }
+
   @Test("the settings tile parks its poll instead of running one")
   func theTilePassesTheStillCadence() throws {
     let call = try Self.theConstruction()
@@ -418,6 +514,60 @@ struct RecordingPillPreviewWiringTests {
       initialLevelHistory is \(expr.trimmedDescription), not the sample waveform this \
       picker owns. `theSampleWaveformIsWellFormed` asserts that array's shape and would \
       then be asserting something nothing draws.
+      """)
+  }
+
+  /// **THE CLOSURE ROW. Every piece of `@State` the poll writes must be seedable,
+  /// and this ENUMERATES them from the poll body rather than from a list I wrote.**
+  ///
+  /// Three cloud-review rounds each found a different member of one set: the
+  /// reading well's words, the meter's history, then the level and the clock. That
+  /// is the signature of DESCRIBING a set instead of enumerating one — a
+  /// description always has a next counterexample, and the reviewer finds it
+  /// faster than the author can extend it.
+  ///
+  /// So the machine prints the structure. It reads `RecordingOverlayView`'s own
+  /// `@State` declarations, finds which of them the view assigns outside its
+  /// initializer, and requires an `initial<Name>` parameter for each. A fifth one
+  /// added later fails HERE, before a picker can ship drawing it wrong.
+  ///
+  /// `audioTick` is the one exemption and it is exempted BY NAME with its reason:
+  /// it is a counter rather than a picture, it exists so the meter appends on
+  /// every poll including silent ones, and seeding it to anything but zero would
+  /// suppress the meter's first append. The meter takes `initialHistory` instead.
+  @Test("every piece of state the poll writes can be seeded")
+  func thePollsStateIsSeedable() throws {
+    let text = try String(
+      contentsOf: RepoRoot.url.appending(path: Self.leaf), encoding: .utf8)
+    let view = try #require(
+      Self.structDecl(named: "RecordingOverlayView", in: Parser.parse(source: text)),
+      "RecordingOverlayView is not in \(Self.leaf) — this guard is pointed at the wrong file")
+
+    let stateNames = Self.stateProperties(of: view)
+    #expect(
+      stateNames.count >= 4,
+      "found \(stateNames.count) @State properties, which is fewer than the four this view is known to hold: \(stateNames)")
+
+    let written = Self.namesAssignedOutsideInit(of: view).intersection(stateNames)
+    #expect(
+      written.contains("audioTick"),
+      """
+      the poll no longer writes audioTick, so this guard's one exemption is stale and \
+      its reason needs re-reading rather than the name being deleted.
+      """)
+
+    let seeds = Self.initParameterNames(of: view)
+    let unseeded = written.subtracting(["audioTick"]).filter {
+      !seeds.contains("initial" + $0.prefix(1).uppercased() + $0.dropFirst())
+    }
+
+    #expect(
+      unseeded.isEmpty,
+      """
+      the poll writes \(unseeded.sorted()) and the view takes no seed for them, so a pill \
+      rendered as a PICTURE draws those at their zero value and then snaps once the single \
+      poll lands. Add `initial<Name>` and pass it from the picker, or state here why this \
+      one is a counter rather than a picture.
       """)
   }
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -1,5 +1,8 @@
 import AppKit
 import EnviousWisprCore
+import Foundation
+import SwiftParser
+import SwiftSyntax
 import SwiftUI
 import Testing
 
@@ -67,8 +70,11 @@ struct RecordingPillTileTests {
     let tileDelta = Self.tileSize(design).height - Self.tileSize(baseline).height
     let leafDelta = try Self.leafHeight(design) - Self.leafHeight(baseline)
 
+    // Equality, with no tolerance: the tile's padding cancels algebraically from
+    // both sides of one in-process comparison, so a tolerance would only be a
+    // number nobody measured.
     #expect(
-      abs(tileDelta - leafDelta) < 0.5,
+      tileDelta == leafDelta,
       """
       the \(design) tile is \(tileDelta)pt taller than the \(baseline) tile while the \
       PILLS differ by \(leafDelta)pt. The tile is not sized by the pill it contains, so \
@@ -86,29 +92,31 @@ struct RecordingPillTileTests {
 
     #expect(capsule > 0 && rail > 0, "measured \(capsule)/\(rail): nothing rendered, which is not a pass")
     #expect(
-      abs(capsule - rail) < 0.5,
+      capsule == rail,
       "the capsule tile is \(capsule)pt and the level rail tile is \(rail)pt, so one of them is not the pill it claims")
   }
 
-  /// **The first frame is already right, and this is the only row that can see
-  /// it.**
+  /// **The reading well ends up taller, which is a FINAL geometry outcome and not
+  /// a claim about the first frame.**
   ///
-  /// The reading well's words come from `initialPreview:`. Without that seed the
-  /// well renders `.off` on its first layout pass, which is an EmptyView — the
-  /// tile would then be SHORTER than a capsule tile rather than taller, and would
-  /// visibly fill in a frame later. No size freeze would catch it; this ordering
-  /// does, and it fails in the informative direction.
-  @Test("the reading well tile already holds words on its first layout pass")
-  func theReadingWellIsSeeded() {
+  /// This row was first named for `initialPreview:` seeding, and it cannot prove
+  /// that: the leaf's first asynchronous provider read can win before
+  /// `fittingSize` is sampled, so an unseeded tile measures tall here too. What
+  /// it does prove is that the design which shows your words renders visibly more
+  /// than one that cannot, which a placeholder-sized well would fail.
+  ///
+  /// The seeding has no rendered observable at all, so it is covered structurally
+  /// by `RecordingPillPreviewWiringTests` below.
+  @Test("the rendered reading well tile is taller than a wordless tile")
+  func theReadingWellRendersTaller() {
     let well = Self.tileSize(.readingWell).height
     let capsule = Self.tileSize(.classic).height
 
     #expect(
       well > capsule,
       """
-      the reading well tile is \(well)pt against a \(capsule)pt capsule tile. A seeded \
-      well is TALLER; an unseeded one collapses to its header strip and fills in later. \
-      `initialPreview:` is not reaching the leaf.
+      the reading well tile is \(well)pt against a \(capsule)pt capsule tile, so the \
+      design that shows your words as you speak is drawn no larger than one that cannot.
       """)
   }
 
@@ -187,5 +195,165 @@ struct RecordingPillTileTests {
     default:
       Issue.record("\(design) is sampled in a transient state, which is not an appearance")
     }
+  }
+}
+
+// MARK: - The wiring that has no rendered observable
+
+/// How the settings tile CONSTRUCTS the recording leaf (#2435).
+///
+/// **Drift Guard, and the class is the point.** When this fails we changed our
+/// own code and the user sees nothing at that moment. It must never be cited as
+/// evidence that the picker looks right — `RecordingPillTileTests` measures what
+/// is drawn, and the Live UAT pass is what proves it to a person.
+///
+/// **It exists because every decision it covers has NO rendered observable, which
+/// was established rather than assumed.** Whether a `repeatForever` animation is
+/// armed cannot be read back from a hosted view; whether the poll parks cannot be
+/// counted from outside a `private` struct's own constant providers; whether the
+/// first frame was seeded is indistinguishable from the first asynchronous read
+/// winning the race to `fittingSize`; and a locked sample changes paint, which
+/// `fittingSize` is blind to. Each would ship green if it silently reverted, and
+/// each costs a user something real: a settings page that animates forever, three
+/// tiles reading their providers sixty times a second between them, a reading well
+/// that flashes empty, and a picker comparing a locked pill against unlocked ones.
+///
+/// **It PARSES rather than matching text**, for the reason
+/// `OverlayRetainedWindowTests` already records: a guard whose subject is a
+/// construct will otherwise match the prose ABOUT that construct, and this file
+/// has a comment beside every one of these arguments explaining it.
+@Suite(.tags(.driftGuard))
+struct RecordingPillPreviewWiringTests {
+
+  private final class OverlayConstructionFinder: SyntaxVisitor {
+    private(set) var calls: [FunctionCallExprSyntax] = []
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+      if let callee = node.calledExpression.as(DeclReferenceExprSyntax.self),
+        callee.baseName.text == "RecordingOverlayView"
+      {
+        calls.append(node)
+      }
+      return .visitChildren
+    }
+  }
+
+  private static let panel =
+    "Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift"
+
+  /// The one construction, required rather than expected: a file that grew a
+  /// second one would make every row below ambiguous rather than failing.
+  private static func theConstruction() throws -> FunctionCallExprSyntax {
+    let text = try String(
+      contentsOf: RepoRoot.url.appending(path: panel), encoding: .utf8)
+    let finder = OverlayConstructionFinder(viewMode: .sourceAccurate)
+    finder.walk(Parser.parse(source: text))
+
+    #expect(
+      finder.calls.count == 1,
+      """
+      \(panel) constructs RecordingOverlayView \(finder.calls.count) times. Zero means \
+      this guard is pointed at the wrong file and proves nothing; more than one means \
+      the rows below are checking an arbitrary one of them.
+      """)
+    return try #require(finder.calls.first)
+  }
+
+  private static func argument(
+    _ label: String, of call: FunctionCallExprSyntax
+  ) -> ExprSyntax? {
+    call.arguments.first { $0.label?.text == label }?.expression
+  }
+
+  @Test("the settings tile parks its poll instead of running one")
+  func theTilePassesTheStillCadence() throws {
+    let call = try Self.theConstruction()
+    let expr = try #require(
+      Self.argument("cadence", of: call), "the tile passes no cadence, so it polls at 50 ms")
+    let member = try #require(
+      expr.as(MemberAccessExprSyntax.self),
+      "the cadence is \(expr.trimmedDescription), which this guard cannot judge")
+
+    #expect(
+      member.declName.baseName.text == "still",
+      """
+      the settings tile passes cadence .\(member.declName.baseName.text). Three tiles on \
+      a live cadence read their providers sixty times a second between them for as long \
+      as the window is open.
+      """)
+  }
+
+  @Test("the settings tile does not breathe")
+  func theTileDisablesTheGlow() throws {
+    let call = try Self.theConstruction()
+    let expr = try #require(
+      Self.argument("animatesGlow", of: call),
+      "the tile passes no animatesGlow, so it takes the default true and pulses forever")
+    let literal = try #require(
+      expr.as(BooleanLiteralExprSyntax.self),
+      "animatesGlow is \(expr.trimmedDescription), which this guard cannot judge")
+
+    #expect(
+      literal.literal.tokenKind == .keyword(.false),
+      "the settings tile passes animatesGlow: true, so every capsule tile runs a permanent two second pulse")
+  }
+
+  /// **The seed and the provider must be the SAME expression**, which is the
+  /// property rather than the spelling. A seed of `.off` renders an empty reading
+  /// well on the first frame; a seed of some OTHER display renders the wrong
+  /// picture until the first poll replaces it. Both are invisible to a size test.
+  @Test("the first frame is seeded with exactly what the provider returns")
+  func theSeedMatchesTheProvider() throws {
+    let call = try Self.theConstruction()
+
+    let seed = try #require(
+      Self.argument("initialPreview", of: call)?.as(DeclReferenceExprSyntax.self),
+      """
+      initialPreview is \
+      \(Self.argument("initialPreview", of: call)?.trimmedDescription ?? "absent"), not a \
+      reference to the same value the provider returns. Absent means it defaults to .off \
+      and the reading well flashes empty.
+      """)
+
+    let provider = try #require(
+      Self.argument("livePreviewProvider", of: call)?.as(ClosureExprSyntax.self),
+      "livePreviewProvider is not a literal closure, so this guard cannot compare the two")
+    let onlyStatement = try #require(
+      provider.statements.count == 1 ? provider.statements.first : nil,
+      "livePreviewProvider has \(provider.statements.count) statements; this guard reads a single expression")
+    let returned = try #require(
+      onlyStatement.item.as(ExprSyntax.self)?.as(DeclReferenceExprSyntax.self),
+      "livePreviewProvider returns \(onlyStatement.item.trimmedDescription), not a plain reference")
+
+    #expect(
+      seed.baseName.text == returned.baseName.text,
+      """
+      the tile seeds its first frame with `\(seed.baseName.text)` and its provider returns \
+      `\(returned.baseName.text)`. The seed is what the user sees before the first poll, so \
+      these disagreeing means the picker briefly shows a picture nothing chose.
+      """)
+  }
+
+  /// The sample is FIXED, and these two are the ones that change the pixels. A
+  /// picker showing one design locked and another unlocked would be comparing
+  /// two different things and calling it a choice.
+  @Test("the sample pill is unlocked and carries no notice")
+  func theSampleStateIsFixed() throws {
+    let call = try Self.theConstruction()
+
+    let locked = try #require(
+      Self.argument("isLocked", of: call)?.as(BooleanLiteralExprSyntax.self),
+      "isLocked is not a literal, so the tile's sample state depends on something")
+    #expect(
+      locked.literal.tokenKind == .keyword(.false),
+      "the tile draws the hands free variant, which is a mode rather than an appearance")
+
+    let notice = Self.argument("noticeText", of: call)
+    #expect(
+      notice?.is(NilLiteralExprSyntax.self) == true,
+      """
+      noticeText is \(notice?.trimmedDescription ?? "absent"). The #1060 banner is a runtime \
+      event, so a picker drawing one is showing a state the design does not have.
+      """)
   }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -130,6 +130,36 @@ struct RecordingPillTileTests {
       "two tiles measured the same width \(widths), so the picker shows one design twice")
   }
 
+  /// **Every tile asks for its design's DECLARED width, and the excess over that
+  /// is one constant shared by all three.**
+  ///
+  /// Cloud review on #2439 raised the reading well overflowing a narrow window.
+  /// This is the half that can be measured rather than argued: the tile's ideal
+  /// width is the design's own `width` plus a padding that does not vary by
+  /// design. Whether the containing window can ever be narrower than that is a
+  /// Live UAT row, and the horizontal scroll fallback is what keeps it from
+  /// clipping when it is.
+  @Test("a tile asks for its design's declared width plus a shared padding")
+  func tileWidthIsTheDesignWidthPlusOnePadding() {
+    let overheads = RecordingPillDesign.allCases.map {
+      Self.tileSize($0).width - $0.width
+    }
+
+    #expect(
+      overheads.allSatisfy { $0 > 0 },
+      """
+      measured overheads \(overheads). A tile no wider than its design's declared width \
+      has no padding at all, which means the pill is touching the tile's border.
+      """)
+    #expect(
+      Set(overheads).count == 1,
+      """
+      the three tiles add \(overheads) to their designs' widths. They share one padding \
+      constant, so a difference means a tile is sized by something other than the pill \
+      inside it.
+      """)
+  }
+
   // MARK: - What a screen reader gets
 
   /// **The words that left the screen have to arrive somewhere, and the LABEL is
@@ -161,6 +191,37 @@ struct RecordingPillTileTests {
       description is no longer on screen, so a reader who cannot see the picture now \
       gets nothing about what this option looks like.
       """)
+  }
+
+  /// **The still pill's meter is DRAWN from this, so it is the picture.**
+  ///
+  /// Nothing rendered can see it: the meter is paint, and `fittingSize` is blind
+  /// to paint. So the shape is asserted here and the wiring in
+  /// `RecordingPillPreviewWiringTests`.
+  @Test("the sample waveform fills the meter and ends where the mark is")
+  func theSampleWaveformIsWellFormed() {
+    let history = RecordingPillPreviewTile.sampleLevelHistory
+
+    #expect(
+      history.count == RainbowLevelMeter.barCount,
+      """
+      the sample waveform has \(history.count) samples for \(RainbowLevelMeter.barCount) \
+      bars. Short pads the OLD end with silence, which is survivable; long silently \
+      drops the oldest, which is not what this array is claiming to be.
+      """)
+    #expect(
+      history.allSatisfy { $0 >= 0 && $0 <= 1 },
+      "a sample outside 0...1 clamps at the meter and is not the shape written here: \(history)")
+    #expect(
+      history.last == CGFloat(RecordingPillPreviewTile.sampleLevel),
+      """
+      the waveform ends at \(history.last ?? -1) while the rainbow mark is driven by \
+      \(RecordingPillPreviewTile.sampleLevel). Both render the same instant, so a picker \
+      showing them disagreeing is drawing a pill that cannot occur.
+      """)
+    #expect(
+      Set(history).count > 1,
+      "every sample is identical, so the meter draws a flat bar rather than a waveform")
   }
 
   @Test("no two tiles announce the same thing")
@@ -331,6 +392,32 @@ struct RecordingPillPreviewWiringTests {
       the tile seeds its first frame with `\(seed.baseName.text)` and its provider returns \
       `\(returned.baseName.text)`. The seed is what the user sees before the first poll, so \
       these disagreeing means the picker briefly shows a picture nothing chose.
+      """)
+  }
+
+  /// **The seeded meter has no rendered observable at all**, because the meter is
+  /// paint and `fittingSize` cannot see paint. Without the seed the rail draws one
+  /// bar at the sample level and twenty-three at the silence floor, which is a
+  /// picture of the wrong design, and every size row in the suite still passes.
+  @Test("the still meter is handed a history to draw")
+  func theMeterIsSeeded() throws {
+    let call = try Self.theConstruction()
+    let expr = try #require(
+      Self.argument("initialLevelHistory", of: call),
+      """
+      the tile passes no initialLevelHistory, so the meter starts empty and a pill that \
+      never polls draws a single bar. The Level Rail IS that meter.
+      """)
+
+    #expect(
+      expr.as(ArrayExprSyntax.self)?.elements.isEmpty != true,
+      "initialLevelHistory is an empty literal, which is the same as not passing it")
+    #expect(
+      expr.trimmedDescription.contains("sampleLevelHistory"),
+      """
+      initialLevelHistory is \(expr.trimmedDescription), not the sample waveform this \
+      picker owns. `theSampleWaveformIsWellFormed` asserts that array's shape and would \
+      then be asserting something nothing draws.
       """)
   }
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -160,6 +160,45 @@ struct RecordingPillTileTests {
       """)
   }
 
+  /// **The page refuses to be narrower than its widest pill.**
+  ///
+  /// Rendered at a 380 point content width the reading well was CUT OFF: a grid
+  /// column cannot shrink below its content and the tile clips its own, so there
+  /// is no width at which a too-narrow layout degrades gracefully. The panel
+  /// therefore carries a minimum that propagates to the window.
+  ///
+  /// Asserted as a RELATION against the tile's own width, so no point value is
+  /// frozen. What this does NOT prove is that the WINDOW honours it — that is a
+  /// Live UAT row, dragging the real window narrow.
+  @Test("the picker will not lay out narrower than its widest pill")
+  func thePanelRefusesToClipItsWidestPill() {
+    let widest = RecordingPillDesign.allCases
+      .filter(\.canHoldWords)
+      .map(RecordingPillPreviewTile.width(for:))
+      .max()
+    let required = try! #require(widest, "no design can hold words, so this guard has no subject")
+
+    #expect(
+      RecordingPillAppearancePanel.widestTile(holdingWords: true) == required,
+      """
+      the panel sizes its with-words column to \
+      \(RecordingPillAppearancePanel.widestTile(holdingWords: true)) while its widest tile \
+      needs \(required). A column narrower than its tile clips the pill, because the tile \
+      clips its own content.
+      """)
+
+    // And the wordless side, which has its own widest design.
+    let wordless = RecordingPillDesign.allCases
+      .filter { !$0.canHoldWords }
+      .map(RecordingPillPreviewTile.width(for:))
+      .max()
+    if let wordless {
+      #expect(
+        RecordingPillAppearancePanel.widestTile(holdingWords: false) == wordless,
+        "the wordless column is sized to something other than its widest tile")
+    }
+  }
+
   // MARK: - What a screen reader gets
 
   /// **The words that left the screen have to arrive somewhere, and the LABEL is

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPollingLifetimeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPollingLifetimeTests.swift
@@ -282,31 +282,56 @@ struct RecordingPollingLifetimeTests {
   /// the live cadence, one layer down, asserted on the cadence VALUE so it holds
   /// however that value is used.
   ///
-  /// **The park is asserted to release BECAUSE of cancellation, not merely to
-  /// return.** A `wait` that did nothing at all would return too, and a row whose
-  /// only assertion is "it came back" passes on it. Reading `Task.isCancelled`
-  /// on the far side of the wait is the terminal outcome: `false` means the park
-  /// released on its own, which is the defect that would put a settings page
-  /// back to twenty reads a second.
+  /// **The park must NOT return while its task is uncancelled — and the earlier
+  /// version of this row could not see that, which a mutation run proved rather
+  /// than suggested.**
   ///
-  /// A park that ignored cancellation still hangs, and is reported by the row's
-  /// own time limit rather than by an assertion — that half cannot be helped, and
-  /// it fails loudly either way.
-  @Test("a still cadence releases when its task is cancelled", .timeLimit(.minutes(1)))
-  func stillReleasesOnCancellation() async {
+  /// It read `Task.isCancelled` on the far side of the wait and required `true`.
+  /// Against a `.still` mutated to `continuation.finish()` — a cadence that parks
+  /// for nothing and returns at once — the row still PASSED, because the mutant's
+  /// wait suspends just long enough for the main actor to run the test's own
+  /// `cancel()` first. So `isCancelled` was true, the assertion held, and the
+  /// guard was decorative. Written after its fix against already-correct code, it
+  /// was indistinguishable from a row that cannot fail.
+  ///
+  /// **The discriminating property is the one the earlier row assumed: does the
+  /// wait return while nothing has cancelled it.** So this never cancels at all
+  /// for that half. `Task.yield()` hands the main actor over repeatedly — a
+  /// SCHEDULING barrier, not elapsed time, so it is not the guess-when-the-subject-
+  /// is-finished shape and adds no real-time dependence. A correct park cannot
+  /// return across any number of yields; the mutant returns on the first.
+  ///
+  /// The cancellation half is kept as the second arm, so the row still proves the
+  /// park RELEASES rather than merely never returning — a `wait` that hangs
+  /// forever would satisfy arm one alone.
+  @Test("a still cadence parks until cancelled, and only until cancelled", .timeLimit(.minutes(1)))
+  func stillParksUntilCancelled() async {
+    final class Flag: @unchecked Sendable { var returned = false }
+
+    // ARM 1: uncancelled, it must not come back.
+    let flag = Flag()
     let entered = Latch()
-    let task = Task { @MainActor in
+    let parked = Task { @MainActor in
       entered.signal()
       await RecordingPollCadence.still.wait()
-      return Task.isCancelled
+      flag.returned = true
     }
-
     await entered.wait()
-    task.cancel()
+    for _ in 0..<32 { await Task.yield() }
 
-    let releasedAfterCancellation = await task.value
     #expect(
-      releasedAfterCancellation,
-      "the still cadence returned before its task was cancelled")
+      !flag.returned,
+      """
+      the still cadence returned with nothing cancelling it, so it does not park at all \
+      and every pill using it polls exactly as fast as the loop can run.
+      """)
+
+    // ARM 2: and it does come back once cancelled, or a park that simply hangs
+    // forever would satisfy arm one.
+    parked.cancel()
+    await parked.value
+    #expect(
+      flag.returned,
+      "the still cadence did not release on cancellation, so its task outlives the view")
   }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPollingLifetimeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPollingLifetimeTests.swift
@@ -118,6 +118,28 @@ struct RecordingPollingLifetimeTests {
     var all: [Int] { [audio, elapsed, preview] }
   }
 
+  /// A one-shot latch: the subject announces, the test suspends until it has.
+  ///
+  /// Signalling BEFORE anyone waits is the ordinary case here rather than an edge
+  /// case, so it latches instead of requiring a waiter to already be present.
+  @MainActor
+  private final class Latch {
+    private var fired = false
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    func signal() {
+      guard !fired else { return }
+      fired = true
+      waiter?.resume()
+      waiter = nil
+    }
+
+    func wait() async {
+      if fired { return }
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in waiter = c }
+    }
+  }
+
   private static let screen = ScreenGeometry(
     id: ScreenID(rawValue: 1),
     frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
@@ -192,5 +214,99 @@ struct RecordingPollingLifetimeTests {
     #expect(
       counts.all == afterOneTick,
       "a hidden pill kept polling: \(afterOneTick) became \(counts.all)")
+  }
+
+  // MARK: - The still cadence (#2435)
+
+  /// **Product Outcome.** The Appearance picker draws three recording pills as
+  /// PICTURES. On `.live` each would read its providers twenty times a second for
+  /// as long as the settings window is open, so a page that shows what a pill
+  /// looks like would cost more than showing one.
+  ///
+  /// **This row proves the FIRST READ still happens and is the LAST one.** The
+  /// count is taken at the moment the loop parks, which the pill's own provider
+  /// announces — no elapsed time, and no inference that a subject is finished.
+  ///
+  /// The non-vacuous control is the row above: with a cadence the test can
+  /// advance, the very same counters move. A subject that never polled at all
+  /// would fail there.
+  @Test("a still recording pill reads its providers once, then parks", .timeLimit(.minutes(1)))
+  func aStillPillReadsOnceThenParks() async throws {
+    let counts = Counts()
+    let parked = Latch()
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } })
+    defer { host.hide() }
+
+    let view = RecordingOverlayView(
+      audioLevelProvider: {
+        counts.audio += 1
+        return 0.4
+      },
+      recordingElapsedProvider: {
+        counts.elapsed += 1
+        return 12
+      },
+      livePreviewProvider: {
+        counts.preview += 1
+        // LAST of the three reads in the loop body, so the latch fires with the
+        // whole first poll complete rather than part-way through it.
+        parked.signal()
+        return .off
+      },
+      onContentHeightChange: { _ in },
+      chrome: RecordingPillDesign.classic.chrome,
+      isLocked: false,
+      noticeText: nil,
+      cadence: .still)
+
+    let hosted = NSHostingView(rootView: AnyView(view))
+    try #require(
+      host.present(
+        hosted, width: .fixed(RecordingPillDesign.classic.width),
+        fixedHeight: RecordingPillDesign.classic.reservedHeight,
+        isFresh: true, position: .top),
+      "the still pill never reached the host")
+
+    await parked.wait()
+    #expect(
+      counts.all == [1, 1, 1],
+      """
+      a still pill read \(counts.all) on its first poll, not one of each. \
+      `.still` suppresses REPEATED reads; the first one is what seeds the frame.
+      """)
+  }
+
+  /// **The other half of `.still`, and the failure it guards is a LEAK.** A park
+  /// that outlives its view keeps the pill's task alive for the rest of the
+  /// session with nothing on screen — the same defect the first row proves for
+  /// the live cadence, one layer down, asserted on the cadence VALUE so it holds
+  /// however that value is used.
+  ///
+  /// **The park is asserted to release BECAUSE of cancellation, not merely to
+  /// return.** A `wait` that did nothing at all would return too, and a row whose
+  /// only assertion is "it came back" passes on it. Reading `Task.isCancelled`
+  /// on the far side of the wait is the terminal outcome: `false` means the park
+  /// released on its own, which is the defect that would put a settings page
+  /// back to twenty reads a second.
+  ///
+  /// A park that ignored cancellation still hangs, and is reported by the row's
+  /// own time limit rather than by an assertion — that half cannot be helped, and
+  /// it fails loudly either way.
+  @Test("a still cadence releases when its task is cancelled", .timeLimit(.minutes(1)))
+  func stillReleasesOnCancellation() async {
+    let entered = Latch()
+    let task = Task { @MainActor in
+      entered.signal()
+      await RecordingPollCadence.still.wait()
+      return Task.isCancelled
+    }
+
+    await entered.wait()
+    task.cancel()
+
+    let releasedAfterCancellation = await task.value
+    #expect(
+      releasedAfterCancellation,
+      "the still cadence returned before its task was cancelled")
   }
 }

--- a/website/src/content/help/sounds-and-appearance.md
+++ b/website/src/content/help/sounds-and-appearance.md
@@ -15,7 +15,7 @@ EnviousWispr follows your macOS appearance setting by default, and you can overr
 
 ### Where the recording bar appears
 
-The recording bar shows you when EnviousWispr is listening, and you can put it wherever suits your screen. Go to **Settings**, then select **Appearance**. Use **Recording Indicator Position** to place the bar at either the top or the bottom of your screen.
+The recording bar shows you when EnviousWispr is listening, and you can put it wherever suits your screen. Go to **Settings**, then select **Appearance**. Use **Pill Position** to place the bar at either the top or the bottom of your screen.
 
 You can also move the bar during a dictation.
 


### PR DESCRIPTION
Closes #2435

## What a user gets

The Appearance page described three pictures in prose. It now shows them. Each
recording-pill option is the REAL pill, drawn by the same view the overlay uses,
so you can see what you are choosing without starting a dictation to find out.

The words that left the screen did not disappear — they moved into the
accessibility label, which is the one channel a macOS user cannot switch off.

The theme cards went horizontal and lost their descriptions, and the page's two
"changes apply next time" sentences became one. (The 191-to-90 figure in the plan
was measured on the mockup; the shipped card's real height is in the Live UAT
screenshots rather than asserted here.)

## Lane

`Tier: MEDIUM | Test: required (AppKit) | Modules: EnviousWisprAppKit`

Lane: **Code** (primary), `mixed_pr: true` — `website/src/content/help/sounds-and-appearance.md`
named "Recording Indicator Position", which this renames to "Pill Position". Found
by the rename sweep, fixed in the same commit.

Live UAT: **Y**.

## The two additive seams, and why a settings page needed them

`RecordingOverlayView` is a heart-path view. Drawing three of them on a settings
page needed exactly two things, both defaulted to today's behaviour:

- **`RecordingPollCadence.still`** parks until its task is cancelled, so a tile
  reads its providers once instead of twenty times a second. A park rather than a
  long sleep: every finite duration eventually repolls for no reason, and the
  duration would be a number nobody measured.
- **`animatesGlow`** on `OverlayCapsuleBackground` and `RecordingOverlayView`
  stops the two-second hairline pulse. A hairline that is not breathing now takes
  the chosen steady 0.5 instead of sitting at the loop's dim 0.3 endpoint — which
  would have shown a duller pill than the user actually gets.

All eight `OverlayCapsuleBackground` call sites and the one production
`RecordingOverlayView` call site are unchanged.

## Founder decisions, taken before any code (2026-08-26)

1. **Group titles stay "Live Preview off" / "Live Preview on".** They name a
   CONDITION, not the current state — read as a status claim they would be false
   at `engineUnsupported` and `modelBeingRemoved`. What makes the condition
   reading the one a user gets is that exactly one group carries the filled dot
   and the other prints its own reason, so both are requirements rather than
   decoration and both are asserted.
2. **One next-recording line** for the page, replacing two.
3. **All three theme descriptions deleted, titles unchanged.** `System` keeps its
   name; a caption and an `Auto` rename were both offered and declined. That the
   split thumbnail can no longer say the card FOLLOWS the Mac is the accepted
   trade, recorded in the type's doc comment so nobody restores it by accident.
4. **Screen readers get the name AND the description in the LABEL.** Consulted
   rather than chosen: WCAG 1.1.1 asks for a text alternative serving an
   EQUIVALENT purpose once the tile is only a picture, and VoiceOver Utility lets
   a user set hints and custom content to "Do Nothing", so the label is the only
   channel guaranteed to be announced.

## Layout

`ViewThatFits` at two levels rather than a width breakpoint, so the groups sit
side by side when they fit and stack when they do not, with every pill drawn at
TRUE SIZE either way. The settings window opens at 820 points, where a
side-by-side arrangement needs a shared 0.47 scale factor and the reading well's
words become unreadable.

## Testing

Debug suite green. `RecordingPillTileTests` measures the tile's height against an
independent measurement of the leaf as a DIFFERENCE, so no absolute rendered size
is frozen — the Debug-green / CI-red lesson of 2026-08-25 is that a point value is
a reading of one Mac's font metrics.

`RecordingPillPreviewWiringTests` is a source-parsing drift guard for the four
decisions with NO rendered observable: the still cadence, the disabled glow, the
seeded first frame, and the fixed sample state. All four would ship green if they
silently reverted.

**Three limits, stated rather than left to be found:**

- A drift guard is a claim about our source, never about pixels. It must not be
  cited as evidence the picker looks right.
- The accessibility VALUE, `.isSelected` TRAIT and DISABLED reporting are not
  asserted — a hosted SwiftUI view's accessibility tree returns one empty
  `AXGroup` (measured 2026-08-25, recorded in `RenderedPillHarness`). Only the
  LABEL is assertable; the rest is the Live UAT VoiceOver pass.
- `ViewThatFits` deliberately has no test. "Narrow renders taller" can pass
  because of unrelated wrapping and never says which candidate rendered.

Overnight hardening: **#2438**, eight rows, all validated runnable.

## Review

Two orchestrator rounds against the real diff. Round 1 returned three findings
(a still capsule frozen at the loop's dim endpoint; a cancellation row that passed
on a no-op wait; a level-meter fade on every view recreation). Round 2 returned
five (a theme grid too narrow for its new row layout; an ambiguous footnote; a
comment asserting grid recycling that does not happen; two unmeasured tolerances;
and a test whose name claimed first-frame seeding it cannot observe). All eight
adopted, one with modified copy: the footnote says "the next time the pill
appears" rather than "the next time you record", because the position setting also
places status notices, which the deleted copy said outright.
