### PR TITLE
Live Preview settings: one status bar, keep the engine cards, retire the 54-row language table (#2436)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
@@ -24,8 +24,18 @@ struct LanguageLockSheet: View {
   /// makes the setting mean what it says.
   let lockableCodes: Set<String>?
 
-  init(lockableCodes: Set<String>? = nil) {
+  /// One line of caller context under the title, or nil for none (#2436).
+  ///
+  /// Live Preview passes the dictation caveat; the Transcription page passes
+  /// nothing and is unchanged by construction, since the parameter is defaulted.
+  /// The sentence lives HERE rather than beside the button that opens this sheet
+  /// because it states a consequence of the action, and a consequence belongs at
+  /// the moment it becomes true.
+  let contextSubtitle: String?
+
+  init(lockableCodes: Set<String>? = nil, contextSubtitle: String? = nil) {
     self.lockableCodes = lockableCodes
+    self.contextSubtitle = contextSubtitle
   }
 
   @State private var searchText: String = ""
@@ -40,6 +50,14 @@ struct LanguageLockSheet: View {
   var body: some View {
     NavigationStack {
       VStack(spacing: 0) {
+        if let contextSubtitle {
+          Text(contextSubtitle)
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+        }
         searchField
 
         ScrollView {

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
@@ -131,10 +131,11 @@ struct LivePreviewPackCatalogSheet: View {
     .overlay(RoundedRectangle(cornerRadius: 9).strokeBorder(Color.stDivider, lineWidth: 1))
   }
 
-  /// Both counts come from the SAME grouping the rows do, so a chip can never disagree
-  /// with the list under it.
+  /// Both counts come from the SAME searched grouping the rows do, so a chip can never
+  /// disagree with the list under it — including while a search is active, which is the
+  /// case that shipped wrong for one review round.
   private var filterChips: some View {
-    let groups = LivePreviewPackPresentation.groups(from: loadedPacks)
+    let groups = visibleGroups
     return HStack(spacing: 6) {
       chip(
         title: LivePreviewSettingsCopy.catalogFilterAvailable,
@@ -217,12 +218,17 @@ struct LivePreviewPackCatalogSheet: View {
     return rows
   }
 
-  /// Filter, then search, then the group's own order. `groups(from:)` still owns the
-  /// installed-first policy, so its tests still mean something.
+  /// **One searched grouping feeds BOTH the chips and the rows.** Computing them
+  /// separately is how the chips came to count the full catalogue while the rows showed
+  /// only matches — a chip reading "Not on this Mac 53" above one row is worse than no
+  /// chip. `groups(from:matching:)` owns the policy, so there is one answer to disagree
+  /// with rather than two.
+  private var visibleGroups: LivePreviewPackPresentation.Groups {
+    LivePreviewPackPresentation.groups(from: loadedPacks, matching: searchText)
+  }
+
   private var visibleRows: [LivePreviewPack] {
-    let groups = LivePreviewPackPresentation.groups(from: loadedPacks)
-    let half = showingInstalled ? groups.installed : groups.available
-    return LivePreviewPackPresentation.matching(half, query: searchText)
+    showingInstalled ? visibleGroups.installed : visibleGroups.available
   }
 
   @ViewBuilder

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
@@ -1,0 +1,281 @@
+import EnviousWisprLivePreview
+import SwiftUI
+
+/// The Apple language catalogue, as a sheet rather than fifty-four rows on the page (#2436).
+///
+/// **Why it left the page.** Founder, 2026-08-25: the settings page had "a super long
+/// never ending scrolling language selector". Measured on his Mac the day #2080 shipped:
+/// one language installed, fifty-three downloadable, so the tallest thing on a page about
+/// switching a feature on was fifty-three downloads nobody asked for.
+///
+/// **The split it preserves is the founder's, not a new one** (`live-preview.md`
+/// RULE: the-picker-offers-what-works-now-the-table-is-the-catalogue): the picker answers
+/// "what can I switch to right now" and lists installed languages only; THIS is the
+/// catalogue, the only place a language is acquired. #2436 makes that split physical —
+/// two sheets — instead of a sheet and an inline table.
+///
+/// Carried verbatim from `packsSection`, on why the Source column existed and why it does
+/// not need to any more:
+///
+/// > **One table, replacing the two cards #2080 shipped.** Those cards existed
+/// > to make the installed/downloadable boundary visible after ten rows, which a
+/// > Source column does better: it aligns, it scans, and it does not split the
+/// > list in half. Group ORDER is preserved — installed first — so
+/// > `LivePreviewPackPresentation.groups(from:)` still owns the policy and its
+/// > tests still mean something.
+///
+/// The boundary is now the FILTER, which does the same job in a place where it can also
+/// be the default: this sheet opens on `Not on this Mac`, because acquiring is the only
+/// reason to be here. `groups(from:)` still owns the policy and still supplies both counts.
+///
+/// Also carried, and still binding:
+///
+/// > No drag handles and no per-row overflow menu, both of which the mockup
+/// > drew: nothing in the app orders languages, and Apple's packs are not ours
+/// > to delete, so each would be a control with nothing behind it (founder,
+/// > Gate 1).
+struct LivePreviewPackCatalogSheet: View {
+  @Environment(\.dismiss) private var dismiss
+
+  /// **Owned by the WINDOW, not by this sheet.** The install workflow outlives any
+  /// presentation: dismissing this sheet mid-download must not cancel it, which is why
+  /// the model is passed in rather than created here.
+  let packs: LivePreviewPacksModel
+
+  /// The pack tag currently producing the preview, or nil.
+  ///
+  /// Resolved by the CALLER, which owns the two gates that decide whether "In use" is a
+  /// claim we may make. Carried verbatim from `isActive`:
+  ///
+  /// > Gated on the toggle because "In use" is a claim about a running preview,
+  /// > and nothing runs while the feature is off. Gated on the ENGINE because
+  /// > these are Apple's packs: with the universal engine selected the badge would
+  /// > name a language that is not the one on screen.
+  let activeTag: String?
+
+  /// Seeded by the status bar's remedy with the missing language's NAME, so the row a
+  /// user was sent here for is already on screen. Empty from the Languages row, where
+  /// there is no particular language in question.
+  init(packs: LivePreviewPacksModel, activeTag: String?, initialSearch: String = "") {
+    self.packs = packs
+    self.activeTag = activeTag
+    _searchText = State(initialValue: initialSearch)
+  }
+
+  /// View-local: a search box is about what this SHEET is showing, not about the
+  /// catalogue, so the model has no reason to know it exists.
+  @State private var searchText: String
+
+  /// Which half of the catalogue is on screen. Not-installed first, because acquiring a
+  /// language is the only reason this sheet opens.
+  @State private var showingInstalled: Bool = false
+
+  var body: some View {
+    NavigationStack {
+      VStack(spacing: 0) {
+        header
+        Divider().overlay(Color.stDivider)
+        content
+      }
+      .frame(minWidth: 460, minHeight: 420)
+      .background(Color.stPageBg)
+      .navigationTitle(LivePreviewSettingsCopy.packsHeader)
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button(LivePreviewSettingsCopy.catalogDoneButton) { dismiss() }
+        }
+      }
+    }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(LivePreviewSettingsCopy.packsDescription).settingsReadingCopy()
+
+      // Only once there is a list to search: a search box over a spinner or over
+      // the "could not read" message is a control that does nothing.
+      if case .loaded = packs.state {
+        searchField
+        filterChips
+      }
+    }
+    .padding(16)
+  }
+
+  /// Carried verbatim from the page's own search box, whose shape this keeps:
+  ///
+  /// > Same shape as `LanguageLockSheet.searchField`, deliberately: the app
+  /// > already has a language search and a second visual idiom for the same job
+  /// > would read as a different feature.
+  ///
+  /// The recessed-with-a-border treatment came from the same decision:
+  ///
+  /// > there because it spans the sheet's full width at the top. Inside a card
+  /// > that underline reads as no container at all (founder, 2026-08-16).
+  ///
+  /// This IS a sheet now, so the underline would have been available again — kept as a
+  /// bordered field anyway, because the third idiom for one job is the cost this comment
+  /// was written to avoid.
+  private var searchField: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "magnifyingglass").foregroundStyle(.stTextSecondary)
+      TextField(LivePreviewSettingsCopy.packsSearchPlaceholder, text: $searchText)
+        .textFieldStyle(.plain)
+        .accessibilityLabel("Search languages")
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 9))
+    .overlay(RoundedRectangle(cornerRadius: 9).strokeBorder(Color.stDivider, lineWidth: 1))
+  }
+
+  /// Both counts come from the SAME grouping the rows do, so a chip can never disagree
+  /// with the list under it.
+  private var filterChips: some View {
+    let groups = LivePreviewPackPresentation.groups(from: loadedPacks)
+    return HStack(spacing: 6) {
+      chip(
+        title: LivePreviewSettingsCopy.catalogFilterAvailable,
+        count: groups.available.count, selected: !showingInstalled
+      ) { showingInstalled = false }
+      chip(
+        title: LivePreviewSettingsCopy.catalogFilterInstalled,
+        count: groups.installed.count, selected: showingInstalled
+      ) { showingInstalled = true }
+      Spacer(minLength: 0)
+    }
+  }
+
+  private func chip(
+    title: String, count: Int, selected: Bool, action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack(spacing: 5) {
+        Text(title)
+        Text("\(count)").opacity(0.65)
+      }
+      .font(.stHelper)
+      .padding(.horizontal, 11)
+      .padding(.vertical, 4)
+      .background(
+        selected ? Color.stAccentSolid : Color.clear,
+        in: Capsule()
+      )
+      .foregroundStyle(selected ? Color.white : Color.stTextSecondary)
+      .overlay(
+        Capsule().strokeBorder(selected ? Color.clear : Color.stDivider, lineWidth: 1))
+    }
+    .buttonStyle(.plain)
+  }
+
+  // MARK: - Content
+
+  @ViewBuilder
+  private var content: some View {
+    switch packs.state {
+    case .loading:
+      // `packsLoading`, NOT `packInstalling` — this spinner is a local inventory
+      // read. The per-row spinner below is the one that means a transfer.
+      centered {
+        HStack(spacing: 8) {
+          ProgressView().controlSize(.small)
+          Text(LivePreviewSettingsCopy.packsLoading).settingsHelperCopy()
+        }
+      }
+    case .failed:
+      centered { Text(LivePreviewSettingsCopy.packsUnavailable).settingsHelperCopy() }
+    case .loaded:
+      if visibleRows.isEmpty {
+        centered { Text(LivePreviewSettingsCopy.packsNoSearchMatch).settingsHelperCopy() }
+      } else {
+        ScrollView {
+          LazyVStack(spacing: 0) {
+            ForEach(visibleRows, id: \.id) { pack in
+              packRow(pack)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+              Divider().overlay(Color.stDivider).padding(.leading, 16)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func centered<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+    VStack {
+      Spacer()
+      content()
+      Spacer()
+    }.frame(maxWidth: .infinity)
+  }
+
+  private var loadedPacks: [LivePreviewPack] {
+    guard case .loaded(let rows) = packs.state else { return [] }
+    return rows
+  }
+
+  /// Filter, then search, then the group's own order. `groups(from:)` still owns the
+  /// installed-first policy, so its tests still mean something.
+  private var visibleRows: [LivePreviewPack] {
+    let groups = LivePreviewPackPresentation.groups(from: loadedPacks)
+    let half = showingInstalled ? groups.installed : groups.available
+    return LivePreviewPackPresentation.matching(half, query: searchText)
+  }
+
+  @ViewBuilder
+  private func packRow(_ pack: LivePreviewPack) -> some View {
+    HStack(spacing: 10) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(pack.localizedName).settingsRowLabel()
+        if pack.nativeName != pack.localizedName {
+          Text(pack.nativeName).settingsHelperCopy()
+        }
+        // The failure needs WORDS, not just a relabelled button. "Try again"
+        // alone leaves the user guessing whether the download broke, whether
+        // they did something wrong, or whether the language is unavailable — and
+        // the remedy is the same for every cause, so one sentence answers all.
+        if packs.failedTag == pack.tag {
+          Text(LivePreviewSettingsCopy.packInstallFailed).settingsHelperCopy()
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      statusCell(pack)
+    }
+  }
+
+  @ViewBuilder
+  private func statusCell(_ pack: LivePreviewPack) -> some View {
+    if pack.tag == activeTag {
+      // "Ready" says the bytes are here; it never said WHICH language you are
+      // actually previewing in. With nine installed, that was the whole confusion.
+      ProviderStatusChip(
+        status: ProviderStatus(label: LivePreviewSettingsCopy.packInUse, tone: .ready))
+    } else if pack.isInstalled {
+      ProviderStatusChip(
+        status: ProviderStatus(
+          label: LivePreviewSettingsCopy.packInstalled, tone: .unavailable))
+    } else if packs.installingTag == pack.tag {
+      // A spinner, never a percentage. Apple's progress object yields two
+      // distinct values across a whole install, so a bar would be a fabrication.
+      HStack(spacing: 6) {
+        ProgressView().controlSize(.small)
+        Text(LivePreviewSettingsCopy.packInstalling).settingsHelperCopy()
+      }
+    } else {
+      Button(
+        packs.failedTag == pack.tag
+          ? LivePreviewSettingsCopy.packRetry
+          : LivePreviewSettingsCopy.packInstall
+      ) {
+        packs.install(tag: pack.tag)
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+      .disabled(packs.installingTag != nil)
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
@@ -80,6 +80,13 @@ struct LivePreviewPackCatalogSheet: View {
       .frame(minWidth: 460, minHeight: 420)
       .background(Color.stPageBg)
       .navigationTitle(LivePreviewSettingsCopy.packsHeader)
+      // **A failed read must be retryable, or the message is a dead end.**
+      // `packsUnavailable` tells the user to reopen; nothing reloaded when they did,
+      // so reopening produced the same failure forever. Only on `.failed`, so an
+      // ordinary open does not re-read an inventory the page already has.
+      .task {
+        if case .failed = packs.state { await packs.load() }
+      }
       .toolbar {
         ToolbarItem(placement: .confirmationAction) {
           Button(LivePreviewSettingsCopy.catalogDoneButton) { dismiss() }
@@ -189,7 +196,10 @@ struct LivePreviewPackCatalogSheet: View {
       centered { Text(LivePreviewSettingsCopy.packsUnavailable).settingsHelperCopy() }
     case .loaded:
       if visibleRows.isEmpty {
-        centered { Text(LivePreviewSettingsCopy.packsNoSearchMatch).settingsHelperCopy() }
+        // **An empty FILTER is not a failed SEARCH.** With every pack installed the
+        // default half is empty and no query was typed, so blaming the search would
+        // accuse the user of something they did not do.
+        centered { Text(emptyMessage).settingsHelperCopy() }
       } else {
         ScrollView {
           LazyVStack(spacing: 0) {
@@ -211,6 +221,17 @@ struct LivePreviewPackCatalogSheet: View {
       content()
       Spacer()
     }.frame(maxWidth: .infinity)
+  }
+
+  /// Which nothing-here message applies: the search found nothing, or this half of the
+  /// catalogue is genuinely empty.
+  private var emptyMessage: String {
+    guard searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return LivePreviewSettingsCopy.packsNoSearchMatch
+    }
+    return showingInstalled
+      ? LivePreviewSettingsCopy.catalogNoneInstalled
+      : LivePreviewSettingsCopy.catalogNothingToInstall
   }
 
   private var loadedPacks: [LivePreviewPack] {

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
@@ -176,6 +176,15 @@ struct LivePreviewPackCatalogSheet: View {
         Capsule().strokeBorder(selected ? Color.clear : Color.stDivider, lineWidth: 1))
     }
     .buttonStyle(.plain)
+    // **Which half is showing lives ONLY in these two colours**, so without this a
+    // VoiceOver user hears two ordinary buttons with labels and counts and has no
+    // way to tell which one the list below is obeying — on a sheet whose entire
+    // job is "the languages you do NOT have". Cloud review on PR #2440.
+    //
+    // `.isSelected` rather than a "(selected)" suffix on the label: the trait is
+    // what assistive tech reads as SELECTION, and baking the state into the visible
+    // title would also change the button's own name every time it is pressed.
+    .accessibilityAddTraits(selected ? [.isSelected] : [])
   }
 
   // MARK: - Content

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackPresentation.swift
@@ -69,6 +69,22 @@ enum LivePreviewPackPresentation {
   ///
   /// The catalogue already sorts alphabetically by the name the user reads, so re-sorting here
   /// would either duplicate that decision or silently disagree with it.
+  /// Group AND search in one pass, so a caller cannot count one population and list
+  /// another (#2436).
+  ///
+  /// The catalogue sheet shipped with exactly that defect for one review round: its chips
+  /// counted the full groups while its rows showed the search-filtered ones, so a chip
+  /// could read "Not on this Mac 53" above a single matching row. Two tests each covered
+  /// one axis — grouping without search, search within one half — and the defect lived at
+  /// the intersection neither reached. Offering only the combined call is what stops the
+  /// next caller reassembling the same mistake.
+  static func groups(from packs: [LivePreviewPack], matching query: String) -> Groups {
+    let groups = groups(from: packs)
+    return Groups(
+      installed: matching(groups.installed, query: query),
+      available: matching(groups.available, query: query))
+  }
+
   static func groups(from packs: [LivePreviewPack]) -> Groups {
     Groups(
       installed: packs.filter(\.isInstalled),

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackPresentation.swift
@@ -65,28 +65,6 @@ enum LivePreviewPackPresentation {
     value.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
   }
 
-  /// What the table's Availability cell shows for a pack.
-  ///
-  /// #2154. **Named for what it COMPUTES, after a first draft called it
-  /// "Source" and was wrong about its own meaning.** It reads `isInstalled` and
-  /// nothing else, so downloading a language through this page flipped its cell
-  /// from "Apple" to "System" — telling the user the pack had come with macOS
-  /// when they had fetched it from Apple moments before. The model carries no
-  /// provenance to report; every one of these is an Apple pack either way.
-  ///
-  /// What it does answer is the question somebody scanning 54 rows is actually
-  /// asking: do I already have this. That is also the honest answer to "why
-  /// does this look like the list in System Settings" — it IS that list
-  /// (`live-preview.md` FACT: language-pack-downloads).
-  ///
-  /// A named function rather than an inline ternary in the view, so the rule is
-  /// testable and has one home — the same reason `groups(from:)` is here.
-  static func availability(for pack: LivePreviewPack) -> String {
-    pack.isInstalled
-      ? LivePreviewSettingsCopy.sourceSystem
-      : LivePreviewSettingsCopy.sourceApple
-  }
-
   /// Split, preserving the incoming order within each group.
   ///
   /// The catalogue already sorts alphabetically by the name the user reads, so re-sorting here

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -306,6 +306,26 @@ enum LivePreviewSettingsCopy {
   static let statusPausedDetail =
     "Your dictation keeps its full speed. Turn Faster Transcription off to see the preview."
 
+  // MARK: - Status-bar language chip (#2436)
+
+  /// The universal engine's "language", which is the absence of one.
+  ///
+  /// It resolves per utterance rather than committing to a locale in advance, so
+  /// there is no single language to name and "Any" is the honest noun.
+  static let languageAnyLanguage = "Any language"
+
+  /// **Where the language came from, which on Auto is NOT where a user assumes.**
+  ///
+  /// Dictation on Auto detects what you actually speak. Apple's preview cannot: it
+  /// is built for one locale chosen before the first word, so it uses the Mac's.
+  /// A bilingual user on Auto therefore gets correct dictation and a preview in the
+  /// wrong language, and naming the Mac as the source is what makes that legible
+  /// instead of a bug report. `activeSource` above carries the same distinction in
+  /// sentence form; these are its two-word shoulders for the status bar.
+  static let languageProvenanceFromMac = "from your Mac"
+  static let languageProvenanceUserPicked = "you picked this"
+  static let languageProvenanceDetected = "detected as you speak"
+
   // MARK: - Language section (#2154)
 
   static let changeLanguageButton = "Change"

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -269,7 +269,9 @@ enum LivePreviewSettingsCopy {
   /// chunk review on #2436, and `chipNeverPromisesOutput` missed it because its forbidden
   /// list did not contain "detect" — the guard and the defect had the same blind spot.
   ///
-  /// **The Auto asymmetry is stated in `pickerDictationCaveat`, not here.**
+  /// **The Auto asymmetry is stated in `pickerAppleCaveat`, not here** — and only there,
+  /// because it is Apple's asymmetry alone; `pickerUniversalCaveat` is the universal
+  /// engine's own sentence and must never repeat Apple's.
   ///
   /// Dictation on Auto detects what you actually speak. Apple's preview cannot: it
   /// is built for one locale chosen before the first word, so it uses the Mac's.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -224,6 +224,24 @@ enum LivePreviewSettingsCopy {
     "It stays on your Mac, is discarded when the recording ends, and never changes a "
     + "character of what gets pasted."
 
+  // MARK: - Pack catalogue sheet (#2436)
+
+  /// The bar's one remedy, named for where it goes rather than what it fetches: the
+  /// catalogue is the only thing that can resolve a display name to an installable pack.
+  static let browseDownloadsButton = "Browse downloads"
+
+  /// The Languages row's trailing button, and the row's own summary.
+  static let packsBrowseButton = "Browse"
+  static func packsInstalledSummary(installed: Int, total: Int) -> String {
+    "\(installed) of \(total) on this Mac"
+  }
+
+  /// **Not-installed first, because acquiring is the only reason this sheet opens.**
+  /// The counts beside them come from the same grouping the rows do.
+  static let catalogFilterAvailable = "Not on this Mac"
+  static let catalogFilterInstalled = "On this Mac"
+  static let catalogDoneButton = "Done"
+
   // MARK: - Status-bar language chip (#2436)
 
   /// The universal engine's "language", which is the absence of one.
@@ -312,21 +330,4 @@ enum LivePreviewSettingsCopy {
     "This sets the language for dictation too, not just the preview. On Auto, dictation "
     + "detects whatever you speak, while the preview has to pick one language in advance "
     + "and uses your Mac's."
-
-  // MARK: - Language table (#2154)
-
-  static let tableColumnLanguage = "Language"
-  static let tableColumnStatus = "Status"
-
-  /// **Availability, NOT provenance, and the first draft got that wrong.**
-  ///
-  /// The column is computed from `isInstalled`, so downloading a language
-  /// through this very page flipped it from "Apple" to "System" — claiming the
-  /// pack had shipped with macOS when the user had just fetched it from Apple
-  /// thirty seconds earlier. The model carries availability and knows nothing
-  /// about origin, so the honest fix is to label what is actually computed.
-  /// Every one of these is an Apple pack either way.
-  static let tableColumnSource = "Availability"
-  static let sourceSystem = "On this Mac"
-  static let sourceApple = "Available from Apple"
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -31,12 +31,6 @@ enum LivePreviewSettingsCopy {
 
   static let toggleLabel = "Show words while I speak"
 
-  /// Shown under the disabled toggle on older systems. Names the requirement and
-  /// stops there: a user on macOS 14 cannot act on this beyond upgrading, and a
-  /// longer explanation would read as an apology.
-  static let needsNewerMacOS =
-    "On-screen preview needs macOS 26 or later. Dictation itself works on macOS 14 and up."
-
   // MARK: - Language packs (#2080)
 
   static let packsHeader = "Languages"
@@ -54,59 +48,6 @@ enum LivePreviewSettingsCopy {
   static let packInstall = "Download"
   static let packInstalling = "Downloading"
   static let packRetry = "Try again"
-
-  // MARK: - Which language is live (#2080)
-
-  /// Names what the section CONTAINS, like "Live Preview" and "Languages" either side of it.
-  /// "Right Now" named a moment instead, which told the reader nothing about what they would find.
-  static let activeHeader = "Preview Language"
-
-  /// States the language, not the mechanism. "Resolved locale" is our word, not the user's.
-  static func activeReady(_ name: String) -> String {
-    "Your words will appear in \(name)."
-  }
-
-  /// Where that came from, so the user knows which setting to change if it is wrong.
-  ///
-  /// **Auto is not symmetrical, and saying it was would have been a false claim.** Dictation on
-  /// Auto detects the language you actually speak (`RecordingSessionKernel` sends no language at
-  /// all). The preview cannot: Apple's transcriber is built for one locale chosen before the first
-  /// word, so it uses the Mac's language. A bilingual user on Auto therefore gets correct
-  /// dictation and a preview in the wrong language, which is exactly the "the preview is not the
-  /// pasted text" confusion this feature's copy exists to prevent. Naming the Mac as a guess is
-  /// what makes that legible instead of a bug report.
-  static func activeSource(_ mode: LanguageMode) -> String {
-    switch mode {
-    case .auto:
-      return "Your dictation language is set to Auto, so the preview goes by your Mac's language."
-    case .locked:
-      return "Following the language you picked for dictation."
-    }
-  }
-
-  static func activeNeedsDownload(_ name: String) -> String {
-    "\(name) isn't downloaded yet, so you won't see words while you speak."
-  }
-
-  static let activeNeedsDownloadHelp = "Download it below and the preview starts working."
-
-  static let activeUnsupportedLanguage =
-    "Apple can't preview the language you picked for dictation."
-  static let activeUnsupportedLanguageHelp =
-    "Dictation still works normally. Only the on-screen preview is unavailable."
-
-  /// Explains WHERE the preview language comes from, because the page shows which one is live but
-  /// cannot change it — and a status you cannot act on is a dead end unless it says where to go.
-  ///
-  /// States the rule rather than the mechanism, and states the ONE case where the rule bends. An
-  /// earlier draft said the preview always uses your dictation language, full stop; that reads
-  /// cleanly and is untrue on Auto, where dictation detects what you speak and the preview has to
-  /// commit to a locale in advance. See `activeSource` for the measurement behind that.
-  static let activeExplainer =
-    "The preview follows the language you pick for dictation, under Transcription. On Auto there "
-    + "is nothing to follow yet, so it goes by your Mac's language: dictation still understands "
-    + "whatever you speak, but the words on screen may appear in the wrong language until you "
-    + "pick one."
 
   /// The row that is genuinely in use, as opposed to merely present. With nine languages
   /// installed, "Ready" on all of them said nothing about which one you are previewing in.
@@ -297,15 +238,11 @@ enum LivePreviewSettingsCopy {
   /// is built for one locale chosen before the first word, so it uses the Mac's.
   /// A bilingual user on Auto therefore gets correct dictation and a preview in the
   /// wrong language, and naming the Mac as the source is what makes that legible
-  /// instead of a bug report. `activeSource` above carries the same distinction in
+  /// instead of a bug report. the deleted `activeSource` carried the same distinction in
   /// sentence form; these are its two-word shoulders for the status bar.
   static let languageProvenanceFromMac = "from your Mac"
   static let languageProvenanceUserPicked = "you picked this"
   static let languageProvenanceDetected = "detected as you speak"
-
-  // MARK: - Language section (#2154)
-
-  static let changeLanguageButton = "Change"
 
   /// **The universal engine follows a LOCK, and only auto-detects on Auto.**
   /// `WhisperPreviewEngineResolver` maps `.locked(code)` straight through to the
@@ -317,11 +254,7 @@ enum LivePreviewSettingsCopy {
   static func universalLocked(_ name: String) -> String {
     "Your words will appear in \(name)."
   }
-  static let universalLockedHelp =
-    "The preview follows the language you picked for dictation, under Transcription."
   static let universalAuto = "The preview detects your language as you speak."
-  static let universalAutoHelp =
-    "On Auto this engine works out the language itself, so there is nothing to set."
 
   /// **Paused variants. The row must DESCRIBE the configuration, never promise
   /// output, whenever the engine is refused.**
@@ -356,7 +289,13 @@ enum LivePreviewSettingsCopy {
   /// preview-only setting: it sets the DICTATION language, on a different page.
   /// A button that silently edits another page's setting is how a user loses
   /// auto-detect without noticing.
-  static let changeLanguageHelp =
+  /// **Re-homed by #2436 from a help line under a Change button to the picker's own
+  /// subtitle.** It states a CONSEQUENCE of the action, so it belongs where the action
+  /// is taken rather than under a button nobody has pressed yet. `activeSummary`'s
+  /// reason for it is carried verbatim in `LivePreviewSettingsView`: one language in
+  /// one place, because two settings that can disagree hand the user a mismatch they
+  /// cannot diagnose.
+  static let pickerDictationCaveat =
     "This sets the language for dictation too, not just the preview."
 
   // MARK: - Language table (#2154)

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -232,7 +232,16 @@ enum LivePreviewSettingsCopy {
   /// there is no single language to name and "Any" is the honest noun.
   static let languageAnyLanguage = "Any language"
 
-  /// **Where the language came from, which on Auto is NOT where a user assumes.**
+  /// **Where the language came from — CONFIGURATION only, never activity.**
+  ///
+  /// `languageProvenanceDetected` was "detected as you speak" and that was a readiness
+  /// claim wearing a provenance label: the chip renders in every state, so it asserted
+  /// live detection while the preview was off, paused, downloading or failed. "auto-detect"
+  /// describes the SETTING, which is true whether or not anything is running. Found by
+  /// chunk review on #2436, and `chipNeverPromisesOutput` missed it because its forbidden
+  /// list did not contain "detect" — the guard and the defect had the same blind spot.
+  ///
+  /// **The Auto asymmetry is stated in `pickerDictationCaveat`, not here.**
   ///
   /// Dictation on Auto detects what you actually speak. Apple's preview cannot: it
   /// is built for one locale chosen before the first word, so it uses the Mac's.
@@ -242,7 +251,11 @@ enum LivePreviewSettingsCopy {
   /// sentence form; these are its two-word shoulders for the status bar.
   static let languageProvenanceFromMac = "from your Mac"
   static let languageProvenanceUserPicked = "you picked this"
-  static let languageProvenanceDetected = "detected as you speak"
+  /// "automatic", not "auto-detect": the guard forbids activity words and "detect" is
+  /// one, even inside a setting's name. Arguing the matcher into an exception would
+  /// have traded a real guard for one word — and the word is not load-bearing, since
+  /// the picker this chip opens calls the same setting Automatic.
+  static let languageProvenanceDetected = "automatic"
 
   /// **The universal engine follows a LOCK, and only auto-detects on Auto.**
   /// `WhisperPreviewEngineResolver` maps `.locked(code)` straight through to the
@@ -296,7 +309,9 @@ enum LivePreviewSettingsCopy {
   /// one place, because two settings that can disagree hand the user a mismatch they
   /// cannot diagnose.
   static let pickerDictationCaveat =
-    "This sets the language for dictation too, not just the preview."
+    "This sets the language for dictation too, not just the preview. On Auto, dictation "
+    + "detects whatever you speak, while the preview has to pick one language in advance "
+    + "and uses your Mac's."
 
   // MARK: - Language table (#2154)
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -29,48 +29,7 @@ enum LivePreviewSettingsCopy {
   /// immediately after this), not by this one staying nameless.
   static let sectionHeader = "Live Preview"
 
-  /// The hero card's headline.
-  ///
-  /// **Deliberately does not assert that the feature is on.** The mockup read
-  /// "Real-time feedback, always on"; it ships OFF with its switch directly
-  /// below, so that headline is false the first time anybody opens this page.
-  static let heroTitle = "Watch your words appear as you talk"
-
   static let toggleLabel = "Show words while I speak"
-
-  /// Says four things, in the order a user cares about them: what they will see,
-  /// where that text goes, that it is not what gets pasted, and that it costs them
-  /// nothing in accuracy. The last is the one that stops "is this making my
-  /// transcription worse?", the natural next question once they know two engines
-  /// are running.
-  ///
-  /// The privacy sentence is here because #1988 asks for it in writing ("It should
-  /// be trivially yes (nothing leaves the Mac), but state it"). Trivially true is
-  /// not the same as visible: a user deciding whether to switch on something that
-  /// watches them speak should not have to infer the answer from our reputation,
-  /// and this is the only surface they read before deciding. It is also the one
-  /// place the claim can be made narrowly and honestly, since this preview really
-  /// is on-device for every user, with no cloud variant to qualify.
-  /// Trimmed once the Preview Language section existed: between them the page opened with six
-  /// lines of prose before anything actionable. Keeps the three claims that matter — what it does,
-  /// that it stays local, and that it cannot alter the result — and drops the restatement of
-  /// "preview", which the heading above it already says.
-  ///
-  /// The third claim is the load-bearing one and may not be dropped by any future rewording: a
-  /// user who concludes the preview IS the pasted text will file a bug that is not one, because
-  /// the preview is measurably less accurate than the engine that produces the paste. An earlier
-  /// draft carried it as the phrase "preview only"; this one carries it as "never changes a
-  /// character of what gets pasted". `LivePreviewSettingsCopyTests` accepts either wording and
-  /// fails if a rewrite drops the claim entirely.
-  static let heroBody =
-    "See your words in the recording pill as you talk, so you know EnviousWispr is hearing you. "
-    + "It stays on your Mac, is discarded when the recording ends, and never changes a character "
-    + "of what gets pasted."
-
-  /// The one line under the switch. The three claims above moved to `heroBody`
-  /// when the hero card took the top of the page (#2154); this is the mockup's
-  /// own wording for the row that remains.
-  static let toggleDescription = "See your words in the recording pill as you talk."
 
   /// Shown under the disabled toggle on older systems. Names the requirement and
   /// stops there: a user on macOS 14 cannot act on this beyond upgrading, and a
@@ -205,16 +164,16 @@ enum LivePreviewSettingsCopy {
   /// RULE: a-language-mismatch-shows-NOTHING-not-garbage), so "showing your
   /// words" would be a promise this page cannot keep.
 
-  static let statusActiveLabel = "Live Preview is active"
+  static let statusActiveLabel = "Activated"
   static let statusActiveDetail = "Ready to show your words while you speak."
 
-  static let statusOffLabel = "Live Preview is off"
+  static let statusOffLabel = "Off"
   /// **Deliberately promises nothing about what happens next.** The off state is
   /// checked BEFORE any engine detail, so switching on can land straight on
   /// "needs a download" or a missing language pack. An earlier draft said
   /// "switch it on to see your words while you speak", which is a promise this
   /// card cannot keep for every user who reads it.
-  static let statusOffDetail = "Switch it on and this card will show whether anything else is needed."
+  static let statusOffDetail = "Switch it on and this bar will show whether anything else is needed."
 
   // `statusUnavailableLabel` / `statusUnavailableDetail` were DELETED by #2154's
   // final sweep, not merely unused. "Not available on this Mac" was returned
@@ -249,7 +208,7 @@ enum LivePreviewSettingsCopy {
   static func statusNeedsLanguageLabel(_ languageName: String) -> String {
     "\(languageName) isn't downloaded yet"
   }
-  static let statusNeedsLanguageDetail = "Download it in the list below and the preview starts working."
+  static let statusNeedsLanguageDetail = "Use Browse downloads below to get it and start the preview."
 
   static let statusUnsupportedLanguageLabel = "Apple can't preview this language"
   /// **Two details, because the advice is only true when the other engine
@@ -305,6 +264,24 @@ enum LivePreviewSettingsCopy {
   static let pausedForFasterTranscription = "Paused while Faster Transcription is on"
   static let statusPausedDetail =
     "Your dictation keeps its full speed. Turn Faster Transcription off to see the preview."
+
+  /// **The claim that may not be dropped, moved rather than deleted (#2436).**
+  ///
+  /// This is `heroBody`'s third sentence, and its own doc comment is explicit that
+  /// the pasted-text half "is the load-bearing one and may not be dropped by any
+  /// future rewording: a user who concludes the preview IS the pasted text will file
+  /// a bug that is not one, because the preview is measurably less accurate than the
+  /// engine that produces the paste." The privacy half is here because #1988 asked
+  /// for it in writing.
+  ///
+  /// **It renders under the status bar, not under the Languages block.** The
+  /// Languages block is gated on `showsApplePacks`, so putting it there would delete
+  /// the sentence on the universal engine and on every Mac too old for Apple's —
+  /// while this is the only surface a user reads before deciding whether to switch
+  /// on something that watches them speak.
+  static let previewPrivacyFooter =
+    "It stays on your Mac, is discarded when the recording ends, and never changes a "
+    + "character of what gets pasted."
 
   // MARK: - Status-bar language chip (#2436)
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -236,7 +236,7 @@ enum LivePreviewSettingsCopy {
   ///
   /// `languageProvenanceDetected` was "detected as you speak" and that was a readiness
   /// claim wearing a provenance label: the chip renders in every state, so it asserted
-  /// live detection while the preview was off, paused, downloading or failed. "auto-detect"
+  /// live detection while the preview was off, paused, downloading or failed. "automatic"
   /// describes the SETTING, which is true whether or not anything is running. Found by
   /// chunk review on #2436, and `chipNeverPromisesOutput` missed it because its forbidden
   /// list did not contain "detect" — the guard and the defect had the same blind spot.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -226,6 +226,13 @@ enum LivePreviewSettingsCopy {
 
   // MARK: - Pack catalogue sheet (#2436)
 
+  /// **An empty FILTER is not a failed SEARCH.** With every pack installed, the default
+  /// "Not on this Mac" half is empty and no search has happened, so
+  /// `packsNoSearchMatch` would blame a query the user never typed.
+  static let catalogNothingToInstall = "Every language Apple offers is already on this Mac."
+  static let catalogNoneInstalled = "No languages downloaded yet."
+
+
   /// The bar's one remedy, named for where it goes rather than what it fetches: the
   /// catalogue is the only thing that can resolve a display name to an installable pack.
   static let browseDownloadsButton = "Browse downloads"
@@ -248,7 +255,10 @@ enum LivePreviewSettingsCopy {
   ///
   /// It resolves per utterance rather than committing to a locale in advance, so
   /// there is no single language to name and "Any" is the honest noun.
-  static let languageAnyLanguage = "Any language"
+  /// "Automatic", not "Any language": the universal engine supports a finite set, so
+  /// "any" is a claim wider than the code (`LanguageLockOptions` restricts the lockable
+  /// set to the backend's own). This names the SETTING, which is what the chip is for.
+  static let languageAnyLanguage = "Automatic"
 
   /// **Where the language came from — CONFIGURATION only, never activity.**
   ///
@@ -273,7 +283,7 @@ enum LivePreviewSettingsCopy {
   /// one, even inside a setting's name. Arguing the matcher into an exception would
   /// have traded a real guard for one word — and the word is not load-bearing, since
   /// the picker this chip opens calls the same setting Automatic.
-  static let languageProvenanceDetected = "automatic"
+  static let languageProvenanceDetected = "no language pinned"
 
   /// **The universal engine follows a LOCK, and only auto-detects on Auto.**
   /// `WhisperPreviewEngineResolver` maps `.locked(code)` straight through to the
@@ -326,8 +336,21 @@ enum LivePreviewSettingsCopy {
   /// reason for it is carried verbatim in `LivePreviewSettingsView`: one language in
   /// one place, because two settings that can disagree hand the user a mismatch they
   /// cannot diagnose.
-  static let pickerDictationCaveat =
+  /// **Two caveats, because one sentence cannot describe both engines.**
+  ///
+  /// The Auto asymmetry is APPLE'S: its preview must commit to a locale before the first
+  /// word, so on Auto it goes by the Mac while dictation still hears whatever is spoken.
+  /// The universal engine has no such constraint — it works the language out per
+  /// utterance — so telling a universal user their preview "uses your Mac's language" is
+  /// false about their own engine. A single shared string shipped exactly that for one
+  /// review round, and the test that guarded it had no engine variable, so it validated
+  /// the Apple sentence and passed while Universal displayed it.
+  static let pickerAppleCaveat =
     "This sets the language for dictation too, not just the preview. On Auto, dictation "
     + "detects whatever you speak, while the preview has to pick one language in advance "
     + "and uses your Mac's."
+
+  static let pickerUniversalCaveat =
+    "This sets the language for dictation too, not just the preview. On Auto, this engine "
+    + "works the language out as you speak, so there is nothing you need to pick."
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -42,14 +42,42 @@ struct LivePreviewSettingsView: View {
   @State private var showLanguageSheet: Bool = false
 
   /// #2436: the pack catalogue, opened by the Languages row or the bar's remedy.
-  @State private var showPackCatalog: Bool = false
+  ///
+  /// **One piece of state, not two, and that is the whole point.** This started as
+  /// a `Bool` beside a separate `catalogSearchSeed` string, written together in one
+  /// button action. Live UAT measured the seed arriving EMPTY at the sheet on every
+  /// presentation, including the first one in a freshly launched process: with
+  /// `.sheet(isPresented:)` the content closure reads the seed through a second,
+  /// independent `@State` at content-build time, and the value it saw was the one
+  /// from before the write. The remedy therefore opened on all 52 rows rather than
+  /// the one language the user was sent here for — the entire value grounded review
+  /// r2 finding C4 added, silently absent.
+  ///
+  /// `.sheet(item:)` closes the class rather than the instance: the seed TRAVELS
+  /// with the presentation instead of being read back out of view state, so there
+  /// is no second value that can be stale. The fresh `id` per request also gives
+  /// each presentation its own view identity, which is what lets the sheet's
+  /// `State(initialValue:)` take effect more than once.
+  ///
+  /// Nothing here is testable from a unit test — presentation is SwiftUI's, not
+  /// ours — so `#2436` item 6 in the Live UAT spec is this fix's binding evidence,
+  /// and it is stated rather than implied.
+  @State private var catalogRequest: CatalogRequest?
 
-  /// What the catalogue's search starts with. The bar's remedy seeds it with the
-  /// missing language's NAME, so the row a user was sent here for is already on
-  /// screen; the Languages row passes nothing, because no particular language is
-  /// in question there.
-  @State private var catalogSearchSeed: String = ""
-
+  /// One catalogue presentation, carrying what it needs to open correctly.
+  ///
+  /// The bar's remedy seeds `search` with the missing language's NAME so the row a
+  /// user was sent here for is already on screen; the Languages row passes nothing,
+  /// because no particular language is in question there.
+  ///
+  /// `id` is fresh per request rather than derived from `search`: two consecutive
+  /// remedies for the SAME language must still be two presentations, and an id
+  /// equal to the search string would silently make the second one reuse the
+  /// first's view identity — the exact failure this type exists to remove.
+  private struct CatalogRequest: Identifiable {
+    let id = UUID()
+    let search: String
+  }
 
   // MARK: - Derived state
 
@@ -227,11 +255,13 @@ struct LivePreviewSettingsView: View {
           ? LivePreviewSettingsCopy.pickerAppleCaveat
           : LivePreviewSettingsCopy.pickerUniversalCaveat)
     }
-    .sheet(isPresented: $showPackCatalog) {
+    .sheet(item: $catalogRequest) { request in
       // The retained model, never a copy: dismissing this sheet mid-install must not
       // cancel the install, because the workflow outlives any presentation.
+      //
+      // `request.search`, never a separately-read `@State`: see `catalogRequest`.
       LivePreviewPackCatalogSheet(
-        packs: packs, activeTag: activePackTag, initialSearch: catalogSearchSeed)
+        packs: packs, activeTag: activePackTag, initialSearch: request.search)
     }
   }
 
@@ -303,9 +333,26 @@ struct LivePreviewSettingsView: View {
           // #2436: "the hero card" is now this same row's left half, so the rule
           // is unchanged and its one-owner property is stronger — there is no
           // longer a second container that could drift.
+          // **`.fixedSize()` is load-bearing, and its absence was a real defect.**
+          // `BrandedToggleStyle` lays out `HStack { label; Spacer(); track }` so that
+          // on an ORDINARY settings row the whole row is the hit target and the switch
+          // sits at its right edge. That is correct where a visible label owns the row.
+          //
+          // This row has no label — #2436 deleted it, because the page header above
+          // already says what the switch does. The style's `Spacer` then claimed every
+          // remaining point: Live UAT measured the checkbox at 738pt wide starting
+          // immediately after the language chip, so the empty middle of the status bar
+          // silently toggled Live Preview, and the chip rendered stranded a third of the
+          // way across instead of beside the switch as designed.
+          //
+          // Sizing to the ideal width collapses the style's internal `Spacer` and lets
+          // this row's own `Spacer(minLength: 12)` above do the pushing. Deliberately
+          // NOT a `.frame(width:)`: the track's size belongs to `BrandedToggleTrack`,
+          // and pinning a number here would be a second place to change it.
           Toggle("", isOn: $settings.livePreviewEnabled)
             .labelsHidden()
             .toggleStyle(BrandedToggleStyle())
+            .fixedSize()
             .disabled(!anyEngineAvailable)
             // The visible label is gone; this is the only thing naming the switch
             // for VoiceOver, which is why `toggleLabel` survives the copy cull.
@@ -324,8 +371,7 @@ struct LivePreviewSettingsView: View {
             switch action {
             case .browseDownloads(let initialSearch):
               Button(LivePreviewSettingsCopy.browseDownloadsButton) {
-                catalogSearchSeed = initialSearch
-                showPackCatalog = true
+                catalogRequest = CatalogRequest(search: initialSearch)
               }
               .buttonStyle(.borderedProminent)
               .controlSize(.small)
@@ -575,8 +621,7 @@ struct LivePreviewSettingsView: View {
             }
             Spacer(minLength: 8)
             Button(LivePreviewSettingsCopy.packsBrowseButton) {
-              catalogSearchSeed = ""
-              showPackCatalog = true
+              catalogRequest = CatalogRequest(search: "")
             }
             .controlSize(.small)
           }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -41,6 +41,15 @@ struct LivePreviewSettingsView: View {
   /// #2154: the dictation-language picker, opened by the Change button.
   @State private var showLanguageSheet: Bool = false
 
+  /// #2436: the pack catalogue, opened by the Languages row or the bar's remedy.
+  @State private var showPackCatalog: Bool = false
+
+  /// What the catalogue's search starts with. The bar's remedy seeds it with the
+  /// missing language's NAME, so the row a user was sent here for is already on
+  /// screen; the Languages row passes nothing, because no particular language is
+  /// in question there.
+  @State private var catalogSearchSeed: String = ""
+
 
   // MARK: - Derived state
 
@@ -214,6 +223,12 @@ struct LivePreviewSettingsView: View {
         // consequence belongs where the action is taken.
         contextSubtitle: LivePreviewSettingsCopy.pickerDictationCaveat)
     }
+    .sheet(isPresented: $showPackCatalog) {
+      // The retained model, never a copy: dismissing this sheet mid-install must not
+      // cancel the install, because the workflow outlives any presentation.
+      LivePreviewPackCatalogSheet(
+        packs: packs, activeTag: activePackTag, initialSearch: catalogSearchSeed)
+    }
   }
 
   // MARK: - Hero card
@@ -248,7 +263,7 @@ struct LivePreviewSettingsView: View {
       appleActive: currentActive, languageMode: settings.languageMode)
 
     return BrandedSection {
-      BrandedRow(showDivider: false) {
+      BrandedRow(showDivider: bar.action != nil) {
         HStack(alignment: .center, spacing: 12) {
           VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 8) {
@@ -294,13 +309,26 @@ struct LivePreviewSettingsView: View {
         }
       }
 
-      // **The remedy button lands in C4, with the sheet it opens.**
-      //
-      // `bar.action` is computed and tested from C1; nothing renders it yet, and
-      // that is deliberate rather than an omission. Until C4 the inline pack table
-      // is still on this page, so `statusNeedsLanguageDetail`'s "Use Browse
-      // downloads below" is satisfied by what is genuinely below. Shipping a button
-      // here would mean shipping one that opens nothing for the length of a chunk.
+      // The bar's one remedy, and the only button on the page. Every other unhappy
+      // state is repaired where the control already lives: the engine cards own
+      // download, cancel, resume, retry and remove, and Faster Transcription is
+      // turned off on its own page.
+      if let action = bar.action {
+        BrandedRow(showDivider: false) {
+          HStack(spacing: 12) {
+            Spacer(minLength: 0)
+            switch action {
+            case .browseDownloads(let initialSearch):
+              Button(LivePreviewSettingsCopy.browseDownloadsButton) {
+                catalogSearchSeed = initialSearch
+                showPackCatalog = true
+              }
+              .buttonStyle(.borderedProminent)
+              .controlSize(.small)
+            }
+          }
+        }
+      }
 
     } footer: {
       // Always visible: never gated on engine, toggle, Apple support or pack state.
@@ -503,197 +531,71 @@ struct LivePreviewSettingsView: View {
 
   // MARK: - Language table
 
-  /// Every language available to the preview, as ONE table.
+  /// One row where fifty-four used to be (#2436).
+  ///
+  /// The catalogue moved to `LivePreviewPackCatalogSheet`, which carries every reason
+  /// the table recorded. What stays here is the summary and the way in.
   ///
   /// Hidden entirely below macOS 26 (no Apple packs exist to manage, and an
   /// empty list under a disabled toggle reads as something being broken) and on
   /// the universal engine, which carries its own languages and has no packs.
   ///
-  /// The catalogue LOAD is deliberately NOT gated the same way: its `.task` is
-  /// keyed on the dictation language, so adding the engine to the condition
-  /// without adding it to the key would leave a user who switches back to Apple
-  /// looking at a snapshot from before.
+  /// Carried verbatim, and still true of the LOAD even though the table is gone:
   ///
-  /// **One table, replacing the two cards #2080 shipped.** Those cards existed
-  /// to make the installed/downloadable boundary visible after ten rows, which a
-  /// Source column does better: it aligns, it scans, and it does not split the
-  /// list in half. Group ORDER is preserved — installed first — so
-  /// `LivePreviewPackPresentation.groups(from:)` still owns the policy and its
-  /// tests still mean something.
-  ///
-  /// No drag handles and no per-row overflow menu, both of which the mockup
-  /// drew: nothing in the app orders languages, and Apple's packs are not ours
-  /// to delete, so each would be a control with nothing behind it (founder,
-  /// Gate 1).
+  /// > The catalogue LOAD is deliberately NOT gated the same way: its `.task` is
+  /// > keyed on the dictation language, so adding the engine to the condition
+  /// > without adding it to the key would leave a user who switches back to Apple
+  /// > looking at a snapshot from before.
   @ViewBuilder
   private var packsSection: some View {
     if showsApplePacks {
       BrandedSection(header: LivePreviewSettingsCopy.packsHeader) {
-        BrandedRow(showDivider: !visibleRows.isEmpty) {
-          VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 12) {
-              Text(LivePreviewSettingsCopy.packsDescription)
-                .settingsReadingCopy()
-              Spacer(minLength: 8)
-              // Only once there is a list to search: a search box over a spinner
-              // or over the "could not read" message is a control that does nothing.
-              if case .loaded = packs.state { searchField }
+        BrandedRow(showDivider: false) {
+          HStack(alignment: .top, spacing: 11) {
+            SettingsRowIcon(systemName: "arrow.down.circle")
+            VStack(alignment: .leading, spacing: 4) {
+              // **No count unless we have one.** A count is a claim about this Mac,
+              // and there is no acceptable stand-in for one we have not read yet.
+              switch packs.state {
+              case .loading:
+                Text(LivePreviewSettingsCopy.packsLoading).settingsRowLabel()
+              case .failed:
+                Text(LivePreviewSettingsCopy.packsUnavailable).settingsRowLabel()
+              case .loaded(let rows):
+                Text(
+                  LivePreviewSettingsCopy.packsInstalledSummary(
+                    installed: rows.filter(\.isInstalled).count, total: rows.count)
+                ).settingsRowLabel()
+              }
+              Text(LivePreviewSettingsCopy.packsDescription).settingsHelperCopy()
             }
-            nonListState
+            Spacer(minLength: 8)
+            Button(LivePreviewSettingsCopy.packsBrowseButton) {
+              catalogSearchSeed = ""
+              showPackCatalog = true
+            }
+            .controlSize(.small)
           }
         }
-        if !visibleRows.isEmpty {
-          tableHeader
-          ForEach(Array(visibleRows.enumerated()), id: \.element.id) { index, pack in
-            BrandedRow(showDivider: index < visibleRows.count - 1) {
-              packRow(pack)
-            }
-          }
-        }
       }
     }
   }
 
-  private var tableHeader: some View {
-    BrandedRow(showDivider: true) {
-      HStack(spacing: 10) {
-        Text(LivePreviewSettingsCopy.tableColumnLanguage)
-          .settingsHelperCopy()
-          .frame(maxWidth: .infinity, alignment: .leading)
-        Text(LivePreviewSettingsCopy.tableColumnSource)
-          .settingsHelperCopy()
-          .frame(width: Self.sourceColumnWidth, alignment: .leading)
-        Text(LivePreviewSettingsCopy.tableColumnStatus)
-          .settingsHelperCopy()
-          .frame(width: Self.statusColumnWidth, alignment: .leading)
-      }
-      .accessibilityHidden(true)  // column labels; each row states its own values
-    }
-  }
-
-  private static let sourceColumnWidth: CGFloat = 90
-  private static let statusColumnWidth: CGFloat = 130
-
-  /// Same shape as `LanguageLockSheet.searchField`, deliberately: the app
-  /// already has a language search and a second visual idiom for the same job
-  /// would read as a different feature.
-  private var searchField: some View {
-    HStack(spacing: 8) {
-      Image(systemName: "magnifyingglass")
-        .foregroundStyle(.stTextSecondary)
-      TextField(LivePreviewSettingsCopy.packsSearchPlaceholder, text: $searchText)
-        .textFieldStyle(.plain)
-        .accessibilityLabel("Search languages")
-    }
-    .frame(maxWidth: 240)
-    .padding(.horizontal, 12)
-    .padding(.vertical, 8)
-    // Recessed surface WITH a border, matching `InsetNotice` on this same page.
-    // The sheet this was ported from underlines its field instead, which works
-    // there because it spans the sheet's full width at the top. Inside a card
-    // that underline reads as no container at all (founder, 2026-08-16).
-    .background(Color.stPageBg, in: RoundedRectangle(cornerRadius: 9))
-    .overlay(
-      RoundedRectangle(cornerRadius: 9).strokeBorder(Color.stDivider, lineWidth: 1)
-    )
-  }
-
-  /// Loading, unreadable, or nothing matching the search.
-  @ViewBuilder
-  private var nonListState: some View {
-    switch packs.state {
-    case .loading:
-      HStack(spacing: 8) {
-        ProgressView().controlSize(.small)
-        // `packsLoading`, NOT `packInstalling` — this spinner is a local
-        // inventory read. The per-row spinner below is the one that means a transfer.
-        Text(LivePreviewSettingsCopy.packsLoading).settingsHelperCopy()
-      }
-    case .failed:
-      Text(LivePreviewSettingsCopy.packsUnavailable).settingsHelperCopy()
-    case .loaded:
-      if visibleRows.isEmpty {
-        Text(LivePreviewSettingsCopy.packsNoSearchMatch).settingsHelperCopy()
-      }
-    }
-  }
-
-  /// Search first, then group, then flatten — installed rows first, so the
-  /// grouping policy survives the move to one table without a visible split.
-  private var visibleRows: [LivePreviewPack] {
-    guard case .loaded(let rows) = packs.state else { return [] }
-    let groups = LivePreviewPackPresentation.groups(
-      from: LivePreviewPackPresentation.matching(rows, query: searchText))
-    return groups.installed + groups.available
-  }
-
-  /// Gated on the toggle because "In use" is a claim about a running preview,
-  /// and nothing runs while the feature is off. Gated on the ENGINE because
-  /// these are Apple's packs: with the universal engine selected the badge would
-  /// name a language that is not the one on screen. Both terms read the same
-  /// values the section above does, so the two cannot disagree.
-  private func isActive(_ pack: LivePreviewPack) -> Bool {
-    // Same reason: an "In use" badge is a claim about the language running NOW.
-    guard isUsingApple, isPreviewOn, case .ready(let tag, _) = currentActive else { return false }
-    return tag == pack.tag
-  }
-
-  @ViewBuilder
-  private func packRow(_ pack: LivePreviewPack) -> some View {
-    HStack(spacing: 10) {
-      VStack(alignment: .leading, spacing: 2) {
-        Text(pack.localizedName).settingsRowLabel()
-        if pack.nativeName != pack.localizedName {
-          Text(pack.nativeName).settingsHelperCopy()
-        }
-        // The failure needs WORDS, not just a relabelled button. "Try again"
-        // alone leaves the user guessing whether the download broke, whether
-        // they did something wrong, or whether the language is unavailable — and
-        // the remedy is the same for every cause, so one sentence answers all.
-        if packs.failedTag == pack.tag {
-          Text(LivePreviewSettingsCopy.packInstallFailed).settingsHelperCopy()
-        }
-      }
-      .frame(maxWidth: .infinity, alignment: .leading)
-
-      Text(LivePreviewPackPresentation.availability(for: pack))
-        .settingsHelperCopy()
-        .frame(width: Self.sourceColumnWidth, alignment: .leading)
-
-      statusCell(pack)
-        .frame(width: Self.statusColumnWidth, alignment: .leading)
-    }
-  }
-
-  @ViewBuilder
-  private func statusCell(_ pack: LivePreviewPack) -> some View {
-    if isActive(pack) {
-      // "Ready" says the bytes are here; it never said WHICH language you are
-      // actually previewing in. With nine installed, that was the whole confusion.
-      ProviderStatusChip(
-        status: ProviderStatus(label: LivePreviewSettingsCopy.packInUse, tone: .ready))
-    } else if pack.isInstalled {
-      ProviderStatusChip(
-        status: ProviderStatus(
-          label: LivePreviewSettingsCopy.packInstalled, tone: .unavailable))
-    } else if packs.installingTag == pack.tag {
-      // A spinner, never a percentage. Apple's progress object yields two
-      // distinct values across a whole install, so a bar would be a fabrication.
-      HStack(spacing: 6) {
-        ProgressView().controlSize(.small)
-        Text(LivePreviewSettingsCopy.packInstalling).settingsHelperCopy()
-      }
-    } else {
-      Button(
-        packs.failedTag == pack.tag
-          ? LivePreviewSettingsCopy.packRetry
-          : LivePreviewSettingsCopy.packInstall
-      ) {
-        packs.install(tag: pack.tag)
-      }
-      .buttonStyle(.bordered)
-      .controlSize(.small)
-      .disabled(packs.installingTag != nil)
-    }
+  /// The pack tag currently producing the preview, or nil.
+  ///
+  /// Carried verbatim from `isActive`, which the catalogue sheet no longer owns because
+  /// the two gates below are the page's to answer, not a row's:
+  ///
+  /// > Gated on the toggle because "In use" is a claim about a running preview,
+  /// > and nothing runs while the feature is off. Gated on the ENGINE because
+  /// > these are Apple's packs: with the universal engine selected the badge would
+  /// > name a language that is not the one on screen.
+  ///
+  /// > Same reason: an "In use" badge is a claim about the language running NOW.
+  ///
+  /// Both terms read the same values the bar does, so the two cannot disagree.
+  private var activePackTag: String? {
+    guard isUsingApple, isPreviewOn, case .ready(let tag, _) = currentActive else { return nil }
+    return tag
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -177,7 +177,6 @@ struct LivePreviewSettingsView: View {
     return SettingsContentView {
       statusBar
       engineSection
-      languageSection
       packsSection
     }
     // **Keyed on the language, not merely on appearance.**
@@ -213,7 +212,10 @@ struct LivePreviewSettingsView: View {
         lockableCodes: LanguageLockOptions.previewLockableCodes(
           backend: settings.selectedBackend,
           previewEngine: settings.livePreviewEngine,
-          installedPackTags: installedPackTags))
+          installedPackTags: installedPackTags),
+        // Re-homed from the help line under the old Change button (#2436): the
+        // consequence belongs where the action is taken.
+        contextSubtitle: LivePreviewSettingsCopy.pickerDictationCaveat)
     }
   }
 
@@ -438,134 +440,69 @@ struct LivePreviewSettingsView: View {
   }
 
   // MARK: - Preview language
-
-  /// Which language the words will appear in, and where that came from.
-  ///
-  /// **Only while the preview is actually on, and only on Apple's engine.** The
-  /// toggle defaults to OFF, so without the first gate the DEFAULT state of the
-  /// page announced "Your words will appear in English" for something that
-  /// cannot run. Without the second, it would state confidently which Apple
-  /// pack is producing words while the universal engine is the one drawing them.
-  @ViewBuilder
-  private var languageSection: some View {
-    // `currentActive`, never `packs.active` — a value resolved for a language the
-    // user has left must not describe this panel either.
-    // **The language control is NOT Apple-specific, and gating it on the pack
-    // list stranded universal users.** `showsApplePacks` correctly hides Apple's
-    // PACK TABLE on the other engine — those are Apple's languages. But the
-    // universal engine honours a LOCK too (`WhisperPreviewEngineResolver` maps
-    // `.locked(code)` straight through and only `.auto` becomes nil), so a user
-    // locked to the wrong language had no way to see or change it from the page
-    // that was telling them the preview was ready. Review r7.
-    if isPreviewOn, !isUsingApple {
-      universalLanguageSection
-    }
-    if showsApplePacks, isPreviewOn, let active = currentActive {
-      // **TWO containers, not one — founder 2026-08-18, comparing the shipped
-      // page against his mockup: "you combined it into 1 container instead of
-      // keeping it 2 containers."** The language row is a CONTROL you act on; the
-      // explainer is background you read once. Folding them into a single card
-      // made the row look like a paragraph with a button in it, and buried the
-      // thing the user came here to change.
-      //
-      // Always visible rather than behind a disclosure: the whole problem was not
-      // knowing where the language comes from, and an explanation you must first
-      // discover does not solve that.
-      BrandedSection(header: LivePreviewSettingsCopy.activeHeader) {
-        BrandedRow(showDivider: false) {
-          activeSummary(active)
-        }
-      }
-      InsetNotice(text: LivePreviewSettingsCopy.activeExplainer)
-    }
-  }
-
-  /// The universal engine's language row.
-  ///
-  /// Deliberately simpler than Apple's: there is no pack to resolve, so there is
-  /// no needs-download or unsupported state to describe. What it must NOT do is
-  /// stay silent — this engine follows a lock, and the whole point of the row is
-  /// that a user locked to the wrong language can see it and change it.
-  @ViewBuilder
-  private var universalLanguageSection: some View {
-    BrandedSection(header: LivePreviewSettingsCopy.activeHeader) {
-      BrandedRow(showDivider: false) {
-        HStack(alignment: .top, spacing: 11) {
-          SettingsRowIcon(systemName: "globe")
-          VStack(alignment: .leading, spacing: 4) {
-            switch settings.languageMode {
-            case .locked(let code):
-              let entry = LanguageCatalog.entry(for: code)
-              // Describe the lock while paused; promise output only when the
-              // resolver would actually deliver it. The help line is unchanged
-              // because it states where the setting lives, which stays true.
-              Text(
-                LivePreviewEnginePresentation.universalRowLabel(
-                  languageName: entry.englishName, engineWillProduceOutput: universalWillProduceOutput)
-              )
-              .settingsRowLabel()
-              Text(LivePreviewSettingsCopy.universalLockedHelp).settingsHelperCopy()
-            case .auto:
-              Text(
-                LivePreviewEnginePresentation.universalRowLabel(
-                  languageName: nil, engineWillProduceOutput: universalWillProduceOutput)
-              )
-              .settingsRowLabel()
-              Text(LivePreviewSettingsCopy.universalAutoHelp).settingsHelperCopy()
-            }
-          }
-          Spacer(minLength: 8)
-          VStack(alignment: .trailing, spacing: 3) {
-            Button(LivePreviewSettingsCopy.changeLanguageButton) { showLanguageSheet = true }
-              .controlSize(.small)
-            Text(LivePreviewSettingsCopy.changeLanguageHelp)
-              .settingsHelperCopy()
-              .multilineTextAlignment(.trailing)
-              .frame(maxWidth: 190, alignment: .trailing)
-          }
-        }
-      }
-    }
-  }
-
-  /// States the resolved language plainly, and where it came from, so "what is
-  /// active" is readable without inferring it from the list.
-  @ViewBuilder
-  private func activeSummary(_ active: LivePreviewPacksModel.ActiveLanguage) -> some View {
-    HStack(alignment: .top, spacing: 11) {
-      SettingsRowIcon(systemName: "globe")
-      VStack(alignment: .leading, spacing: 4) {
-        switch active {
-        case .ready(_, let name):
-          Text(LivePreviewSettingsCopy.activeReady(name)).settingsRowLabel()
-          Text(LivePreviewSettingsCopy.activeSource(settings.languageMode)).settingsHelperCopy()
-        case .needsDownload(let name):
-          Text(LivePreviewSettingsCopy.activeNeedsDownload(name)).settingsRowLabel()
-          Text(LivePreviewSettingsCopy.activeNeedsDownloadHelp).settingsHelperCopy()
-        case .unsupportedLanguage:
-          Text(LivePreviewSettingsCopy.activeUnsupportedLanguage).settingsRowLabel()
-          Text(LivePreviewSettingsCopy.activeUnsupportedLanguageHelp).settingsHelperCopy()
-        case .unsupportedSystem:
-          Text(LivePreviewSettingsCopy.needsNewerMacOS).settingsReadingCopy()
-        }
-      }
-      Spacer(minLength: 8)
-      // #2154. The panel used to state the language and point at another page,
-      // which is a dead end for the one thing somebody reading it wants to
-      // change. The help line under the button says the consequence out loud:
-      // this sets the DICTATION language, not a preview-only one. Founder
-      // decision, one language in one place — two settings that can disagree
-      // hand the user a mismatch they cannot diagnose.
-      VStack(alignment: .trailing, spacing: 3) {
-        Button(LivePreviewSettingsCopy.changeLanguageButton) { showLanguageSheet = true }
-          .controlSize(.small)
-        Text(LivePreviewSettingsCopy.changeLanguageHelp)
-          .settingsHelperCopy()
-          .multilineTextAlignment(.trailing)
-          .frame(maxWidth: 190, alignment: .trailing)
-      }
-    }
-  }
+  //
+  // **The section is gone; the language moved into the status bar (#2436).** What
+  // follows is every reason the three deleted members recorded, carried verbatim
+  // rather than summarised, because each one still constrains the bar that replaced
+  // them.
+  //
+  // From `languageSection`, on which value may describe the language:
+  //
+  // > `currentActive`, never `packs.active` — a value resolved for a language the
+  // > user has left must not describe this panel either.
+  //
+  // Still binding, and `LivePreviewStatusBarPresentation.appleLanguage` is where it
+  // now lives.
+  //
+  // From `languageSection`, on why the control may not be Apple-only:
+  //
+  // > **The language control is NOT Apple-specific, and gating it on the pack
+  // > list stranded universal users.** `showsApplePacks` correctly hides Apple's
+  // > PACK TABLE on the other engine — those are Apple's languages. But the
+  // > universal engine honours a LOCK too (`WhisperPreviewEngineResolver` maps
+  // > `.locked(code)` straight through and only `.auto` becomes nil), so a user
+  // > locked to the wrong language had no way to see or change it from the page
+  // > that was telling them the preview was ready. Review r7.
+  //
+  // The bar honours this by construction: the language region renders on BOTH
+  // engines, and only `showsApplePacks` gates the pack table below.
+  //
+  // From `universalLanguageSection`, on what the universal row must not do:
+  //
+  // > Deliberately simpler than Apple's: there is no pack to resolve, so there is
+  // > no needs-download or unsupported state to describe. What it must NOT do is
+  // > stay silent — this engine follows a lock, and the whole point of the row is
+  // > that a user locked to the wrong language can see it and change it.
+  //
+  // `universalLanguage` in the presentation is never nil for either language mode,
+  // which is that requirement expressed as a return type rather than a habit, and
+  // `chipNeverPromisesOutput`'s scenario table asserts it for both modes.
+  //
+  // From `activeSummary`, on where the Change button leads:
+  //
+  // > #2154. The panel used to state the language and point at another page,
+  // > which is a dead end for the one thing somebody reading it wants to
+  // > change. The help line under the button says the consequence out loud:
+  // > this sets the DICTATION language, not a preview-only one. Founder
+  // > decision, one language in one place — two settings that can disagree
+  // > hand the user a mismatch they cannot diagnose.
+  //
+  // The button survives as the language region itself. The consequence sentence
+  // moves into `LanguageLockSheet`'s context subtitle in C4, next to the moment it
+  // becomes true, rather than sitting under a button nobody has pressed yet.
+  //
+  // **The one reason NOT carried forward is the two-container rule**, and it is
+  // superseded rather than dropped:
+  //
+  // > **TWO containers, not one — founder 2026-08-18, comparing the shipped
+  // > page against his mockup: "you combined it into 1 container instead of
+  // > keeping it 2 containers."**
+  //
+  // That rule separated a CONTROL from its EXPLAINER so the control was not buried
+  // in a paragraph. #2436 deletes the explainer instead: the fact it carried (on
+  // Auto the preview follows the Mac, not the dictation language) is now two words
+  // under the language itself. There is no paragraph left for the control to be
+  // buried in. Founder direction, 2026-08-25.
 
   // MARK: - Language table
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -134,13 +134,10 @@ struct LivePreviewSettingsView: View {
     WhisperPreviewDeliveryWiring.heartIsStreaming(settings: settings)
   }
 
-  /// Readiness for the universal row, from the same owner the hero reads. Never
-  /// re-derive this from a blocker here: r8 and r9 were both a surface deciding
-  /// readiness for itself and reaching a different answer from the card above it.
-  private var universalWillProduceOutput: Bool {
-    LivePreviewStatusMapping.universalWillProduceOutput(
-      exists: universalExists, state: universalState, heartIsStreaming: heartIsStreaming)
-  }
+  // `universalWillProduceOutput` was deleted with the row that asked it (#2436).
+  // Readiness now has exactly one consumer — the status text — and it reads the
+  // mapping's `Summary` directly. A second local property re-deriving it, even an
+  // unused one, is the shape r8 and r9 of #2154 cost two rounds to remove.
 
   /// **The ONE place staleness is decided, and every consumer of the resolved
   /// language reads THIS rather than `packs.active`.**

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -485,7 +485,7 @@ struct LivePreviewSettingsView: View {
   // > hand the user a mismatch they cannot diagnose.
   //
   // The button survives as the language region itself. The consequence sentence
-  // moves into `LanguageLockSheet`'s context subtitle in C4, next to the moment it
+  // moved into `LanguageLockSheet`'s context subtitle in this same chunk, next to the moment it
   // becomes true, rather than sitting under a button nobody has pressed yet.
   //
   // **The one reason NOT carried forward is the two-container rule**, and it is

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -318,7 +318,14 @@ struct LivePreviewSettingsView: View {
             }
             .buttonStyle(.plain)
             .contentShape(Rectangle())
-            .accessibilityLabel("Change dictation language: \(language.name)")
+            // **The provenance is IN the label, not just on screen.** An explicit
+            // `accessibilityLabel` REPLACES the child text announcement, so naming
+            // only `language.name` dropped the second line entirely for VoiceOver —
+            // and that line is the one carrying the Auto asymmetry, the distinction
+            // between a language the Mac chose and one the user picked. A sighted
+            // user reads both; a VoiceOver user heard one. Cloud review on PR #2440.
+            .accessibilityLabel(
+              "Change dictation language: \(language.name), \(language.provenance)")
           }
 
           // **The reason lives in the hero card now, and only there.**

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -41,6 +41,7 @@ struct LivePreviewSettingsView: View {
   /// #2154: the dictation-language picker, opened by the Change button.
   @State private var showLanguageSheet: Bool = false
 
+
   // MARK: - Derived state
 
   /// Whether APPLE's engine can run here. Still the gate for the pack list and
@@ -174,8 +175,7 @@ struct LivePreviewSettingsView: View {
   var body: some View {
     @Bindable var settings = settings
     return SettingsContentView {
-      heroCard
-      toggleCard
+      statusBar
       engineSection
       languageSection
       packsSection
@@ -219,72 +219,93 @@ struct LivePreviewSettingsView: View {
 
   // MARK: - Hero card
 
-  /// What the feature is, and whether it is working right now.
+  // MARK: - Status bar
+
+  /// What is happening, which language, and the switch — on one line (#2436).
   ///
-  /// Two columns because they answer different questions and a returning user
-  /// only needs the right one. The left half is read once, on the first visit;
-  /// the right half is the reason anybody comes back.
-  private var heroCard: some View {
-    BrandedSection {
-      BrandedRow(showDivider: false) {
-        HStack(alignment: .top, spacing: 18) {
-          HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "text.viewfinder")
-              .font(.system(size: 20, weight: .medium))
-              .foregroundStyle(.stAccent)
-              .frame(width: 44, height: 44)
-              .background(Color.stAccentLight, in: RoundedRectangle(cornerRadius: 11))
-              .overlay(
-                RoundedRectangle(cornerRadius: 11)
-                  .strokeBorder(Color.stAccent.opacity(0.22), lineWidth: 1)
-              )
-              .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 4) {
-              Text(LivePreviewSettingsCopy.heroTitle).settingsRowTitle()
-              Text(LivePreviewSettingsCopy.heroBody).settingsReadingCopy()
-            }
-          }
-          .frame(maxWidth: .infinity, alignment: .leading)
-
-          Divider().overlay(Color.stDivider).frame(width: 1)
-
-          VStack(alignment: .leading, spacing: 4) {
-            ProviderStatusChip(status: status.chip)
-            Text(status.detail).settingsHelperCopy()
-          }
-          .frame(maxWidth: 260, alignment: .leading)
-        }
-      }
-    }
-  }
-
-  // MARK: - Toggle
-
-  private var toggleCard: some View {
+  /// Replaces the hero card, its status column and the toggle row. Those three said
+  /// the same sentence three times before the page said anything: the page header
+  /// already carries "See your words on screen while you are still speaking"
+  /// (`SettingsSection.swift:92`), the hero repeated it, and the toggle repeated the
+  /// hero. Founder, 2026-08-25: "the current live preview page is just information
+  /// overload."
+  ///
+  /// **Carried verbatim from `heroCard`, whose two columns this row replaces:**
+  ///
+  /// > Two columns because they answer different questions and a returning user
+  /// > only needs the right one. The left half is read once, on the first visit;
+  /// > the right half is the reason anybody comes back.
+  ///
+  /// That reasoning is why the left half is gone rather than shrunk: what it said
+  /// once now lives one line above in the page header, and what the right half said
+  /// is the only thing left here.
+  ///
+  /// Composition is `LivePreviewStatusBarPresentation`, not this body, so the rules
+  /// about what may be named in which state are testable without rendering.
+  private var statusBar: some View {
     @Bindable var settings = settings
+    let bar = LivePreviewStatusBarPresentation.bar(
+      summary: status, engine: settings.livePreviewEngine,
+      appleActive: currentActive, languageMode: settings.languageMode)
+
     return BrandedSection {
       BrandedRow(showDivider: false) {
-        HStack(alignment: .center, spacing: 11) {
+        HStack(alignment: .center, spacing: 12) {
           VStack(alignment: .leading, spacing: 3) {
-            Text(LivePreviewSettingsCopy.toggleLabel).settingsRowLabel()
-            Text(LivePreviewSettingsCopy.toggleDescription).settingsHelperCopy()
-            // **The reason lives in the hero card now, and only there.**
-            // This row used to repeat `needsNewerMacOS` whenever neither engine
-            // could run — but that condition is an OR of two independent causes,
-            // so on macOS 14 with a defective build it told the user to upgrade
-            // macOS when upgrading would not have helped. The status card above
-            // states the SELECTED engine's own reason, which is specific by
-            // construction, and two places saying why is how they come to
-            // disagree.
+            HStack(spacing: 8) {
+              ProviderStatusChip(status: status.chip)
+            }
+            Text(bar.detail).settingsHelperCopy()
           }
           Spacer(minLength: 12)
+
+          if let language = bar.language {
+            Button {
+              showLanguageSheet = true
+            } label: {
+              VStack(alignment: .trailing, spacing: 1) {
+                Text(language.name).settingsRowLabel()
+                Text(language.provenance).settingsHelperCopy()
+              }
+            }
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+            .accessibilityLabel("Change dictation language: \(language.name)")
+          }
+
+          // **The reason lives in the hero card now, and only there.**
+          // This row used to repeat `needsNewerMacOS` whenever neither engine
+          // could run — but that condition is an OR of two independent causes,
+          // so on macOS 14 with a defective build it told the user to upgrade
+          // macOS when upgrading would not have helped. The status card above
+          // states the SELECTED engine's own reason, which is specific by
+          // construction, and two places saying why is how they come to
+          // disagree.
+          //
+          // #2436: "the hero card" is now this same row's left half, so the rule
+          // is unchanged and its one-owner property is stronger — there is no
+          // longer a second container that could drift.
           Toggle("", isOn: $settings.livePreviewEnabled)
             .labelsHidden()
             .toggleStyle(BrandedToggleStyle())
             .disabled(!anyEngineAvailable)
+            // The visible label is gone; this is the only thing naming the switch
+            // for VoiceOver, which is why `toggleLabel` survives the copy cull.
             .accessibilityLabel(LivePreviewSettingsCopy.toggleLabel)
         }
       }
+
+      // **The remedy button lands in C4, with the sheet it opens.**
+      //
+      // `bar.action` is computed and tested from C1; nothing renders it yet, and
+      // that is deliberate rather than an omission. Until C4 the inline pack table
+      // is still on this page, so `statusNeedsLanguageDetail`'s "Use Browse
+      // downloads below" is satisfied by what is genuinely below. Shipping a button
+      // here would mean shipping one that opens nothing for the length of a chunk.
+
+    } footer: {
+      // Always visible: never gated on engine, toggle, Apple support or pack state.
+      Text(LivePreviewSettingsCopy.previewPrivacyFooter).settingsHelperCopy()
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -220,8 +220,12 @@ struct LivePreviewSettingsView: View {
           previewEngine: settings.livePreviewEngine,
           installedPackTags: installedPackTags),
         // Re-homed from the help line under the old Change button (#2436): the
-        // consequence belongs where the action is taken.
-        contextSubtitle: LivePreviewSettingsCopy.pickerDictationCaveat)
+        // consequence belongs where the action is taken. **Engine-specific**, because
+        // the Auto asymmetry is Apple's alone — telling a universal user their preview
+        // "uses your Mac's language" is false about their own engine.
+        contextSubtitle: settings.livePreviewEngine == .apple
+          ? LivePreviewSettingsCopy.pickerAppleCaveat
+          : LivePreviewSettingsCopy.pickerUniversalCaveat)
     }
     .sheet(isPresented: $showPackCatalog) {
       // The retained model, never a copy: dismissing this sheet mid-install must not

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
@@ -130,7 +130,30 @@ enum LivePreviewStatusBarPresentation {
     switch active {
     case .ready(_, let name), .needsDownload(let name):
       return Language(name: name, provenance: provenance(for: languageMode))
-    case .unsupportedLanguage, .unsupportedSystem:
+    case .unsupportedLanguage:
+      // **The control that UNSTRANDS the user must not be hidden by the state that
+      // stranded them.** Apple cannot preview this language, the language chip IS
+      // the picker, and returning nil here removed the only way to change it from
+      // this page — leaving a user whose preview is broken BY their language with
+      // no control on the page that could fix it. Cloud review on PR #2440.
+      //
+      // `universalLanguage` two functions down already carries this exact reason,
+      // from #2154 review r7, which hid the control on Universal and stranded
+      // exactly those users. The reason was written down and applied to one branch
+      // of two — so the shared derivation below is the fix, not a second copy of
+      // the sentence (`workflow-process.md` RULE: fix-the-path-that-runs-first,
+      // "name the TWIN of every site you change").
+      //
+      // The name comes from the LOCK rather than from `active`, because
+      // `ActiveLanguage.unsupportedLanguage` carries none — and the lock is what
+      // made it unsupported, so it is also the honest thing to name.
+      return languageFromLock(
+        languageMode, autoProvenance: LivePreviewSettingsCopy.languageProvenanceFromMac)
+    case .unsupportedSystem:
+      // Unreachable in practice — that value maps to `.needsMacOS26`, which the
+      // caller already returned nil for — and correct to hide regardless: no
+      // control on this page changes the macOS version, so offering the picker
+      // would imply a remedy that does not exist. The engine card says why.
       return nil
     }
   }
@@ -140,12 +163,27 @@ enum LivePreviewStatusBarPresentation {
   /// engine honours a lock, and the row's whole purpose is that a user locked to the
   /// wrong language can see it and change it. An earlier #2154 draft hid the control
   /// on this engine and stranded exactly those users (review r7).
-  private static func universalLanguage(_ mode: LanguageMode) -> Language? {
+  private static func universalLanguage(_ mode: LanguageMode) -> Language {
+    languageFromLock(
+      mode, autoProvenance: LivePreviewSettingsCopy.languageProvenanceDetected)
+  }
+
+  /// The language derived from the LOCK alone, for every state where pack
+  /// resolution cannot name one but the user must still be able to change it.
+  ///
+  /// **Only the Auto provenance differs between its two callers, and that
+  /// difference is the whole Auto asymmetry**: Apple's preview picks one locale
+  /// before the first word and takes it from the Mac, so `from your Mac`; the
+  /// universal engine pins nothing, so `no language pinned`. Passing it in keeps
+  /// one derivation with one honest parameter rather than two functions that
+  /// agree today.
+  private static func languageFromLock(
+    _ mode: LanguageMode, autoProvenance: String
+  ) -> Language {
     switch mode {
     case .auto:
       return Language(
-        name: LivePreviewSettingsCopy.languageAnyLanguage,
-        provenance: LivePreviewSettingsCopy.languageProvenanceDetected)
+        name: LivePreviewSettingsCopy.languageAnyLanguage, provenance: autoProvenance)
     case .locked(let code):
       return Language(
         name: LanguageCatalog.entry(for: code).englishName,

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
@@ -24,8 +24,9 @@ enum LivePreviewStatusBarPresentation {
   /// dictation language the way a user assumes: dictation detects what they
   /// actually speak, while this preview must commit to one locale before the first
   /// word and so uses the Mac's. Saying only "German" invites the reading that they
-  /// chose it. `LivePreviewSettingsCopy.activeSource` records the measurement, and
-  /// an earlier draft of that copy claimed the symmetrical version and was wrong.
+  /// chose it. `LivePreviewSettingsCopy.pickerDictationCaveat` states that asymmetry in
+  /// full, at the moment somebody acts on the language; an earlier draft of the copy it
+  /// replaced claimed the symmetrical version and was wrong.
   struct Language: Equatable {
     let name: String
     let provenance: String

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
@@ -141,7 +141,7 @@ enum LivePreviewStatusBarPresentation {
       // from #2154 review r7, which hid the control on Universal and stranded
       // exactly those users. The reason was written down and applied to one branch
       // of two — so the shared derivation below is the fix, not a second copy of
-      // the sentence (`workflow-process.md` RULE: fix-the-path-that-runs-first,
+      // the sentence (`workflow-process.md` RULE: fix-the-path-that-runs-first-not-the-one-you-were-reading,
       // "name the TWIN of every site you change").
       //
       // The name comes from the LOCK rather than from `active`, because

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
@@ -24,7 +24,7 @@ enum LivePreviewStatusBarPresentation {
   /// dictation language the way a user assumes: dictation detects what they
   /// actually speak, while this preview must commit to one locale before the first
   /// word and so uses the Mac's. Saying only "German" invites the reading that they
-  /// chose it. `LivePreviewSettingsCopy.pickerDictationCaveat` states that asymmetry in
+  /// chose it. `LivePreviewSettingsCopy.pickerAppleCaveat` states that asymmetry in
   /// full, at the moment somebody acts on the language; an earlier draft of the copy it
   /// replaced claimed the symmetrical version and was wrong.
   struct Language: Equatable {

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusBarPresentation.swift
@@ -1,0 +1,177 @@
+import EnviousWisprCore
+import EnviousWisprServices
+
+/// What the Live Preview status bar shows, as a value rather than a layout (#2436).
+///
+/// **Why a presentation type and not just a `body`.** The bar replaces three
+/// containers that each used to decide something for themselves — the hero card's
+/// status column, the toggle row, and the language panel. Those three disagreeing
+/// with each other is the entire history of this page: rounds r8 and r9 of #2154
+/// were the same defect twice, a second surface deciding readiness for itself and
+/// contradicting the card four points above it. A pure mapping is the only shape
+/// where "these two surfaces cannot disagree" is a property a test can hold,
+/// because a SwiftUI `body` cannot be asserted without rendering it.
+///
+/// **This type decides NOTHING about readiness.** `LivePreviewStatusMapping` owns
+/// that, alone, and this re-shapes the answer it already gave. If a future change
+/// finds itself asking here whether the preview will work, the question belongs one
+/// file over.
+enum LivePreviewStatusBarPresentation {
+
+  /// The language and where it came from, stacked under one another in the bar.
+  ///
+  /// **Provenance is not decoration.** On Auto the preview cannot follow the
+  /// dictation language the way a user assumes: dictation detects what they
+  /// actually speak, while this preview must commit to one locale before the first
+  /// word and so uses the Mac's. Saying only "German" invites the reading that they
+  /// chose it. `LivePreviewSettingsCopy.activeSource` records the measurement, and
+  /// an earlier draft of that copy claimed the symmetrical version and was wrong.
+  struct Language: Equatable {
+    let name: String
+    let provenance: String
+  }
+
+  /// The single remedy the bar may offer.
+  ///
+  /// **One case, deliberately.** Every other unhappy state is repaired somewhere
+  /// that already owns the control: the engine cards own download, cancel, resume,
+  /// retry and remove, and Faster Transcription is turned off on its own page. A
+  /// second button here would be a second owner for an action that already has one.
+  enum Action: Equatable {
+    /// Opens the pack catalogue, already searched for the language that is missing.
+    ///
+    /// Carries a display NAME rather than an install tag because
+    /// `ActiveLanguage.needsDownload` has no tag to give (`LivePreviewPacksModel`),
+    /// and inventing a reverse lookup from a localized display name back to a pack
+    /// identifier would be a new failure mode in exchange for saving one tap.
+    case browseDownloads(initialSearch: String)
+  }
+
+  /// Everything the bar draws.
+  ///
+  /// `detail` is NOT optional. An earlier draft of #2436 hid it while the preview
+  /// was working, reasoning that a green dot and a language chip already said so.
+  /// `LivePreviewStatusMappingTests.noLabelPromisesVisibleWords` refutes that from
+  /// the other direction: it carries a positive control requiring the ready detail
+  /// to contain "ready to show", the deliberately WEAKER claim, because a correctly
+  /// configured preview still shows nothing when the user speaks a language it is
+  /// not set to. "Activated" alone is a stronger promise than this page can keep.
+  struct Bar: Equatable {
+    let label: String
+    let detail: String
+    let language: Language?
+    let action: Action?
+  }
+
+  /// Compose the bar.
+  ///
+  /// **The engine is an explicit parameter, and leaving it out was a real defect.**
+  /// `appleActive` is Apple's pack resolution; it cannot describe the universal
+  /// engine at all, which resolves its language from the lock and nothing else. A
+  /// signature taking only the resolved Apple value could not have produced a
+  /// universal language, and would have reused Apple state to describe an engine
+  /// that never reads it. Grounded review r2 on #2436.
+  static func bar(
+    summary: LivePreviewStatusMapping.Summary,
+    engine: LivePreviewEngineChoice,
+    appleActive: LivePreviewPacksModel.ActiveLanguage?,
+    languageMode: LanguageMode
+  ) -> Bar {
+    Bar(
+      label: summary.chip.label,
+      detail: summary.detail,
+      language: language(
+        kind: summary.kind, engine: engine, appleActive: appleActive,
+        languageMode: languageMode),
+      action: action(for: summary.kind))
+  }
+
+  // MARK: - Language
+
+  /// **Named only when naming it is true.** Three of the states describe a preview
+  /// that cannot run at all — the engine is missing from the build, the Mac is too
+  /// old, or we have not finished reading the inventory. A language beside any of
+  /// those reads as a promise about words that will not appear, which is the exact
+  /// claim `RULE: the-status-card-may-only-claim-what-its-inputs-prove` forbids.
+  /// Hidden, never rendered empty: an empty chip reads as a resolved language whose
+  /// name we lost.
+  private static func language(
+    kind: LivePreviewStatusMapping.Kind,
+    engine: LivePreviewEngineChoice,
+    appleActive: LivePreviewPacksModel.ActiveLanguage?,
+    languageMode: LanguageMode
+  ) -> Language? {
+    switch kind {
+    case .buildCannotRun, .needsMacOS26, .checking:
+      return nil
+    case .active, .off, .needsLanguage, .unsupportedLanguage, .needsDownload,
+      .gettingReady, .downloadFailed, .paused:
+      break
+    }
+
+    switch engine {
+    case .apple:
+      return appleLanguage(appleActive, languageMode: languageMode)
+    case .universal:
+      return universalLanguage(languageMode)
+    }
+  }
+
+  /// Apple's language comes from the staleness-aware resolved value and nowhere
+  /// else. Reading `packs.active` directly is the #2154 r3 defect, where three
+  /// surfaces shared one guard and a value resolved for a language the user had
+  /// already left kept describing two of them.
+  private static func appleLanguage(
+    _ active: LivePreviewPacksModel.ActiveLanguage?,
+    languageMode: LanguageMode
+  ) -> Language? {
+    guard let active else { return nil }
+    switch active {
+    case .ready(_, let name), .needsDownload(let name):
+      return Language(name: name, provenance: provenance(for: languageMode))
+    case .unsupportedLanguage, .unsupportedSystem:
+      return nil
+    }
+  }
+
+  /// The universal engine resolves its language from the lock alone, so it needs no
+  /// pack state and is always representable. **It must not stay silent**: this
+  /// engine honours a lock, and the row's whole purpose is that a user locked to the
+  /// wrong language can see it and change it. An earlier #2154 draft hid the control
+  /// on this engine and stranded exactly those users (review r7).
+  private static func universalLanguage(_ mode: LanguageMode) -> Language? {
+    switch mode {
+    case .auto:
+      return Language(
+        name: LivePreviewSettingsCopy.languageAnyLanguage,
+        provenance: LivePreviewSettingsCopy.languageProvenanceDetected)
+    case .locked(let code):
+      return Language(
+        name: LanguageCatalog.entry(for: code).englishName,
+        provenance: LivePreviewSettingsCopy.languageProvenanceUserPicked)
+    }
+  }
+
+  private static func provenance(for mode: LanguageMode) -> String {
+    switch mode {
+    case .auto: return LivePreviewSettingsCopy.languageProvenanceFromMac
+    case .locked: return LivePreviewSettingsCopy.languageProvenanceUserPicked
+    }
+  }
+
+  // MARK: - Action
+
+  /// **Switched on `kind`, never on copy.** The only other discriminator on a
+  /// `Summary` is `chip.label`, and branching on that would make a user-facing
+  /// sentence into a behavioural API: a copy edit would silently change what this
+  /// button does, with no test standing between the two. `Kind` exists for this.
+  private static func action(for kind: LivePreviewStatusMapping.Kind) -> Action? {
+    switch kind {
+    case .needsLanguage(let name):
+      return .browseDownloads(initialSearch: name)
+    case .active, .off, .needsMacOS26, .checking, .unsupportedLanguage,
+      .needsDownload, .gettingReady, .downloadFailed, .buildCannotRun, .paused:
+      return nil
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusMapping.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewStatusMapping.swift
@@ -26,7 +26,27 @@ enum LivePreviewStatusMapping {
 
   /// Both halves of the card's right column. One type rather than two calls, so
   /// a new state cannot ship with a fresh label and a stale detail line.
+  /// **What the state IS, separate from what it SAYS.**
+  ///
+  /// Added by #2436 for one reason, and it is worth stating because the obvious
+  /// reading is that this duplicates the label. It does not: a consumer that has
+  /// to BRANCH on the state — the status bar picks a remedy button from it —
+  /// otherwise has only `chip.label` to look at, and branching on a user-facing
+  /// string makes copy a behavioural API. A reworded sentence would then silently
+  /// change what a button does, months later, with no test between the two.
+  ///
+  /// So every consumer switches on `kind` and NOTHING switches on copy. Grounded
+  /// review r2 finding C1 on #2436 is the enumeration that produced it.
+  enum Kind: Equatable {
+    case active, off, needsMacOS26, checking
+    case needsLanguage(name: String)
+    case unsupportedLanguage, needsDownload, gettingReady
+    case downloadFailed, buildCannotRun, paused
+  }
+
   struct Summary: Equatable {
+    /// The state itself, for consumers that branch. See `Kind`.
+    let kind: Kind
     /// Dot + label, for `ProviderStatusChip`.
     let chip: ProviderStatus
     /// The second line, specific to this state.
@@ -67,11 +87,13 @@ enum LivePreviewStatusMapping {
       case .universal:
         // The Mac is fine for this engine. Our package is not.
         return Summary(
+          kind: .buildCannotRun,
           chip: ProviderStatus(
             label: LivePreviewSettingsCopy.statusBuildCannotRunLabel, tone: .error),
           detail: LivePreviewSettingsCopy.statusBuildCannotRunDetailNoAlternative)
       case .apple:
         return Summary(
+          kind: .needsMacOS26,
           chip: ProviderStatus(
             label: LivePreviewSettingsCopy.statusNeedsMacOS26Label, tone: .needsSetup),
           detail: LivePreviewSettingsCopy.statusNeedsMacOS26DetailNoAlternative)
@@ -82,6 +104,7 @@ enum LivePreviewStatusMapping {
     // none of it is true while the feature is off.
     guard isEnabled else {
       return Summary(
+        kind: .off,
         chip: ProviderStatus(label: LivePreviewSettingsCopy.statusOffLabel, tone: .unavailable),
         detail: LivePreviewSettingsCopy.statusOffDetail)
     }
@@ -112,6 +135,7 @@ enum LivePreviewStatusMapping {
   ) -> Summary {
     guard supported else {
       return Summary(
+        kind: .needsMacOS26,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusNeedsMacOS26Label, tone: .needsSetup),
         detail: universalIsAnOption
@@ -131,6 +155,7 @@ enum LivePreviewStatusMapping {
     // review round.
     guard !activeDescribesAnotherLanguage else {
       return Summary(
+        kind: .checking,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusCheckingLabel, tone: .unavailable),
         detail: LivePreviewSettingsCopy.statusLanguageChangedDetail)
@@ -142,6 +167,7 @@ enum LivePreviewStatusMapping {
     // this card exists to fix.
     guard let active else {
       return Summary(
+        kind: .checking,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusCheckingLabel, tone: .unavailable),
         detail: LivePreviewSettingsCopy.statusCheckingDetail)
@@ -182,16 +208,19 @@ enum LivePreviewStatusMapping {
       // unresolved case already makes.
       guard !anInstallIsInFlight else {
         return Summary(
+          kind: .checking,
           chip: ProviderStatus(
             label: LivePreviewSettingsCopy.statusCheckingLabel, tone: .unavailable),
           detail: LivePreviewSettingsCopy.statusInstallInFlightDetail)
       }
       return Summary(
+        kind: .needsLanguage(name: name),
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusNeedsLanguageLabel(name), tone: .needsSetup),
         detail: LivePreviewSettingsCopy.statusNeedsLanguageDetail)
     case .unsupportedLanguage:
       return Summary(
+        kind: .unsupportedLanguage,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusUnsupportedLanguageLabel, tone: .needsSetup),
         detail: universalIsAnOption
@@ -202,6 +231,7 @@ enum LivePreviewStatusMapping {
       // resolver instead of the static check. Answered identically rather than
       // with a second sentence saying the same thing differently.
       return Summary(
+        kind: .needsMacOS26,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusNeedsMacOS26Label, tone: .needsSetup),
         detail: LivePreviewSettingsCopy.statusNeedsMacOS26Detail)
@@ -243,6 +273,7 @@ enum LivePreviewStatusMapping {
     // registered to download.
     guard exists else {
       return Summary(
+        kind: .buildCannotRun,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusBuildCannotRunLabel, tone: .error),
         detail: LivePreviewSettingsCopy.statusBuildCannotRunDetail)
@@ -264,6 +295,7 @@ enum LivePreviewStatusMapping {
     // the download need, which is a correct sequence of answers.
     if heartIsStreaming {
       return Summary(
+        kind: .paused,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.pausedForFasterTranscription, tone: .needsSetup),
         detail: LivePreviewSettingsCopy.statusPausedDetail)
@@ -275,6 +307,7 @@ enum LivePreviewStatusMapping {
 
     case .downloading, .preparing, .verifying:
       return Summary(
+        kind: .gettingReady,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusGettingReadyLabel, tone: .needsSetup),
         detail: LivePreviewSettingsCopy.statusGettingReadyDetail)
@@ -289,6 +322,7 @@ enum LivePreviewStatusMapping {
     // keeps paying for.
     case .failed(let failure):
       return Summary(
+        kind: .downloadFailed,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusDownloadFailedLabel, tone: .error),
         detail: ModelDeliveryCopy.message(reason: failure.reason, detail: failure.detail))
@@ -299,6 +333,7 @@ enum LivePreviewStatusMapping {
     // surfaces drift.
     case .cancelled, .notReady:
       return Summary(
+        kind: .needsDownload,
         chip: ProviderStatus(
           label: LivePreviewSettingsCopy.statusNeedsDownloadLabel, tone: .needsSetup),
         detail: LivePreviewSettingsCopy.statusNeedsDownloadDetail)
@@ -309,6 +344,7 @@ enum LivePreviewStatusMapping {
   /// saying "it works" two different ways.
   private static var activeSummary: Summary {
     Summary(
+      kind: .active,
       chip: ProviderStatus(label: LivePreviewSettingsCopy.statusActiveLabel, tone: .ready),
       detail: LivePreviewSettingsCopy.statusActiveDetail)
   }

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -1089,9 +1089,10 @@ struct LivePreviewCoordinatorTests {
     #expect(coordinator.display == .off)
     #expect(
       // Moved from `toggleDescription` to `heroBody` by #2154, when the hero card
-      // took the top of the page. The PROMISE is what this pins, not the symbol
+      // took the top of the page, and to `previewPrivacyFooter` by #2436, when the
+      // bar replaced that card. The PROMISE is what this pins, not the symbol
       // that carries it — following the string is the whole point of the check.
-      LivePreviewSettingsCopy.heroBody.contains("discarded"),
+      LivePreviewSettingsCopy.previewPrivacyFooter.contains("discarded"),
       "if this sentence goes, the assertion above stops being the promise it pins")
   }
 

--- a/Tests/EnviousWisprTests/App/LivePreviewPackPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackPresentationTests.swift
@@ -175,6 +175,31 @@ struct LivePreviewPackPresentationTests {
     #expect(unionTags == Set(rows.map(\.tag)))
   }
 
+  /// **The counts must describe the rows that are actually on screen.**
+  ///
+  /// This is the case the two tests above did not reach between them: one grouped without
+  /// searching, the other searched within one half, and the defect lived at the
+  /// intersection — chips counting the full catalogue while the rows showed only matches,
+  /// so "Not on this Mac 53" could sit above a single row. A fixture that covers each
+  /// axis separately is not a fixture that covers their combination.
+  @Test("Filter counts describe the rows remaining after a search")
+  func filterCountsFollowSearch() {
+    let rows = [
+      pack("en-US", "English", "English", installed: true),
+      pack("it-IT", "Italian", "Italiano", installed: false),
+      pack("de-DE", "German", "Deutsch", installed: false),
+    ]
+    let searched = LivePreviewPackPresentation.groups(from: rows, matching: "Italian")
+    #expect(searched.installed.isEmpty)
+    #expect(searched.available.map(\.tag) == ["it-IT"])
+
+    // Two-way control: with no query the same call is the plain grouping, so the test
+    // above cannot be passing because the search silently swallowed everything.
+    let unsearched = LivePreviewPackPresentation.groups(from: rows, matching: "")
+    #expect(unsearched.installed.count == 1)
+    #expect(unsearched.available.count == 2)
+  }
+
   /// The sheet searches WITHIN the selected half, so a match in the other half must not
   /// leak into the visible list. That is the one behaviour the old single table could not
   /// have, and the one a filter makes possible to get wrong.

--- a/Tests/EnviousWisprTests/App/LivePreviewPackPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackPresentationTests.swift
@@ -135,39 +135,60 @@ struct LivePreviewPackPresentationTests {
     }
   }
 
-  // MARK: - Availability column (#2154)
+  // **The two `availability(for:)` cases are DELETED by #2436 with the Source column
+  // they described.** They protected that an installed pack read "On this Mac" and a
+  // downloadable one "Available from Apple". No defect distinguishes those rows once
+  // the column does not exist; the installed/downloadable boundary is now the filter,
+  // and the two cases below assert it as a partition rather than as two strings.
+  //
+  // Deleted AFTER those cases were green, not in the same edit — the plan made that an
+  // ordering condition because an earlier draft cited a covering case it had not written.
 
-  /// **Product Outcome.** The Availability column is what makes 54 rows scannable:
-  /// it answers "do I already have this" without reading the Status cell. It
-  /// replaced the two-card installed/downloadable split, so if it stops telling
-  /// the truth the table loses the only boundary it has.
-  @Test("Availability says On this Mac for what is installed and Available from Apple for what is not")
-  func availabilityDistinguishesInstalledFromDownloadable() {
-    let installed = LivePreviewPack(
-      tag: "en-US", nativeName: "English (US)", localizedName: "English (US)", isInstalled: true)
-    let available = LivePreviewPack(
-      tag: "fr-FR", nativeName: "Français (France)", localizedName: "French (France)",
-      isInstalled: false)
+  // MARK: - Catalogue filter (#2436)
 
-    #expect(LivePreviewPackPresentation.availability(for: installed) == LivePreviewSettingsCopy.sourceSystem)
-    #expect(LivePreviewPackPresentation.availability(for: available) == LivePreviewSettingsCopy.sourceApple)
-    // The two must differ. A refactor collapsing them would leave a column that
-    // renders on every row and distinguishes nothing.
-    #expect(LivePreviewSettingsCopy.sourceSystem != LivePreviewSettingsCopy.sourceApple)
+  /// **The counts and the rows come from ONE grouping, so a chip cannot lie about the
+  /// list beneath it.** This replaces what the deleted Source column made visible: the
+  /// installed/downloadable boundary. The column stated it per row; the filter states it
+  /// once and can also be the default.
+  ///
+  /// Swapping either group turns this red, which is the property that matters — a chip
+  /// reading "Not on this Mac 53" above the installed rows is worse than no chip.
+  @Test("Both catalogue filter halves come from the same grouping, and partition the packs")
+  func filterHalvesComeFromOneGrouping() {
+    let rows = [
+      pack("en-US", "English", "English", installed: true),
+      pack("de-DE", "German", "Deutsch", installed: false),
+      pack("fr-FR", "French", "Français", installed: false),
+    ]
+    let groups = LivePreviewPackPresentation.groups(from: rows)
+
+    #expect(groups.installed.count == 1)
+    #expect(groups.available.count == 2)
+
+    // A partition: every pack in exactly one half, nothing invented, nothing dropped.
+    let installedAreInstalled = groups.installed.filter(\.isInstalled).count
+    let availableAreNot = groups.available.filter { !$0.isInstalled }.count
+    let unionTags = Set((groups.installed + groups.available).map(\.tag))
+    #expect(groups.installed.count + groups.available.count == rows.count)
+    #expect(installedAreInstalled == groups.installed.count)
+    #expect(availableAreNot == groups.available.count)
+    #expect(unionTags == Set(rows.map(\.tag)))
   }
 
-  /// The column tracks `isInstalled` and nothing else — not the tag, not the
-  /// name. Pinned because the obvious wrong implementation (guessing from the
-  /// locale) would look right on a US machine and be wrong everywhere else.
-  @Test("Availability depends only on whether the pack is installed")
-  func availabilityIgnoresEverythingButInstalledness() {
-    for tag in ["en-US", "zh-CN", "hi-IN", "pt-BR"] {
-      let present = LivePreviewPack(
-        tag: tag, nativeName: tag, localizedName: tag, isInstalled: true)
-      let absent = LivePreviewPack(
-        tag: tag, nativeName: tag, localizedName: tag, isInstalled: false)
-      #expect(LivePreviewPackPresentation.availability(for: present) == LivePreviewSettingsCopy.sourceSystem)
-      #expect(LivePreviewPackPresentation.availability(for: absent) == LivePreviewSettingsCopy.sourceApple)
-    }
+  /// The sheet searches WITHIN the selected half, so a match in the other half must not
+  /// leak into the visible list. That is the one behaviour the old single table could not
+  /// have, and the one a filter makes possible to get wrong.
+  @Test("Searching inside one filter half never returns the other half's matches")
+  func searchIsScopedToTheSelectedHalf() {
+    let rows = [
+      pack("en-US", "English", "English", installed: true),
+      pack("de-DE", "German", "Deutsch", installed: false),
+    ]
+    let groups = LivePreviewPackPresentation.groups(from: rows)
+
+    #expect(LivePreviewPackPresentation.matching(groups.available, query: "German").count == 1)
+    #expect(LivePreviewPackPresentation.matching(groups.installed, query: "German").isEmpty)
+    #expect(LivePreviewPackPresentation.matching(groups.installed, query: "English").count == 1)
+    #expect(LivePreviewPackPresentation.matching(groups.available, query: "English").isEmpty)
   }
 }

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -1,0 +1,177 @@
+import EnviousWisprCore
+import EnviousWisprModelDelivery
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2436 — what the Live Preview status bar shows, for every state it can be in.
+///
+/// Class: **Product Outcome.** "When this fails, the user sees ___" completes as
+/// "a bar that names a language it has not resolved, or loses a state's
+/// explanation, or offers a remedy for the wrong problem". All three are claims a
+/// person acts on.
+///
+/// **Why these live here and not in `LivePreviewStatusMappingTests`.** That suite's
+/// subject is which state we are in; this one's is what we draw for it. A mapping
+/// suite cannot prove a composition, and a SwiftUI `body` cannot be asserted
+/// without rendering it — the seam is what makes these rules checkable at all.
+@Suite(.tags(.productOutcome))
+@MainActor
+struct LivePreviewStatusBarPresentationTests {
+
+  // MARK: - Fixtures
+
+  /// Every kind the mapping can return, so the sweeps below are over the real
+  /// closed set rather than the ones a test author happened to think of.
+  private static let allKinds: [LivePreviewStatusMapping.Kind] = [
+    .active, .off, .needsMacOS26, .checking,
+    .needsLanguage(name: "German"),
+    .unsupportedLanguage, .needsDownload, .gettingReady,
+    .downloadFailed, .buildCannotRun, .paused,
+  ]
+
+  private func summary(
+    _ kind: LivePreviewStatusMapping.Kind,
+    label: String = "Activated",
+    detail: String = "Ready to show your words while you speak."
+  ) -> LivePreviewStatusMapping.Summary {
+    LivePreviewStatusMapping.Summary(
+      kind: kind,
+      chip: ProviderStatus(label: label, tone: .ready),
+      detail: detail)
+  }
+
+  private func bar(
+    _ kind: LivePreviewStatusMapping.Kind,
+    engine: LivePreviewEngineChoice = .apple,
+    appleActive: LivePreviewPacksModel.ActiveLanguage? = .ready(
+      tag: "en-US", name: "English (United States)"),
+    languageMode: LanguageMode = .auto,
+    label: String = "Activated",
+    detail: String = "Ready to show your words while you speak."
+  ) -> LivePreviewStatusBarPresentation.Bar {
+    LivePreviewStatusBarPresentation.bar(
+      summary: summary(kind, label: label, detail: detail),
+      engine: engine, appleActive: appleActive, languageMode: languageMode)
+  }
+
+  // MARK: - Label and detail
+
+  /// The bar never drops a state's explanation.
+  ///
+  /// An earlier draft hid the detail while the preview was working. The positive
+  /// control in `noLabelPromisesVisibleWords` is why it may not: the ready detail
+  /// carries "ready to show", the deliberately weaker claim, and the label alone
+  /// promises more than this page can keep.
+  @Test("Every state renders both a label and a detail, active included")
+  func everyStateKeepsItsExplanation() {
+    for kind in Self.allKinds {
+      let b = bar(kind, label: "L", detail: "D")
+      #expect(!b.label.isEmpty, "empty label for \(kind)")
+      #expect(!b.detail.isEmpty, "empty detail for \(kind)")
+    }
+  }
+
+  @Test("Label and detail are passed through from the mapping, never re-derived")
+  func labelAndDetailComeFromTheMapping() {
+    let b = bar(.active, label: "Activated", detail: "Ready to show your words while you speak.")
+    #expect(b.label == "Activated")
+    #expect(b.detail == "Ready to show your words while you speak.")
+  }
+
+  // MARK: - Language
+
+  @Test("Apple names its language only once the pack resolution is in hand")
+  func appleLanguageHiddenWhenUnresolved() {
+    #expect(bar(.checking, appleActive: nil).language == nil)
+    #expect(bar(.active, appleActive: nil).language == nil)
+    #expect(bar(.active).language?.name == "English (United States)")
+  }
+
+  /// The universal engine resolves per utterance, so it has a language to state in
+  /// every configuration and never depends on Apple's pack inventory. Reusing Apple
+  /// state here would have made this engine unrepresentable.
+  @Test("Universal always states a language, with no Apple pack state at all")
+  func universalLanguageIsIndependentOfApple() {
+    let auto = bar(.active, engine: .universal, appleActive: nil, languageMode: .auto)
+    #expect(auto.language?.name == "Any language")
+    #expect(auto.language?.provenance == "detected as you speak")
+
+    let locked = bar(
+      .active, engine: .universal, appleActive: nil, languageMode: .locked("de"))
+    #expect(locked.language?.name.isEmpty == false)
+    #expect(locked.language?.provenance == "you picked this")
+  }
+
+  /// **The claim this page is least allowed to get wrong.** On Auto the preview
+  /// goes by the Mac, while dictation detects what is actually spoken; saying the
+  /// preview follows the dictation language is the sentence an earlier draft of
+  /// `activeSource` shipped and had to withdraw.
+  @Test("Provenance names the Mac on Auto and the user on a lock")
+  func provenanceDistinguishesAutoFromLocked() {
+    #expect(bar(.active, languageMode: .auto).language?.provenance == "from your Mac")
+    #expect(bar(.active, languageMode: .locked("de")).language?.provenance == "you picked this")
+  }
+
+  @Test("No language is named while nothing can run, on either engine")
+  func noLanguageWhenNothingCanRun() {
+    for kind in [
+      LivePreviewStatusMapping.Kind.buildCannotRun, .needsMacOS26, .checking,
+    ] {
+      for engine in LivePreviewEngineChoice.allCases {
+        #expect(
+          bar(kind, engine: engine).language == nil,
+          "named a language for \(kind) on \(engine)")
+      }
+    }
+  }
+
+  /// The chip states configuration, never readiness. #2154's r8 and r9 were both a
+  /// second surface promising output the card denied; the fix is that no second
+  /// surface makes a readiness claim at all, so there is nothing left to disagree.
+  @Test("The language chip contains no readiness vocabulary, in any state")
+  func chipNeverPromisesOutput() {
+    let forbidden = ["will appear", "ready", "working", "active", "showing"]
+    for kind in Self.allKinds {
+      for engine in LivePreviewEngineChoice.allCases {
+        for mode in [LanguageMode.auto, .locked("de")] {
+          guard let language = bar(kind, engine: engine, languageMode: mode).language
+          else { continue }
+          let text = (language.name + " " + language.provenance).lowercased()
+          for phrase in forbidden {
+            #expect(
+              !text.contains(phrase),
+              "the language chip makes a readiness claim: \(text)")
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Action
+
+  @Test("Only a missing language offers a remedy, and it carries that language")
+  func onlyMissingLanguageOffersARemedy() {
+    #expect(
+      bar(.needsLanguage(name: "German")).action
+        == .browseDownloads(initialSearch: "German"))
+
+    for kind in Self.allKinds {
+      if case .needsLanguage = kind { continue }
+      #expect(bar(kind).action == nil, "unexpected action for \(kind)")
+    }
+  }
+
+  /// **The reason `Kind` exists.** If the action were chosen by reading
+  /// `chip.label`, a copy edit would silently change what the button does. Editing
+  /// every string the bar receives must leave the action untouched.
+  @Test("The remedy is derived from the state, never from the copy")
+  func actionIsIndependentOfCopy() {
+    for kind in Self.allKinds {
+      let a = bar(kind, label: "one wording", detail: "one detail").action
+      let b = bar(kind, label: "a completely different wording", detail: "and detail").action
+      #expect(a == b, "action moved when only copy changed, for \(kind)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -64,20 +64,19 @@ struct LivePreviewStatusBarPresentationTests {
   /// control in `noLabelPromisesVisibleWords` is why it may not: the ready detail
   /// carries "ready to show", the deliberately weaker claim, and the label alone
   /// promises more than this page can keep.
-  @Test("Every state renders both a label and a detail, active included")
+  /// **Sentinels, not "non-empty".** Asserting only that the strings are non-empty
+  /// passes against an implementation that hard-codes them, which is the whole class
+  /// of defect this seam exists to make visible. A value unique per state proves the
+  /// mapping's own string arrived here and was not re-derived.
+  @Test("Every state passes through both its label and its detail, active included")
   func everyStateKeepsItsExplanation() {
-    for kind in Self.allKinds {
-      let b = bar(kind, label: "L", detail: "D")
-      #expect(!b.label.isEmpty, "empty label for \(kind)")
-      #expect(!b.detail.isEmpty, "empty detail for \(kind)")
+    for (index, kind) in Self.allKinds.enumerated() {
+      let label = "__label_\(index)__"
+      let detail = "__detail_\(index)__"
+      let b = bar(kind, label: label, detail: detail)
+      #expect(b.label == label, "label changed for \(kind)")
+      #expect(b.detail == detail, "detail changed for \(kind)")
     }
-  }
-
-  @Test("Label and detail are passed through from the mapping, never re-derived")
-  func labelAndDetailComeFromTheMapping() {
-    let b = bar(.active, label: "Activated", detail: "Ready to show your words while you speak.")
-    #expect(b.label == "Activated")
-    #expect(b.detail == "Ready to show your words while you speak.")
   }
 
   // MARK: - Language
@@ -100,7 +99,7 @@ struct LivePreviewStatusBarPresentationTests {
 
     let locked = bar(
       .active, engine: .universal, appleActive: nil, languageMode: .locked("de"))
-    #expect(locked.language?.name.isEmpty == false)
+    #expect(locked.language?.name == LanguageCatalog.entry(for: "de").englishName)
     #expect(locked.language?.provenance == "you picked this")
   }
 
@@ -136,8 +135,20 @@ struct LivePreviewStatusBarPresentationTests {
     for kind in Self.allKinds {
       for engine in LivePreviewEngineChoice.allCases {
         for mode in [LanguageMode.auto, .locked("de")] {
-          guard let language = bar(kind, engine: engine, languageMode: mode).language
-          else { continue }
+          let candidate = bar(kind, engine: engine, languageMode: mode).language
+          // **Assert presence or absence per kind rather than skipping a nil.**
+          // `guard ... else { continue }` let a state that WRONGLY hides its
+          // language pass this test silently, which is the vacuity shape the
+          // suite is meant to catch rather than commit.
+          switch kind {
+          case .buildCannotRun, .needsMacOS26, .checking:
+            #expect(candidate == nil, "named a language for \(kind) on \(engine)")
+            continue
+          case .active, .off, .needsLanguage, .unsupportedLanguage, .needsDownload,
+            .gettingReady, .downloadFailed, .paused:
+            #expect(candidate != nil, "missing language for \(kind) on \(engine)")
+          }
+          guard let language = candidate else { continue }
           let text = (language.name + " " + language.provenance).lowercased()
           for phrase in forbidden {
             #expect(
@@ -153,9 +164,11 @@ struct LivePreviewStatusBarPresentationTests {
 
   @Test("Only a missing language offers a remedy, and it carries that language")
   func onlyMissingLanguageOffersARemedy() {
-    #expect(
-      bar(.needsLanguage(name: "German")).action
-        == .browseDownloads(initialSearch: "German"))
+    // Two names, because one hard-coded string would satisfy a single case.
+    for name in ["German", "Japanese"] {
+      #expect(
+        bar(.needsLanguage(name: name)).action == .browseDownloads(initialSearch: name))
+    }
 
     for kind in Self.allKinds {
       if case .needsLanguage = kind { continue }
@@ -168,10 +181,17 @@ struct LivePreviewStatusBarPresentationTests {
   /// every string the bar receives must leave the action untouched.
   @Test("The remedy is derived from the state, never from the copy")
   func actionIsIndependentOfCopy() {
+    // **Asserting a == b is not enough: always-nil satisfies it.** Each kind's
+    // EXPECTED action is stated, then required to survive both copy mutations.
     for kind in Self.allKinds {
-      let a = bar(kind, label: "one wording", detail: "one detail").action
-      let b = bar(kind, label: "a completely different wording", detail: "and detail").action
-      #expect(a == b, "action moved when only copy changed, for \(kind)")
+      let expected: LivePreviewStatusBarPresentation.Action?
+      if case .needsLanguage(let name) = kind {
+        expected = .browseDownloads(initialSearch: name)
+      } else {
+        expected = nil
+      }
+      #expect(bar(kind, label: "__one__", detail: "__first__").action == expected)
+      #expect(bar(kind, label: "__two__", detail: "__second__").action == expected)
     }
   }
 }

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -93,14 +93,18 @@ struct LivePreviewStatusBarPresentationTests {
   /// state here would have made this engine unrepresentable.
   @Test("Universal always states a language, with no Apple pack state at all")
   func universalLanguageIsIndependentOfApple() {
+    // Compared against the constants, not their literals: the wording changed twice
+    // during review ("Any language" overclaimed a finite engine, "detected as you speak"
+    // asserted activity) and a test pinning the words rather than the symbol fails on
+    // every honest correction while catching none of the wrong ones.
     let auto = bar(.active, engine: .universal, appleActive: nil, languageMode: .auto)
-    #expect(auto.language?.name == "Any language")
-    #expect(auto.language?.provenance == "automatic")
+    #expect(auto.language?.name == LivePreviewSettingsCopy.languageAnyLanguage)
+    #expect(auto.language?.provenance == LivePreviewSettingsCopy.languageProvenanceDetected)
 
     let locked = bar(
       .active, engine: .universal, appleActive: nil, languageMode: .locked("de"))
     #expect(locked.language?.name == LanguageCatalog.entry(for: "de").englishName)
-    #expect(locked.language?.provenance == "you picked this")
+    #expect(locked.language?.provenance == LivePreviewSettingsCopy.languageProvenanceUserPicked)
   }
 
   /// **The claim this page is least allowed to get wrong.** On Auto the preview
@@ -109,8 +113,10 @@ struct LivePreviewStatusBarPresentationTests {
   /// `activeSource` shipped and had to withdraw.
   @Test("Provenance names the Mac on Auto and the user on a lock")
   func provenanceDistinguishesAutoFromLocked() {
-    #expect(bar(.active, languageMode: .auto).language?.provenance == "from your Mac")
-    #expect(bar(.active, languageMode: .locked("de")).language?.provenance == "you picked this")
+    #expect(bar(.active, languageMode: .auto).language?.provenance == LivePreviewSettingsCopy.languageProvenanceFromMac)
+    #expect(
+      bar(.active, languageMode: .locked("de")).language?.provenance
+        == LivePreviewSettingsCopy.languageProvenanceUserPicked)
   }
 
   @Test("No language is named while nothing can run, on either engine")

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -166,9 +166,14 @@ struct LivePreviewStatusBarPresentationTests {
     // rendered while the preview was off, paused, downloading or failed. The guard
     // and the defect shared one blind spot, which is the argument for widening the
     // list at the moment a member escapes rather than only naming the instance.
+    // **Activity FORMS, not the stem.** An earlier version banned the substring
+    // "detect", which rejects honest configuration copy like "automatic detection"
+    // — an over-broad guard is a real cost, not a safe default, because a guard that
+    // fails innocent work is the one people learn to bypass.
     let forbidden = [
-      "will appear", "ready", "working", "active", "showing", "detect", "hearing",
-      "listening", "as you speak",
+      "will appear", "ready", "working", "active", "showing",
+      "detects", "detecting", "detected as you speak", "will detect",
+      "hearing", "listening", "as you speak",
     ]
     for scenario in scenarios {
       for mode in [LanguageMode.auto, .locked("de")] {

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -129,32 +129,59 @@ struct LivePreviewStatusBarPresentationTests {
   /// The chip states configuration, never readiness. #2154's r8 and r9 were both a
   /// second surface promising output the card denied; the fix is that no second
   /// surface makes a readiness claim at all, so there is nothing left to disagree.
-  @Test("The language chip contains no readiness vocabulary, in any state")
+  ///
+  /// **The scenarios are REACHABLE pairs, not a cross-product.** An earlier version
+  /// swept every kind against a fixed `.ready` Apple value, which pairs
+  /// `.unsupportedLanguage` with a resolved language — a combination the mapping
+  /// cannot produce — while never once constructing a real Apple `.needsLanguage`.
+  /// The consequence was a live branch nobody tested: returning nil from
+  /// `appleLanguage`'s `.needsDownload` case passed the whole suite. Testing a state
+  /// the code cannot reach and missing one it can are the same defect, and both come
+  /// from a fixture built out of defaults rather than out of the real pairings.
+  @Test("The language chip contains no readiness vocabulary, in every reachable state")
   func chipNeverPromisesOutput() {
+    typealias Scenario = (
+      kind: LivePreviewStatusMapping.Kind,
+      engine: LivePreviewEngineChoice,
+      appleActive: LivePreviewPacksModel.ActiveLanguage?,
+      expectsLanguage: Bool
+    )
+    let scenarios: [Scenario] = [
+      (.active, .apple, .ready(tag: "en-US", name: "English"), true),
+      (.off, .apple, .ready(tag: "en-US", name: "English"), true),
+      (.needsMacOS26, .apple, .unsupportedSystem, false),
+      (.checking, .apple, nil, false),
+      (.needsLanguage(name: "German"), .apple, .needsDownload(name: "German"), true),
+      (.unsupportedLanguage, .apple, .unsupportedLanguage, false),
+      (.active, .universal, nil, true),
+      (.off, .universal, nil, true),
+      (.needsDownload, .universal, nil, true),
+      (.gettingReady, .universal, nil, true),
+      (.downloadFailed, .universal, nil, true),
+      (.paused, .universal, nil, true),
+      (.buildCannotRun, .universal, nil, false),
+    ]
     let forbidden = ["will appear", "ready", "working", "active", "showing"]
-    for kind in Self.allKinds {
-      for engine in LivePreviewEngineChoice.allCases {
-        for mode in [LanguageMode.auto, .locked("de")] {
-          let candidate = bar(kind, engine: engine, languageMode: mode).language
-          // **Assert presence or absence per kind rather than skipping a nil.**
-          // `guard ... else { continue }` let a state that WRONGLY hides its
-          // language pass this test silently, which is the vacuity shape the
-          // suite is meant to catch rather than commit.
-          switch kind {
-          case .buildCannotRun, .needsMacOS26, .checking:
-            #expect(candidate == nil, "named a language for \(kind) on \(engine)")
-            continue
-          case .active, .off, .needsLanguage, .unsupportedLanguage, .needsDownload,
-            .gettingReady, .downloadFailed, .paused:
-            #expect(candidate != nil, "missing language for \(kind) on \(engine)")
-          }
-          guard let language = candidate else { continue }
-          let text = (language.name + " " + language.provenance).lowercased()
-          for phrase in forbidden {
-            #expect(
-              !text.contains(phrase),
-              "the language chip makes a readiness claim: \(text)")
-          }
+    for scenario in scenarios {
+      for mode in [LanguageMode.auto, .locked("de")] {
+        let candidate = bar(
+          scenario.kind, engine: scenario.engine, appleActive: scenario.appleActive,
+          languageMode: mode
+        ).language
+        #expect(
+          (candidate != nil) == scenario.expectsLanguage,
+          "language presence wrong for \(scenario.kind) on \(scenario.engine)")
+        // The missing-language state must name the language it is missing, which is
+        // the branch the previous fixture could not reach at all.
+        if case .needsLanguage(let name) = scenario.kind {
+          #expect(candidate?.name == name)
+        }
+        guard let candidate else { continue }
+        let text = "\(candidate.name) \(candidate.provenance)".lowercased()
+        for phrase in forbidden {
+          #expect(
+            !text.contains(phrase),
+            "the language chip makes a readiness claim: \(text)")
         }
       }
     }

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -56,6 +56,90 @@ struct LivePreviewStatusBarPresentationTests {
       engine: engine, appleActive: appleActive, languageMode: languageMode)
   }
 
+  // MARK: - Reachability of the language control
+
+  /// **The language chip IS the picker, so hiding it removes the only way to change
+  /// the language from this page.** That makes its visibility a REACHABILITY
+  /// property, not a cosmetic one, and the states where a user most needs the
+  /// picker are exactly the states the language itself has broken.
+  ///
+  /// `chipNeverPromisesOutput` sweeps reachable pairs and had a row asserting the
+  /// chip was hidden for Apple `.unsupportedLanguage` — an expectation written to
+  /// match the implementation, which is why a whole passing suite said nothing
+  /// about a stranded user. Cloud review on PR #2440 found it.
+  ///
+  /// This test is the complement of that one: it states WHICH states may hide the
+  /// control and requires a reason for each, so the next kind added has to be
+  /// classified rather than inheriting whatever `appleLanguage` happens to return.
+  /// The three below are the only ones where no picker choice is a remedy —
+  /// nothing the user can select fixes a macOS version, a broken build, or an
+  /// answer that has not arrived yet.
+  @Test("The language control is reachable in every state where changing the language could help")
+  func languageControlSurvivesTheStatesThatNeedIt() {
+    let mayHide: Set<String> = ["needsMacOS26", "buildCannotRun", "checking"]
+
+    /// Apple pack state paired so each kind is REACHABLE, per the fixture lesson in
+    /// `chipNeverPromisesOutput`: a kind swept against a default `.ready` tests
+    /// pairs the mapping cannot produce.
+    func appleValue(
+      for kind: LivePreviewStatusMapping.Kind
+    ) -> LivePreviewPacksModel.ActiveLanguage? {
+      switch kind {
+      case .needsMacOS26: return .unsupportedSystem
+      case .checking: return nil
+      case .unsupportedLanguage: return .unsupportedLanguage
+      case .needsLanguage(let name): return .needsDownload(name: name)
+      default: return .ready(tag: "en-US", name: "English (United States)")
+      }
+    }
+
+    for kind in Self.allKinds {
+      let name = "\(kind)".split(separator: "(").first.map(String.init) ?? "\(kind)"
+      for engine in [LivePreviewEngineChoice.apple, .universal] {
+        // Universal reads no pack state at all, so it must answer for every kind
+        // the page can reach — #2154 r7 hid it here and stranded locked users.
+        let active = engine == .apple ? appleValue(for: kind) : nil
+        let language = bar(kind, engine: engine, appleActive: active).language
+        if mayHide.contains(name) && engine == .apple {
+          #expect(language == nil, "\(name) on Apple has no picker remedy, so it hides")
+        } else if mayHide.contains(name) && engine == .universal {
+          // Universal has no macOS floor and no pack build to fail, so only the
+          // build-cannot-run kind hides there.
+          continue
+        } else {
+          // One interpolated literal, never `"a" + "b"`: `Comment` is expressible by
+          // string interpolation but not built from a runtime `String`, so the
+          // concatenated form does not compile.
+          #expect(
+            language != nil,
+            "\(name) on \(engine) hides the language chip, the only control on this page that can change the language"
+          )
+        }
+      }
+    }
+  }
+
+  /// The locked language is NAMED when Apple cannot preview it, rather than the row
+  /// falling back to something generic. A user who locked Danish and is told the
+  /// preview cannot do it needs to see Danish to know what to change.
+  @Test("An unsupported Apple lock still names the language the user chose")
+  func unsupportedAppleLockNamesTheLock() {
+    let locked = bar(
+      .unsupportedLanguage, engine: .apple, appleActive: .unsupportedLanguage,
+      languageMode: .locked("da"))
+    #expect(locked.language?.name == LanguageCatalog.entry(for: "da").englishName)
+    #expect(locked.language?.provenance == LivePreviewSettingsCopy.languageProvenanceUserPicked)
+
+    // On Auto there is no lock to name, and Apple's preview takes the locale from
+    // the Mac — which is the Auto asymmetry, so the provenance must say so rather
+    // than borrowing the universal engine's "no language pinned".
+    let auto = bar(
+      .unsupportedLanguage, engine: .apple, appleActive: .unsupportedLanguage,
+      languageMode: .auto)
+    #expect(auto.language?.provenance == LivePreviewSettingsCopy.languageProvenanceFromMac)
+    #expect(auto.language?.provenance != LivePreviewSettingsCopy.languageProvenanceDetected)
+  }
+
   // MARK: - Label and detail
 
   /// The bar never drops a state's explanation.
@@ -113,7 +197,9 @@ struct LivePreviewStatusBarPresentationTests {
   /// `activeSource` shipped and had to withdraw.
   @Test("Provenance names the Mac on Auto and the user on a lock")
   func provenanceDistinguishesAutoFromLocked() {
-    #expect(bar(.active, languageMode: .auto).language?.provenance == LivePreviewSettingsCopy.languageProvenanceFromMac)
+    #expect(
+      bar(.active, languageMode: .auto).language?.provenance
+        == LivePreviewSettingsCopy.languageProvenanceFromMac)
     #expect(
       bar(.active, languageMode: .locked("de")).language?.provenance
         == LivePreviewSettingsCopy.languageProvenanceUserPicked)
@@ -158,7 +244,14 @@ struct LivePreviewStatusBarPresentationTests {
       (.needsMacOS26, .apple, .unsupportedSystem, false),
       (.checking, .apple, nil, false),
       (.needsLanguage(name: "German"), .apple, .needsDownload(name: "German"), true),
-      (.unsupportedLanguage, .apple, .unsupportedLanguage, false),
+      // **Was `false`, and that expectation was written to match the code rather
+      // than the requirement.** Hiding the chip here hides the PICKER, which is the
+      // only control on this page that can change the language — so the state
+      // caused by a language became the state in which the language cannot be
+      // changed. Found by cloud review on PR #2440, after this suite passed.
+      // A row that agrees with the implementation proves the implementation is
+      // self-consistent, never that it is right.
+      (.unsupportedLanguage, .apple, .unsupportedLanguage, true),
       (.active, .universal, nil, true),
       (.off, .universal, nil, true),
       (.needsDownload, .universal, nil, true),

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -95,7 +95,7 @@ struct LivePreviewStatusBarPresentationTests {
   func universalLanguageIsIndependentOfApple() {
     let auto = bar(.active, engine: .universal, appleActive: nil, languageMode: .auto)
     #expect(auto.language?.name == "Any language")
-    #expect(auto.language?.provenance == "detected as you speak")
+    #expect(auto.language?.provenance == "automatic")
 
     let locked = bar(
       .active, engine: .universal, appleActive: nil, languageMode: .locked("de"))
@@ -161,7 +161,15 @@ struct LivePreviewStatusBarPresentationTests {
       (.paused, .universal, nil, true),
       (.buildCannotRun, .universal, nil, false),
     ]
-    let forbidden = ["will appear", "ready", "working", "active", "showing"]
+    // **"detect" is here because its absence is what let a real defect through.**
+    // `languageProvenanceDetected` said "detected as you speak", which the chip
+    // rendered while the preview was off, paused, downloading or failed. The guard
+    // and the defect shared one blind spot, which is the argument for widening the
+    // list at the moment a member escapes rather than only naming the instance.
+    let forbidden = [
+      "will appear", "ready", "working", "active", "showing", "detect", "hearing",
+      "listening", "as you speak",
+    ]
     for scenario in scenarios {
       for mode in [LanguageMode.auto, .locked("de")] {
         let candidate = bar(

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusMappingTests.swift
@@ -425,57 +425,19 @@ struct LivePreviewStatusMappingTests {
     // Positive control: the ready detail DOES make the weaker, true claim.
     #expect(LivePreviewSettingsCopy.statusActiveDetail.lowercased().contains("ready to show"))
   }
-
-  /// **The row and the hero may never disagree, across the WHOLE input space.**
-  ///
-  /// r8 and r9 were one defect found twice: the universal language row decided
-  /// readiness for itself from a SUBSET of the blockers, so it promised "Your
-  /// words will appear in German" while the card four points above it correctly
-  /// reported the model missing, downloading, verifying, failed, or absent from
-  /// the build. r8 gated the row on the streaming refusal; r9 found the other
-  /// five.
-  ///
-  /// Hand-picked rows are what let the second round happen, so this is generated:
-  /// every `DeliveryState` case, both `exists` values, both streaming values. A
-  /// seventh blocker added to the hero and not to `universalWillProduceOutput`
-  /// fails here instead of shipping a page that contradicts itself.
-  @Test("Universal row readiness agrees with the hero card in every state")
-  func universalReadinessAgreesWithTheHero() {
-    let everyState: [DeliveryState] = [
-      .notReady,
-      .preparing(validatingExistingCache: false),
-      .preparing(validatingExistingCache: true),
-      .downloading(fractionCompleted: 0.5, bytesWritten: 1, totalBytes: 2),
-      .verifying,
-      .admitted,
-      .cancelled(resumable: true),
-      .cancelled(resumable: false),
-      .failed(DeliveryFailure(reason: .source5xx, detail: "t")),
-    ]
-    var sawReady = false
-    var sawNotReady = false
-    for exists in [true, false] {
-      for streaming in [true, false] {
-        for state in everyState {
-          let rowPromises = LivePreviewStatusMapping.universalWillProduceOutput(
-            exists: exists, state: state, heartIsStreaming: streaming)
-          let heroSaysReady =
-            summary(
-              engine: .universal, universalExists: exists, universalState: state,
-              heartIsStreaming: streaming
-            ).chip.tone == .ready
-          #expect(
-            rowPromises == heroSaysReady,
-            """
-            row and hero disagree for exists=\(exists) streaming=\(streaming) \(state): \
-            row promises output=\(rowPromises), hero says ready=\(heroSaysReady)
-            """)
-          if rowPromises { sawReady = true } else { sawNotReady = true }
-        }
-      }
-    }
-    // Both verdicts must actually occur, or the agreement above is vacuous.
-    #expect(sawReady, "no input produced a ready verdict; the sweep proves nothing")
-    #expect(sawNotReady, "no input produced a blocked verdict; the sweep proves nothing")
-  }
+  // **`universalReadinessAgreesWithTheHero` and `universalRowPromisesOnlyWhenRunning`
+  // are DELETED by #2436, not retargeted, and that is the point.**
+  //
+  // They existed because r8 and r9 of #2154 each found a SECOND surface promising
+  // output the hero card denied, and they held the two in agreement across the whole
+  // input space. #2436 removes the second surface: the status text is the only
+  // readiness claim on the page, and the language chip states configuration and
+  // provenance only — it never calls `universalWillProduceOutput` and never
+  // enumerates a blocker.
+  //
+  // Retargeting them to the chip would have made the chip a readiness surface again,
+  // which is the exact thing being removed. What replaces them is stronger and lives
+  // in `LivePreviewStatusBarPresentationTests`: `chipNeverPromisesOutput` asserts the
+  // chip contains no readiness vocabulary in any reachable state, which fails for a
+  // wider class of change than agreement ever did.
 }

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -73,7 +73,10 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.statusBuildCannotRunDetailNoAlternative,
       LivePreviewSettingsCopy.pausedForFasterTranscription,
       LivePreviewSettingsCopy.statusPausedDetail,
-      LivePreviewSettingsCopy.pickerDictationCaveat,
+      LivePreviewSettingsCopy.pickerAppleCaveat,
+      LivePreviewSettingsCopy.pickerUniversalCaveat,
+      LivePreviewSettingsCopy.catalogNothingToInstall,
+      LivePreviewSettingsCopy.catalogNoneInstalled,
       LivePreviewSettingsCopy.universalAuto,
       // r8: paused variants, which must describe rather than promise.
       LivePreviewSettingsCopy.universalLockedPaused("German"),
@@ -181,33 +184,40 @@ struct LivePreviewSettingsCopyTests {
   /// not fix that; it would only trade this gap for a false failure on every honest
   /// rewrite, which is what sent an earlier draft to a comment insisting the phrase
   /// was frozen.
-  /// **The Auto asymmetry, pinned at whichever symbol carries it (#2436).**
+  /// **The Auto asymmetry, pinned per ENGINE (#2436).**
   ///
-  /// Dictation on Auto detects what the user actually speaks; the preview must pick
-  /// one language before the first word and uses the Mac's. A bilingual user who does
-  /// not know that reads a wrong-language preview as broken dictation. It lived in
-  /// `activeExplainer` until the explainer box was deleted, and now lives in the
-  /// picker's context subtitle, where somebody is acting on the language.
-  ///
-  /// Written as a floor: it requires the sentence to spend words on both halves, which
-  /// catches the failure actually seen (a trim that keeps the source and drops the
-  /// contrast) without failing every honest rewrite.
-  @Test("The picker caveat keeps the Auto asymmetry, not just the source")
-  func pickerCaveatKeepsTheAutoAsymmetry() {
-    // **Pin the RELATIONSHIP, not the vocabulary.** An earlier version required the
-    // words "dictation", "mac" and "detect" somewhere in the sentence, which
-    // "Mac detects dictation" satisfies while reversing the fact. Each half is now
-    // pinned as a pair, with alternatives so an honest rewrite still passes.
-    let c = LivePreviewSettingsCopy.pickerDictationCaveat.lowercased()
-    #expect(c.contains("auto"), "the caveat stopped naming the mode it describes")
+  /// Dictation on Auto detects what the user actually speaks. Apple's preview cannot: it
+  /// must pick one language before the first word and uses the Mac's, so a bilingual user
+  /// who does not know that reads a wrong-language preview as broken dictation. **The
+  /// universal engine has no such constraint**, and an earlier version of this test had no
+  /// engine variable at all — it validated the Apple sentence and passed while the
+  /// universal picker displayed it. A test that cannot tell the two engines apart cannot
+  /// catch one being given the other's explanation.
+  @Test("Apple's caveat keeps the Auto asymmetry, and Universal's does not claim it")
+  func caveatsAreEngineSpecific() {
+    let apple = LivePreviewSettingsCopy.pickerAppleCaveat.lowercased()
+    #expect(apple.contains("auto"), "Apple's caveat stopped naming the mode it describes")
     #expect(
-      ["dictation detects", "dictation understands"].contains(where: c.contains)
-        && ["you speak", "spoken"].contains(where: c.contains),
-      "the caveat stopped saying DICTATION is what hears the spoken language")
+      ["dictation detects", "dictation understands"].contains(where: apple.contains)
+        && ["you speak", "spoken"].contains(where: apple.contains),
+      "Apple's caveat stopped saying DICTATION is what hears the spoken language")
     #expect(
-      c.contains("preview")
-        && ["uses your mac", "follows your mac", "goes by your mac"].contains(where: c.contains),
-      "the caveat stopped saying the PREVIEW is what falls back to the Mac")
+      apple.contains("preview")
+        && ["uses your mac", "follows your mac", "goes by your mac"].contains(where: apple.contains),
+      "Apple's caveat stopped saying the PREVIEW is what falls back to the Mac")
+
+    // The universal engine resolves per utterance, so the Mac fallback is not its story.
+    // Asserting its ABSENCE is the half that would have caught the shared-string defect.
+    let universal = LivePreviewSettingsCopy.pickerUniversalCaveat.lowercased()
+    #expect(
+      !["uses your mac", "follows your mac", "goes by your mac"].contains(where: universal.contains),
+      "Universal's caveat claims Apple's Mac fallback, which is false for that engine")
+    #expect(universal.contains("auto"), "Universal's caveat stopped naming the mode")
+
+    // Both still state the shared consequence, which is why the sheet carries either.
+    for c in [apple, universal] {
+      #expect(c.contains("dictation"), "a caveat stopped naming dictation at all")
+    }
   }
 
   /// The status bar's provenance describes CONFIGURATION, never activity: the chip

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -23,12 +23,6 @@ struct LivePreviewSettingsCopyTests {
     [
       LivePreviewSettingsCopy.sectionHeader,
       LivePreviewSettingsCopy.toggleLabel,
-      LivePreviewSettingsCopy.needsNewerMacOS,
-      LivePreviewSettingsCopy.activeHeader,
-      LivePreviewSettingsCopy.activeExplainer,
-      LivePreviewSettingsCopy.activeNeedsDownloadHelp,
-      LivePreviewSettingsCopy.activeUnsupportedLanguage,
-      LivePreviewSettingsCopy.activeUnsupportedLanguageHelp,
       LivePreviewSettingsCopy.packsHeader,
       LivePreviewSettingsCopy.packsDescription,
       LivePreviewSettingsCopy.packsLoading,
@@ -73,11 +67,8 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.statusBuildCannotRunDetailNoAlternative,
       LivePreviewSettingsCopy.pausedForFasterTranscription,
       LivePreviewSettingsCopy.statusPausedDetail,
-      LivePreviewSettingsCopy.changeLanguageButton,
-      LivePreviewSettingsCopy.changeLanguageHelp,
-      LivePreviewSettingsCopy.universalLockedHelp,
+      LivePreviewSettingsCopy.pickerDictationCaveat,
       LivePreviewSettingsCopy.universalAuto,
-      LivePreviewSettingsCopy.universalAutoHelp,
       // r8: paused variants, which must describe rather than promise.
       LivePreviewSettingsCopy.universalLockedPaused("German"),
       LivePreviewSettingsCopy.universalAutoPaused,
@@ -285,37 +276,8 @@ struct LivePreviewSettingsCopyTests {
         "each engine's copy must separate this setting from Live Preview: \(description)")
     }
   }
-
-  /// **The four cells of the universal row, because the SELECTION is the subject.**
-  ///
-  /// Cloud review r8: with Faster Transcription streaming, `WhisperPreviewEngineResolver`
-  /// returns `.blocked(.heartIsStreaming)` and the hero correctly reads "Paused",
-  /// while this row went on saying "Your words will appear in German" and "The
-  /// preview detects your language as you speak". One page asserted a fact and
-  /// denied it a few points lower.
-  ///
-  /// Asserting only that the paused strings avoid a promise verb would pass
-  /// unchanged if the view stopped consulting the refusal, so these assert the
-  /// mapping from (language, streaming) to the string actually chosen.
-  @Test("The universal row promises output only when the engine is not paused")
-  func universalRowPromisesOnlyWhenRunning() {
-    #expect(
-      LivePreviewEnginePresentation.universalRowLabel(languageName: "German", engineWillProduceOutput: true)
-        == LivePreviewSettingsCopy.universalLocked("German"),
-      "a locked language must promise output when the engine is ready")
-    #expect(
-      LivePreviewEnginePresentation.universalRowLabel(languageName: "German", engineWillProduceOutput: false)
-        == LivePreviewSettingsCopy.universalLockedPaused("German"),
-      "a locked language must be described, not promised, when the engine will not run")
-    #expect(
-      LivePreviewEnginePresentation.universalRowLabel(languageName: nil, engineWillProduceOutput: true)
-        == LivePreviewSettingsCopy.universalAuto,
-      "Auto must say detection is happening when the engine is ready")
-    #expect(
-      LivePreviewEnginePresentation.universalRowLabel(languageName: nil, engineWillProduceOutput: false)
-        == LivePreviewSettingsCopy.universalAutoPaused,
-      "Auto must not claim detection is happening when the engine will not run")
-  }
+  // Deleted by #2436 with the universal language row it guarded; see
+  // LivePreviewStatusMappingTests for why the replacement is stronger.
 
   /// The paused strings must still NAME the language, because the row exists so a
   /// user locked to the wrong one can see it. Silencing the row while paused would

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -42,6 +42,12 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.languageProvenanceDetected,
       // #2154 additions.
       LivePreviewSettingsCopy.previewPrivacyFooter,
+      // #2436 catalogue sheet.
+      LivePreviewSettingsCopy.browseDownloadsButton,
+      LivePreviewSettingsCopy.packsBrowseButton,
+      LivePreviewSettingsCopy.catalogFilterAvailable,
+      LivePreviewSettingsCopy.catalogFilterInstalled,
+      LivePreviewSettingsCopy.catalogDoneButton,
       LivePreviewSettingsCopy.statusActiveLabel,
       LivePreviewSettingsCopy.statusActiveDetail,
       LivePreviewSettingsCopy.statusOffLabel,
@@ -72,11 +78,6 @@ struct LivePreviewSettingsCopyTests {
       // r8: paused variants, which must describe rather than promise.
       LivePreviewSettingsCopy.universalLockedPaused("German"),
       LivePreviewSettingsCopy.universalAutoPaused,
-      LivePreviewSettingsCopy.tableColumnLanguage,
-      LivePreviewSettingsCopy.tableColumnSource,
-      LivePreviewSettingsCopy.tableColumnStatus,
-      LivePreviewSettingsCopy.sourceSystem,
-      LivePreviewSettingsCopy.sourceApple,
       LivePreviewCopy.needsNewerMacOS,
       LivePreviewCopy.languageUnsupported,
       LivePreviewCopy.notReady,

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -180,6 +180,45 @@ struct LivePreviewSettingsCopyTests {
   /// not fix that; it would only trade this gap for a false failure on every honest
   /// rewrite, which is what sent an earlier draft to a comment insisting the phrase
   /// was frozen.
+  /// **The Auto asymmetry, pinned at whichever symbol carries it (#2436).**
+  ///
+  /// Dictation on Auto detects what the user actually speaks; the preview must pick
+  /// one language before the first word and uses the Mac's. A bilingual user who does
+  /// not know that reads a wrong-language preview as broken dictation. It lived in
+  /// `activeExplainer` until the explainer box was deleted, and now lives in the
+  /// picker's context subtitle, where somebody is acting on the language.
+  ///
+  /// Written as a floor: it requires the sentence to spend words on both halves, which
+  /// catches the failure actually seen (a trim that keeps the source and drops the
+  /// contrast) without failing every honest rewrite.
+  @Test("The picker caveat keeps the Auto asymmetry, not just the source")
+  func pickerCaveatKeepsTheAutoAsymmetry() {
+    let c = LivePreviewSettingsCopy.pickerDictationCaveat.lowercased()
+    #expect(c.contains("dictation"), "the caveat stopped naming dictation")
+    #expect(c.contains("mac"), "the caveat stopped naming where the preview's language comes from")
+    #expect(
+      c.contains("detect") || c.contains("whatever you speak"),
+      "the caveat stopped saying dictation hears what is actually spoken")
+  }
+
+  /// The status bar's provenance describes CONFIGURATION, never activity: the chip
+  /// renders in every state, including off and failed, so any word implying live
+  /// detection is a claim the bar cannot keep.
+  @Test("Language provenance never claims the preview is doing something")
+  func provenanceIsConfigurationOnly() {
+    let strings = [
+      LivePreviewSettingsCopy.languageProvenanceFromMac,
+      LivePreviewSettingsCopy.languageProvenanceUserPicked,
+      LivePreviewSettingsCopy.languageProvenanceDetected,
+    ]
+    for s in strings {
+      let t = s.lowercased()
+      for claim in ["detect", "appear", "show", "ready", "working", "active", "hearing"] {
+        #expect(!t.contains(claim), "provenance claims activity: \(s)")
+      }
+    }
+  }
+
   @Test("The description says the preview is not the pasted text")
   func descriptionDisclaimsThePastedText() {
     // Moved to `heroBody` by #2154 when the hero card took the top of the page, and

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -42,6 +42,11 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.packInstalling,
       LivePreviewSettingsCopy.packInstallFailed,
       LivePreviewSettingsCopy.packRetry,
+      // #2436 additions: the status bar's language chip.
+      LivePreviewSettingsCopy.languageAnyLanguage,
+      LivePreviewSettingsCopy.languageProvenanceFromMac,
+      LivePreviewSettingsCopy.languageProvenanceUserPicked,
+      LivePreviewSettingsCopy.languageProvenanceDetected,
       // #2154 additions.
       LivePreviewSettingsCopy.heroTitle,
       LivePreviewSettingsCopy.heroBody,

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -23,7 +23,6 @@ struct LivePreviewSettingsCopyTests {
     [
       LivePreviewSettingsCopy.sectionHeader,
       LivePreviewSettingsCopy.toggleLabel,
-      LivePreviewSettingsCopy.toggleDescription,
       LivePreviewSettingsCopy.needsNewerMacOS,
       LivePreviewSettingsCopy.activeHeader,
       LivePreviewSettingsCopy.activeExplainer,
@@ -48,8 +47,7 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.languageProvenanceUserPicked,
       LivePreviewSettingsCopy.languageProvenanceDetected,
       // #2154 additions.
-      LivePreviewSettingsCopy.heroTitle,
-      LivePreviewSettingsCopy.heroBody,
+      LivePreviewSettingsCopy.previewPrivacyFooter,
       LivePreviewSettingsCopy.statusActiveLabel,
       LivePreviewSettingsCopy.statusActiveDetail,
       LivePreviewSettingsCopy.statusOffLabel,
@@ -193,9 +191,11 @@ struct LivePreviewSettingsCopyTests {
   /// was frozen.
   @Test("The description says the preview is not the pasted text")
   func descriptionDisclaimsThePastedText() {
-    // Moved to `heroBody` by #2154 when the hero card took the top of the page.
-    // The CLAIM is what is frozen, not which symbol carries it.
-    let d = LivePreviewSettingsCopy.heroBody.lowercased()
+    // Moved to `heroBody` by #2154 when the hero card took the top of the page, and
+    // to `previewPrivacyFooter` by #2436 when the bar replaced that card. The CLAIM
+    // is what is frozen, not which symbol carries it — that is why this assertion
+    // has now followed the sentence across three owners without ever being deleted.
+    let d = LivePreviewSettingsCopy.previewPrivacyFooter.lowercased()
     // Any wording that carries the claim is accepted; the list grows when copy changes.
     let disclaimers = ["preview only", "never changes", "does not change", "doesn't change"]
     #expect(

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -193,12 +193,20 @@ struct LivePreviewSettingsCopyTests {
   /// contrast) without failing every honest rewrite.
   @Test("The picker caveat keeps the Auto asymmetry, not just the source")
   func pickerCaveatKeepsTheAutoAsymmetry() {
+    // **Pin the RELATIONSHIP, not the vocabulary.** An earlier version required the
+    // words "dictation", "mac" and "detect" somewhere in the sentence, which
+    // "Mac detects dictation" satisfies while reversing the fact. Each half is now
+    // pinned as a pair, with alternatives so an honest rewrite still passes.
     let c = LivePreviewSettingsCopy.pickerDictationCaveat.lowercased()
-    #expect(c.contains("dictation"), "the caveat stopped naming dictation")
-    #expect(c.contains("mac"), "the caveat stopped naming where the preview's language comes from")
+    #expect(c.contains("auto"), "the caveat stopped naming the mode it describes")
     #expect(
-      c.contains("detect") || c.contains("whatever you speak"),
-      "the caveat stopped saying dictation hears what is actually spoken")
+      ["dictation detects", "dictation understands"].contains(where: c.contains)
+        && ["you speak", "spoken"].contains(where: c.contains),
+      "the caveat stopped saying DICTATION is what hears the spoken language")
+    #expect(
+      c.contains("preview")
+        && ["uses your mac", "follows your mac", "goes by your mac"].contains(where: c.contains),
+      "the caveat stopped saying the PREVIEW is what falls back to the Mac")
   }
 
   /// The status bar's provenance describes CONFIGURATION, never activity: the chip

--- a/website/src/content/help/live-preview-words-on-screen.md
+++ b/website/src/content/help/live-preview-words-on-screen.md
@@ -38,21 +38,21 @@ If you want to watch your words appear as you talk without anything being writte
 
 The preview needs its own small engine, separate from the one that produces your final text. There are two, and you pick one on the same settings page.
 
-**Apple** is built into macOS. There is nothing extra to download for the engine itself. It needs **macOS 26 or later**, and it only recognises languages your Mac has installed. Most Macs arrive with a handful. Any others are a download, and you can add them from the language list further down the same page.
+**Apple** is built into macOS. There is nothing extra to download for the engine itself. It needs **macOS 26 or later**, and it only recognises languages your Mac has installed. Most Macs arrive with a handful. Any others are a download. Open **Browse** beside **Languages** on the same settings page to add one.
 
 **Universal** works on **macOS 14 and later** and covers more languages. It needs one optional **217 MB** download, which only starts when you ask for it. You can remove it again later from the same card to get the space back.
 
-If you are on macOS 26 and Apple supports your language, use Apple immediately if its pack is installed, or download that pack from the list below. Choose Universal on older macOS versions, or when Apple does not support your language.
+If you are on macOS 26 and Apple supports your language, use Apple immediately if its pack is installed, or open **Browse** beside **Languages** to add that pack. Choose Universal on older macOS versions, or when Apple does not support your language.
 
 ### Which language the preview uses
 
 This works differently on the two engines, and the difference only matters if your dictation language is set to **Auto**.
 
-**On Apple**, the preview follows the language you picked for dictation, under **Transcription**. On **Auto** it has nothing to follow yet, because it must commit to one language before you say your first word, so it goes by your Mac's language instead. Dictation still understands whatever you actually speak. Only the words on screen may come out in the wrong language until you pick one. You can change the language from the Live Preview page using the **Change** button beside it, which sets your dictation language everywhere, not just the preview.
+**On Apple**, the preview follows the language you picked for dictation, under **Transcription**. On **Auto** it has nothing to follow yet, because it must commit to one language before you say your first word, so it goes by your Mac's language instead. Dictation still understands whatever you actually speak. Only the words on screen may come out in the wrong language until you pick one. You can change it from the Live Preview page by clicking the language at the top of the page, which sets your dictation language everywhere, not just the preview.
 
-**On Universal**, it depends on the same setting. If you have picked a language for dictation, the preview uses that one. If your dictation language is **Auto**, this engine works out the language itself as you speak, so Auto is not a problem for it. Either way the **Change** button is there if the language is wrong.
+**On Universal**, it depends on the same setting. If you have picked a language for dictation, the preview uses that one. If your dictation language is **Auto**, this engine works out the language itself as you speak, so Auto is not a problem for it. Either way, clicking the language at the top of the page changes it if it is wrong.
 
-The list of downloadable languages further down is Apple's, so it only appears with the Apple engine selected. The language row and the **Change** button appear for both engines whenever Live Preview is switched on. The picker lists **Auto-detect** at the top, so you can hand the choice back to the app as easily as you took it.
+The **Languages** row is Apple's, so it only appears with the Apple engine selected; **Browse** opens the full catalogue, starting with the languages your Mac does not have yet. The language itself sits at the top of the page for both engines and is clickable whenever Live Preview is switched on. The picker lists **Auto-detect** at the top, so you can hand the choice back to the app as easily as you took it.
 
 ### If you see no words at all
 
@@ -60,10 +60,10 @@ Work down this list.
 
 **Check the card at the top of the settings page.** It says whether the preview is off, ready, waiting for a download, or unavailable for your language. That answers most cases on its own.
 
-**Check the language.** If you are speaking one language and the preview is set to another, the pill stays empty rather than showing wrong words. This is the most common cause. Pick your language under **Transcription**, or with the **Change** button on the Live Preview page.
+**Check the language.** If you are speaking one language and the preview is set to another, the pill stays empty rather than showing wrong words. This is the most common cause. Pick your language under **Transcription**, or by clicking the language at the top of the Live Preview page.
 
-**Check whether the language is downloaded.** On the Apple engine, a language your Mac does not have shows a **Download** button in the language list. Until you download it, there is nothing to show.
+**Check whether the language is downloaded.** On the Apple engine, a language your Mac does not have needs downloading first. The top of the page says so and offers **Browse downloads**, which opens the catalogue with that language already searched for. Until you download it, there is nothing to show.
 
-**Check that Faster Transcription is off.** On the Universal engine, the preview steps aside while Faster Transcription is running, so your main dictation keeps its full speed. The status card says so when this is why.
+**Check that Faster Transcription is off.** On the Universal engine, the preview steps aside while Faster Transcription is running, so your main dictation keeps its full speed. The top of the page says so when this is why.
 
 Your dictation is unaffected in every one of these cases. An empty preview never means a lost recording.


### PR DESCRIPTION
Part of #2436.

The Live Preview settings page opened by explaining itself three times before it said anything, then asked you to scroll past fifty-three languages you did not ask for.

Interactive mockup, all states, both themes: https://claude.ai/code/artifact/0fb5dce3-24d1-41a8-9d75-db52167a1f5d

## What changed

**One status bar** replaces the hero card, its status column and the toggle row. State on the left, language and where it came from on the right, the switch at the end. When there is something to press, one button appears beneath — the only button on the page.

**The engine cards are untouched.** They were never the problem. They keep `EngineCard`, shared with Transcription since #2136, and each keeps its own unavailability copy and footer action.

**The 54-row table is one row plus a sheet.** "N of M on this Mac" and a Browse button opening `LivePreviewPackCatalogSheet`, which starts on the languages you do NOT have. The Availability column is deleted: it read "Available from Apple" on fifty-three consecutive rows.

**Readiness has ONE surface now.** The page previously had two — the hero column and the universal language row — and r8 and r9 of #2154 were the same defect twice, a second surface promising output the first denied. The status text is the only readiness claim; the language chip states configuration and provenance only.

## The one domain change

`LivePreviewStatusMapping.Summary` gains a `Kind`. The bar has to pick a remedy from the state, and without it the only discriminator is `chip.label` — a user-facing string. Branching on that would make copy a behavioural API, where a reworded sentence silently changes what a button does. Sixteen returns each receive one kind; no input, guard order or emitted string changes. `barActionIsIndependentOfCopy` asserts the property.

## Review record

| Pass | Found |
|---|---|
| Coverage | The switch would have lost its VoiceOver label; the help article states one fact at four sites |
| Grounded r1-r4 | The bar could not produce a Universal language at all; `Bar.action` could only discriminate on copy; four sections specified a state a modal sheet makes unreachable |
| Chunk C1 x4 | Four tests passed against a stub; a fixture pairing every state with one default both tested unreachable pairs and left a live branch untested |
| Chunk C2-C4 | The chip claimed live detection while nothing ran; filter chips counted the catalogue while rows showed the search |
| Second pass | **Universal was shown Apple's explanation of Auto** — false about its own engine, in a sentence added to fix a different false claim |

Every finding above was reproduced with a mutation before its fix was accepted, and the tree restored byte-identical after each.

Rounds 2, 3 and 4 of the grounded review returned one root — a decision changed in review leaving stale statements elsewhere in the plan — so per GR-REVIEW-GATE that stopped being an instance hunt: the class was named, all twelve changed decisions swept mechanically, and the plan now carries a decision register with one owner per decision.

## Receipts

- Full Debug lane: `lane executed 7059 tests`, reconciled 6853 + 206 = 7059, result bundle all accepted, 0 `Fatal error`.
- Branch battery over `LivePreviewStatusBarPresentation`: 12 branches, 12 caught, 0 survived, tree byte-identical. `docs/audits/2026-08-26-2436-c1-branch-battery{.sh,-result.txt}`.
- Website, all three checks (the worktree had no `node_modules`, so `npm ci` first — a build without it would not have been a build of these changes): content 55 articles 0 errors · routes 68/68/68, 0 dead links · search 42 passed 0 failed.

## Live UAT: DONE, and it did not come back clean

## Recorded limits, routed not adopted

No discovery metric and no telemetry for catalogue opens. Both are real gaps and both would widen a UI cleanup into something else; a follow-up records that `live_preview_catalog_opened` and a status-remedy event would make Browse discoverability answerable, and that both carry shape only, never content.

## Live UAT found two defects, the cloud round found three more

Every one of the five was invisible to four grounded rounds, a second local pass and a clean cloud round on the previous head. Two of the five are worth stating as classes rather than as fixes.

**The switch owned 738pt of the status bar.** `BrandedToggleStyle` is `HStack { label; Spacer(); track }` under `.contentShape(Rectangle())`, so an ordinary labelled row is clickable end to end. This row deleted its label, and the style's `Spacer` claimed everything left: clicking the empty middle of the bar toggled Live Preview, and the language chip rendered stranded a third of the way across. `.fixedSize()` → 46pt at x=1414, chip ending at x=1402.

Deleting a label is a LAYOUT change wearing a copy change's clothes. No screenshot shows a hit rectangle and no assertion in this repo reads one, so UAT item 9 now **measures** `AXSize` rather than looking.

**The catalogue's pre-filled search never arrived.** `.sheet(isPresented:)` read the seed back out of a second `@State` at content-build time and got the pre-write value — measured empty on a freshly launched process *and* on presentations 2 and 3, which rules out the obvious `State(initialValue:)`-identity story. `.sheet(item:)` makes the seed travel with the presentation.

`swiftui-view-patterns.md` **already carried `swiftui-sheet-item` forbidding the boolean form for exactly this.** The rule existed and the code shipped anyway, because reviewers read the diff, not the rule list. Tightened in place with the measurement rather than given a sibling entry.

## The cloud round's first finding, and why it is the one to remember

`.unsupportedLanguage` returned no language, so no chip rendered — and **the chip is the picker.** A user whose preview was broken *by* their language had no control on the page that could change it.

The reason not to do that was already in the same file, two functions below:

> **It must not stay silent**: this engine honours a lock, and the row's whole purpose is that a user locked to the wrong language can see it and change it. An earlier #2154 draft hid the control on this engine and stranded exactly those users (review r7).

Written for `universalLanguage`, never applied to `appleLanguage` one screen up. **Proximity reads as coverage.** Both branches now share one `languageFromLock` derivation whose only parameter is the Auto provenance, so there is no second place left to diverge.

**And the suite was asserting the defect.** `chipNeverPromisesOutput` carried `(.unsupportedLanguage, .apple, .unsupportedLanguage, false)` — expectation written from the implementation. A green suite had encoded the bug as the requirement, every round.

Two accessibility findings, both adopted: the filter chips carried selection only in colour, and the language button's explicit `accessibilityLabel` replaced the child announcement and silently dropped `provenance` — the line carrying the whole Auto asymmetry.

## Receipts

- Debug lane `7061` tests, PASS. Up exactly 2 from `7059`, matching the two tests added.
- Mutation check on the new guard: `docs/audits/2026-08-26-2436-unsupported-language-mutant{.sh,-result.txt}`. It restores the reviewer-flagged line and requires the suite to go red; restore verified by content hash, not mtime.
- Live UAT run recorded in the plan §11.2, cloud round in §11.3, every step pinned to this worktree's executable path.

## Stated limits, not hidden

- `languageControlSurvivesTheStatesThatNeedIt` keys off `String(describing:)` against three hardcoded state names, and its universal branch skips those three rather than asserting. A renamed case would silently rewrite its own expectation. Routed to #2441 with the specific attacks; the honest fix is probably to replace the literal set with a question the code can answer.
- The two accessibility fixes have **no binding evidence yet** — one-line changes to real findings, verified by reading. #2441 asks for an AX-tree pass on `AXSelected` and the label string.
- Both UAT fixes live in SwiftUI presentation, which nothing here can unit-test. Items 6 and 9 are their only oracle, which is why the plan now says they must never be softened to "the catalogue opens".

## Routed out, not fixed here

- Whether the Languages row should hide when the switch is off — product, and the UAT spec asserted it without the design or the code ever saying so. Plan §14.5.
- The shared picker's `ALL LANGUAGES` header over a list filtered to installed packs — pre-existing on `origin/main`, now #2443.


## Two accessibility fixes and the stranding fix, verified on the RUNNING app

These three were cloud findings fixed by reading, which is not evidence. All three are now measured on the rebuilt artifact.

**The stranding case, staged for real rather than by proxy.** Locked the dictation language to one Apple genuinely cannot preview:

| Language | Status bar | Language control |
|---|---|---|
| Bulgarian | `Apple can't preview this language` | `Change dictation language: Bulgarian, you picked this` |
| Estonian | `Apple can't preview this language` | `Change dictation language: Estonian, you picked this` |
| Maltese | `Apple can't preview this language` | `Change dictation language: Maltese, you picked this` |

Before the fix the control was ABSENT in exactly these three.

**Method correction, recorded because the first attempt gave a confident wrong answer.** Candidates were first derived by harvesting pack names out of the catalogue sheet's accessibility tree under six searches, then subtracting from the lockable set. That named Greek, Swedish and Ukrainian as unsupported. All three wrong — the app reports `<name> isn't downloaded yet` for each, which is the pack-EXISTS state. **The catalogue list is lazily rendered, so the tree holds only the rows on screen**: the harvest read one screenful per query and the subtraction treated it as complete. No error, well-formed output, fails toward a confident absence claim. The working method is to ask the SUBJECT one candidate at a time.

**`.isSelected` on the filter chips, checked BOTH ways rather than for presence** — presence alone passes against a trait hardcoded on one chip:

```
before: ('Not on this Mac, 52', selected=True)  ('On this Mac, 2', selected=None)
after:  ('Not on this Mac, 52', selected=None)  ('On this Mac, 2', selected=True)
```

**Provenance restored to the label:** `Change dictation language: English (United States), from your Mac`.

**Item 9 re-measured on the final artifact:** 46pt, from 738pt.

Founder settings recorded and restored: dictation Auto-detect ON, Live Preview ON, engine Apple. Not restored, and stated so he knows: German (Germany) is installed as a real Apple pack, acquired by items 5 and 7, which need a genuine install to prove anything.

## The push gate refused twice, correctly, and neither was bypassed

First on a build of the MUTATED tree — genuinely stale, and stale for a reason the gate cannot see. Then on a comment-only commit, which is the documented case where "nothing needed rebuilding" and "never built" are the same answer to an mtime comparison. Fixed by deleting the linked product to force a real relink, not by `SKIP_PUSH_CHECKS=1`.
