### PR TITLE
Hover states across every settings section: one vocabulary, applied section by section (#2447)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
@@ -189,6 +189,22 @@ struct HotkeyRecorderView: View {
   enum Style {
     case compact
     case prominent
+
+    /// The radius of the field each style draws.
+    ///
+    /// **One owner, because three places now need to agree.** The field's
+    /// `background`, its border `overlay`, and the hover tint
+    /// `KeyCaptureBehavior` applies all have to describe the same shape, and
+    /// each was free to name its own number. That is the shape of both #2447
+    /// review findings -- a decision made in one place that a second place can
+    /// silently contradict -- so it does not get to survive in the change that
+    /// introduced the third reader.
+    var fieldRadius: CGFloat {
+      switch self {
+      case .compact: return 6
+      case .prominent: return 10
+      }
+    }
   }
 
   @Binding var keyCode: UInt16
@@ -250,9 +266,9 @@ struct HotkeyRecorderView: View {
       .padding(.horizontal, 8)
       .padding(.vertical, 4)
       .background(isRecording ? colors.recordingBackground : colors.fieldBackground)
-      .cornerRadius(6)
+      .cornerRadius(Style.compact.fieldRadius)
       .overlay(
-        RoundedRectangle(cornerRadius: 6)
+        RoundedRectangle(cornerRadius: Style.compact.fieldRadius)
           .stroke(isRecording ? colors.recordingBorder : Color.clear, lineWidth: 1)
       )
       .modifier(keyCaptureBehavior)
@@ -300,10 +316,10 @@ struct HotkeyRecorderView: View {
       .frame(maxWidth: .infinity, minHeight: 62)
       .background(
         isRecording ? Color.stAccentLight : Color.stPageBg,
-        in: RoundedRectangle(cornerRadius: 10)
+        in: RoundedRectangle(cornerRadius: Style.prominent.fieldRadius)
       )
       .overlay(
-        RoundedRectangle(cornerRadius: 10)
+        RoundedRectangle(cornerRadius: Style.prominent.fieldRadius)
           .strokeBorder(Color.stAccent, lineWidth: isRecording ? 2 : 1.5)
       )
       .modifier(keyCaptureBehavior)
@@ -330,6 +346,7 @@ struct HotkeyRecorderView: View {
       // with an emoji for the Globe key. Visible text is unchanged.
       valueDescription: KeySymbols.accessibilityDescription(
         keyCode: keyCode, modifiers: modifiers),
+      cornerRadius: style.fieldRadius,
       onKeyEvent: handleKeyEvent,
       onToggle: toggleRecording
     )
@@ -409,11 +426,23 @@ private struct KeyCaptureBehavior: ViewModifier {
   let isRecording: Bool
   let label: String
   let valueDescription: String
+  /// The radius of the visual field this behaviour is attached to, so the hover
+  /// tint follows the same shape. The two styles draw 6 and 10; passing it in
+  /// keeps the one interaction layer from having to guess which it is wrapping.
+  let cornerRadius: CGFloat
   let onKeyEvent: (NSEvent) -> Void
   let onToggle: () -> Void
 
   func body(content: Content) -> some View {
     content
+      // A keybind field is a plain view with `onTapGesture`, deliberately not a
+      // `Button` so a Button cannot swallow the key events being recorded (see
+      // `.focusable()` in `KeybindsSettingsView`). The cost of that choice is
+      // that it inherits none of a control's affordances, which is why the
+      // field looked like a text label showing a shortcut rather than something
+      // to click. Suppressed while RECORDING, where the field already has a
+      // loud active treatment and a hover tint would fight it.
+      .settingsHoverRow(cornerRadius: cornerRadius, isEnabled: !isRecording)
       // Overlay a zero-size KeyCaptureView so it can steal first responder
       // without affecting visual layout.
       .overlay(

--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -105,6 +105,9 @@ struct StatusView: View {
                 RoundedRectangle(cornerRadius: 8)
                   .stroke(.stError, lineWidth: 1.5)
               )
+              // Stops a recording in progress, so it is worth being certain the
+              // pointer is on it before pressing.
+              .settingsHoverRow(cornerRadius: 8, tint: Color.stError.opacity(0.12))
             }
             .buttonStyle(.plain)
             .foregroundStyle(.stError)
@@ -126,6 +129,12 @@ struct StatusView: View {
                 Text("Cancel")
               }
               .foregroundStyle(.secondary)
+              // Bare secondary text beside a bordered Stop: the quietest thing
+              // in the row and the one that discards the take.
+              .padding(.horizontal, 8)
+              .padding(.vertical, 4)
+              .contentShape(Rectangle())
+              .settingsHoverRow(cornerRadius: 7)
             }
             .buttonStyle(.plain)
           }
@@ -405,6 +414,14 @@ struct RecordButton: View {
           .strokeBorder(Color.white.opacity(0.16), lineWidth: 1)
       )
       .shadow(color: (recording ? Color.stError : Color.stAccent).opacity(0.35), radius: 5, y: 2)
+      // The most-pressed control in the window, and gradient-filled, so a tint
+      // beneath it would not show. The veil goes on top for the same reason the
+      // selected sidebar row's does. Gated on the same condition as `.disabled`
+      // below, so a button that cannot be pressed does not answer the pointer.
+      .settingsHoverRow(
+        cornerRadius: 8,
+        tint: SettingsHover.selectedRowVeil,
+        isEnabled: !(state.isActive && !recording))
       .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
     .buttonStyle(.plain)

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -142,6 +142,10 @@ struct TranscriptDetailView: View {
         transcriptCoordinator.delete(transcript)
       } label: {
         Image(systemName: "trash")
+          // The only irreversible control in the bar and the quietest thing in
+          // it: borderless, secondary grey, no border. Hover in the error tone
+          // so what it does is legible before it is pressed rather than after.
+          .settingsHoverQuiet(tint: .stError)
       }
       .buttonStyle(.borderless)
       .foregroundStyle(.stTextSecondary)

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
@@ -55,6 +55,7 @@ struct TranscriptHistoryView: View {
         } label: {
           Label("Delete All", systemImage: "trash")
             .font(.caption)
+            .settingsHoverQuiet(tint: .stError)
         }
         .buttonStyle(.borderless)
         .padding(.vertical, 6)
@@ -227,6 +228,12 @@ struct TranscriptRowView: View {
           isSelected ? Color.stAccent : Color.stDivider,
           lineWidth: isSelected ? 2 : 1)
     )
+    // The `List` row's own selection highlight is deliberately painted over
+    // (see `.listRowBackground` in `TranscriptHistoryView`), and painting it out
+    // took the system's hover with it -- so History, which is the first page the
+    // app opens on and a list whose whole purpose is picking one of many rows,
+    // had no pointer feedback at all.
+    .settingsHoverCard(cornerRadius: 12, isSelected: isSelected)
     .contentShape(RoundedRectangle(cornerRadius: 12))
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -420,7 +420,14 @@ struct ProviderRailRow: View {
   let namespace: Namespace.ID
   let onSelect: () -> Void
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var hovering = false
+  /// See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  /// DERIVED, never stored. See `SettingsHover.respondsToPointer`.
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, true, environmentEnabled)
+  }
 
   var body: some View {
     Button(action: onSelect) {
@@ -470,6 +477,14 @@ struct ProviderRailRow: View {
             .matchedGeometryEffect(id: "railSelection", in: namespace)
         }
       }
+      // #2447. The scale below was this rail's ONLY hover, and it is gated on
+      // reduce-motion -- so the users who turn motion off had no hover at all on
+      // the one control in the window that had any. A transform is a nice
+      // secondary cue and a poor sole one: it says "something is happening here"
+      // without saying WHAT is under the pointer, and it is the first thing an
+      // accessibility setting removes. The tint carries the meaning and survives;
+      // the scale stays as the flourish it was always meant to be.
+      .settingsHoverRow(cornerRadius: 10)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
@@ -477,8 +492,8 @@ struct ProviderRailRow: View {
     // so the row's frame and hover hit-region do not move (no jitter loop); it
     // only grows (1.006), never shrinks. Gated on reduce-motion. #1298.
     .scaleEffect(hovering && !reduceMotion ? 1.006 : 1.0)
-    .onHover { hovering = $0 }
-    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .onHover { pointerInside = $0 }
+    .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
     .accessibilityElement(children: .combine)
     .accessibilityAddTraits(.isButton)
     .accessibilityLabel("\(entry.name), \(entry.group.accessibilityPhrase)")

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -569,6 +569,7 @@ struct AIPolishSettingsView: View {
           }
         } label: {
           Image(systemName: "arrow.clockwise")
+            .settingsHoverQuiet()
         }
         .buttonStyle(.borderless)
         .help("Refresh available models")
@@ -898,7 +899,9 @@ struct AIPolishSettingsView: View {
 
         validationBadge
 
-        Button("Save") {
+        SettingsActionButton(
+          title: "Save", isEnabled: !activeKeyBinding.wrappedValue.isEmpty, emphasis: .filled
+        ) {
           let provider = settings.llmProvider
           let key = activeKeyBinding.wrappedValue
           guard saveKey(key: key, keychainId: descriptor.keychainId) else { return }
@@ -908,19 +911,17 @@ struct AIPolishSettingsView: View {
               provider: provider, settings: settings, source: .save)
           }
         }
-        .disabled(activeKeyBinding.wrappedValue.isEmpty)
-        .buttonStyle(.borderedProminent)
-        .controlSize(.small)
 
-        Button("Clear") {
+        // Save genuinely disables on an empty field and Clear destroys a stored
+        // key, and on this page the system styles drew both, plus the enabled
+        // Save, in the same grey. The red `foregroundStyle` on Clear was the
+        // only thing separating a destructive action from an inert one.
+        SettingsActionButton(title: "Clear", isEnabled: true, emphasis: .destructive) {
           guard clearKey(keychainId: descriptor.keychainId) else { return }
           activeKeyBinding.wrappedValue = ""
           setKeySaved(false)
           llmDiscovery.reset()
         }
-        .buttonStyle(.bordered)
-        .controlSize(.small)
-        .foregroundStyle(.stError)
       }
 
       Text(descriptor.privacySentence)
@@ -1277,13 +1278,11 @@ struct AIPolishSettingsView: View {
         .foregroundStyle(Color.stTextSecondary)
 
         HStack {
-          Button("Download Ollama") {
+          SettingsActionButton(title: "Download Ollama", isEnabled: true, emphasis: .filled) {
             if let url = URL(string: "https://ollama.com/download") {
               NSWorkspace.shared.open(url)
             }
           }
-          .buttonStyle(.borderedProminent)
-          .controlSize(.small)
 
           ollamaRefreshButton()
         }
@@ -1302,11 +1301,9 @@ struct AIPolishSettingsView: View {
           .foregroundStyle(Color.stTextSecondary)
 
         HStack {
-          Button("Start Ollama") {
+          SettingsActionButton(title: "Start Ollama", isEnabled: true, emphasis: .filled) {
             setup.ollamaSetup.startServer()
           }
-          .buttonStyle(.borderedProminent)
-          .controlSize(.small)
 
           ollamaRefreshButton()
         }
@@ -1325,20 +1322,23 @@ struct AIPolishSettingsView: View {
           .foregroundStyle(Color.stTextSecondary)
 
         HStack {
-          Button("Download \(settings.ollamaModel)") {
+          // #1956: the SECOND control that can reach `pullModel`, and the one my
+          // catalog-row sweep missed (review r4). The service has one pull slot,
+          // so if this is pressed while a hosted Add is still probing, the
+          // resolution's own pull arrives second and cancels this download. Both
+          // pull entry points now read the same signal — which #2447 makes
+          // legible, because the system prominent style drew the probing and the
+          // ready states in the same grey.
+          SettingsActionButton(
+            title: "Download \(settings.ollamaModel)",
+            isEnabled: !hostedAddIsResolving,
+            emphasis: .filled
+          ) {
             // #1950: through the funnel, not straight to `pullModel`. The shipped default is a
             // recommended model so this normally downloads immediately, but a user who has changed
             // the setting to something that failed every test gets asked first.
             requestOllamaDownload(modelID: settings.ollamaModel)
           }
-          .buttonStyle(.borderedProminent)
-          .controlSize(.small)
-          // #1956: the SECOND control that can reach `pullModel`, and the one my
-          // catalog-row sweep missed (review r4). The service has one pull slot,
-          // so if this is pressed while a hosted Add is still probing, the
-          // resolution's own pull arrives second and cancels this download. Both
-          // pull entry points now read the same signal.
-          .disabled(hostedAddIsResolving)
 
           ollamaRefreshButton()
         }
@@ -1559,6 +1559,7 @@ struct AIPolishSettingsView: View {
           egOne.activateAndProbe()
         } label: {
           Image(systemName: "arrow.clockwise")
+            .settingsHoverQuiet()
         }
         .buttonStyle(.borderless)
         .help("Test that EG-1 is live")
@@ -1660,6 +1661,7 @@ struct AIPolishSettingsView: View {
         aiAvailability.debouncedCheck()
       } label: {
         Image(systemName: "arrow.clockwise")
+          .settingsHoverQuiet()
       }
       .buttonStyle(.borderless)
       .disabled(aiAvailability.isChecking)
@@ -1861,6 +1863,7 @@ struct AIPolishSettingsView: View {
         Task { await setup.ollamaSetup.refreshCloudCatalog(force: true) }
       } label: {
         Text("Retry")
+          .settingsHoverQuiet()
       }
       .controlSize(.small)
       .buttonStyle(.borderless)
@@ -2089,6 +2092,7 @@ struct AIPolishSettingsView: View {
             } label: {
               Text("Cancel")
                 .foregroundStyle(.stError)
+                .settingsHoverQuiet(tint: .stError)
             }
             .controlSize(.small)
             .buttonStyle(.borderless)
@@ -2108,6 +2112,7 @@ struct AIPolishSettingsView: View {
           } label: {
             Text("Delete")
               .foregroundStyle(.stError)
+              .settingsHoverQuiet(tint: .stError)
           }
           .controlSize(.small)
           .buttonStyle(.borderless)
@@ -2261,6 +2266,7 @@ struct AIPolishSettingsView: View {
       }
     } label: {
       Image(systemName: "arrow.clockwise")
+        .settingsHoverQuiet()
     }
     .buttonStyle(.borderless)
     .help("Re-check Ollama status")
@@ -2309,6 +2315,7 @@ struct AIPolishSettingsView: View {
         setup.ollamaSetup.warmUpModel(settings.llmModel)
       } label: {
         Image(systemName: "arrow.clockwise")
+          .settingsHoverQuiet()
       }
       .buttonStyle(.borderless)
       .help("Prepare model")

--- a/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AppearanceSettingsView.swift
@@ -131,6 +131,11 @@ private struct AppearanceCard: View {
             isSelected ? Color.stAccent : Color.stDivider,
             lineWidth: isSelected ? 2 : 1)
       )
+      // Three cards that look like labelled previews and behave like radio
+      // buttons. Nothing at rest distinguishes the two unselected ones from
+      // decoration.
+      .settingsHoverCard(
+        cornerRadius: SettingsLayout.sectionRadius, isSelected: isSelected)
     }
     .buttonStyle(.plain)
     .animation(.easeInOut(duration: 0.15), value: isSelected)

--- a/Sources/EnviousWisprAppKit/Views/Settings/BulkDeleteConfirmSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/BulkDeleteConfirmSheet.swift
@@ -42,12 +42,13 @@ struct BulkDeleteConfirmSheet: View {
       }
 
       HStack {
-        Button("Cancel", action: onCancel)
-          .keyboardShortcut(.cancelAction)
-          .disabled(isExporting)
+        SettingsActionButton(
+          title: "Cancel", isEnabled: !isExporting, shortcut: .cancelAction, action: onCancel)
 
         Spacer()
 
+        // The ProgressView swap stays a raw Button: this control replaces its
+        // whole label while exporting, which a title-taking control cannot do.
         Button {
           exportCopy()
         } label: {
@@ -59,10 +60,17 @@ struct BulkDeleteConfirmSheet: View {
         }
         .disabled(isExporting)
 
-        Button("Delete \(ids.count) \(ids.count == 1 ? "word" : "words")", role: .destructive) {
+        // Deletes words permanently, and on this sheet it sat in the same grey
+        // as Cancel with only the system's destructive ROLE separating them --
+        // a role that renders as red TEXT on macOS and disappears entirely
+        // against this palette.
+        SettingsActionButton(
+          title: "Delete \(ids.count) \(ids.count == 1 ? "word" : "words")",
+          isEnabled: !isExporting,
+          emphasis: .destructive
+        ) {
           deleteSelection()
         }
-        .disabled(isExporting)
       }
     }
     .padding(24)

--- a/Sources/EnviousWisprAppKit/Views/Settings/ContactsImportConfirm.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ContactsImportConfirm.swift
@@ -32,16 +32,21 @@ struct ContactsImportConfirm: View {
 
       HStack {
         Spacer()
+        // #2447 finishes the sheet-dismissal class #2445 opened. The founder's
+        // finding there was not any single button but the PAIR: "you improved
+        // the 'done' button on the install pop up but then didn't fix the cancel
+        // button on the language selector." Both halves of each pair move
+        // together here for that reason.
         if hasNewNames {
-          Button("Cancel", action: onCancel)
-            .keyboardShortcut(.cancelAction)
-          Button(addButtonTitle, action: onConfirm)
-            .keyboardShortcut(.defaultAction)
-            .buttonStyle(.borderedProminent)
+          SettingsActionButton(
+            title: "Cancel", isEnabled: true, shortcut: .cancelAction, action: onCancel)
+          SettingsActionButton(
+            title: addButtonTitle, isEnabled: true, emphasis: .filled,
+            shortcut: .defaultAction, action: onConfirm)
         } else {
-          Button("Done", action: onCancel)
-            .keyboardShortcut(.defaultAction)
-            .buttonStyle(.borderedProminent)
+          SettingsActionButton(
+            title: "Done", isEnabled: true, emphasis: .filled,
+            shortcut: .defaultAction, action: onCancel)
         }
       }
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -69,6 +69,7 @@ struct CustomTermsSection: View {
               Image(systemName: "xmark.circle.fill")
                 .foregroundStyle(.stTextSecondary)
                 .font(.system(size: 12))
+                .settingsHoverQuiet()
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Clear search")
@@ -89,10 +90,12 @@ struct CustomTermsSection: View {
               .font(.stHelper)
               .foregroundStyle(.stTextSecondary)
             Spacer()
-            Button("Delete…", role: .destructive) {
+            // The one irreversible action on this page. The system destructive
+            // role renders as ordinary grey here, so the control that deletes a
+            // word list looked exactly like the control that cancels.
+            SettingsActionButton(title: "Delete…", isEnabled: true, emphasis: .destructive) {
               pendingBulkDelete = BulkDeleteRequest(ids: selectedIDs)
             }
-            .controlSize(.small)
           }
         }
       }
@@ -124,6 +127,7 @@ struct CustomTermsSection: View {
               if currentPage > 0 { currentPage -= 1 }
             } label: {
               Image(systemName: "chevron.left")
+                .settingsHoverQuiet(isEnabled: currentPage > 0)
             }
             .buttonStyle(.plain)
             .disabled(currentPage == 0)
@@ -137,6 +141,7 @@ struct CustomTermsSection: View {
               if currentPage < pageCount - 1 { currentPage += 1 }
             } label: {
               Image(systemName: "chevron.right")
+                .settingsHoverQuiet(isEnabled: currentPage < pageCount - 1)
             }
             .buttonStyle(.plain)
             .disabled(currentPage >= pageCount - 1)
@@ -202,10 +207,9 @@ struct CustomTermsSection: View {
         // convention, so the two sheets this section presents never both
         // apply to the same row at once.
         if !isSelecting {
-          Button("Edit") {
+          SettingsActionButton(title: "Edit", isEnabled: true) {
             editingWord = word
           }
-          .controlSize(.small)
         }
       }
     }
@@ -229,23 +233,22 @@ struct CustomTermsSection: View {
     if isSelecting {
       let allSelected =
         !filteredSelectableIDs.isEmpty && filteredSelectableIDs.isSubset(of: selectedIDs)
-      Button(allSelected ? "Deselect All" : "Select All") {
+      SettingsActionButton(
+        title: allSelected ? "Deselect All" : "Select All",
+        isEnabled: !filteredSelectableIDs.isEmpty
+      ) {
         selectedIDs = CustomTermListPolicy.toggledSelection(
           current: selectedIDs, target: filteredSelectableIDs)
       }
-      .controlSize(.small)
-      .disabled(filteredSelectableIDs.isEmpty)
 
-      Button("Cancel") {
+      SettingsActionButton(title: "Cancel", isEnabled: true) {
         selectedIDs = []
         isSelecting = false
       }
-      .controlSize(.small)
     } else if !filteredSelectableIDs.isEmpty {
-      Button("Select") {
+      SettingsActionButton(title: "Select", isEnabled: true) {
         isSelecting = true
       }
-      .controlSize(.small)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -114,8 +114,11 @@ struct CustomWordEditSheet: View {
                   Button {
                     word.aliases.removeAll { $0 == alias }
                   } label: {
+                    // An 8pt glyph inside a chip: the smallest target in the
+                    // whole window, and the one that deletes an alias.
                     Image(systemName: "xmark")
                       .font(.system(size: 8, weight: .bold))
+                      .settingsHoverQuiet(inset: 2, tint: .stError)
                   }
                   .buttonStyle(.plain)
                   .fixedSize()
@@ -200,16 +203,20 @@ struct CustomWordEditSheet: View {
       // Actions
       HStack {
         if onDelete != nil {
-          Button(role: .destructive) {
+          SettingsActionButton(title: "Delete", isEnabled: true, emphasis: .destructive) {
             showingDeleteConfirmation = true
-          } label: {
-            Text("Delete")
           }
         }
         Spacer()
-        Button("Cancel") { dismiss() }
-          .keyboardShortcut(.cancelAction)
-        Button("Save") {
+        SettingsActionButton(title: "Cancel", isEnabled: true, shortcut: .cancelAction) {
+          dismiss()
+        }
+        SettingsActionButton(
+          title: "Save",
+          isEnabled: !word.canonical.trimmingCharacters(in: .whitespaces).isEmpty,
+          emphasis: .filled,
+          shortcut: .defaultAction
+        ) {
           if let error = onSave(word) {
             saveError = error
           } else {
@@ -217,8 +224,6 @@ struct CustomWordEditSheet: View {
             dismiss()
           }
         }
-        .keyboardShortcut(.defaultAction)
-        .disabled(word.canonical.trimmingCharacters(in: .whitespaces).isEmpty)
       }
     }
     .confirmationDialog(

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsImportSheet.swift
@@ -125,7 +125,7 @@ struct CustomWordsImportSheet: View {
   private var header: some View {
     HStack(spacing: 8) {
       if model.canGoBack {
-        Button("Back") { model.goBack() }
+        SettingsActionButton(title: "Back", isEnabled: true) { model.goBack() }
       }
       Text(title)
         .font(.title3)
@@ -160,24 +160,53 @@ struct CustomWordsImportSheet: View {
         // VoiceOver/Full Keyboard Access from exposing two overlapping
         // "Done" controls at the same location (Codex, round 6) — it only
         // affects the accessibility tree, not keyboard shortcut dispatch.
-        Button("Done") { requestCancel() }
-          .keyboardShortcut(.defaultAction)
-          .buttonStyle(.borderedProminent)
-          .overlay {
-            Button("Done") { requestCancel() }
-              .keyboardShortcut(.cancelAction)
-              .opacity(0)
-              .accessibilityHidden(true)
-          }
+        //
+        // #2447 restyles the VISIBLE button only. The zero-opacity overlay below
+        // stays a raw `Button` deliberately: it exists to carry `.cancelAction`
+        // and is never seen, so a hover treatment on it would be decoration for
+        // a control nobody can look at -- and every word of the comment above
+        // describes constraints on THAT button, which restyling risks quietly
+        // invalidating.
+        SettingsActionButton(
+          title: "Done", isEnabled: true, emphasis: .filled, shortcut: .defaultAction
+        ) {
+          requestCancel()
+        }
+        .overlay {
+          Button("Done") { requestCancel() }
+            .keyboardShortcut(.cancelAction)
+            .opacity(0)
+            .accessibilityHidden(true)
+            // **`.opacity(0)` hides it from the EYE, not from the POINTER.** The
+            // comment above records why `.hidden()` was rejected -- a hidden view
+            // receives no interaction, which killed shortcut dispatch. What that
+            // left behind is a fully hit-testable control sitting on top of the
+            // visible one: clicks reached the same action so nothing looked
+            // wrong, and the visible button's hover never fired because the
+            // pointer never reached it (cloud review, #2447).
+            //
+            // Hit testing and shortcut dispatch are separate paths: Apple
+            // documents `allowsHitTesting` as governing "hit test operations"
+            // and pointer interaction, while a keyboard shortcut fires for a
+            // control "anywhere in the frontmost window", which is a presence
+            // condition. This restores the pointer to the button underneath
+            // while leaving Escape's route intact -- verified by pressing Escape
+            // on this screen, not inferred from the two doc pages.
+            .allowsHitTesting(false)
+        }
       case .review:
-        Button("Cancel") { requestCancel() }
-          .keyboardShortcut(.cancelAction)
-        Button(confirmTitle) { model.confirm() }
-          .keyboardShortcut(.defaultAction)
-          .buttonStyle(.borderedProminent)
+        SettingsActionButton(title: "Cancel", isEnabled: true, shortcut: .cancelAction) {
+          requestCancel()
+        }
+        SettingsActionButton(
+          title: confirmTitle, isEnabled: true, emphasis: .filled, shortcut: .defaultAction
+        ) {
+          model.confirm()
+        }
       case .methodPicker, .paste, .upload, .smartImportAppPicker, .working:
-        Button("Cancel") { requestCancel() }
-          .keyboardShortcut(.cancelAction)
+        SettingsActionButton(title: "Cancel", isEnabled: true, shortcut: .cancelAction) {
+          requestCancel()
+        }
       }
     }
   }
@@ -294,6 +323,9 @@ private struct ImportMethodCard: View {
       .overlay(
         RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1)
       )
+      // The first screen of the import flow is three of these and nothing else,
+      // so if they do not read as choices the flow has no visible entry point.
+      .settingsHoverCard(cornerRadius: 10)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
@@ -440,18 +472,21 @@ private struct ImportPasteScreen: View {
           .font(.stHelper)
           .foregroundStyle(.stTextSecondary)
         Spacer(minLength: 0)
-        Button("Continue") {
-          model.begin(with: PasteWordsImportSource(text: model.pasteDraft))
-        }
-        .keyboardShortcut(.defaultAction)
-        .buttonStyle(.borderedProminent)
         // Over-limit is a refusal, not a warning: Confirm would throw and land
         // the user on the terminal failure screen, which has no Back, so the
         // draft they could have split is gone. Block it where they can still
-        // edit it (cloud review, #1683).
-        .disabled(
-          isCounting || wordCount == 0
-            || wordCount > CustomWordsImportLimits.maximumCandidates)
+        // edit it (cloud review, #1683) -- and #2447 makes that refusal VISIBLE,
+        // since the system style drew the blocked and the ready states in the
+        // same grey.
+        SettingsActionButton(
+          title: "Continue",
+          isEnabled: !(isCounting || wordCount == 0
+            || wordCount > CustomWordsImportLimits.maximumCandidates),
+          emphasis: .filled,
+          shortcut: .defaultAction
+        ) {
+          model.begin(with: PasteWordsImportSource(text: model.pasteDraft))
+        }
       }
     }
     .onAppear {
@@ -555,16 +590,15 @@ private struct ImportUploadScreen: View {
         .font(.stHelper)
         .foregroundStyle(.stTextSecondary)
 
-      Button {
+      SettingsActionButton(
+        title: "Choose a file", isEnabled: true, emphasis: .filled, systemImage: "folder"
+      ) {
         // The panel is opened first and the file read only after a choice, so
         // cancelling reads nothing and starts no work.
         if let url = CustomWordsImportFilePanel.chooseFile() {
           model.begin(with: FileImportSource(url: url))
         }
-      } label: {
-        Label("Choose a file", systemImage: "folder")
       }
-      .buttonStyle(.borderedProminent)
 
       Text("Spreadsheets aren't supported yet.")
         .font(.stHelper)

--- a/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
@@ -302,6 +302,10 @@ private struct RecordingModeCard: View {
             isSelected ? Color.stAccent : Color.stDivider,
             lineWidth: isSelected ? 2 : 1)
       )
+      // Inside the label, where the padding and `background` already are, so the
+      // tint cannot outgrow the region the `Button` responds on.
+      .settingsHoverCard(
+        cornerRadius: SettingsLayout.sectionRadius, isSelected: isSelected)
     }
     .buttonStyle(.plain)
     .animation(.easeInOut(duration: 0.15), value: isSelected)

--- a/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LanguageLockSheet.swift
@@ -108,7 +108,7 @@ struct LanguageLockSheet: View {
         .font(.system(size: 15, weight: .semibold))
         .foregroundStyle(Color.stTextPrimary)
       Spacer(minLength: 12)
-      LanguageSheetCloseButton { dismiss() }
+      SettingsSheetCloseButton(accessibilityTitle: "Close") { dismiss() }
     }
     .padding(.horizontal, Self.inset)
     .padding(.vertical, 12)
@@ -127,8 +127,9 @@ struct LanguageLockSheet: View {
       // WITHOUT choosing is a secondary action here, because the rows are the
       // primary one. `Done` on the catalogue sheet is filled because nothing
       // competes with it there.
-      SettingsActionButton(title: "Cancel", isEnabled: true) { dismiss() }
-        .keyboardShortcut(.cancelAction)
+      SettingsActionButton(title: "Cancel", isEnabled: true, shortcut: .cancelAction) {
+        dismiss()
+      }
     }
     .padding(.horizontal, Self.inset)
     .padding(.vertical, 12)
@@ -202,8 +203,16 @@ struct LanguageLockSheet: View {
           }
           .padding(.horizontal, 14)
           .padding(.vertical, 10)
+          // The TWIN of `LanguageLockRow`, and it was drifting from it in two
+          // ways at once. Live UAT caught the first: every language row beneath
+          // this one lit up under the pointer and this one did not, on the first
+          // row of the list. The second was only visible once both were read
+          // together -- the selected wash here was 0.06 against the rows' 0.10,
+          // so "this is the current choice" was drawn two different strengths
+          // depending on which kind of choice it was.
+          .background(isAuto ? Color.stAccent.opacity(0.10) : Color.clear)
+          .settingsHoverRow(cornerRadius: 0)
           .contentShape(Rectangle())
-          .background(isAuto ? Color.stAccent.opacity(0.06) : Color.clear)
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Auto-detect language")
@@ -413,9 +422,6 @@ private struct LanguageLockRow: View {
   let isSelected: Bool
   let action: () -> Void
 
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var hovering = false
-
   var body: some View {
     Button(action: action) {
       HStack(spacing: 10) {
@@ -434,44 +440,20 @@ private struct LanguageLockRow: View {
       }
       .padding(.horizontal, 14)
       .padding(.vertical, 10)
-      .contentShape(Rectangle())
       // Selection outranks hover: a selected row keeps its accent wash even while
       // the pointer sits on a neighbour, so the current choice never disappears.
-      .background(background)
+      // The hover tint composites ON TOP of that wash rather than replacing it,
+      // so the selected row under the pointer reads as both.
+      .background(isSelected ? Color.stAccent.opacity(0.10) : Color.clear)
+      .settingsHoverRow(cornerRadius: 0)
+      .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .onHover { hovering = $0 }
-    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
     .accessibilityLabel("\(entry.englishName), native \(entry.nativeName)")
     .accessibilityValue(isSelected ? "selected" : "")
   }
-
-  private var background: Color {
-    if isSelected { return Color.stAccent.opacity(0.10) }
-    return hovering ? Color.stAccent.opacity(0.06) : Color.clear
-  }
 }
 
-/// Matches `LivePreviewPackCatalogSheet`'s close control. Duplicated rather than
-/// shared for now because the two sheets live in different features; if a third
-/// appears, this is the one to promote.
-private struct LanguageSheetCloseButton: View {
-  let action: () -> Void
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var hovering = false
-
-  var body: some View {
-    Button(action: action) {
-      Image(systemName: "xmark")
-        .font(.system(size: 11, weight: .bold))
-        .foregroundStyle(hovering ? Color.stTextPrimary : Color.stTextSecondary)
-        .frame(width: 22, height: 22)
-        .background(Circle().fill(hovering ? Color.stSectionBg : Color.clear))
-        .contentShape(Circle())
-    }
-    .buttonStyle(.plain)
-    .onHover { hovering = $0 }
-    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
-    .accessibilityLabel("Close")
-  }
-}
+// The close control this file used to declare is now
+// `SettingsSheetCloseButton` in `SettingsComponents.swift`, shared with
+// `LivePreviewPackCatalogSheet`, which held a byte-identical copy.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -115,9 +115,13 @@ struct LearningSection: View {
       ProgressView()
         .controlSize(.small)
     case .denied:
-      Button("Open Settings") { openContactsSettings() }
+      SettingsActionButton(title: "Open Settings", isEnabled: true, emphasis: .filled) {
+        openContactsSettings()
+      }
     default:
-      Button(contactsImport.importedCount > 0 ? "Re-scan" : "Import") {
+      SettingsActionButton(
+        title: contactsImport.importedCount > 0 ? "Re-scan" : "Import", isEnabled: true
+      ) {
         Task { await contactsImport.prepareImport() }
       }
     }
@@ -131,6 +135,9 @@ struct LearningSection: View {
         contactsImport.bulkRemoveImported()
       } label: {
         Image(systemName: "xmark.circle.fill")
+          // Bulk-removes every imported name, from a glyph inside a status
+          // pill -- the least button-shaped thing on the page doing the most.
+          .settingsHoverQuiet(tint: .stError)
       }
       .buttonStyle(.plain)
       .help("Remove all imported names")

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewPackCatalogSheet.swift
@@ -113,7 +113,9 @@ struct LivePreviewPackCatalogSheet: View {
         .font(.system(size: 15, weight: .semibold))
         .foregroundStyle(Color.stTextPrimary)
       Spacer(minLength: 12)
-      CatalogCloseButton { dismiss() }
+      SettingsSheetCloseButton(
+        accessibilityTitle: LivePreviewSettingsCopy.catalogCloseLabel
+      ) { dismiss() }
     }
     .padding(.horizontal, Self.inset)
     .padding(.vertical, 12)
@@ -136,11 +138,11 @@ struct LivePreviewPackCatalogSheet: View {
       SettingsActionButton(
         title: LivePreviewSettingsCopy.catalogDoneButton,
         isEnabled: true,
-        emphasis: .filled
+        emphasis: .filled,
+        shortcut: .defaultAction
       ) {
         dismiss()
       }
-      .keyboardShortcut(.defaultAction)
     }
     .padding(.horizontal, Self.inset)
     .padding(.vertical, 12)
@@ -349,29 +351,7 @@ struct LivePreviewPackCatalogSheet: View {
 
 /// The sheet's close control.
 ///
-/// Deliberately a symbol rather than a second worded button: `Done` at the
-/// bottom already carries the words, and two worded exits invite the reading
-/// that they do different things. Nothing in this sheet is committed on exit,
-/// so both simply leave.
-private struct CatalogCloseButton: View {
-  let action: () -> Void
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var hovering = false
-
-  var body: some View {
-    Button(action: action) {
-      Image(systemName: "xmark")
-        .font(.system(size: 11, weight: .bold))
-        .foregroundStyle(hovering ? Color.stTextPrimary : Color.stTextSecondary)
-        .frame(width: 22, height: 22)
-        .background(
-          Circle().fill(hovering ? Color.stSectionBg : Color.clear)
-        )
-        .contentShape(Circle())
-    }
-    .buttonStyle(.plain)
-    .onHover { hovering = $0 }
-    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
-    .accessibilityLabel(LivePreviewSettingsCopy.catalogCloseLabel)
-  }
-}
+// Nothing in this sheet is committed on exit, so the X and `Done` simply both
+// leave. The control itself is now
+// `SettingsSheetCloseButton` in `SettingsComponents.swift`, shared with
+// `LanguageLockSheet`, which held a byte-identical copy.

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -383,11 +383,15 @@ struct LivePreviewSettingsView: View {
             Spacer(minLength: 0)
             switch action {
             case .browseDownloads(let initialSearch):
-              Button(LivePreviewSettingsCopy.browseDownloadsButton) {
+              // The last system-styled button left on this page after #2445
+              // replaced the other three. Same fact, same fix.
+              SettingsActionButton(
+                title: LivePreviewSettingsCopy.browseDownloadsButton,
+                isEnabled: true,
+                emphasis: .filled
+              ) {
                 catalogRequest = CatalogRequest(search: initialSearch)
               }
-              .buttonStyle(.borderedProminent)
-              .controlSize(.small)
             }
           }
         }
@@ -689,7 +693,14 @@ struct LivePreviewLanguageMenuButton: View {
   let action: () -> Void
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var hovering = false
+  /// See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  /// DERIVED, never stored. See `SettingsHover.respondsToPointer`.
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, true, environmentEnabled)
+  }
 
   var body: some View {
     Button(action: action) {
@@ -721,8 +732,8 @@ struct LivePreviewLanguageMenuButton: View {
       .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
     .buttonStyle(.plain)
-    .onHover { hovering = $0 }
-    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .onHover { pointerInside = $0 }
+    .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
   }
 }
 
@@ -745,7 +756,14 @@ struct LivePreviewInstallRow: View {
   let action: () -> Void
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var hovering = false
+  /// See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  /// DERIVED, never stored. See `SettingsHover.respondsToPointer`.
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, true, environmentEnabled)
+  }
 
   var body: some View {
     Button(action: action) {
@@ -770,8 +788,8 @@ struct LivePreviewInstallRow: View {
       .background(hovering ? Color.stAccent.opacity(0.06) : Color.clear)
     }
     .buttonStyle(.plain)
-    .onHover { hovering = $0 }
-    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .onHover { pointerInside = $0 }
+    .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
     .accessibilityElement(children: .combine)
     .accessibilityAddTraits(.isButton)
     .accessibilityLabel(title)

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -333,6 +333,15 @@ struct RecordingPillPreviewTile: View {
             isSelected && isEnabled ? Color.stAccent : Color.stDivider,
             lineWidth: isSelected && isEnabled ? 2 : 1)
       )
+      // These tiles SHOW the product rather than describing it (#2435), which
+      // makes them read as illustrations. Hover is what says they are also the
+      // control. Gated on `isEnabled` for the same reason `.disabled` is below:
+      // a tile at 45% opacity that still answers the pointer is worse than one
+      // that does nothing, because it invites the press it will refuse.
+      .settingsHoverCard(
+        cornerRadius: SettingsLayout.sectionRadius,
+        isEnabled: isEnabled,
+        isSelected: isSelected && isEnabled)
     }
     .buttonStyle(.plain)
     .disabled(!isEnabled)

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingSoundsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingSoundsSettingsView.swift
@@ -56,14 +56,18 @@ struct RecordingSoundsSettingsView: View {
                 .settingsReadingCopy()
             }
             Spacer()
-            Button(action: startPreview) {
-              Label("Preview", systemImage: "play.fill")
-                .padding(.horizontal, 4)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.regular)
+            // This one genuinely disables while a recording runs, and the
+            // system prominent style renders grey on a settings page, so the
+            // enabled and disabled states were the same pixels on the only
+            // control in the row.
+            SettingsActionButton(
+              title: "Preview",
+              isEnabled: !liveRecordingState.isDictationActive,
+              emphasis: .filled,
+              systemImage: "play.fill",
+              action: startPreview
+            )
             .accessibilityLabel("Preview \(displayName(for: settings.recordingSoundPairing))")
-            .disabled(liveRecordingState.isDictationActive)
             .help(
               liveRecordingState.isDictationActive
                 ? "Preview is unavailable while a recording is in progress."
@@ -191,6 +195,11 @@ private struct RecordingSoundPairingCard: View {
       RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
         .strokeBorder(isSelected ? Color.stAccent : Color.stDivider, lineWidth: isSelected ? 2 : 1)
     )
+    // Safe to hang off the card rather than the label here: the comment above
+    // this type records that the ENTIRE card is one `Button` with no second
+    // interactive region inside it, so the card's bounds and the hit region are
+    // already the same rectangle.
+    .settingsHoverCard(cornerRadius: SettingsLayout.sectionRadius, isSelected: isSelected)
     .animation(.easeInOut(duration: 0.15), value: isSelected)
     .accessibilityLabel(displayName(for: pairing))
     .accessibilityValue(isSelected ? "Selected" : "")

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -398,6 +398,13 @@ struct BrandedToggleStyle: ToggleStyle {
         Spacer()
         BrandedToggleTrack(isOn: configuration.isOn)
       }
+      // The whole row commits the change -- `contentShape(Rectangle())` below
+      // has always made the label, the gap and the track one target -- and
+      // until #2447 nothing said so, so the 38pt track was the only part users
+      // aimed at. The tint covers exactly the rectangle `contentShape` claims,
+      // which is the point: it does not advertise a target that is not there,
+      // and it does not hide the one that is.
+      .settingsHoverRow(cornerRadius: 7)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
@@ -522,6 +529,14 @@ struct BrandedSegmentedPicker<T: Hashable>: View {
             RoundedRectangle(cornerRadius: 7, style: .continuous)
               .fill(isSelected ? Color.stAccentSolid : Color.clear)
           )
+          // An UNSELECTED segment is drawn as bare text on the track: no fill,
+          // no border, nothing separating it from a label. Hover is the only
+          // thing that says the other options are reachable. The selected
+          // segment is a solid accent pill, so it takes the white veil for the
+          // same reason the selected sidebar row does.
+          .settingsHoverRow(
+            cornerRadius: 7,
+            tint: isSelected ? SettingsHover.selectedRowVeil : SettingsHover.rowTint)
         }
         .buttonStyle(.plain)
         .accessibilityValue(isSelected ? "selected" : "")
@@ -565,8 +580,12 @@ struct BrandedStatusRow: View {
       Spacer()
 
       if !isGranted, let actionLabel, let action {
-        Button(actionLabel, action: action)
-          .controlSize(.small)
+        // The whole Permissions page is two of these rows, so this button is
+        // that page's only control -- and the persona it exists for is someone
+        // who came here because dictation stopped working. On the system style
+        // it rendered as grey text beside a red X, which is a poor thing for
+        // "Open System Settings" to look like.
+        SettingsActionButton(title: actionLabel, isEnabled: true, emphasis: .filled, action: action)
       }
     }
   }
@@ -762,6 +781,13 @@ struct EngineCard<Footer: View>: View {
           maxWidth: .infinity,
           maxHeight: fillsHeight ? .infinity : nil,
           alignment: .topLeading)
+        // Applied to the LABEL, inside the same frame the hit region uses, so
+        // the tint and the target are one rectangle and stay one rectangle when
+        // `fillsHeight` grows them. On a card that carries a footer button the
+        // tint deliberately stops where the selection area stops: the footer is
+        // a different action, and a highlight running under it would say
+        // otherwise.
+        .settingsHoverRow(cornerRadius: SettingsLayout.sectionRadius)
         .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
@@ -898,6 +924,35 @@ struct ProviderStatusChip: View {
     .accessibilityLabel("Status: \(status.label)")
   }
 }
+/// The close control in a settings sheet's title bar.
+///
+/// Promoted from the two byte-identical copies in `LivePreviewPackCatalogSheet`
+/// and `LanguageLockSheet`, whose own comment said "if a third appears, this is
+/// the one to promote". A third appeared.
+///
+/// Deliberately a symbol rather than a second worded button: the sheet's footer
+/// already carries the words, and two worded exits invite the reading that they
+/// do different things.
+struct SettingsSheetCloseButton: View {
+  /// What the assistive label says. The two sheets word it differently on
+  /// purpose, so it stays a parameter rather than becoming a shared constant.
+  let accessibilityTitle: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: "xmark")
+        .font(.system(size: 11, weight: .bold))
+        .foregroundStyle(Color.stTextSecondary)
+        .frame(width: 22, height: 22)
+        .settingsHoverQuiet()
+        .contentShape(Circle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(accessibilityTitle)
+  }
+}
+
 /// A branded action button for settings sheets and rows.
 ///
 /// **Enabled and disabled must not look alike.** The bordered style this
@@ -915,49 +970,128 @@ struct SettingsActionButton: View {
   /// How loud this button is. `outlined` is a row-level action, `filled` the one
   /// primary on a surface — a hierarchy the system styles could not express here
   /// because their rendering depended on the container.
-  enum Emphasis { case outlined, filled }
+  /// `destructive` is `outlined` in the error tone, for Clear / Delete / Remove
+  /// All. Those sites reached for `.bordered` plus a red `foregroundStyle`,
+  /// which on a settings page rendered as grey with red text — the same
+  /// "looks disabled" reading that made the Download buttons unreadable, on the
+  /// one class of action where a misread is expensive.
+  enum Emphasis { case outlined, filled, destructive }
 
   let title: String
   let isEnabled: Bool
   var emphasis: Emphasis = .outlined
+  /// An optional leading SF Symbol, for the few actions whose glyph does real
+  /// work: Preview's play triangle, Refresh's arrows.
+  var systemImage: String? = nil
+  /// Return or Escape for a sheet's confirm and cancel.
+  ///
+  /// **A parameter rather than something the call site applies, so the shortcut
+  /// lands on a control rather than on a wrapper.** Apple documents
+  /// `keyboardShortcut(_:modifiers:)` as assigning the shortcut to "the modified
+  /// control"; this type is a composite `View`, not a control, so a call site
+  /// writing the modifier on the outside is relying on behaviour the
+  /// documentation does not describe. Passed in, it is applied to the `Button`
+  /// below, which is unambiguously the control.
+  ///
+  /// The failure this avoids is a silent one: a footer that swapped `Button` for
+  /// this type and kept its own modifier still works when CLICKED, so nothing on
+  /// screen would say Escape had stopped answering.
+  var shortcut: KeyboardShortcut? = nil
   let action: () -> Void
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @State private var hovering = false
+  /// A PARENT can disable this control without touching `isEnabled`, and then
+  /// the two disagree. See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  /// DERIVED, never stored. See `SettingsHover.respondsToPointer`.
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, isEnabled, environmentEnabled)
+  }
 
   var body: some View {
-    Button(action: action) {
-      Text(title)
-        .font(.system(size: 12, weight: .semibold))
-        .padding(.horizontal, 14)
-        .padding(.vertical, 6)
-        .foregroundStyle(foreground)
-        .background(fill, in: Capsule())
-        .overlay(Capsule().strokeBorder(border, lineWidth: 1))
-        .contentShape(Capsule())
-    }
-    .buttonStyle(.plain)
+    shortcutBound(button)
+      .buttonStyle(.plain)
     .disabled(!isEnabled)
-    .onHover { hovering = $0 && isEnabled }
-    .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+    .onHover { pointerInside = $0 }
+    .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
   }
+
+  private var button: some View {
+    // **The ROLE, not just the colour.** `emphasis` decides how this looks;
+    // `role` is what AppKit and VoiceOver read, and the system `Button`s this
+    // replaced supplied it. Carrying the tone visually while dropping the
+    // semantics would leave an irreversible action indistinguishable from an
+    // ordinary one to anyone not looking at the pixels -- which is the same
+    // defect as the grey Delete button, one sense over (cloud review, #2447).
+    Button(role: emphasis == .destructive ? .destructive : nil, action: action) {
+      HStack(spacing: 5) {
+        if let systemImage {
+          Image(systemName: systemImage)
+            .font(.system(size: 11, weight: .semibold))
+            // Decoration. Without this the symbol contributes its own
+            // symbol-derived name beside the title, so "Add term" is announced
+            // as a plus sign AND the words -- where the `Label` this replaced
+            // announced one thing.
+            .accessibilityHidden(true)
+        }
+        Text(title)
+          .font(.system(size: 12, weight: .semibold))
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 6)
+      .foregroundStyle(foreground)
+      .background(fill, in: Capsule())
+      .overlay(Capsule().strokeBorder(border, lineWidth: 1))
+      .contentShape(Capsule())
+    }
+  }
+
+  /// Binds `shortcut` to the `Button`, and leaves the shortcut ALONE when there
+  /// is none.
+  ///
+  /// **The branch is the fix, not a style choice.** An unconditional
+  /// `.keyboardShortcut(shortcut)` also runs for `nil`, and a caller that
+  /// applies its own modifier on the OUTSIDE of this composite then has it
+  /// overridden from within -- which is how a Cancel button keeps working when
+  /// clicked and silently stops answering Escape. Found by review on exactly
+  /// that: the two #2445 sheet footers had their `.cancelAction` and
+  /// `.defaultAction` cleared by this type's own default.
+  @ViewBuilder
+  private func shortcutBound(_ content: some View) -> some View {
+    if let shortcut {
+      content.keyboardShortcut(shortcut)
+    } else {
+      content
+    }
+  }
+
+  /// The one place emphasis becomes a colour. `destructive` is the only
+  /// emphasis that leaves the brand accent, so the three rules below read the
+  /// tone from here instead of each testing the emphasis themselves.
+  private var tone: Color { emphasis == .destructive ? Color.stError : Color.stAccent }
 
   private var foreground: Color {
     guard isEnabled else { return Color.stTextTertiary }
     if emphasis == .filled { return Color.white }
-    return hovering ? Color.white : Color.stAccent
+    return hovering ? Color.white : tone
   }
 
   private var fill: Color {
     guard isEnabled else { return Color.clear }
-    if emphasis == .filled {
+    switch emphasis {
+    case .filled:
       return hovering ? Color.stAccent : Color.stAccentSolid
+    case .destructive:
+      return hovering ? Color.stError : Color.stError.opacity(0.12)
+    case .outlined:
+      return hovering ? Color.stAccentSolid : Color.stAccentLight
     }
-    return hovering ? Color.stAccentSolid : Color.stAccentLight
   }
 
   private var border: Color {
     guard isEnabled else { return Color.stDivider }
     if emphasis == .filled { return Color.clear }
-    return hovering ? Color.clear : Color.stAccent
+    return hovering ? Color.clear : tone
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsHover.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsHover.swift
@@ -1,0 +1,301 @@
+import SwiftUI
+
+// MARK: - The hover vocabulary for Settings
+
+/// Every hover treatment in the settings window, named once.
+///
+/// **Why this is one file and not a modifier written at each site.** #2445
+/// measured what happens when an affordance is re-derived per call site: five
+/// separate defects turned out to be one fact, that `.borderedProminent` renders
+/// accent-filled inside a sheet and plain grey on a settings page in the same
+/// build. A button's appearance had become a property of its container. Hover is
+/// the same shape of risk across many more sites, so the treatments live here
+/// and the sites opt in.
+///
+/// Regenerate the coverage figure rather than trusting a number written here:
+/// `grep -rn "\.settingsHover" Sources --include='*.swift'`.
+///
+/// **The honesty rule, which decides the geometry at every site: the hover
+/// region must be exactly the region that responds to a click.** A tint wider
+/// than the hit area promises a press that does nothing; a tint narrower than it
+/// hides a target the user has already found. Two treatments therefore paint
+/// exactly the rectangle their `Button` already claimed, and the third
+/// (`settingsHoverQuiet`) pads INSIDE the label so the target grows with the
+/// shape rather than the shape outgrowing the target.
+///
+/// **Motion is gated, colour is not.** Under Reduce Motion the state change
+/// still happens, it simply arrives without the fade. Hover carries information
+/// about what is clickable, so suppressing it entirely would remove an
+/// affordance rather than an animation.
+enum SettingsHover {
+  /// The one curve and duration, so nothing in the window fades at a different
+  /// speed from anything else. It is the value the four hand-rolled hovers had
+  /// each written out separately before this file existed; the two that still
+  /// keep local hover state read it from here.
+  static let animation = Animation.easeOut(duration: 0.12)
+
+  /// A row or list item under the pointer. Deliberately faint: this reads on a
+  /// dark card without competing with a selected row, which carries the solid
+  /// brand gradient.
+  static let rowTint = Color.stAccent.opacity(0.06)
+
+  /// A row that is ALREADY selected. The selected background is a saturated
+  /// brand gradient, so `rowTint` beneath it is invisible; hover is carried by a
+  /// white veil on top instead.
+  static let selectedRowVeil = Color.white.opacity(0.10)
+
+  /// A card-sized target -- an engine card, a theme swatch, a sound preview.
+  /// Larger than a row, so the border does the work and the fill stays quiet.
+  static let cardTint = Color.stAccent.opacity(0.05)
+
+  /// The default corner radius for a row tint, matching the sidebar row's
+  /// selection pill so a row that is hovered and then selected does not change
+  /// shape. Every call site whose own shape differs passes its own -- the picker
+  /// segment is 7, a settings card is `SettingsLayout.sectionRadius`.
+  static let rowRadius: CGFloat = 9
+
+  /// Whether this control should currently be lit up.
+  ///
+  /// **Ask this at RENDER time, from a stored pointer POSITION -- never store its
+  /// answer.** SwiftUI emits `onHover` when the pointer crosses the boundary, so
+  /// a control that becomes disabled while the pointer is already inside it gets
+  /// no second event: a stored `true` would keep advertising an unavailable
+  /// control until the pointer left. Press the Apple Intelligence refresh button
+  /// and leave the mouse where it is, and that is exactly the window. Derived,
+  /// the answer follows `isEnabled` the instant it changes (review r2, #2447).
+  ///
+  /// **Two sources, and BOTH have to say yes, because each is blind to the other
+  /// half of the truth.** The explicit parameter carries a condition the call
+  /// site knows and SwiftUI does not -- a keybind field that is mid-recording is
+  /// perfectly enabled and still should not tint. The environment carries the
+  /// `.disabled(...)` a PARENT applied, which the call site usually does not
+  /// restate and often does not own: `.disabled` propagates down, so a glyph
+  /// inside a disabled button reads the flag its button set.
+  ///
+  /// Reading only the parameter is the defect this exists to fix (review, #2447):
+  /// it defaults to `true`, so the Apple Intelligence refresh button while
+  /// checking, and the Ollama Delete button while a pull runs, both brightened
+  /// under the pointer while refusing every click. **Hover that answers a
+  /// control which will not respond is worse than no hover**, because it is a
+  /// promise rather than a decoration.
+  ///
+  /// **Two review rounds found this same root, so here is the enumeration and
+  /// the condition that would reopen it.** A rendered hover can disagree with
+  /// whether a control accepts a click in exactly three ways: an input is
+  /// MISSING, an input is STALE, or the refusal is expressed through a channel
+  /// neither input can see. The first two are closed by construction -- both
+  /// inputs are read here, at render, and nothing stores the answer.
+  ///
+  /// The third is the live one, and it is `allowsHitTesting(false)` applied
+  /// above a hovering control, which refuses clicks while leaving `\.isEnabled`
+  /// true. **A third finding would have to look like that**, and today it cannot:
+  /// the only uses in this window are the three decoration overlays in this file
+  /// and the zero-size key-capture overlay in `HotkeyRecorderView`, none of which
+  /// sits above a control that hovers. Anything that changes is what reopens
+  /// this.
+  static func respondsToPointer(
+    _ inside: Bool, _ callSiteEnabled: Bool, _ environmentEnabled: Bool
+  ) -> Bool {
+    inside && callSiteEnabled && environmentEnabled
+  }
+}
+
+// MARK: - Row hover
+
+/// Tints the receiver's own bounds when the pointer is over it.
+///
+/// Apply INSIDE a `Button`'s label, before `contentShape`, so the tint and the
+/// hit area are the same rectangle. Applied outside the button, the tint tracks
+/// the pointer over a region that does not respond to a click.
+private struct SettingsHoverRowModifier: ViewModifier {
+  var cornerRadius: CGFloat
+  var tint: Color
+  var isEnabled: Bool
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  /// See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  /// DERIVED, never stored. See `SettingsHover.respondsToPointer`.
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, isEnabled, environmentEnabled)
+  }
+
+  func body(content: Content) -> some View {
+    content
+      // OVERLAY, not background, and this is load-bearing rather than a style
+      // preference. A selected sidebar row paints a saturated brand gradient in
+      // its own `.background`; a hover fill added behind that gradient is
+      // invisible, so the one row the pointer is most often over would be the
+      // one row that never responded. An overlay is also equivalent for the
+      // unselected case -- a 6% accent over a transparent row composites to the
+      // same pixels as a 6% accent behind it -- so one treatment covers both
+      // states instead of two that can drift apart.
+      //
+      // `allowsHitTesting(false)` is not optional here. A filled `Shape` is
+      // hit-testable in SwiftUI even when its fill is `Color.clear`, so an
+      // un-disabled overlay would sit on top of the very button it decorates and
+      // swallow the click -- the same defect shape #2445 shipped and the founder
+      // caught ("the bottom half of the preview engine cards are not clickable").
+      // A decoration must never be in the hit path.
+      .overlay(
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+          .fill(hovering ? tint : Color.clear)
+          .allowsHitTesting(false)
+      )
+      .onHover { pointerInside = $0 }
+      .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
+  }
+}
+
+/// Lifts a card-sized target so the shape reads as reachable rather than drawn.
+///
+/// **Which half does the work depends on what the card already spends.** An
+/// UNSELECTED card rests on a 1pt divider border, so hover draws an accent
+/// border over it -- at card size a fill alone is close to invisible against
+/// `stSectionBg`. A SELECTED card already draws a 2pt accent border, so a hover
+/// border would land on an identical line and change nothing; that branch
+/// brightens the fill instead. Neither branch removes the resting border: both
+/// overlay on top of it.
+///
+/// The pre-existing card hover (`AIPolishProviderRail`) reached for a scale
+/// effect for the same "a fill is invisible here" reason, and a scale effect is
+/// suppressed entirely under Reduce Motion, taking the affordance with it. That
+/// is the trade this modifier exists to avoid.
+private struct SettingsHoverCardModifier: ViewModifier {
+  var cornerRadius: CGFloat
+  var isEnabled: Bool
+  /// A selected card already draws a 2pt accent border of its own, so a hover
+  /// border would land on top of an identical line and change nothing. The
+  /// selected case brightens its FILL instead -- the one channel the resting
+  /// selected state leaves unused.
+  var isSelected: Bool
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  /// See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  /// DERIVED, never stored. See `SettingsHover.respondsToPointer`.
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, isEnabled, environmentEnabled)
+  }
+
+  func body(content: Content) -> some View {
+    content
+      .overlay(
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+          .fill(hovering ? (isSelected ? SettingsHover.rowTint : SettingsHover.cardTint) : Color.clear)
+          .allowsHitTesting(false)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+          .strokeBorder(
+            hovering && !isSelected ? Color.stAccent.opacity(0.55) : Color.clear,
+            lineWidth: 1)
+          .allowsHitTesting(false)
+      )
+      .onHover { pointerInside = $0 }
+      .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
+  }
+}
+
+/// A small quiet control: a close X, a play triangle, a trash, or a bare word
+/// like Retry or Delete standing in for a button. It brightens and gains a soft
+/// shape behind it.
+///
+/// **The shape is a `Capsule`, not a `Circle`, and that is the whole reason one
+/// treatment covers both cases.** A `Circle` sizes to the smaller dimension and
+/// centres, so behind a square glyph it is a disc and behind the word "Delete"
+/// it is a disc in the middle of the word with the letters hanging off both
+/// ends. A capsule is a circle when the content is square and a pill when it is
+/// wide, which is exactly the pair this modifier is asked for.
+private struct SettingsHoverQuietModifier: ViewModifier {
+  var isEnabled: Bool
+  /// How much room the capsule gets around the content.
+  ///
+  /// **A parameter because this modifier GROWS its site, and 5pt is not small
+  /// everywhere.** Around a 12pt refresh glyph in a row it is the difference
+  /// between a comfortable target and a smudge; around the 8pt xmark inside an
+  /// alias chip it would be most of the chip. The default suits a row; tight
+  /// contexts pass their own.
+  var inset: CGFloat
+  /// Optional tone for a glyph whose ACTION has one: the error red on a trash,
+  /// where hover is the last moment before something irreversible and is worth
+  /// spending colour on. `nil` keeps the neutral brighten, which is right for a
+  /// close X or a page chevron.
+  var tint: Color?
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  /// See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  /// DERIVED, never stored. See `SettingsHover.respondsToPointer`.
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, isEnabled, environmentEnabled)
+  }
+
+  func body(content: Content) -> some View {
+    recoloured(content)
+      // The padding is part of the treatment, not spacing. A bare SF Symbol is
+      // 12-14pt of glyph, so a shape drawn tight to it reads as a smudge and the
+      // hit region is smaller than a pointer can comfortably land on. Padding
+      // first, shape second, so both grow -- and because this sits inside the
+      // `Button`'s label at every call site, the target grows with them.
+      .padding(inset)
+      .background(
+        Capsule()
+          .fill(hovering ? (tint?.opacity(0.15) ?? Color.stSectionBg) : Color.clear)
+      )
+      // Brightness is the UNTINTED path only. On a red glyph it washes toward
+      // pink, which reads as less urgent at the exact moment more urgency is
+      // wanted.
+      .brightness(hovering && tint == nil ? 0.18 : 0)
+      .onHover { pointerInside = $0 }
+      .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
+  }
+
+  /// Applies the tint ONLY while hovering, and only when there is one.
+  ///
+  /// An unconditional `foregroundStyle` here would win over the colour each call
+  /// site already set on its own glyph -- the clear-search X sets
+  /// `.stTextSecondary` immediately before this modifier -- so a decoration
+  /// meant to describe the hover state would silently repaint the resting one.
+  @ViewBuilder
+  private func recoloured(_ content: Content) -> some View {
+    if let tint, hovering {
+      content.foregroundStyle(tint)
+    } else {
+      content
+    }
+  }
+}
+
+extension View {
+  /// Row-sized hover tint. See `SettingsHoverRowModifier` for where to apply it.
+  func settingsHoverRow(
+    cornerRadius: CGFloat = SettingsHover.rowRadius,
+    tint: Color = SettingsHover.rowTint,
+    isEnabled: Bool = true
+  ) -> some View {
+    modifier(
+      SettingsHoverRowModifier(cornerRadius: cornerRadius, tint: tint, isEnabled: isEnabled))
+  }
+
+  /// Card-sized hover lift: faint fill plus an accent border.
+  func settingsHoverCard(
+    cornerRadius: CGFloat,
+    isEnabled: Bool = true,
+    isSelected: Bool = false
+  ) -> some View {
+    modifier(
+      SettingsHoverCardModifier(
+        cornerRadius: cornerRadius, isEnabled: isEnabled, isSelected: isSelected))
+  }
+
+  /// Quiet-control hover: brighten the content, add a soft capsule behind it.
+  func settingsHoverQuiet(
+    isEnabled: Bool = true, inset: CGFloat = 5, tint: Color? = nil
+  ) -> some View {
+    modifier(SettingsHoverQuietModifier(isEnabled: isEnabled, inset: inset, tint: tint))
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -336,6 +336,17 @@ private struct SidebarNavRow<Icon: View>: View {
             .shadow(color: Color.stAccent.opacity(0.40), radius: 7, y: 2)
         }
       }
+      // The pointer's answer to "is this a thing I can click". Fifteen rows,
+      // the most-visited control in the window, and until #2447 not one of them
+      // reacted. Tint radius matches the selection pill's 9 so a row that is
+      // hovered and then selected does not change shape.
+      //
+      // A SELECTED row already carries the brand gradient, which a 6% accent
+      // tint disappears into, so it takes a white veil instead -- otherwise the
+      // row the pointer rests on most often is the one row that looks dead.
+      .settingsHoverRow(
+        cornerRadius: 9,
+        tint: isSelected ? SettingsHover.selectedRowVeil : SettingsHover.rowTint)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SpeechEngineSettingsView.swift
@@ -281,13 +281,20 @@ struct SpeechEngineSettingsView: View {
                 }
               }
               Spacer()
+              // #2447: both were system styles on a settings PAGE, where
+              // `.borderedProminent` renders plain grey and `.bordered` renders
+              // grey one shade darker — so Cancel and Resume were the same
+              // colour as each other and as this app's disabled treatment, with
+              // no hover to contradict it.
               if row.showsCancel {
-                Button("Cancel") { modelDelivery.cancelParakeetDownload() }
-                  .buttonStyle(.bordered)
+                SettingsActionButton(title: "Cancel", isEnabled: true) {
+                  modelDelivery.cancelParakeetDownload()
+                }
               }
               if let action = row.actionLabel {
-                Button(action) { modelDelivery.resumeParakeetDownload() }
-                  .buttonStyle(.borderedProminent)
+                SettingsActionButton(title: action, isEnabled: true, emphasis: .filled) {
+                  modelDelivery.resumeParakeetDownload()
+                }
               }
             }
           }
@@ -587,11 +594,11 @@ struct SpeechEngineSettingsView: View {
         .settingsReadingCopy()
 
         HStack {
-          Button("Download WhisperKit Model") {
+          SettingsActionButton(
+            title: "Download WhisperKit Model", isEnabled: true, emphasis: .filled
+          ) {
             setup.whisperKitSetup.downloadModel()
           }
-          .buttonStyle(.borderedProminent)
-          .controlSize(.small)
 
           whisperKitRefreshButton
         }
@@ -616,8 +623,10 @@ struct SpeechEngineSettingsView: View {
               .monospacedDigit()
               .foregroundStyle(.stTextSecondary)
           }
-          Button("Cancel") {
+          Button {
             setup.whisperKitSetup.cancelDownload()
+          } label: {
+            Text("Cancel").settingsHoverQuiet(tint: .stError)
           }
           .controlSize(.small)
           .buttonStyle(.borderless)
@@ -631,11 +640,9 @@ struct SpeechEngineSettingsView: View {
         Text("Download paused. Resume anytime.")
           .settingsReadingCopy()
         HStack {
-          Button("Resume") {
+          SettingsActionButton(title: "Resume", isEnabled: true, emphasis: .filled) {
             setup.whisperKitSetup.downloadModel()
           }
-          .buttonStyle(.borderedProminent)
-          .controlSize(.small)
           whisperKitRefreshButton
         }
       }
@@ -695,8 +702,10 @@ struct SpeechEngineSettingsView: View {
                 .foregroundStyle(.stTextSecondary)
             }
           } else {
-            Button("Remove Model") {
+            Button {
               setup.whisperKitSetup.removeModel()
+            } label: {
+              Text("Remove Model").settingsHoverQuiet(tint: .stError)
             }
             .controlSize(.small)
             .buttonStyle(.borderless)
@@ -737,6 +746,7 @@ struct SpeechEngineSettingsView: View {
       Task { await setup.whisperKitSetup.forceDetectState() }
     } label: {
       Image(systemName: "arrow.clockwise")
+        .settingsHoverQuiet()
     }
     .buttonStyle(.borderless)
     .help("Re-check model status")
@@ -755,6 +765,7 @@ struct SpeechEngineSettingsView: View {
       Image(systemName: "questionmark.circle")
         .foregroundStyle(Color.stTextSecondary)
         .font(.stHelper)
+        .settingsHoverQuiet()
     }
     .buttonStyle(.borderless)
     .help(LiveTranscriptionCopy.helpButtonAccessibilityLabel)
@@ -848,6 +859,7 @@ struct SpeechEngineSettingsView: View {
       Image(systemName: "questionmark.circle")
         .foregroundStyle(Color.stTextSecondary)
         .font(.stHelper)
+        .settingsHoverQuiet()
     }
     .buttonStyle(.borderless)
     .help(SpokenPunctuationCopy.helpButtonAccessibilityLabel)

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
@@ -35,8 +35,10 @@ struct VocabPacksSection: View {
                   .padding(.top, 2)
               }
               Spacer()
-              Button("See all") { selectedPack = id }
-                .controlSize(.small)
+              // No `.controlSize` here: this control owns its own metrics, so the
+              // modifier the previous system `Button` needed became a dead line
+              // that reads as if it still sizes something.
+              SettingsActionButton(title: "See all", isEnabled: true) { selectedPack = id }
                 .accessibilityLabel("See all words in the \(id.displayName) pack")
 
               Toggle(

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -52,6 +52,7 @@ struct VocabularyPackDetailSheet: View {
             Image(systemName: "xmark.circle.fill")
               .foregroundStyle(.stTextSecondary)
               .font(.system(size: 12))
+              .settingsHoverQuiet()
           }
           .buttonStyle(.plain)
           .accessibilityLabel("Clear search")
@@ -95,8 +96,11 @@ struct VocabularyPackDetailSheet: View {
       // Done
       HStack {
         Spacer()
-        Button("Done") { dismiss() }
-          .keyboardShortcut(.cancelAction)
+        SettingsActionButton(
+          title: "Done", isEnabled: true, emphasis: .filled, shortcut: .cancelAction
+        ) {
+          dismiss()
+        }
       }
     }
     .padding(20)

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -41,19 +41,23 @@ struct YourWordsView: View {
       // "Add term" action (the page title + description now live in the page header).
       HStack {
         Spacer()
-        Button {
+        // Three page-level actions that were on the system default style, which
+        // on this dark surface renders as the same grey as a disabled control
+        // and gives no hover of its own. Add term is the primary, so it is the
+        // one that fills.
+        SettingsActionButton(
+          title: "Add term", isEnabled: true, emphasis: .filled, systemImage: "plus"
+        ) {
           sheetRoute = .addTerm
-        } label: {
-          Label("Add term", systemImage: "plus")
         }
         // The ONLY doorway into Custom Words import (epic #1619). Shipped to
         // release users from v2.4.1 by founder decision, 2026-07-24; every
         // import PR still carries "adds no second entry point" in its
         // definition of done, so this stays the single doorway.
-        Button {
+        SettingsActionButton(
+          title: "Import", isEnabled: true, systemImage: "square.and.arrow.down"
+        ) {
           sheetRoute = .importWords
-        } label: {
-          Label("Import", systemImage: "square.and.arrow.down")
         }
         // Export (#1680). ONE body-render snapshot drives both the count shown
         // in the save dialog and the array handed to the action, so the number
@@ -63,10 +67,11 @@ struct YourWordsView: View {
         // (#1715).
         let proposed = CustomWordsExportAction.exportableWords(
           from: customWordsCoordinator.customWords)
-        Button {
+        SettingsActionButton(
+          title: "Export your words", isEnabled: true,
+          systemImage: "square.and.arrow.up"
+        ) {
           exportWords(proposed: proposed)
-        } label: {
-          Label("Export your words", systemImage: "square.and.arrow.up")
         }
       }
 
@@ -244,10 +249,15 @@ private struct BulkImportEnrichmentProgressCard: View {
       HStack {
         Text("Importing your words").settingsRowLabel()
         Spacer()
-        Button("Cancel", action: onCancel)
-          .buttonStyle(.plain)
-          .font(.stHelper)
-          .foregroundStyle(.stAccent)
+        Button(action: onCancel) {
+          // The only way out of a running import, drawn as accent-coloured
+          // helper text -- which on this page is also how non-interactive
+          // labels are drawn.
+          Text("Cancel").settingsHoverQuiet()
+        }
+        .buttonStyle(.plain)
+        .font(.stHelper)
+        .foregroundStyle(.stAccent)
       }
 
       ProgressView(value: fraction)

--- a/Tests/EnviousWisprTests/Architecture/SettingsControlAffordanceTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SettingsControlAffordanceTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Testing
+
+/// The settings window draws its own controls, and this suite freezes the two
+/// facts that made it stop doing so.
+///
+/// **Why a source scan and not a UI test.** Hover is a runtime state of a
+/// SwiftUI view with no headless harness in this tree, so nothing here claims a
+/// pointer produced a colour. What it CAN hold is the structural precondition
+/// underneath: that the settings surfaces use the app's own control rather than
+/// a system button style whose rendering depends on which container it lands in.
+///
+/// **The regression is measured, not hypothetical (#2436, #2445, #2447).**
+/// `.borderedProminent` renders accent-filled inside a sheet and plain grey on a
+/// settings page, in the same build, from the same modifier. Seventeen call
+/// sites carried a system style; on the pages, they rendered as the same grey
+/// this app uses for DISABLED, on rows whose only action they were. The founder
+/// found them by using the app -- every one had a clean build and a green suite.
+///
+/// Class: `driftGuard`. When this fails, nobody's dictation breaks; a settings
+/// button starts depending on its container again.
+@Suite("Settings controls own their own affordance (#2447)", .tags(.driftGuard))
+struct SettingsControlAffordanceTests {
+
+  private static var repoRoot: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // Architecture
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+      .deletingLastPathComponent()  // repo root
+  }
+
+  /// Every `.swift` under the settings view directory, with its repo-relative path.
+  ///
+  /// **Fails closed.** An empty or unreadable directory would otherwise make
+  /// every assertion below vacuously true, which is the shape where a guard
+  /// stops guarding without anything going red.
+  private static func settingsSources() throws -> [(path: String, text: String)] {
+    let dir = repoRoot.appendingPathComponent("Sources/EnviousWisprAppKit/Views/Settings")
+    let names = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+      .filter { $0.hasSuffix(".swift") }
+      .sorted()
+    let files = try names.map { name -> (String, String) in
+      let url = dir.appendingPathComponent(name)
+      return ("Sources/EnviousWisprAppKit/Views/Settings/\(name)", try String(contentsOf: url, encoding: .utf8))
+    }
+    #expect(files.count > 20, "settings source scan found \(files.count) files; the directory moved")
+    return files
+  }
+
+  /// The system button styles whose appearance is a property of the CONTAINER
+  /// rather than of the control.
+  ///
+  /// `.plain` and `.borderless` are deliberately NOT here: both render exactly
+  /// what the call site draws, which is the opposite problem, and both are used
+  /// correctly throughout for hand-drawn cards and rows.
+  private static let containerDependentStyles = [
+    "buttonStyle(.borderedProminent)",
+    "buttonStyle(.bordered)",
+  ]
+
+  @Test("No settings surface uses a container-dependent button style")
+  func settingsAvoidsContainerDependentButtonStyles() throws {
+    var offenders: [String] = []
+    for file in try Self.settingsSources() {
+      for (index, line) in file.text.split(separator: "\n", omittingEmptySubsequences: false)
+        .enumerated()
+      {
+        for style in Self.containerDependentStyles where line.contains(style) {
+          offenders.append("\(file.path):\(index + 1) \(style)")
+        }
+      }
+    }
+    #expect(
+      offenders.isEmpty,
+      """
+      Use `SettingsActionButton`, which owns its fill, border, hover and disabled \
+      state, so the appearance travels with the control instead of with its \
+      container. Offenders:
+      \(offenders.joined(separator: "\n"))
+      """)
+  }
+
+  /// A two-way control on the scanner itself.
+  ///
+  /// Without this, a pattern that matched nothing and a directory that resolved
+  /// nowhere both report the same clean green as a genuinely clean tree. This
+  /// asserts the detector finds a string it is pointed at, using the ONE file
+  /// that is guaranteed to contain it: this test's own source, which spells the
+  /// pattern out in `containerDependentStyles` above.
+  @Test("The style scanner can actually find a match")
+  func scannerFindsAKnownOccurrence() throws {
+    let ownSource = try String(contentsOf: URL(fileURLWithPath: #filePath), encoding: .utf8)
+    for style in Self.containerDependentStyles {
+      #expect(
+        ownSource.contains(style),
+        "scanner pattern \(style) did not match its own literal; the detector is broken")
+    }
+  }
+
+  /// Hover is DERIVED at render time, never stored by an `onHover` closure.
+  ///
+  /// **Round one of review found hover ignoring a parent's `.disabled(...)`.
+  /// Round two found the same defect one layer down, in the fix: SwiftUI emits
+  /// `onHover` only when the pointer CROSSES the boundary, so a control that
+  /// disables while the pointer is already inside it never gets a second event
+  /// and a stored `true` keeps advertising it.** Storing the answer is the
+  /// defect; storing the pointer POSITION and asking
+  /// `SettingsHover.respondsToPointer` at render time is the fix, because the
+  /// answer then follows `isEnabled` with no event required.
+  ///
+  /// So the invariant is narrow and mechanical: **no `onHover` closure in the
+  /// settings window assigns to `hovering`.** A closure that does has stored an
+  /// answer that can go stale.
+  ///
+  /// **This test parses the whole closure, and the reason is worth keeping.**
+  /// Its first version matched a single LINE containing both `.onHover` and the
+  /// assignment, and passed -- while every modifier this change added uses the
+  /// multiline form and would have sailed through a raw assignment untouched.
+  /// The two-way control run against it proved only the shape that was injected,
+  /// which was the single-line one. A detector and its control can agree with
+  /// each other and both miss the code (review r2, #2447).
+  @Test("No settings onHover closure stores a hover answer")
+  func hoverIsDerivedRatherThanStored() throws {
+    var offenders: [String] = []
+    for file in try Self.settingsSources() {
+      for (line, body) in Self.onHoverClosures(in: file.text) {
+        if body.contains("hovering =") || body.contains("hovering=") {
+          offenders.append("\(file.path):\(line)")
+        }
+      }
+    }
+    #expect(
+      offenders.isEmpty,
+      """
+      Store the pointer POSITION and derive `hovering` in a computed property \
+      via `SettingsHover.respondsToPointer(_:_:_:)`; a stored answer cannot \
+      follow a control that disables under a stationary pointer. Offenders:
+      \(offenders.joined(separator: "\n"))
+      """)
+  }
+
+  /// Every `.onHover` closure in a file, as (1-indexed opening line, closure body).
+  ///
+  /// Brace-counted from the closure's opening `{` rather than line-matched, so
+  /// the single-line and multiline forms are read identically. String literals
+  /// and comments are not excluded: a brace inside either would mis-slice, and
+  /// the failure direction is a LONGER body, which over-reports rather than
+  /// under-reports. That is the right way round for a guard.
+  private static func onHoverClosures(in text: String) -> [(line: Int, body: String)] {
+    let chars = Array(text)
+    var results: [(Int, String)] = []
+    var index = 0
+    let needle = Array(".onHover")
+    while index < chars.count - needle.count {
+      guard Array(chars[index..<(index + needle.count)]) == needle else {
+        index += 1
+        continue
+      }
+      var cursor = index + needle.count
+      while cursor < chars.count, chars[cursor] != "{", chars[cursor] != "\n" { cursor += 1 }
+      guard cursor < chars.count, chars[cursor] == "{" else {
+        index += needle.count
+        continue
+      }
+      var depth = 0
+      let bodyStart = cursor
+      while cursor < chars.count {
+        if chars[cursor] == "{" { depth += 1 }
+        if chars[cursor] == "}" {
+          depth -= 1
+          if depth == 0 { break }
+        }
+        cursor += 1
+      }
+      let line = chars[0..<index].filter { $0 == "\n" }.count + 1
+      results.append((line, String(chars[bodyStart...min(cursor, chars.count - 1)])))
+      index = cursor
+    }
+    return results
+  }
+
+  /// A keyboard shortcut is never applied to the OUTSIDE of `SettingsActionButton`.
+  ///
+  /// **The failure this catches is silent in the one direction that matters.**
+  /// `SettingsActionButton` is a composite `View`, not a control, and it binds
+  /// its own `shortcut` to the `Button` inside. A caller that writes
+  /// `.keyboardShortcut` on the outside instead is relying on behaviour Apple
+  /// documents for "the modified control", and the button still works when
+  /// CLICKED -- so a sheet can stop answering Escape with nothing on screen to
+  /// say so. Two #2445 footers were doing exactly this and were found by review,
+  /// not by use.
+  @Test("Keyboard shortcuts reach the control, not the wrapper")
+  func shortcutsArePassedRatherThanApplied() throws {
+    var offenders: [String] = []
+    for file in try Self.settingsSources() {
+      let lines = file.text.split(separator: "\n", omittingEmptySubsequences: false)
+        .map(String.init)
+      for (index, line) in lines.enumerated() where line.contains(".keyboardShortcut(") {
+        // Walk back to the nearest line that opens a control, and report only
+        // when that opener is this composite. A raw `Button` is the correct and
+        // common case, and must not be flagged.
+        for back in stride(from: index, through: max(0, index - 12), by: -1) {
+          let candidate = lines[back]
+          if candidate.contains("SettingsActionButton(") {
+            offenders.append("\(file.path):\(index + 1)")
+            break
+          }
+          if candidate.contains("Button(") || candidate.contains("Button<") { break }
+        }
+      }
+    }
+    #expect(
+      offenders.isEmpty,
+      """
+      Pass the shortcut as `SettingsActionButton(..., shortcut: .cancelAction)` \
+      so it binds to the `Button` inside. Offenders:
+      \(offenders.joined(separator: "\n"))
+      """)
+  }
+}


### PR DESCRIPTION
Closes #2447.

Founder goal: *"apply hover effects all over EnviousWispr menues. Go through each menu section 1 by 1 and find appropriate places to introduce the hover affect and implement it."*

**Before this, no settings PAGE had a single hover-responsive control.** All five in the window lived in a sheet or in the AI Polish rail; four of them shipped this morning in #2445. The sidebar, every toggle row, every selection card, every engine card and the History list had none. 39 sites now do.

## One vocabulary, not thirty-nine decisions

`SettingsHover.swift` names four things once: a row tint, a card lift, a quiet capsule for glyph-and-short-text controls, and the one duration everything fades at.

This is the shape of the problem, not tidiness. #2445 measured what happens when an affordance is re-derived per call site: five separate defects turned out to be one fact, that `.borderedProminent` renders accent-filled in a sheet and plain grey on a page in the same build. Hover is the same risk with more sites.

**The rule that decides geometry everywhere: the hover region must be exactly the region that responds to a click.** Wider, and it promises a press that does nothing. Narrower, and it hides a target already found. Where the two disagreed, the hit area moved rather than the tint.

Two consequences worth stating because both are how this goes wrong:

- Every treatment is applied **inside** the `Button`'s label, so growing the control grows the target with it. That is the defect #2445 shipped and the founder caught in minutes: *"the bottom half of the preview engine cards are not clickable."*
- Every decoration carries `allowsHitTesting(false)`. A filled `Shape` is hit-testable in SwiftUI **even when its fill is `Color.clear`**, so an overlay added to decorate a button will happily swallow its click.

**Motion is gated, colour is not.** Under Reduce Motion the state still changes, it just arrives without the fade. The AI Polish rail is the argument for that rule: its only hover was a 1.006 scale, which that setting removes entirely, so the users who turn motion off had no hover on the one control in the window that had any.

## The other half: 17 buttons that looked disabled

Sweeping for the #2445 class found 17 system-styled call sites in the settings window. On a page `.borderedProminent` renders the same grey this app uses for **disabled**, and several were the only action in their row:

| | |
|---|---|
| **Open System Settings** | The Permissions page is two rows and this is its only control. The persona it exists for is someone who came here because dictation stopped working. Grey text beside a red X. |
| **Delete N words** | Sat in the same grey as Cancel beside it, separated only by the system's destructive *role*, which renders as red text and disappears against this palette. |
| **Save / Clear** on an API key | Save genuinely disables on an empty field. Enabled and disabled were the same pixels. |
| **Preview** on Sounds | Genuinely disables during a recording. Same. |
| **Continue** on word import | Blocked over the word limit, and the block was invisible. |

All 17 now use `SettingsActionButton`, which gained a `destructive` emphasis, an optional leading symbol, and a `shortcut` parameter.

**That last one is a seam, not a convenience.** Apple documents `keyboardShortcut` as binding to "the modified control", and this type is a composite `View` rather than a control, so a footer that swapped `Button` for it and kept its own modifier would still work when **clicked** while silently no longer answering Escape. Nothing on screen would say so. Every sheet's shortcut count is unchanged, checked per file against `origin/main`.

## Sections walked, in sidebar order

History · What's New · Appearance · Transcription · Live Preview · Microphone · Sounds · Keybinds · AI Polish · Your Words · Clipboard · Permissions · Open Source Licenses, plus the seven sheets those pages open.

A few worth calling out:

- **The sidebar.** Fifteen rows, the most-visited control in the window, none of them reacting. A selected row carries the brand gradient, which a 6% accent tint disappears into, so it takes a white veil instead — otherwise the row the pointer rests on most often is the one that looks dead.
- **The toggle rows.** `BrandedToggleStyle` has always made label, gap and track one target. Nothing said so, so the 38pt track was the only part users aimed at.
- **The keybind fields.** A plain view with `onTapGesture`, deliberately not a `Button` so a Button cannot swallow the keys being recorded. The cost of that choice is that it inherits none of a control's affordances, so it read as a label showing a shortcut. Suppressed while recording, where the field already has a loud active state.
- **History.** The `List` row's system selection highlight is painted over on purpose, and that took the system's hover with it — on the first page the app opens on, whose whole purpose is picking one row of many.

## Consolidations this surfaced

- The two sheet close buttons were byte-identical under a comment reading *"if a third appears, this is the one to promote."* A third appeared.
- The hover duration was written out four times. One constant now.
- `LanguageLockRow` hand-rolled the row tint the vocabulary owns.

Two controls keep a local hover flag on purpose: they drive a glyph colour **and** a container together, which a background-painting modifier cannot do. They take their timing from the shared constant.

## Not here, stated rather than skipped

Onboarding, the recording pill, the menu-bar extra, Quick Add. Separate surfaces with their own interaction model.

## Review round one found two things, and they were one shape

**Both were a decision made in one place that a second place could silently contradict, and both fail while still looking correct.**

**The shortcut one is the worse of the two.** `SettingsActionButton` applied `.keyboardShortcut(shortcut)` unconditionally, which also runs for `nil` — so this type overrode, from the inside, the `.cancelAction` and `.defaultAction` that two #2445 sheet footers apply on the outside. **Escape stopped dismissing the language picker and Return stopped dismissing the catalogue**, while both buttons kept working when clicked. That is precisely the failure the `shortcut` parameter's own doc comment describes, arriving through the parameter's default path.

**The hover one is a promise the control cannot keep.** Hover read only its explicit `isEnabled`, which defaults to `true`, and ignored the `.disabled(...)` a parent applied. The Apple Intelligence refresh button while checking, and the Ollama Delete button during a pull, brightened under the pointer while refusing every press.

**Fixing the four named sites would have left both classes open.** Instead: the shortcut binds in a branch that leaves `nil` alone, and every hover in the window — all of them, not the two that were wrong — routes through `SettingsHover.respondsToPointer`, which ANDs the call site's condition with the environment's. **Zero raw `hovering = $0` assignments remain in `Sources`.**

## Guard

`SettingsControlAffordanceTests`, four tests:

1. No settings surface uses a container-dependent button style.
2. The scanner can find a string it is pointed at — a **two-way control**, because a pattern that matches nothing and a directory that resolves nowhere both report the same green as a clean tree.
3. Every hover consults `respondsToPointer`.
4. No `.keyboardShortcut` is applied to the outside of `SettingsActionButton`.

3 and 4 exist because review found those classes. They are what makes "the class is closed" a claim rather than a hope.

**All three detectors were proven to fail, not assumed to.** Each defect was reintroduced deliberately, watched go red naming the exact file and line, then removed with `git status` confirmed clean:

| injected | reported |
|---|---|
| `.borderedProminent` in `ClipboardSettingsView` | `ClipboardSettingsView.swift:60` |
| outer `.keyboardShortcut` on `LanguageLockSheet`'s Cancel | `LanguageLockSheet.swift:133` |
| raw `hovering = $0` in `AIPolishProviderRail` | `AIPolishProviderRail.swift:490` |

**A fifth test was written and deleted.** It would have banned per-page hover state — right for most sites, wrong for the two that drive a glyph colour and a container together. A guard that forces worse code is worse than no guard.

## Receipts

- Debug lane **7085 PASS** (7083 + the two new).
- Every backticked symbol resolves; `check-cited-symbols.py` caught one that did not (`SettingsComponents.SettingsSheetCloseButton` — a file is not a namespace in Swift) and it is fixed.
- Live UAT pending the dev-app slot, which another session holds for the founder. The item that needs it most is Escape and Return in the converted sheet footers, which no unit test in this tree can reach.
