### PR TITLE
Live Preview: sixteen things found by using the page, not by reading the diff

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
@@ -48,47 +48,90 @@ struct LanguageLockSheet: View {
   private let maxRecents = 5
 
   var body: some View {
-    NavigationStack {
-      VStack(spacing: 0) {
+    // **Same chrome as `LivePreviewPackCatalogSheet`, for the same reason.**
+    // `.navigationTitle` renders through AppKit's title chrome, whose inset this
+    // sheet does not control — measured here at ~178pt from the sheet edge while
+    // the body copy under it started at ~115pt, so the title read as belonging to
+    // a different container (founder, 2026-08-26, on both sheets independently).
+    // One shared inset makes them line up by construction.
+    VStack(spacing: 0) {
+      titleBar
+      Divider().overlay(Color.stDivider)
+
+      VStack(alignment: .leading, spacing: 12) {
         if let contextSubtitle {
-          Text(contextSubtitle)
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
+          // **Reading copy, not microcopy.** This was `stHelper`, the app's
+          // smallest token, on the one sentence explaining that the choice reaches
+          // dictation and not only the preview — "too wordy and too small to read"
+          // (founder). The words are shorter now and the type is the reading size.
+          Text(contextSubtitle).settingsReadingCopy()
         }
         searchField
+      }
+      .padding(Self.inset)
 
-        ScrollView {
-          VStack(alignment: .leading, spacing: 16) {
-            if searchText.isEmpty {
-              autoDetectSection
-            }
-            if !recents.isEmpty && searchText.isEmpty {
-              recentSection
-            }
-            allLanguagesSection
+      Divider().overlay(Color.stDivider)
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+          if searchText.isEmpty {
+            autoDetectSection
           }
-          .padding(.horizontal, 16)
-          .padding(.vertical, 12)
+          if !recents.isEmpty && searchText.isEmpty {
+            recentSection
+          }
+          allLanguagesSection
         }
+        .padding(.horizontal, Self.inset)
+        .padding(.vertical, 12)
       }
-      .background(Color.stPageBg)
-      // "Lock language" while the first row CLEARS the lock is the sheet
-      // contradicting itself, the same defect r8 and r9 fixed on the page that
-      // opens it. This title is true of both actions and of both presenters —
-      // and it matches the Change button's copy, which already says out loud
-      // that this sets the DICTATION language, not a preview-only one.
-      .navigationTitle("Dictation language")
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") { dismiss() }
-        }
-      }
+
+      Divider().overlay(Color.stDivider)
+      footer
     }
+    .background(Color.stPageBg)
     .frame(minWidth: 420, minHeight: 520)
     .onAppear(perform: loadRecents)
+  }
+
+  /// One inset shared by the title, the header and the list beneath them.
+  private static let inset: CGFloat = 16
+
+  // "Lock language" while the first row CLEARS the lock is the sheet
+  // contradicting itself, the same defect r8 and r9 fixed on the page that
+  // opens it. This title is true of both actions and of both presenters —
+  // and it matches the Change button's copy, which already says out loud
+  // that this sets the DICTATION language, not a preview-only one.
+  private var titleBar: some View {
+    HStack(spacing: 8) {
+      Text("Dictation language")
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundStyle(Color.stTextPrimary)
+      Spacer(minLength: 12)
+      LanguageSheetCloseButton { dismiss() }
+    }
+    .padding(.horizontal, Self.inset)
+    .padding(.vertical, 12)
+  }
+
+  /// `Cancel`, not `Done`: this sheet COMMITS on row selection, so the bottom
+  /// action is an abandon rather than a confirm. Kept alongside the close control
+  /// because the word is what says nothing was changed.
+  private var footer: some View {
+    HStack {
+      Spacer(minLength: 0)
+      // **Outlined, not filled, and not a bare accent word.** The catalogue
+      // sheet's `Done` became a filled primary and this was left as coloured
+      // text — one sheet's exit polished, its twin untouched, in the same change
+      // (founder, 2026-08-26). Same control now, one emphasis lower: leaving
+      // WITHOUT choosing is a secondary action here, because the rows are the
+      // primary one. `Done` on the catalogue sheet is filled because nothing
+      // competes with it there.
+      SettingsActionButton(title: "Cancel", isEnabled: true) { dismiss() }
+        .keyboardShortcut(.cancelAction)
+    }
+    .padding(.horizontal, Self.inset)
+    .padding(.vertical, 12)
   }
 
   // MARK: - Subviews
@@ -103,13 +146,13 @@ struct LanguageLockSheet: View {
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 8)
-    .background(Color.stSectionBg)
-    .overlay(
-      Rectangle()
-        .fill(Color.stDivider)
-        .frame(height: 1),
-      alignment: .bottom
-    )
+    // **Was full-bleed with an underline**, which put it flush against the
+    // sentence above with no gap and made it read as part of that paragraph
+    // rather than as a control ("placement and size feels weird", founder).
+    // Same recessed bordered field the catalogue sheet uses: one idiom for one
+    // job, across both language sheets.
+    .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 9))
+    .overlay(RoundedRectangle(cornerRadius: 9).strokeBorder(Color.stDivider, lineWidth: 1))
   }
 
   /// **The way BACK. Without it this sheet is a one-way door.**
