### PR TITLE
fix(paste): route Chromium's address bar past the AX-direct write Enter can't see

### DIFF
--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -243,6 +243,21 @@ extension PasteFocusClassification {
   }
 }
 
+/// Why Tier 1 (AX direct write) did not run, or `nil` when it should. Pulled
+/// out of `deliver()`'s body so the ROUTING decision — as opposed to the live
+/// AX read `isChromiumOmnibox` is computed from — is unit-testable without a
+/// real focused element (#2297).
+internal func tier1DeclineReason(
+  axTrusted: Bool, classification: PasteFocusClassification, isChromiumOmnibox: Bool
+) -> PasteService.AXDeclineReason? {
+  if !axTrusted { return .accessibilityDenied }
+  switch classification {
+  case .textField: return isChromiumOmnibox ? .chromiumOmniboxNavigationSeam : nil
+  case .missing: return .focusMissing
+  case .nonText: return .focusNonText
+  }
+}
+
 /// Executes the tiered paste cascade: AX direct -> CGEvent Cmd+V -> AppleScript -> clipboard.
 ///
 /// Thin orchestrator over PasteService static methods. Both pipelines call this
@@ -384,17 +399,24 @@ internal final class PasteCascadeExecutor {
       targetDiagnostics = .missing
     }
     let canAttemptKeyPaste = classification.canAttemptKeyPaste
+    // #2297: a Chromium (Chrome/Brave/Edge) address bar specifically. Decided
+    // here, alongside `classification`, because it changes whether Tier 1
+    // should even be attempted — a direct AX write lands the text but never
+    // sets Chromium's own "user typed this" tracker, so Enter has nothing to
+    // navigate to. Only meaningful when Tier 1 would otherwise run at all, so
+    // gated on `.textField` and a present element; Safari is unaffected
+    // (`addressBarFamily` returns `nil` for it) and keeps using Tier 1.
+    let isChromiumOmnibox: Bool =
+      if classification == .textField, let element = request.targetElement {
+        PasteService.addressBarFamily(of: element) == .chromium
+      } else {
+        false
+      }
     // Why Tier 1 did not run, decided HERE rather than inside the write. These
     // are the majority of declines — a reason set covering only the write's own
     // exits would be nil for most of them (#1332).
-    var axDeclineReason: PasteService.AXDeclineReason? = {
-      if !axTrusted { return .accessibilityDenied }
-      switch classification {
-      case .textField: return nil  // Tier 1 runs; the write reports its own.
-      case .missing: return .focusMissing
-      case .nonText: return .focusNonText
-      }
-    }()
+    var axDeclineReason: PasteService.AXDeclineReason? = tier1DeclineReason(
+      axTrusted: axTrusted, classification: classification, isChromiumOmnibox: isChromiumOmnibox)
     var axSettability: PasteService.AXSettability?
     // Which payload was submitted by the route that last attempted a write.
     // Nil until one does. A later route may legitimately overwrite this: Tier 1