@@ -198,7 +241,12 @@ struct LanguageLockSheet: View {
     let filtered = filteredLanguages
 
     VStack(alignment: .leading, spacing: 6) {
-      Text("ALL LANGUAGES")
+      // **`ALL LANGUAGES` was a claim wider than the list.** Opened from Live
+      // Preview this sheet shows only the languages installed AND lockable — on a
+      // stock Mac, one — under a heading saying all, so the app appeared to speak
+      // one language (#2443). The caller knows whether its list is complete;
+      // `lockableCodes == nil` is exactly "no filter applied".
+      Text(lockableCodes == nil ? "ALL LANGUAGES" : "AVAILABLE ON THIS MAC")
         .font(.stSectionHeader)
         .foregroundStyle(.stTextSecondary)
         .padding(.leading, 4)
@@ -238,35 +286,19 @@ struct LanguageLockSheet: View {
 
   @ViewBuilder
   private func languageRow(_ entry: LanguageCatalog.Entry, showDivider: Bool) -> some View {
-    let isSelected = isCurrentLock(entry.code)
-
     VStack(spacing: 0) {
-      Button {
+      // **Hover is what makes a row read as a row you can press.** These are the
+      // only way to choose a language and nothing changed under the pointer, so
+      // the list looked like a table of facts ("hovering over the languages
+      // doesn't highlight so it doesn't feel like it's clickable", founder).
+      // Extracted into a type because a hover needs its own `@State`, which a
+      // `@ViewBuilder` function cannot hold.
+      LanguageLockRow(
+        entry: entry,
+        isSelected: isCurrentLock(entry.code)
+      ) {
         select(entry)
-      } label: {
-        HStack(spacing: 10) {
-          VStack(alignment: .leading, spacing: 2) {
-            Text(entry.nativeName)
-              .settingsRowLabel()
-            Text("\(entry.englishName) · \(entry.code)")
-              .font(.stHelper)
-              .foregroundStyle(.stTextSecondary)
-          }
-          Spacer()
-          if isSelected {
-            Image(systemName: "checkmark")
-              .font(.system(size: 12, weight: .semibold))
-              .foregroundStyle(Color.stAccent)
-          }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .contentShape(Rectangle())
-        .background(isSelected ? Color.stAccent.opacity(0.06) : Color.clear)
       }
-      .buttonStyle(.plain)
-      .accessibilityLabel("\(entry.englishName), native \(entry.nativeName)")
-      .accessibilityValue(isSelected ? "selected" : "")
 
       if showDivider {
         Divider()
@@ -366,5 +398,80 @@ struct LanguageLockSheet: View {
       }
 
     recents = Array(sorted)
+  }
+}
+
+// MARK: - Row
+
+/// One selectable language.
+///
+/// A `View` rather than a builder function purely so it can own the hover state;
+/// selection still lives with the caller, which is the only thing that knows what
+/// is currently locked.
+private struct LanguageLockRow: View {
+  let entry: LanguageCatalog.Entry
+  let isSelected: Bool
+  let action: () -> Void
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 10) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(entry.nativeName).settingsRowLabel()
+          Text("\(entry.englishName) · \(entry.code)")
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
+        }
+        Spacer()
+        if isSelected {
+          Image(systemName: "checkmark")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(Color.stAccent)
+        }
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 10)
+      .contentShape(Rectangle())
+      // Selection outranks hover: a selected row keeps its accent wash even while
+      // the pointer sits on a neighbour, so the current choice never disappears.
+      .background(background)
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering = $0 }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .accessibilityLabel("\(entry.englishName), native \(entry.nativeName)")
+    .accessibilityValue(isSelected ? "selected" : "")
+  }
+
+  private var background: Color {
+    if isSelected { return Color.stAccent.opacity(0.10) }
+    return hovering ? Color.stAccent.opacity(0.06) : Color.clear
+  }
+}
+
+/// Matches `LivePreviewPackCatalogSheet`'s close control. Duplicated rather than
+/// shared for now because the two sheets live in different features; if a third
+/// appears, this is the one to promote.
+private struct LanguageSheetCloseButton: View {
+  let action: () -> Void
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: "xmark")
+        .font(.system(size: 11, weight: .bold))
+        .foregroundStyle(hovering ? Color.stTextPrimary : Color.stTextSecondary)
+        .frame(width: 22, height: 22)
+        .background(Circle().fill(hovering ? Color.stSectionBg : Color.clear))
+        .contentShape(Circle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering = $0 }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .accessibilityLabel("Close")
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
@@ -42,23 +42,16 @@ struct LivePreviewPackCatalogSheet: View {
   /// the model is passed in rather than created here.
   let packs: LivePreviewPacksModel
 
-  /// The pack tag currently producing the preview, or nil.
-  ///
-  /// Resolved by the CALLER, which owns the two gates that decide whether "In use" is a
-  /// claim we may make. Carried verbatim from `isActive`:
-  ///
-  /// > Gated on the toggle because "In use" is a claim about a running preview,
-  /// > and nothing runs while the feature is off. Gated on the ENGINE because
-  /// > these are Apple's packs: with the universal engine selected the badge would
-  /// > name a language that is not the one on screen.
-  let activeTag: String?
-
   /// Seeded by the status bar's remedy with the missing language's NAME, so the row a
   /// user was sent here for is already on screen. Empty from the Languages row, where
   /// there is no particular language in question.
-  init(packs: LivePreviewPacksModel, activeTag: String?, initialSearch: String = "") {
+  /// **No `activeTag` any more, and it is removed rather than defaulted.** It fed
+  /// the "In use" badge, which only ever rendered on an installed row — a row this
+  /// sheet no longer shows. A defaulted-but-ignored parameter would have left every
+  /// call site passing a value nothing reads, which is how a dead argument survives
+  /// a migration.
+  init(packs: LivePreviewPacksModel, initialSearch: String = "") {
     self.packs = packs
-    self.activeTag = activeTag
     _searchText = State(initialValue: initialSearch)
   }
 
@@ -66,36 +59,92 @@ struct LivePreviewPackCatalogSheet: View {
   /// catalogue, so the model has no reason to know it exists.
   @State private var searchText: String
 
-  /// Which half of the catalogue is on screen. Not-installed first, because acquiring a
-  /// language is the only reason this sheet opens.
-  @State private var showingInstalled: Bool = false
-
   var body: some View {
-    NavigationStack {
-      VStack(spacing: 0) {
-        header
-        Divider().overlay(Color.stDivider)
-        content
-      }
-      .frame(minWidth: 460, minHeight: 420)
-      .background(Color.stPageBg)
-      .navigationTitle(LivePreviewSettingsCopy.packsHeader)
-      // **A failed read must be retryable, or the message is a dead end.**
-      // `packsUnavailable` tells the user to reopen; nothing reloaded when they did,
-      // so reopening produced the same failure forever. Only on `.failed`, so an
-      // ordinary open does not re-read an inventory the page already has.
-      .task {
-        if case .failed = packs.state { await packs.load() }
-      }
-      .toolbar {
-        ToolbarItem(placement: .confirmationAction) {
-          Button(LivePreviewSettingsCopy.catalogDoneButton) { dismiss() }
-        }
-      }
+    // **No `NavigationStack`, and that is the fix rather than a simplification.**
+    // `.navigationTitle` renders through AppKit's own title chrome, which insets
+    // the text by a value this sheet does not control — measured sitting ~64pt
+    // from the sheet edge while the body copy below it starts at 16pt, so the
+    // title read as belonging to a different container than everything under it
+    // (founder, 2026-08-26). A plain header row shares ONE inset constant with
+    // the body, which is what makes them line up by construction rather than by
+    // a number someone has to keep matching.
+    //
+    // Losing the navigation bar also loses the toolbar that carried the only
+    // dismissal, so `titleBar` provides both the title and an explicit close.
+    VStack(spacing: 0) {
+      titleBar
+      Divider().overlay(Color.stDivider)
+      header
+      Divider().overlay(Color.stDivider)
+      content
+      Divider().overlay(Color.stDivider)
+      // **Explicit, because dropping `NavigationStack` dropped the toolbar that
+      // used to render this.** `Done` lived in a `confirmationAction` toolbar
+      // item; removing the navigation chrome to fix the title's inset would have
+      // silently removed the sheet's primary exit with it. Kept alongside the
+      // close control rather than replaced by it: `Done` is where a keyboard user
+      // lands by default, and it is what the earlier screenshots trained.
+      footer
+    }
+    .frame(minWidth: 460, minHeight: 420)
+    .background(Color.stPageBg)
+    // **A failed read must be retryable, or the message is a dead end.**
+    // `packsUnavailable` tells the user to reopen; nothing reloaded when they did,
+    // so reopening produced the same failure forever. Only on `.failed`, so an
+    // ordinary open does not re-read an inventory the page already has.
+    .task {
+      if case .failed = packs.state { await packs.load() }
     }
   }
 
+  // MARK: - Title bar
+
+  /// The sheet's own title row, sharing `Self.inset` with the body beneath it.
+  ///
+  /// **The close control is not decoration.** Before this the only way out was
+  /// the `Done` button at the far bottom-right, which on a long scrolled list is
+  /// off-screen and reads as "commit" rather than "leave" — nothing here is
+  /// committed, so a user looking for the ordinary way to abandon a sheet found
+  /// none (founder, 2026-08-26). Escape already dismissed it, but an invisible
+  /// keyboard-only exit is not an affordance.
+  private var titleBar: some View {
+    HStack(spacing: 8) {
+      Text(LivePreviewSettingsCopy.packsHeader)
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundStyle(Color.stTextPrimary)
+      Spacer(minLength: 12)
+      CatalogCloseButton { dismiss() }
+    }
+    .padding(.horizontal, Self.inset)
+    .padding(.vertical, 12)
+  }
+
   // MARK: - Header
+
+  /// One inset for the title and for everything under it. Shared rather than
+  /// repeated, because the defect this replaced was two containers disagreeing
+  /// about their left edge.
+  private static let inset: CGFloat = 16
+
+  private var footer: some View {
+    HStack {
+      Spacer(minLength: 0)
+      // Filled, where the row actions are outlined: one primary, many secondaries.
+      // NOT `.borderedProminent`, which rendered filled while it lived in the
+      // navigation toolbar and grey the moment it moved into a plain row — the
+      // same container-dependence measured on `Browse`.
+      SettingsActionButton(
+        title: LivePreviewSettingsCopy.catalogDoneButton,
+        isEnabled: true,
+        emphasis: .filled
+      ) {
+        dismiss()
+      }
+      .keyboardShortcut(.defaultAction)
+    }
+    .padding(.horizontal, Self.inset)
+    .padding(.vertical, 12)
+  }
 
   private var header: some View {
     VStack(alignment: .leading, spacing: 10) {
@@ -105,10 +154,9 @@ struct LivePreviewPackCatalogSheet: View {
       // the "could not read" message is a control that does nothing.
       if case .loaded = packs.state {
         searchField
-        filterChips
       }
     }
-    .padding(16)
+    .padding(Self.inset)
   }
 
   /// Carried verbatim from the page's own search box, whose shape this keeps:
@@ -138,54 +186,19 @@ struct LivePreviewPackCatalogSheet: View {
     .overlay(RoundedRectangle(cornerRadius: 9).strokeBorder(Color.stDivider, lineWidth: 1))
   }
 
-  /// Both counts come from the SAME searched grouping the rows do, so a chip can never
-  /// disagree with the list under it — including while a search is active, which is the
-  /// case that shipped wrong for one review round.
-  private var filterChips: some View {
-    let groups = visibleGroups
-    return HStack(spacing: 6) {
-      chip(
-        title: LivePreviewSettingsCopy.catalogFilterAvailable,
-        count: groups.available.count, selected: !showingInstalled
-      ) { showingInstalled = false }
-      chip(
-        title: LivePreviewSettingsCopy.catalogFilterInstalled,
-        count: groups.installed.count, selected: showingInstalled
-      ) { showingInstalled = true }
-      Spacer(minLength: 0)
-    }
-  }
-
-  private func chip(
-    title: String, count: Int, selected: Bool, action: @escaping () -> Void
-  ) -> some View {
-    Button(action: action) {
-      HStack(spacing: 5) {
-        Text(title)
-        Text("\(count)").opacity(0.65)
-      }
-      .font(.stHelper)
-      .padding(.horizontal, 11)
-      .padding(.vertical, 4)
-      .background(
-        selected ? Color.stAccentSolid : Color.clear,
-        in: Capsule()
-      )
-      .foregroundStyle(selected ? Color.white : Color.stTextSecondary)
-      .overlay(
-        Capsule().strokeBorder(selected ? Color.clear : Color.stDivider, lineWidth: 1))
-    }
-    .buttonStyle(.plain)
-    // **Which half is showing lives ONLY in these two colours**, so without this a
-    // VoiceOver user hears two ordinary buttons with labels and counts and has no
-    // way to tell which one the list below is obeying — on a sheet whose entire
-    // job is "the languages you do NOT have". Cloud review on PR #2440.
-    //
-    // `.isSelected` rather than a "(selected)" suffix on the label: the trait is
-    // what assistive tech reads as SELECTION, and baking the state into the visible
-    // title would also change the button's own name every time it is pressed.
-    .accessibilityAddTraits(selected ? [.isSelected] : [])
-  }
+  // **The installed half is GONE, and that is a scope change, not a tidy-up.**
+  // Two chips asked the user to understand a split before they could act, on a
+  // sheet that exists for exactly one reason: acquiring a language you do not
+  // have (founder, 2026-08-26 — "remove on this mac part because that is the
+  // confusing part"). What is already installed is answerable from the language
+  // control at the top of the page, which lists precisely the installed
+  // languages you can switch to.
+  //
+  // Consequence, stated rather than discovered later: a pack that is installed
+  // but NOT lockable for dictation now appears in neither place. That is
+  // reachable only when Apple ships a preview pack for a language the
+  // transcription backend cannot lock, and such a pack cannot be selected or
+  // used, so nothing is lost but its visibility.
 
   // MARK: - Content
 
@@ -232,15 +245,18 @@ struct LivePreviewPackCatalogSheet: View {
     }.frame(maxWidth: .infinity)
   }
 
-  /// Which nothing-here message applies: the search found nothing, or this half of the
-  /// catalogue is genuinely empty.
+  /// Which nothing-here message applies: the search found nothing, or every
+  /// language is already installed.
+  ///
+  /// **Still two cases, and the distinction is the one that shipped wrong once.**
+  /// An empty list because you searched for "qqq" and an empty list because there
+  /// is genuinely nothing left to install are different facts, and blaming the
+  /// search for the second is the defect this branch exists to prevent.
   private var emptyMessage: String {
     guard searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       return LivePreviewSettingsCopy.packsNoSearchMatch
     }
-    return showingInstalled
-      ? LivePreviewSettingsCopy.catalogNoneInstalled
-      : LivePreviewSettingsCopy.catalogNothingToInstall
+    return LivePreviewSettingsCopy.catalogNothingToInstall
   }
 
   private var loadedPacks: [LivePreviewPack] {
@@ -248,17 +264,25 @@ struct LivePreviewPackCatalogSheet: View {
     return rows
   }
 
-  /// **One searched grouping feeds BOTH the chips and the rows.** Computing them
-  /// separately is how the chips came to count the full catalogue while the rows showed
-  /// only matches — a chip reading "Not on this Mac 53" above one row is worse than no
-  /// chip. `groups(from:matching:)` owns the policy, so there is one answer to disagree
-  /// with rather than two.
+  /// The searched grouping. Carried from when it also fed two filter chips:
+  ///
+  /// > **One searched grouping feeds BOTH the chips and the rows.** Computing them
+  /// > separately is how the chips came to count the full catalogue while the rows
+  /// > showed only matches — a chip reading "Not on this Mac 53" above one row is
+  /// > worse than no chip.
+  ///
+  /// The chips are gone, so that particular disagreement is no longer reachable —
+  /// kept as one call anyway, because `groups(from:matching:)` owning the split is
+  /// what makes the classification testable independently of this view.
   private var visibleGroups: LivePreviewPackPresentation.Groups {
     LivePreviewPackPresentation.groups(from: loadedPacks, matching: searchText)
   }
 
+  /// Always the not-installed half. `groups(from:matching:)` still owns the
+  /// split and still applies the search to both, so the classification and its
+  /// tests are untouched; this sheet simply renders one side of it.
   private var visibleRows: [LivePreviewPack] {
-    showingInstalled ? visibleGroups.installed : visibleGroups.available
+    visibleGroups.available
   }
 
   @ViewBuilder
@@ -283,18 +307,15 @@ struct LivePreviewPackCatalogSheet: View {
     }
   }
 
+  /// **Two branches were deleted here, not left unreachable.** `packInUse` and
+  /// `packInstalled` could only render for a pack this sheet no longer lists, so
+  /// keeping them would have been dead code that reads as live coverage — and the
+  /// next person to add a state would copy the shape. The claims they made still
+  /// exist where they are true: which language is actually previewing is the
+  /// status bar's job, and what is installed is the language control's.
   @ViewBuilder
   private func statusCell(_ pack: LivePreviewPack) -> some View {
-    if pack.tag == activeTag {
-      // "Ready" says the bytes are here; it never said WHICH language you are
-      // actually previewing in. With nine installed, that was the whole confusion.
-      ProviderStatusChip(
-        status: ProviderStatus(label: LivePreviewSettingsCopy.packInUse, tone: .ready))
-    } else if pack.isInstalled {
-      ProviderStatusChip(
-        status: ProviderStatus(
-          label: LivePreviewSettingsCopy.packInstalled, tone: .unavailable))
-    } else if packs.installingTag == pack.tag {
+    if packs.installingTag == pack.tag {
       // A spinner, never a percentage. Apple's progress object yields two
       // distinct values across a whole install, so a bar would be a fabrication.
       HStack(spacing: 6) {
@@ -302,16 +323,55 @@ struct LivePreviewPackCatalogSheet: View {
         Text(LivePreviewSettingsCopy.packInstalling).settingsHelperCopy()
       }
     } else {
-      Button(
-        packs.failedTag == pack.tag
+      // **`.bordered` was the defect, not the size.** On this dark surface AppKit
+      // renders a bordered button as a low-contrast grey capsule that is very
+      // nearly the app's own disabled treatment — so the one action on every row
+      // read as unavailable, and hovering changed nothing to contradict that
+      // (founder, 2026-08-26). It was ALSO genuinely disabled whenever any other
+      // install was running, which meant "looks disabled" and "is disabled" were
+      // indistinguishable at exactly the moment the difference mattered.
+      //
+      // `SettingsActionButton` carries an accent tint, a hover fill, and a
+      // disabled state that is visibly different from both.
+      SettingsActionButton(
+        title: packs.failedTag == pack.tag
           ? LivePreviewSettingsCopy.packRetry
-          : LivePreviewSettingsCopy.packInstall
+          : LivePreviewSettingsCopy.packInstall,
+        isEnabled: packs.installingTag == nil
       ) {
         packs.install(tag: pack.tag)
       }
-      .buttonStyle(.bordered)
-      .controlSize(.small)
-      .disabled(packs.installingTag != nil)
     }
+  }
+}
+
+// MARK: - Catalogue controls
+
+/// The sheet's close control.
+///
+/// Deliberately a symbol rather than a second worded button: `Done` at the
+/// bottom already carries the words, and two worded exits invite the reading
+/// that they do different things. Nothing in this sheet is committed on exit,
+/// so both simply leave.
+private struct CatalogCloseButton: View {
+  let action: () -> Void
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: "xmark")
+        .font(.system(size: 11, weight: .bold))
+        .foregroundStyle(hovering ? Color.stTextPrimary : Color.stTextSecondary)
+        .frame(width: 22, height: 22)
+        .background(
+          Circle().fill(hovering ? Color.stSectionBg : Color.clear)
+        )
+        .contentShape(Circle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering = $0 }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .accessibilityLabel(LivePreviewSettingsCopy.catalogCloseLabel)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsCopy.swift
@@ -44,14 +44,9 @@ enum LivePreviewSettingsCopy {
     + "languages; the rest are about 140 MB each and download only when you ask. "
     + "Nothing downloads on its own."
 
-  static let packInstalled = "Ready"
   static let packInstall = "Download"
   static let packInstalling = "Downloading"
   static let packRetry = "Try again"
-
-  /// The row that is genuinely in use, as opposed to merely present. With nine languages
-  /// installed, "Ready" on all of them said nothing about which one you are previewing in.
-  static let packInUse = "In use"
 
   /// Placeholder and empty state for the language search. Wording matches `LanguageLockSheet`
   /// verbatim: the app already has a language search and a second phrasing for the same job would
@@ -114,7 +109,8 @@ enum LivePreviewSettingsCopy {
   /// "needs a download" or a missing language pack. An earlier draft said
   /// "switch it on to see your words while you speak", which is a promise this
   /// card cannot keep for every user who reads it.
-  static let statusOffDetail = "Switch it on and this bar will show whether anything else is needed."
+  static let statusOffDetail =
+    "Switch it on and this bar will show whether anything else is needed."
 
   // `statusUnavailableLabel` / `statusUnavailableDetail` were DELETED by #2154's
   // final sweep, not merely unused. "Not available on this Mac" was returned
@@ -149,7 +145,8 @@ enum LivePreviewSettingsCopy {
   static func statusNeedsLanguageLabel(_ languageName: String) -> String {
     "\(languageName) isn't downloaded yet"
   }
-  static let statusNeedsLanguageDetail = "Use Browse downloads below to get it and start the preview."
+  static let statusNeedsLanguageDetail =
+    "Use Browse downloads below to get it and start the preview."
 
   static let statusUnsupportedLanguageLabel = "Apple can't preview this language"
   /// **Two details, because the advice is only true when the other engine
@@ -230,24 +227,43 @@ enum LivePreviewSettingsCopy {
   /// "Not on this Mac" half is empty and no search has happened, so
   /// `packsNoSearchMatch` would blame a query the user never typed.
   static let catalogNothingToInstall = "Every language Apple offers is already on this Mac."
-  static let catalogNoneInstalled = "No languages downloaded yet."
-
-
   /// The bar's one remedy, named for where it goes rather than what it fetches: the
   /// catalogue is the only thing that can resolve a display name to an installable pack.
   static let browseDownloadsButton = "Browse downloads"
 
   /// The Languages row's trailing button, and the row's own summary.
-  static let packsBrowseButton = "Browse"
-  static func packsInstalledSummary(installed: Int, total: Int) -> String {
-    "\(installed) of \(total) on this Mac"
-  }
+  // `packsBrowseButton` ("Browse") was DELETED, not left unused. The Languages
+  // row IS the button now, so the word had nothing to label — and a second name
+  // for one action is what made "Browse" versus "Install new languages" a
+  // question in the first place (founder, 2026-08-26). A trailing chevron says
+  // "this opens something" without needing a word that must then agree with the
+  // title above it.
 
-  /// **Not-installed first, because acquiring is the only reason this sheet opens.**
-  /// The counts beside them come from the same grouping the rows do.
-  static let catalogFilterAvailable = "Not on this Mac"
-  static let catalogFilterInstalled = "On this Mac"
+  /// **The Languages row names its action, not an inventory.** It read
+  /// "N of 54 on this Mac" — a count of something the reader was not asking about
+  /// and could not act on, which the sheet then restated as two filter chips
+  /// (founder, 2026-08-26: "remove on this mac part because that is the confusing
+  /// part - they can see what is on the mac on the top of the live preview page").
+  /// What is already installed is answered by the language control at the top of
+  /// the page, which lists exactly the languages you can switch to.
+  static let packsInstallRowTitle = "Install new languages"
+
+  // `packInstalled` ("Ready"), `packInUse` ("In use"), `packsInstalledSummary`,
+  // `catalogFilterAvailable`, `catalogFilterInstalled` and `catalogNoneInstalled`
+  // were DELETED here, not left unused. All six existed to describe the installed
+  // half of the catalogue, which this sheet no longer renders. Kept strings would
+  // have read as available vocabulary for a surface that cannot show them, and the
+  // copy-coverage test would have gone on asserting words nothing displays.
+  //
+  // The facts they carried are still stated where they are true: which language is
+  // previewing NOW is the status bar's, and what is installed is the language
+  // control's, which lists exactly what you can switch to.
   static let catalogDoneButton = "Done"
+
+  /// The close control carries no visible text, so this IS its name for
+  /// VoiceOver. "Close" rather than "Done": both leave, and only one of them
+  /// implies something was committed — nothing in this sheet is.
+  static let catalogCloseLabel = "Close"
 
   // MARK: - Status-bar language chip (#2436)
 
@@ -347,12 +363,21 @@ enum LivePreviewSettingsCopy {
   /// false about their own engine. A single shared string shipped exactly that for one
   /// review round, and the test that guarded it had no engine variable, so it validated
   /// the Apple sentence and passed while Universal displayed it.
+  /// **Shortened 2026-08-26 — "too wordy and too small to read" (founder).** Three
+  /// lines of the smallest type, above a search box it was flush against, on a
+  /// sheet somebody opened to press one row. The first sentence is the one that
+  /// changes behaviour and it leads; the Auto asymmetry follows in half the words.
+  ///
+  /// **What could NOT be cut: that Apple's preview uses the MAC's language on
+  /// Auto.** A bilingual user on Auto gets correct dictation and a preview in the
+  /// wrong language, and naming the source is what makes that legible instead of a
+  /// bug report.
   static let pickerAppleCaveat =
-    "This sets the language for dictation too, not just the preview. On Auto, dictation "
-    + "detects whatever you speak, while the preview has to pick one language in advance "
-    + "and uses your Mac's."
+    "This changes dictation too, not just the preview. On Automatic, dictation "
+    + "follows what you speak, but the preview must pick one language up front and "
+    + "uses your Mac's."
 
   static let pickerUniversalCaveat =
-    "This sets the language for dictation too, not just the preview. On Auto, this engine "
-    + "works the language out as you speak, so there is nothing you need to pick."
+    "This changes dictation too, not just the preview. On Automatic, this engine "
+    + "works the language out as you speak."
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -261,7 +261,7 @@ struct LivePreviewSettingsView: View {
       //
       // `request.search`, never a separately-read `@State`: see `catalogRequest`.
       LivePreviewPackCatalogSheet(
-        packs: packs, activeTag: activePackTag, initialSearch: request.search)
+        packs: packs, initialSearch: request.search)
     }
   }
 
@@ -301,23 +301,29 @@ struct LivePreviewSettingsView: View {
         HStack(alignment: .center, spacing: 12) {
           VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 8) {
-              ProviderStatusChip(status: status.chip)
+              ProviderStatusChip(status: status.chip, isHeadline: true)
             }
             Text(bar.detail).settingsHelperCopy()
           }
           Spacer(minLength: 12)
 
           if let language = bar.language {
-            Button {
+            // **It has to LOOK like a control, and two stacked Texts did not.**
+            // `.buttonStyle(.plain)` over a bare VStack renders as ordinary
+            // right-aligned copy — the founder read the most important control on
+            // the page as a status readout and did not know it could be pressed
+            // (2026-08-26). A bordered container plus a disclosure chevron is the
+            // platform's own vocabulary for "this opens a list", which is exactly
+            // what it does.
+            //
+            // The provenance moves INSIDE the container rather than under it: it
+            // describes the value, so leaving it outside made the control look
+            // like it ended at the name.
+            LivePreviewLanguageMenuButton(
+              name: language.name, provenance: language.provenance
+            ) {
               showLanguageSheet = true
-            } label: {
-              VStack(alignment: .trailing, spacing: 1) {
-                Text(language.name).settingsRowLabel()
-                Text(language.provenance).settingsHelperCopy()
-              }
             }
-            .buttonStyle(.plain)
-            .contentShape(Rectangle())
             // **The provenance is IN the label, not just on screen.** An explicit
             // `accessibilityLabel` REPLACES the child text announcement, so naming
             // only `language.name` dropped the second line entirely for VoiceOver —
@@ -430,8 +436,22 @@ struct LivePreviewSettingsView: View {
         .foregroundStyle(.stAccent)
       }
 
+      // **`GridItem` defaults to `.center`, which is why the two cards did not
+      // line up.** Measured on the live page: Apple 101.5pt tall starting at
+      // y=341, Universal 82.5pt starting at y=330.5 — two cards presented as
+      // equal choices, disagreeing on both edges, which reads as unfinished and
+      // makes the taller one look more important (Codex UX review, 2026-08-26).
+      //
+      // Two changes, because one alone is not enough: `alignment: .top` settles
+      // the top edge, and `maxHeight: .infinity` on the cards below makes them
+      // fill the row so the bottoms agree too. The heights differ legitimately —
+      // Apple's tagline runs to two lines and Universal carries a footer button —
+      // so equalising is the fix rather than trimming copy to match.
       LazyVGrid(
-        columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+        columns: [
+          GridItem(.flexible(), spacing: 12, alignment: .top),
+          GridItem(.flexible(), spacing: 12, alignment: .top),
+        ],
         spacing: 12
       ) {
         engineCard(
@@ -473,6 +493,7 @@ struct LivePreviewSettingsView: View {
       unavailability: card.unavailability,
       isSelected: card.isSelected,
       onSelect: { settings.livePreviewEngine = choice },
+      fillsHeight: true,
       footer: {
         if card.action != nil || card.progress != nil {
           VStack(alignment: .leading, spacing: 8) {
@@ -480,14 +501,24 @@ struct LivePreviewSettingsView: View {
               ProgressView(value: progress)
             }
             if let action = card.action {
-              // Removal is bordered, everything else prominent: the destructive
-              // action should not be the most inviting thing on the card.
-              if action == .remove {
-                Button(Self.label(for: action)) { perform(action) }
-                  .buttonStyle(.bordered)
-              } else {
-                Button(Self.label(for: action)) { perform(action) }
-                  .buttonStyle(.borderedProminent)
+              // **Same intent as before, on a control that renders it.** Kept
+              // verbatim, because the reason still holds:
+              //
+              // > Removal is bordered, everything else prominent: the destructive
+              // > action should not be the most inviting thing on the card.
+              //
+              // What changed is the mechanism. `.bordered` rendered `Remove` as a
+              // flat grey capsule indistinguishable from this app's disabled
+              // treatment, so "quieter than the primary" became "looks broken"
+              // (Codex UX review, 2026-08-26) — the same defect already measured
+              // on Download and Browse. Outlined is the quiet-but-alive rung, and
+              // it has a hover state, which the flat one did not.
+              SettingsActionButton(
+                title: Self.label(for: action),
+                isEnabled: true,
+                emphasis: action == .remove ? .outlined : .filled
+              ) {
+                perform(action)
               }
             }
           }
@@ -607,51 +638,143 @@ struct LivePreviewSettingsView: View {
   private var packsSection: some View {
     if showsApplePacks {
       BrandedSection(header: LivePreviewSettingsCopy.packsHeader) {
-        BrandedRow(showDivider: false) {
-          HStack(alignment: .top, spacing: 11) {
-            SettingsRowIcon(systemName: "arrow.down.circle")
-            VStack(alignment: .leading, spacing: 4) {
-              // **No count unless we have one.** A count is a claim about this Mac,
-              // and there is no acceptable stand-in for one we have not read yet.
-              switch packs.state {
-              case .loading:
-                Text(LivePreviewSettingsCopy.packsLoading).settingsRowLabel()
-              case .failed:
-                Text(LivePreviewSettingsCopy.packsUnavailable).settingsRowLabel()
-              case .loaded(let rows):
-                Text(
-                  LivePreviewSettingsCopy.packsInstalledSummary(
-                    installed: rows.filter(\.isInstalled).count, total: rows.count)
-                ).settingsRowLabel()
-              }
-              Text(LivePreviewSettingsCopy.packsDescription).settingsHelperCopy()
+        // **The ROW is the button, not a card containing one** (founder,
+        // 2026-08-26). Everything here did one thing: the title named the action,
+        // the paragraph explained it, and a separate `Browse` performed it — so
+        // the row was an explanation wrapped around a control, with two names for
+        // one job and a small target at the far right.
+        //
+        // Collapsing them removes a control rather than restyling one, and it
+        // dissolves the naming question with it: there is no longer a second word
+        // to reconcile with "Install new languages".
+        //
+        // Pressable in EVERY state on purpose, including `.failed` — the sheet
+        // re-reads the inventory when it opens, so pressing a row that says "could
+        // not read the language list" is exactly the retry a user wants. A
+        // disabled row there would be a dead end wearing a reason.
+        LivePreviewInstallRow(
+          title: {
+            switch packs.state {
+            case .loading: return LivePreviewSettingsCopy.packsLoading
+            case .failed: return LivePreviewSettingsCopy.packsUnavailable
+            case .loaded: return LivePreviewSettingsCopy.packsInstallRowTitle
             }
-            Spacer(minLength: 8)
-            Button(LivePreviewSettingsCopy.packsBrowseButton) {
-              catalogRequest = CatalogRequest(search: "")
-            }
-            .controlSize(.small)
-          }
+          }(),
+          detail: LivePreviewSettingsCopy.packsDescription
+        ) {
+          catalogRequest = CatalogRequest(search: "")
         }
       }
     }
   }
 
-  /// The pack tag currently producing the preview, or nil.
-  ///
-  /// Carried verbatim from `isActive`, which the catalogue sheet no longer owns because
-  /// the two gates below are the page's to answer, not a row's:
-  ///
-  /// > Gated on the toggle because "In use" is a claim about a running preview,
-  /// > and nothing runs while the feature is off. Gated on the ENGINE because
-  /// > these are Apple's packs: with the universal engine selected the badge would
-  /// > name a language that is not the one on screen.
-  ///
-  /// > Same reason: an "In use" badge is a claim about the language running NOW.
-  ///
-  /// Both terms read the same values the bar does, so the two cannot disagree.
-  private var activePackTag: String? {
-    guard isUsingApple, isPreviewOn, case .ready(let tag, _) = currentActive else { return nil }
-    return tag
+
+}
+
+// MARK: - Status-bar language control
+
+/// The dictation-language control in the status bar, shaped like the pop-up menu
+/// it behaves as.
+///
+/// **Why it is not an `NSPopUpButton` / SwiftUI `Menu`.** The list it opens is a
+/// searchable sheet over fifty-plus entries with its own caveat subtitle
+/// (`LanguageLockSheet`), which a menu cannot host. So this borrows the pop-up's
+/// APPEARANCE — bordered container, value, disclosure chevron — while keeping the
+/// sheet's behaviour. The chevron is `chevron.up.chevron.down`, the platform's
+/// pop-up glyph, rather than a plain `chevron.down`, which reads as "expand a
+/// section".
+struct LivePreviewLanguageMenuButton: View {
+  let name: String
+  let provenance: String
+  let action: () -> Void
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 10) {
+        VStack(alignment: .leading, spacing: 1) {
+          Text(name)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(Color.stTextPrimary)
+            .lineLimit(1)
+          Text(provenance)
+            .font(.stHelper)
+            .foregroundStyle(Color.stTextSecondary)
+            .lineLimit(1)
+        }
+        Image(systemName: "chevron.up.chevron.down")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(hovering ? Color.stAccent : Color.stTextSecondary)
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 7)
+      .background(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .fill(hovering ? Color.stAccentLight : Color.stSectionBg)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .strokeBorder(hovering ? Color.stAccent : Color.stDivider, lineWidth: 1)
+      )
+      .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering = $0 }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+  }
+}
+
+// MARK: - Languages row
+
+/// The whole Languages row, as one control.
+///
+/// **A row whose title is a verb should be pressable.** This replaced a card that
+/// contained a `Browse` button: the title said "Install new languages", the body
+/// explained downloads, and a small button at the far right did the only thing
+/// available. That is two names for one job, and the smallest part of the row was
+/// the only part that worked.
+///
+/// The chevron replaces the button rather than joining it. A trailing disclosure
+/// is the platform's own "this opens something" mark, and it does not need a word
+/// that would then have to agree with the title.
+struct LivePreviewInstallRow: View {
+  let title: String
+  let detail: String
+  let action: () -> Void
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
+
+  var body: some View {
+    Button(action: action) {
+      HStack(alignment: .top, spacing: 11) {
+        SettingsRowIcon(systemName: "arrow.down.circle")
+        VStack(alignment: .leading, spacing: 4) {
+          Text(title).settingsRowLabel()
+          Text(detail).settingsHelperCopy()
+        }
+        Spacer(minLength: 8)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(hovering ? Color.stAccent : Color.stTextTertiary)
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 12)
+      // The whole row, so the target is the row rather than the chevron. Without
+      // this the hit area is the rendered content and the gaps between the icon,
+      // the text and the chevron are dead (`swift-patterns.md`
+      // RULE: plain-button-content-shape).
+      .contentShape(Rectangle())
+      .background(hovering ? Color.stAccent.opacity(0.06) : Color.clear)
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering = $0 }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .accessibilityElement(children: .combine)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityLabel(title)
+    .accessibilityHint(detail)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -672,6 +672,20 @@ struct EngineCard<Footer: View>: View {
   let onSelect: () -> Void
   /// The action area: a Download/Cancel/Resume/Remove button, a progress bar,
   /// or nothing. Rendered as a sibling of the selection button, never a child.
+  /// Whether this card should fill its container's height.
+  ///
+  /// **Defaulted off so the Transcription page is byte-identical.** Live Preview
+  /// puts two cards in a grid row where their content legitimately differs in
+  /// height — one tagline wraps, the other carries a footer button — so without
+  /// this their bottom edges disagree and the pair reads as unfinished (Codex UX
+  /// review, 2026-08-26).
+  ///
+  /// **It has to live HERE, not at the call site.** An outer `.frame` applied by
+  /// the caller stretches a transparent box around a card whose `.background`
+  /// and border were already sized to content — measured doing exactly that
+  /// before this parameter existed: tops aligned, bottoms still ragged.
+  var fillsHeight: Bool = false
+
   @ViewBuilder var footer: Footer
 
   var body: some View {
@@ -737,7 +751,17 @@ struct EngineCard<Footer: View>: View {
           }
         }
         .padding(16)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        // **The stretch belongs to the BUTTON'S LABEL, not to the card.**
+        // `fillsHeight` first put `maxHeight: .infinity` on the outer container,
+        // which made the two cards match — and made the added space UNSELECTABLE,
+        // because the `Button` wraps only this content. The founder found it
+        // immediately: "the bottom half of the preview engine cards are not
+        // clickable" (2026-08-26). Growing a card without growing its hit region
+        // is a worse defect than the ragged edge it was fixing.
+        .frame(
+          maxWidth: .infinity,
+          maxHeight: fillsHeight ? .infinity : nil,
+          alignment: .topLeading)
         .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
@@ -844,16 +868,96 @@ struct ProviderStatus: Equatable {
 struct ProviderStatusChip: View {
   let status: ProviderStatus
 
+  /// Whether this chip is the HEADLINE state of its surface.
+  ///
+  /// **Defaulted off, so `AIPolishProviderRail` is byte-identical.** There it is
+  /// one badge among many rows and the quiet microcopy treatment is right.
+  ///
+  /// On the Live Preview status bar it is the opposite: the label is the single
+  /// thing the page exists to tell you, and it was rendered in `stHelper` — the
+  /// microcopy token — tinted by tone. In the OFF state that tone is grey, so the
+  /// page's main fact was its quietest text while a large purple engine card kept
+  /// the eye (Codex UX review r2, 2026-08-26: "the eye lands on the engine card
+  /// before the condition that currently matters").
+  ///
+  /// **The DOT keeps the tone colour and the label takes primary contrast.** Tone
+  /// still carries the meaning for anyone reading colour; the label stops
+  /// depending on it, which also helps where grey-on-dark is the hardest to read.
+  var isHeadline: Bool = false
+
   var body: some View {
     HStack(spacing: 5) {
       Circle()
         .fill(status.tone.color)
-        .frame(width: 7, height: 7)
+        .frame(width: isHeadline ? 8 : 7, height: isHeadline ? 8 : 7)
       Text(status.label)
-        .font(.stHelper)
-        .foregroundStyle(status.tone.color)
+        .font(isHeadline ? .system(size: 15, weight: .semibold) : .stHelper)
+        .foregroundStyle(isHeadline ? Color.stTextPrimary : status.tone.color)
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Status: \(status.label)")
+  }
+}
+/// A branded action button for settings sheets and rows.
+///
+/// **Enabled and disabled must not look alike.** The bordered style this
+/// replaced rendered both as low-contrast grey on this surface, and every row's
+/// button genuinely disables while any other install runs — so the state that
+/// mattered was the state that could not be read.
+///
+/// **And the SYSTEM prominent style is not a substitute, measured rather than
+/// assumed.** `.borderedProminent` renders accent-filled inside the sheet and
+/// plain grey on the settings page, in the same build, from the same modifier —
+/// so a button's affordance depended on which container it landed in. Owning the
+/// fill, border and hover here makes the appearance a property of the control
+/// rather than of its surroundings.
+struct SettingsActionButton: View {
+  /// How loud this button is. `outlined` is a row-level action, `filled` the one
+  /// primary on a surface — a hierarchy the system styles could not express here
+  /// because their rendering depended on the container.
+  enum Emphasis { case outlined, filled }
+
+  let title: String
+  let isEnabled: Bool
+  var emphasis: Emphasis = .outlined
+  let action: () -> Void
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
+
+  var body: some View {
+    Button(action: action) {
+      Text(title)
+        .font(.system(size: 12, weight: .semibold))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .foregroundStyle(foreground)
+        .background(fill, in: Capsule())
+        .overlay(Capsule().strokeBorder(border, lineWidth: 1))
+        .contentShape(Capsule())
+    }
+    .buttonStyle(.plain)
+    .disabled(!isEnabled)
+    .onHover { hovering = $0 && isEnabled }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+  }
+
+  private var foreground: Color {
+    guard isEnabled else { return Color.stTextTertiary }
+    if emphasis == .filled { return Color.white }
+    return hovering ? Color.white : Color.stAccent
+  }
+
+  private var fill: Color {
+    guard isEnabled else { return Color.clear }
+    if emphasis == .filled {
+      return hovering ? Color.stAccent : Color.stAccentSolid
+    }
+    return hovering ? Color.stAccentSolid : Color.stAccentLight
+  }
+
+  private var border: Color {
+    guard isEnabled else { return Color.stDivider }
+    if emphasis == .filled { return Color.clear }
+    return hovering ? Color.clear : Color.stAccent
   }
 }

--- a/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewPackCopyTests.swift
@@ -82,7 +82,6 @@ struct LivePreviewPackCopyTests {
     let strings = [
       LivePreviewSettingsCopy.packsHeader,
       LivePreviewSettingsCopy.packsDescription,
-      LivePreviewSettingsCopy.packInstalled,
       LivePreviewSettingsCopy.packInstall,
       LivePreviewSettingsCopy.packInstalling,
       LivePreviewSettingsCopy.packRetry,

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -29,8 +29,6 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.packsUnavailable,
       LivePreviewSettingsCopy.packsSearchPlaceholder,
       LivePreviewSettingsCopy.packsNoSearchMatch,
-      LivePreviewSettingsCopy.packInstalled,
-      LivePreviewSettingsCopy.packInUse,
       LivePreviewSettingsCopy.packInstall,
       LivePreviewSettingsCopy.packInstalling,
       LivePreviewSettingsCopy.packInstallFailed,
@@ -44,10 +42,10 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.previewPrivacyFooter,
       // #2436 catalogue sheet.
       LivePreviewSettingsCopy.browseDownloadsButton,
-      LivePreviewSettingsCopy.packsBrowseButton,
-      LivePreviewSettingsCopy.catalogFilterAvailable,
-      LivePreviewSettingsCopy.catalogFilterInstalled,
       LivePreviewSettingsCopy.catalogDoneButton,
+      // #2445 catalogue-sheet polish.
+      LivePreviewSettingsCopy.catalogCloseLabel,
+      LivePreviewSettingsCopy.packsInstallRowTitle,
       LivePreviewSettingsCopy.statusActiveLabel,
       LivePreviewSettingsCopy.statusActiveDetail,
       LivePreviewSettingsCopy.statusOffLabel,
@@ -76,7 +74,6 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.pickerAppleCaveat,
       LivePreviewSettingsCopy.pickerUniversalCaveat,
       LivePreviewSettingsCopy.catalogNothingToInstall,
-      LivePreviewSettingsCopy.catalogNoneInstalled,
       LivePreviewSettingsCopy.universalAuto,
       // r8: paused variants, which must describe rather than promise.
       LivePreviewSettingsCopy.universalLockedPaused("German"),
@@ -195,16 +192,51 @@ struct LivePreviewSettingsCopyTests {
   /// catch one being given the other's explanation.
   @Test("Apple's caveat keeps the Auto asymmetry, and Universal's does not claim it")
   func caveatsAreEngineSpecific() {
+    // **Attribution by PROXIMITY, not by a list of verbs.** This used to require
+    // one of ["dictation detects", "dictation understands"] — a description of a
+    // set, which grew a new member the moment the copy said "dictation follows".
+    // Extending it would buy one more rewording before the next.
+    //
+    // The property the test actually exists for is WHICH SUBJECT each claim hangs
+    // on: hearing the spoken language belongs to dictation, and falling back to
+    // the Mac belongs to the preview. Nearest-mention answers that for any verb,
+    // and it is what the reversal defect ("Mac detects dictation") violated.
+    // **The subject that GOVERNS a claim is the last one named BEFORE it**, which
+    // is what English word order gives us and what a nearest-mention measure does
+    // not. Measured, after nearest-mention picked the wrong answer on correct copy:
+    // in "dictation follows what you speak, but the preview must pick one", the
+    // word "preview" sits 16 characters after "you speak" while "dictation" is 25
+    // before it, so proximity attributed the hearing to the preview.
+    func governingSubject(_ text: String, of claim: String) -> String? {
+      guard let claimAt = text.range(of: claim)?.lowerBound else { return nil }
+      var best: (String, Int)?
+      for subject in ["dictation", "preview"] {
+        for r in text.ranges(of: subject) where r.lowerBound < claimAt {
+          let d = text.distance(from: r.lowerBound, to: claimAt)
+          if best == nil || d < best!.1 { best = (subject, d) }
+        }
+      }
+      return best?.0
+    }
+
     let apple = LivePreviewSettingsCopy.pickerAppleCaveat.lowercased()
     #expect(apple.contains("auto"), "Apple's caveat stopped naming the mode it describes")
     #expect(
-      ["dictation detects", "dictation understands"].contains(where: apple.contains)
-        && ["you speak", "spoken"].contains(where: apple.contains),
-      "Apple's caveat stopped saying DICTATION is what hears the spoken language")
+      governingSubject(apple, of: "you speak") == "dictation",
+      "Apple's caveat no longer attributes hearing the spoken language to DICTATION")
     #expect(
-      apple.contains("preview")
-        && ["uses your mac", "follows your mac", "goes by your mac"].contains(where: apple.contains),
-      "Apple's caveat stopped saying the PREVIEW is what falls back to the Mac")
+      governingSubject(apple, of: "your mac") == "preview",
+      "Apple's caveat no longer attributes the Mac fallback to the PREVIEW")
+
+    // Two-way control: the reversal that shipped once must still fail this.
+    let reversed = "on auto, the preview follows what you speak, while dictation uses your mac's."
+    // AND, not OR: the swap breaks BOTH attributions, so requiring both to be
+    // detected is the stronger control. An OR would pass while half the check
+    // was inert.
+    #expect(
+      governingSubject(reversed, of: "you speak") == "preview"
+        && governingSubject(reversed, of: "your mac") == "dictation",
+      "the attribution check cannot detect the swapped-subjects defect it exists for")
 
     // The universal engine resolves per utterance, so the Mac fallback is not its story.
     // Asserting its ABSENCE is the half that would have caught the shared-string defect.


### PR DESCRIPTION
#2436 shipped the Live Preview redesign this morning. The founder then **used** it, and found sixteen things. Every one had a clean build and green tests.

## The class behind five of them

`.borderedProminent` renders **accent-filled inside a sheet and plain grey on the settings page, in the same build, from the same modifier.** A button's prominence was therefore a property of its CONTAINER, not of the button.

It hit `Browse`. Then `Done`, the moment fixing the sheet title moved it out of the toolbar. Then `Remove`. And `.bordered` on the Download buttons was the same fact one shade darker — indistinguishable from this app's own disabled treatment, on the only action each row had, while those buttons genuinely DO disable during another install. "Looks disabled" and "is disabled" were the same pixels at the moment the difference mattered.

`SettingsActionButton` owns its fill, border, hover and disabled state. Three call sites.

## What the founder found

| | |
|---|---|
| The Languages row | Was a card **containing** a small `Browse`. Title named the action, paragraph explained it, a separate control did it — two names for one job, and the smallest part was the only part that worked. Now the row IS the button. `packsBrowseButton` deleted. |
| "2 of 54 on this Mac" | A count nobody could act on. Now "Install new languages". |
| The "On this Mac" filter | Gone, with the filter state, both chips, the In-use and Ready badges, `activeTag` and six copy constants. What is installed is answered by the language control at the top of the page. |
| The language control | Two stacked `Text`s under a plain button read as a status readout. Now a bordered container with the platform's pop-up chevron. |
| Both sheet titles | `.navigationTitle` renders through AppKit chrome whose inset the sheet does not control — measured 178pt and 64pt from the edge while the body under them started at 115pt and 16pt. Both now share ONE inset constant with their own content. |
| No way to close a sheet | Close control added to both, top-right. |
| Picker rows | No hover, so the only way to choose a language read as a table of facts. |
| Picker search field | Full-bleed and flush against the paragraph above it. Now the same inset field the other sheet uses. |
| Picker explanation | Three lines of the smallest type. Shorter, at reading size. |
| `Cancel` vs `Done` | One sheet's exit polished, its twin left as coloured text. **He caught it.** Enumerated the class while fixing: eight sheet dismissals across settings; six are on pages outside this change and were left alone. |

## Two of the sixteen were mine, from earlier in the same session

**Equalising the card heights created a dead click zone.** `fillsHeight` stretched the outer container, which the `Button` does not wrap — so the taller the card got, the more of it was unclickable. He found it in minutes: "the bottom half of the preview engine cards are not clickable". The stretch now happens inside the button's label. Apple's hit region: 101.5pt → 125.5pt, reaching the bottom edge.

**A text-range edit duplicated a region** because the end index preceded the start. Three declarations existed twice; the file went 657 → 937 lines. Caught by counting declarations rather than trusting the edit.

## Codex UX review, two rounds, images attached

**Round one** (ON state only) — adopted two: the engine cards disagreeing on geometry (`GridItem` defaults to `.center`, so different-height cards get different top edges; measured 341 vs 330.5) and `Remove` reading as disabled.

**Rejected one, and the reason matters:** it proposed replacing "Activated" with "Live Preview is on", having seen one frame and inferred the label was a fixed word. It is a state machine — `Off`, `Checking`, `<Language> isn't downloaded yet`, `Apple can't preview this language`. A conclusion drawn from a gap in what I sent it. The founder had independently settled that wording.

**Round two**, given the OFF state: **no layout jank** — nothing moves, resizes or disappears between states. One finding adopted: in OFF the page's own headline was its quietest text, in the microcopy token tinted grey, while a large purple engine card kept the eye. The dot keeps the tone colour; the label takes primary contrast and headline size. Opt-in, so `AIPolishProviderRail` is byte-identical.

**Codex stated the limit of its own evidence** — two states, one window width — which was the most useful line in either round. Tested exactly that gap: 760pt (the window's floor) with Maltese locked, producing the longest label the page can render. Text wraps, nothing clips or overlaps, cards stay equal and side by side.

## Receipts

- Debug lane **7083 PASS**.
- Every backticked symbol in the new comments resolves; the eight this change deleted are recorded with reasons and re-verified as absent by `check-cited-symbols.py`.
- Live-verified on the running app after every change. On this page the build has been clean and the screen wrong five times.
- Founder settings recorded and restored after each state test.

## Routed, not silently dropped

Naming the two language TASKS apart (top control changes DICTATION language; the row downloads PREVIEW support), and the privacy sentence's alignment between two sections. Both are the founder's calls, both stated to him. The secondary-text contrast finding is partly addressed by the headline change and partly still open.