@@ -414,7 +436,7 @@ internal final class PasteCascadeExecutor {
     // gets the text — Tier 3 puts it on the clipboard and shows the existing
     // "press Cmd+V" notice — but we never place it twice on their behalf.
     var axAllowsRetry = true
-    if classification == .textField, let element = request.targetElement {
+    if classification == .textField, !isChromiumOmnibox, let element = request.targetElement {
       tiersAttempted.append(.axDirect)
       // The payload choice happens INSIDE the write, against the range read in
       // the same breath as the write itself (plan §6). Nothing is chosen here.

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -489,7 +489,30 @@ internal final class PasteCascadeExecutor {
       let activated = activation.activated
       let elapsed = activation.elapsed
 
-      if activated {
+      // Cloud review round 2 (PR #2451): activation itself — not only the
+      // pipeline time before it — can move focus off the omnibox (the
+      // REVALIDATED comment below already says so, for the payload; this is
+      // the same fact applied to whether Tier 2 should even fire a BLIND
+      // paste at all). The round 1 `freshFocusedElement` check runs before
+      // `await activate(app)` and cannot see a shift `activate` itself causes.
+      // Re-checked HERE, after activation, at the latest possible moment
+      // before the irreversible CGEvent — closing the window rather than
+      // narrowing it, because there is no later commit point left to defer to.
+      let chromiumOmniboxStillFocused: Bool =
+        if isChromiumOmnibox, let element = request.targetElement {
+          PasteService.freshFocusedElement(matching: element) != nil
+        } else {
+          true
+        }
+      if activated, !chromiumOmniboxStillFocused {
+        // Refuse the blind paste rather than guess where it lands — the same
+        // "not confident enough to act automatically" floor PR #220 already
+        // uses for a non-text focus: fall through to clipboard-only below.
+        tierFailures["cgevent"] = "chromium_omnibox_lost_focus_during_activation"
+        emitTierFailureBreadcrumb(
+          stage: "cgevent", reason: "chromium_omnibox_lost_focus_during_activation",
+          bundleId: bundleId)
+      } else if activated {
         tiersAttempted.append(.cgEvent)
         // Revalidated AFTER activation, because bringing the app frontmost is
         // itself capable of moving focus and selection.

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -489,30 +489,7 @@ internal final class PasteCascadeExecutor {
       let activated = activation.activated
       let elapsed = activation.elapsed
 
-      // Cloud review round 2 (PR #2451): activation itself — not only the
-      // pipeline time before it — can move focus off the omnibox (the
-      // REVALIDATED comment below already says so, for the payload; this is
-      // the same fact applied to whether Tier 2 should even fire a BLIND
-      // paste at all). The round 1 `freshFocusedElement` check runs before
-      // `await activate(app)` and cannot see a shift `activate` itself causes.
-      // Re-checked HERE, after activation, at the latest possible moment
-      // before the irreversible CGEvent — closing the window rather than
-      // narrowing it, because there is no later commit point left to defer to.
-      let chromiumOmniboxStillFocused: Bool =
-        if isChromiumOmnibox, let element = request.targetElement {
-          PasteService.freshFocusedElement(matching: element) != nil
-        } else {
-          true
-        }
-      if activated, !chromiumOmniboxStillFocused {
-        // Refuse the blind paste rather than guess where it lands — the same
-        // "not confident enough to act automatically" floor PR #220 already
-        // uses for a non-text focus: fall through to clipboard-only below.
-        tierFailures["cgevent"] = "chromium_omnibox_lost_focus_during_activation"
-        emitTierFailureBreadcrumb(
-          stage: "cgevent", reason: "chromium_omnibox_lost_focus_during_activation",
-          bundleId: bundleId)
-      } else if activated {
+      if activated {
         tiersAttempted.append(.cgEvent)
         // Revalidated AFTER activation, because bringing the app frontmost is
         // itself capable of moving focus and selection.
@@ -524,37 +501,60 @@ internal final class PasteCascadeExecutor {
           candidateDeletesDictatedText: request.candidateDeletesDictatedText,
           requireCaretUnchanged: request.targetElementIsRetried,
           terminalBudget: request.terminalBudget)
-        // Snapshot AFTER that revalidation, immediately before the write. The
-        // re-check makes accessibility calls, and anything copied while they run
-        // would otherwise be captured as "the user's old clipboard" and then
-        // restored over (Codex review r5). The window is a fraction of a
-        // millisecond in practice, so this is narrowing rather than closing a
-        // proven gap — taken because it costs one moved line.
-        let snapshot: ClipboardSnapshot? =
-          request.restoreClipboardAfterPaste
-          ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
-          : nil
-        submittedKind = payload.kind
-        let dispatchResult = PasteService.pasteToActiveApp(
-          payload.text, to: self.pasteboard)
-        submittedClipboardChangeCount = dispatchResult.changeCount
-        switch dispatchResult {
-        case .dispatched:
-          tier = .cgEvent
-        case .cgEventCreationFailed(let accessibilityTrusted, _):
-          cgEventFailureAccessibilityTrusted = accessibilityTrusted
-          tierFailures["cgevent"] = "creation_failed (ax_trusted=\(accessibilityTrusted))"
+        // Cloud review rounds 2 and 4 (PR #2451): both activation AND
+        // `payloadAtCommitBoundary`'s own AX re-reads above can move focus off
+        // the omnibox before the CGEvent fires. Checking after activation but
+        // before the payload re-read (round 2's fix) still left this window
+        // open — round 4 caught it. Moved to run LAST, after every AX call
+        // this branch makes and immediately before the dispatch, so there is
+        // no remaining AX-touching step between the check and the write.
+        let chromiumOmniboxStillFocused: Bool =
+          if isChromiumOmnibox, let element = request.targetElement {
+            PasteService.freshFocusedElement(matching: element) != nil
+          } else {
+            true
+          }
+        if !chromiumOmniboxStillFocused {
+          // Refuse the blind paste rather than guess where it lands — the same
+          // "not confident enough to act automatically" floor PR #220 already
+          // uses for a non-text focus: fall through to clipboard-only below.
+          tierFailures["cgevent"] = "chromium_omnibox_lost_focus_during_activation"
           emitTierFailureBreadcrumb(
-            stage: "cgevent",
-            reason: "creation_failed (ax_trusted=\(accessibilityTrusted))",
-            bundleId: bundleId
-          )
-        }
-        if let snapshot {
-          // Scheduled, not awaited (#2197). The delay and the guard are
-          // unchanged; the dictation just stops queueing behind them.
-          ClipboardCleanup.scheduleRestore(
-            snapshot, changeCountAfterPaste: dispatchResult.changeCount, tier: tier)
+            stage: "cgevent", reason: "chromium_omnibox_lost_focus_during_activation",
+            bundleId: bundleId)
+        } else {
+          // Snapshot immediately before the write, in the SAME block as the
+          // write itself (ClipboardIsolationFreezeTests.pasteRoutesUseCleanupSnapshot
+          // asserts every automatic route's snapshot and write share one code
+          // block). The re-check above makes accessibility calls, and anything
+          // copied while it runs would otherwise be captured as "the user's old
+          // clipboard" and then restored over (Codex review r5).
+          let snapshot: ClipboardSnapshot? =
+            request.restoreClipboardAfterPaste
+            ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
+            : nil
+          submittedKind = payload.kind
+          let dispatchResult = PasteService.pasteToActiveApp(
+            payload.text, to: self.pasteboard)
+          submittedClipboardChangeCount = dispatchResult.changeCount
+          switch dispatchResult {
+          case .dispatched:
+            tier = .cgEvent
+          case .cgEventCreationFailed(let accessibilityTrusted, _):
+            cgEventFailureAccessibilityTrusted = accessibilityTrusted
+            tierFailures["cgevent"] = "creation_failed (ax_trusted=\(accessibilityTrusted))"
+            emitTierFailureBreadcrumb(
+              stage: "cgevent",
+              reason: "creation_failed (ax_trusted=\(accessibilityTrusted))",
+              bundleId: bundleId
+            )
+          }
+          if let snapshot {
+            // Scheduled, not awaited (#2197). The delay and the guard are
+            // unchanged; the dictation just stops queueing behind them.
+            ClipboardCleanup.scheduleRestore(
+              snapshot, changeCountAfterPaste: dispatchResult.changeCount, tier: tier)
+          }
         }
       } else {
         // Activation timed out. Record it as a distinct failure stage so

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -490,7 +490,6 @@ internal final class PasteCascadeExecutor {
       let elapsed = activation.elapsed
 
       if activated {
-        tiersAttempted.append(.cgEvent)
         // Revalidated AFTER activation, because bringing the app frontmost is
         // itself capable of moving focus and selection.
         let payload = PasteService.payloadAtCommitBoundary(
@@ -518,11 +517,16 @@ internal final class PasteCascadeExecutor {
           // Refuse the blind paste rather than guess where it lands — the same
           // "not confident enough to act automatically" floor PR #220 already
           // uses for a non-text focus: fall through to clipboard-only below.
+          // Cloud review round 5: `.cgEvent` must NOT be recorded as attempted
+          // here — `pasteToActiveApp` is never called, so a clipboard-only
+          // outcome from this path would otherwise falsely claim Cmd+V was
+          // tried in its own telemetry.
           tierFailures["cgevent"] = "chromium_omnibox_lost_focus_during_activation"
           emitTierFailureBreadcrumb(
             stage: "cgevent", reason: "chromium_omnibox_lost_focus_during_activation",
             bundleId: bundleId)
         } else {
+          tiersAttempted.append(.cgEvent)
           // Snapshot immediately before the write, in the SAME block as the
           // write itself (ClipboardIsolationFreezeTests.pasteRoutesUseCleanupSnapshot
           // asserts every automatic route's snapshot and write share one code
@@ -565,7 +569,6 @@ internal final class PasteCascadeExecutor {
           stage: "activation", reason: "timeout_ms=\(elapsed)", bundleId: bundleId
         )
         // Tier 2b: AppleScript Edit > Paste
-        tiersAttempted.append(.appleScript)
         _ = PasteService.forceActivateApp(pid: app.processIdentifier)
         app.activate()
         // Not a clipboard delay — this waits for the activation to settle before
@@ -603,15 +606,22 @@ internal final class PasteCascadeExecutor {
             true
           }
         if !chromiumOmniboxStillFocusedForAppleScript {
+          // Cloud review round 5 (same shape, Tier 2b): `.appleScript` must NOT
+          // be recorded as attempted here — `pasteViaAppleScript` is never
+          // called, so a clipboard-only outcome would otherwise falsely claim
+          // the AppleScript paste was tried in its own telemetry.
           tierFailures["applescript"] = "chromium_omnibox_lost_focus_during_activation"
           emitTierFailureBreadcrumb(
             stage: "applescript", reason: "chromium_omnibox_lost_focus_during_activation",
             bundleId: bundleId)
-        } else if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
-          tier = .appleScript
         } else {
-          tierFailures["applescript"] = "refused"
-          emitTierFailureBreadcrumb(stage: "applescript", reason: "refused", bundleId: bundleId)
+          tiersAttempted.append(.appleScript)
+          if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
+            tier = .appleScript
+          } else {
+            tierFailures["applescript"] = "refused"
+            emitTierFailureBreadcrumb(stage: "applescript", reason: "refused", bundleId: bundleId)
+          }
         }
         if let snapshot {
           ClipboardCleanup.scheduleRestore(

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -590,7 +590,24 @@ internal final class PasteCascadeExecutor {
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
           payload.text, to: self.pasteboard)
         submittedClipboardChangeCount = changeCount
-        if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
+        // #2297 cloud review round 3: Tier 2b never consulted the omnibox-focus
+        // decision at all — the force-activate and settle sleep above can move
+        // focus exactly as `activate(app)` does for Tier 2, and a blind
+        // AppleScript "Paste" click has the same "lands wherever focus is"
+        // property as Tier 2's Cmd+V. Same gate, same latest-possible-moment
+        // placement, reusing the primitive already proven for Tier 2.
+        let chromiumOmniboxStillFocusedForAppleScript: Bool =
+          if isChromiumOmnibox, let element = request.targetElement {
+            PasteService.freshFocusedElement(matching: element) != nil
+          } else {
+            true
+          }
+        if !chromiumOmniboxStillFocusedForAppleScript {
+          tierFailures["applescript"] = "chromium_omnibox_lost_focus_during_activation"
+          emitTierFailureBreadcrumb(
+            stage: "applescript", reason: "chromium_omnibox_lost_focus_during_activation",
+            bundleId: bundleId)
+        } else if PasteService.pasteViaAppleScript(pid: app.processIdentifier) {
           tier = .appleScript
         } else {
           tierFailures["applescript"] = "refused"

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -406,9 +406,20 @@ internal final class PasteCascadeExecutor {
     // navigate to. Only meaningful when Tier 1 would otherwise run at all, so
     // gated on `.textField` and a present element; Safari is unaffected
     // (`addressBarFamily` returns `nil` for it) and keeps using Tier 1.
+    //
+    // Cloud review (PR #2451): `addressBarFamily` answers a question about the
+    // CAPTURED element handle, which stays true even if the user has since
+    // moved focus to a different control in the same Chromium app — Tier 2's
+    // Cmd+V goes wherever CURRENT focus is, unlike Tier 1's targeted write
+    // into the captured element. `freshFocusedElement` closes that: only skip
+    // Tier 1 when the omnibox is PROVABLY still focused right now; if focus
+    // moved on, fall through to Tier 1's existing targeted-write behavior,
+    // exactly as before this fix existed.
     let isChromiumOmnibox: Bool =
-      if classification == .textField, let element = request.targetElement {
+      if classification == .textField, let element = request.targetElement,
         PasteService.addressBarFamily(of: element) == .chromium
+      {
+        PasteService.freshFocusedElement(matching: element) != nil
       } else {
         false
       }

--- a/Sources/EnviousWisprServices/BrowserAddressBarDetector.swift
+++ b/Sources/EnviousWisprServices/BrowserAddressBarDetector.swift
@@ -24,7 +24,7 @@ package enum BrowserAddressBarDetector {
   /// Which family of browser owns the focused element, and therefore which
   /// AX attribute is worth reading — never both, since each family exposes
   /// only its own signal. `nil` for anything not recognized at all.
-  package enum Family: Sendable {
+  package enum Family: Sendable, Equatable {
     case safari
     case chromium
   }

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -411,6 +411,15 @@ public enum PasteService {
     case setFailed = "set_failed"
     case noMutation = "no_mutation"
     case unverifiable
+    /// A Chromium (Chrome/Brave/Edge) address bar specifically, decided by the
+    /// CASCADE before Tier 1 is even attempted. #2297: a direct AX value write
+    /// lands the text but never touches Chromium's own "did the user actually
+    /// type this" tracker, so Enter has nothing to navigate to. Tier 2's
+    /// CGEvent Cmd+V — the same mechanism a human uses to paste a URL and hit
+    /// Enter — does set that tracker. Safari is unaffected (measured, #2297)
+    /// and is deliberately not routed here: `addressBarFamily(of:)` returns
+    /// `nil` for it.
+    case chromiumOmniboxNavigationSeam = "not_attempted_chromium_omnibox_navigation_seam"
   }
 
   /// What a Tier 1 attempt produced, including the evidence behind it.
@@ -1283,7 +1292,7 @@ public enum PasteService {
     else { return nil }
 
     let isBrowserAddressBar = bounded(
-      "browser_address_bar", { browserAddressBarSignature(of: fresh) })
+      "browser_address_bar", { addressBarFamily(of: fresh) != nil })
     guard isBrowserAddressBar else { return assembled }
     return CaretContext(
       leftWindow: assembled.leftWindow, rightWindow: assembled.rightWindow,
@@ -1314,12 +1323,18 @@ public enum PasteService {
   /// remove a wrapper Chromium itself inserts around everything it renders. So a
   /// signature match is trusted only once the ancestor chain is POSITIVELY
   /// verified clean of `AXWebArea`.
-  private static func browserAddressBarSignature(of element: AXUIElement) -> Bool {
+  ///
+  /// Returns the MATCHED family rather than a bare `Bool` (#2297): the paste
+  /// cascade needs to tell Chromium apart from Safari, which is unaffected by
+  /// the Enter-navigation defect this exists to route around.
+  package static func addressBarFamily(
+    of element: AXUIElement
+  ) -> BrowserAddressBarDetector.Family? {
     var pid: pid_t = 0
-    guard AXUIElementGetPid(element, &pid) == .success else { return false }
+    guard AXUIElementGetPid(element, &pid) == .success else { return nil }
     let bundleIdentifier = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
     guard let family = BrowserAddressBarDetector.family(forBundleIdentifier: bundleIdentifier)
-    else { return false }
+    else { return nil }
 
     let signatureMatches: Bool
     switch family {
@@ -1340,8 +1355,8 @@ public enum PasteService {
       signatureMatches = BrowserAddressBarDetector.matches(
         bundleIdentifier: bundleIdentifier, axIdentifier: nil, axDOMClassList: axDOMClassList)
     }
-    guard signatureMatches else { return false }
-    return ancestorChainVerifiedFreeOfWebArea(element)
+    guard signatureMatches else { return nil }
+    return ancestorChainVerifiedFreeOfWebArea(element) ? family : nil
   }
 
   /// Whether `element`'s AX ancestor chain can be POSITIVELY VERIFIED clean of

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -919,7 +919,7 @@ public enum PasteService {
   ///
   /// Returns nil for untrusted accessibility, a dead process, an unreadable
   /// focus, or a different element — every one of which means "do not repair".
-  static func freshFocusedElement(
+  package static func freshFocusedElement(
     matching element: AXUIElement,
     messagingTimeout: Double = axMessagingTimeoutSeconds
   ) -> AXUIElement? {

--- a/Tests/EnviousWisprTests/Pipeline/PasteCascadeAXOutcomeTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteCascadeAXOutcomeTests.swift
@@ -61,3 +61,46 @@ struct PasteCascadeAXOutcomeTests {
     #expect(Set(dispositions.map(String.init(describing:))).count == 3)
   }
 }
+
+// #2297: whether Tier 1 (AX direct write) runs at all is decided before the
+// write, from `classification` and `isChromiumOmnibox` — never inside
+// `insertViaAccessibility`, which has no way to know a route was skipped.
+// Product outcome: when this misroutes, the user's dictated URL sits
+// correctly in Chrome's address bar and Enter silently does nothing.
+@Suite("PasteCascadeExecutor Tier 1 decline reason", .tags(.productOutcome))
+struct PasteCascadeTier1DeclineReasonTests {
+
+  @Test("A Chromium address bar declines Tier 1 with its own reason, never `nil`")
+  func chromiumOmniboxDeclinesWithItsOwnReason() {
+    let reason = tier1DeclineReason(
+      axTrusted: true, classification: .textField, isChromiumOmnibox: true)
+    #expect(reason == .chromiumOmniboxNavigationSeam)
+  }
+
+  @Test("An ordinary text field — Chromium or not — still runs Tier 1")
+  func ordinaryTextFieldRunsTier1() {
+    let reason = tier1DeclineReason(
+      axTrusted: true, classification: .textField, isChromiumOmnibox: false)
+    #expect(reason == nil)
+  }
+
+  @Test("Accessibility being untrusted outranks the Chromium omnibox reason")
+  func accessibilityDeniedOutranksChromiumReason() {
+    // If AX itself is denied, `isChromiumOmnibox` could never have been
+    // computed truthfully (it requires an AX read) — the untrusted branch
+    // must win regardless of what is passed for it.
+    let reason = tier1DeclineReason(
+      axTrusted: false, classification: .textField, isChromiumOmnibox: true)
+    #expect(reason == .accessibilityDenied)
+  }
+
+  @Test("A Chromium address bar still yields the ordinary reason for .missing and .nonText")
+  func nonTextFieldClassificationsUnaffectedByChromiumFlag() {
+    #expect(
+      tier1DeclineReason(axTrusted: true, classification: .missing, isChromiumOmnibox: true)
+        == .focusMissing)
+    #expect(
+      tier1DeclineReason(axTrusted: true, classification: .nonText, isChromiumOmnibox: true)
+        == .focusNonText)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/PasteSettabilityTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteSettabilityTests.swift
@@ -87,10 +87,10 @@ struct PasteDeclineReasonTests {
         != PasteService.declineReason(for: .unverifiable))
   }
 
-  @Test("every one of the fourteen raw values is pinned exactly")
+  @Test("every one of the fifteen raw values is pinned exactly")
   func rawValuesAreStable() {
     // Frozen because they are grouped on in PostHog and Sentry, so a rename is a
-    // silent data break rather than a refactor. All fourteen, not a sample: the
+    // silent data break rather than a refactor. All fifteen, not a sample: the
     // earlier version pinned five and would have let a rename of the other nine
     // through (chunk whole-diff review).
     //
@@ -112,11 +112,12 @@ struct PasteDeclineReasonTests {
       (.setFailed, "set_failed"),
       (.noMutation, "no_mutation"),
       (.unverifiable, "unverifiable"),
+      (.chromiumOmniboxNavigationSeam, "not_attempted_chromium_omnibox_navigation_seam"),
     ]
     for (reason, rawValue) in expected {
       #expect(reason.rawValue == rawValue, "raw value drifted for \(reason)")
     }
-    #expect(expected.count == 14)
+    #expect(expected.count == 15)
   }
 
   @Test("no two reasons share a raw value")
@@ -126,8 +127,9 @@ struct PasteDeclineReasonTests {
       .accessibilityDenied, .focusMissing, .focusNonText, .roleUnreadable, .roleNotText,
       .selectedTextNotSettable, .countUnreadableOrInvalid, .rangeUnreadable, .rangeInvalid,
       .beforeImageUnreadableOrIncomplete, .focusUnconfirmed, .setFailed, .noMutation, .unverifiable,
+      .chromiumOmniboxNavigationSeam,
     ]
     #expect(Set(all.map(\.rawValue)).count == all.count)
-    #expect(all.count == 14)
+    #expect(all.count == 15)
   }
 }


### PR DESCRIPTION
## Summary
- Chrome and Brave's address bar tracks whether the user "actually typed" something separately from the field's raw value. Our direct AX write landed the text but never touched that tracker, so Enter had nothing to navigate to — reproducible on any plain dictated URL, no custom word involved.
- Fix: for a confirmed Chromium address bar (reusing the #2258 detector), skip the direct write and let the cascade fall through to the simulated-paste tier — the same mechanism a human uses to paste a URL and hit Enter, which already works.
- Safari is unaffected (measured) and keeps using the direct write.
- Codex local review (round 1) found the new telemetry reason wasn't pinned in the closed-set PostHog/Sentry contract test — fixed in a follow-up commit.

Part of #2316. Fixes #2297.

## Test plan
- [x] Full suite: 6890 + 206 tests, TEST SUCCEEDED
- [x] New unit tests for the Tier 1 routing decision (Chromium omnibox skips, Safari/ordinary fields don't, AX-denied outranks the new reason, .missing/.nonText unaffected)
- [x] Closed-set telemetry contract test updated (15 raw values, pinned + uniqueness)
- [x] Local Codex review — one real finding, fixed
- [ ] Live UAT: dictate a plain URL into Chrome/Brave's address bar, confirm Enter navigates; confirm Safari unaffected (blocked — founder actively using the shared dev-app slot; will run before merge)
