### PR TITLE
The pill picker is three identical cards, and tapping one sets Live Preview

### DIFF
--- a/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LivePreview/LivePreviewCoordinator.swift
@@ -301,8 +301,8 @@ final class LivePreviewCoordinator: CorrectorVocabularyConsumer {
   /// supposed to protect this.** Settings is reachable while recording — the menu
   /// item carries no recording gate, and the Live Preview toggle is disabled only
   /// when no engine is available — so a user could start a take, switch Live
-  /// Preview off, open Appearance, and be told "Live Preview is on, so the pill
-  /// shows your words" about a next recording where it will not be. That
+  /// Preview off, open Appearance, and be told to "Turn off Live Preview to use
+  /// these" about a next recording where it already is off. That
   /// contradicts the panel's own promise that changes apply the next time you
   /// record.
   ///

--- a/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
+++ b/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
@@ -51,11 +51,6 @@ final class PillAppearanceModel {
   }
 
 
-  /// The designs in one group, in the catalog's own order.
-  func designs(holdingWords: Bool) -> [RecordingPillDesign] {
-    PillCatalog.designs(holdingWords: holdingWords)
-  }
-
   /// **Whether this design may be chosen, asked of the CATALOG.** The picker
   /// decides nothing: a design it greys out is exactly a design the pill would
   /// refuse, because `PillCatalog.offers` is defined in terms of the same
@@ -69,6 +64,59 @@ final class PillAppearanceModel {
     holdingWords
       ? settings.recordingPillDesignWithWords
       : settings.recordingPillDesignWithoutWords
+  }
+
+  /// Choose a design AND put Live Preview into the state that design needs
+  /// (founder, 2026-08-26).
+  ///
+  /// **This is the first thing in the app that writes `livePreviewEnabled` on the
+  /// user's behalf** — until now only the user's own toggle did. The founder was
+  /// offered a confirm step and declined it: picking a pill switches the setting
+  /// silently, because the pill IS the choice and being asked to confirm the
+  /// consequence of your own tap is friction.
+  ///
+  /// The cost, stated because nothing in the UI states it: someone who turned
+  /// Live Preview on, then picks a compact pill because they prefer how it looks,
+  /// loses Live Preview and is not told. That is the accepted trade, not an
+  /// oversight.
+  ///
+  /// **Only reachable for a design the picker OFFERS.** Where words are
+  /// impossible — no engine here, or a model mid-removal — the words-capable card
+  /// is disabled and this is never called for it, so the setting is never written
+  /// to a value the engine cannot honour.
+  func chooseCoupled(_ design: RecordingPillDesign) {
+    settings.livePreviewEnabled = design.canHoldWords
+    choose(design, holdingWords: design.canHoldWords)
+  }
+
+  /// Whether this design can be picked RIGHT NOW, given that picking it will set
+  /// Live Preview to whatever it needs.
+  ///
+  /// **Asked of the CATALOG, about the state the tap would produce.** A first
+  /// version answered it here — wordless always true, words-capable true when the
+  /// capability is `.available` or `.previewOff` — which put a SECOND derivation of
+  /// offerability beside `PillCatalog.offers`, free to disagree with it the day
+  /// either moved. `offers(_:holdingWords:)` above exists precisely so the picker
+  /// decides nothing, and coupling is not a reason to stop using it.
+  ///
+  /// The only genuinely local judgment left is whether words are POSSIBLE on this
+  /// machine, which is about the engine rather than about any design.
+  func offersCoupled(_ design: RecordingPillDesign, capability: PillWordsCapability) -> Bool {
+    offers(design, holdingWords: design.canHoldWords && Self.wordsArePossible(capability))
+  }
+
+  /// Whether words could be produced here AT ALL, switch aside.
+  ///
+  /// **`.engineUnsupported` and `.modelBeingRemoved` are not about the switch**, so
+  /// no tap can reach them; `.previewOff` is, which is exactly what makes the
+  /// coupling meaningful. An exhaustive switch rather than a two-case comparison,
+  /// so a capability added later fails to compile here instead of silently
+  /// defaulting to "words are impossible".
+  static func wordsArePossible(_ capability: PillWordsCapability) -> Bool {
+    switch capability {
+    case .available, .previewOff: return true
+    case .engineUnsupported, .modelBeingRemoved: return false
+    }
   }
 
   /// Choose a design for ONE group. Writing only that group's key is what

--- a/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
+++ b/Sources/EnviousWisprAppKit/App/PillAppearanceModel.swift
@@ -59,11 +59,23 @@ final class PillAppearanceModel {
     PillCatalog.offers(design, capabilityHasWords: holdingWords)
   }
 
-  /// The design currently chosen for a group.
-  func selection(holdingWords: Bool) -> RecordingPillDesign {
-    holdingWords
-      ? settings.recordingPillDesignWithWords
-      : settings.recordingPillDesignWithoutWords
+  /// The design the NEXT recording will actually use.
+  ///
+  /// **Through `resolve`, exactly as the recording director does it.** The raw
+  /// slot can hold a design the current capability cannot render — a downgrade or
+  /// a hand-edited plist reaches it — and the director substitutes in that case.
+  /// A picker reading the raw value ticks a card the pill will not draw.
+  ///
+  /// `substituted` is deliberately discarded here: the picker's job is to show
+  /// what WILL happen, and a substitution is exactly what will happen. Surfacing
+  /// the fact that it occurred is a separate question nobody has asked.
+  func resolvedSelection() -> RecordingPillDesign {
+    PillDesignSelections(
+      withoutWords: settings.recordingPillDesignWithoutWords,
+      withWords: settings.recordingPillDesignWithWords
+    )
+    .resolve(capabilityHasWords: wordsCapability.hasWords)
+    .design
   }
 
   /// Choose a design AND put Live Preview into the state that design needs

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -41,6 +41,7 @@ import SwiftUI
 struct RecordingPillAppearancePanel: View {
 
   @Environment(PillAppearanceModel.self) private var model
+  @Environment(\.settingsNavigate) private var navigate
 
   var body: some View {
     BrandedPanel(
@@ -69,37 +70,47 @@ struct RecordingPillAppearancePanel: View {
             RecordingPillPreviewTile(
               design: design,
               isSelected: Self.selected(in: model) == design,
-              isEnabled: model.offers(design, holdingWords: model.wordsCapability.hasWords),
-              // **Written to the slot this DESIGN belongs to, which is what keeps
-              // the two remembered choices alive behind one flat row.** A card is
-              // only enabled when its group matches the current capability, so
-              // this is always the slot the pill will read next.
-              onSelect: { model.choose(design, holdingWords: design.canHoldWords) })
+              isEnabled: model.offersCoupled(design, capability: model.wordsCapability),
+              // **Picking a pill also sets Live Preview to what that pill needs**
+              // (founder, 2026-08-26). The slot written is still the design's own,
+              // so the two remembered choices survive; what is new is that the
+              // capability follows the tap instead of gating it.
+              onSelect: { model.chooseCoupled(design) })
           }
         }
 
-        // ONE line for the whole row, and only when something in it is greyed.
+        // ONE line for the whole row, and only when something in it is greyed —
+        // which is now only a Mac that cannot show words at all.
         if let reason = Self.reason(for: model.wordsCapability) {
           Text(reason)
             .settingsReadingCopy()
         }
+
+        // **The way out to the settings this choice just turned on** (founder,
+        // 2026-08-26). Picking the pill that shows words switches Live Preview on
+        // silently, and the user's next question is how to configure it — which
+        // lives on another page. Shown only when that pill is the live choice,
+        // because it is answering a question nobody else has asked.
+        if Self.selected(in: model).canHoldWords {
+          Button {
+            navigate(.livePreview)
+          } label: {
+            Text("Configure Live Preview")
+          }
+          .buttonStyle(.link)
+          .accessibilityHint("Opens the Live Preview settings page")
+        }
       }
-    } footnote: {
-      // ONE quiet line for the whole page's pill settings (founder, 2026-08-26),
-      // replacing the sentence this panel and the position panel each carried.
-      //
-      // **It NAMES both settings, because it sits inside the Recording Pill
-      // panel** and an unqualified "Changes" reads there as design changes only,
-      // leaving the position panel above silently uncovered.
-      //
-      // "the next time the pill appears", not "the next time you record": the
-      // position setting also places status notices, which the deleted copy said
-      // outright ("Changes apply the next time one appears"). A notice can arrive
-      // without a recording, so scoping this line to recording would be wrong for
-      // half of what it now covers.
-      Text("Design and position changes apply the next time the pill appears.")
-        .settingsReadingCopy()
     }
+    // **NO footnote.** "Design and position changes apply the next time the pill
+    // appears." was a founder decision earlier in this same work and was DELETED
+    // by the founder on 2026-08-26 along with the two instruction lines above it.
+    // The page is now three pictures and one link, and a caveat about when a
+    // change takes effect is not what a user came here to read.
+    //
+    // Recorded rather than silently dropped because it was ASKED FOR: the thing
+    // it warned about is still true — a design or position change does not touch a
+    // recording already on screen.
   }
 
   /// The order the cards appear in, left to right.
@@ -136,11 +147,12 @@ struct RecordingPillAppearancePanel: View {
   /// status report on a page the user opened to choose a picture.
   static func reason(for capability: PillWordsCapability) -> String? {
     switch capability {
-    case .available:
-      // Words ARE available, so the wordless designs are the greyed ones.
-      return "Turn off Live Preview to use the other designs."
-    case .previewOff:
-      return "Turn on Live Preview to use the one that shows words."
+    case .available, .previewOff:
+      // **Nothing is greyed in these two states any more, so there is nothing to
+      // explain.** Picking a design now sets Live Preview to whatever that design
+      // needs, which is what the two sentences here used to instruct the user to
+      // go and do by hand.
+      return nil
     case .engineUnsupported:
       return "Your engine cannot show words on this Mac."
     case .modelBeingRemoved:
@@ -221,9 +233,7 @@ struct RecordingPillPreviewTile: View {
   /// rule would draw a compact pill at nearly 5x in a wide window. The bound keeps
   /// the pictures comparable to each other, which is the property that actually
   /// mattered underneath the life-size argument.
-  static func thumbnailScale(for design: RecordingPillDesign) -> CGFloat {
-    scale(for: design, inWidth: thumbnailSize.width)
-  }
+
 
   /// The same rule against a REAL card width, which is what the view uses.
   ///
@@ -241,7 +251,22 @@ struct RecordingPillPreviewTile: View {
   /// pictures rather than as stamps, without the widest one and the narrowest one
   /// arriving at visibly the same size — which is the failure the rejected shared
   /// scale had, and the one the fill rule would recreate if nothing bounded it.
-  static let maxMagnification: CGFloat = 2
+  ///
+  /// **It also has to keep the tallest-for-its-width design inside
+  /// `thumbnailSize.height`, and that is the binding constraint.** The card height
+  /// matches a theme card by instruction, so it cannot grow to accommodate a
+  /// magnified pill; at 2 the capsule drew 71pt into a 63pt box and was silently
+  /// clipped. `thePreviewIsTheRealPillScaled` measures every design against the box
+  /// and is what caught it — a new design taller for its width than the capsule
+  /// fails there LOUDLY rather than shipping cut off.
+  /// **1.4, and the number is the CAPSULE's height budget, not a taste call.** Its
+  /// pill is 44pt tall against a 63pt box, so anything above ~1.43 clips it — and
+  /// 2 and 1.7 both did, the second only because the card WIDTH happened to bound
+  /// the scale below the cap and hid it. Tuned against
+  /// `thePreviewIsTheRealPillScaled` rather than derived, because the view cannot
+  /// measure a leaf's height; that test is what makes a wrong value loud instead of
+  /// silently cropping a pill.
+  static let maxMagnification: CGFloat = 1.4
 
   /// What this design's pill measures ON THE CARD, after its own scale.
   ///
@@ -249,7 +274,7 @@ struct RecordingPillPreviewTile: View {
   /// can hold the RELATION — the widest design fills the box, the others are
   /// proportionally narrower — without hosting anything.
   static func thumbnailWidth(for design: RecordingPillDesign) -> CGFloat {
-    design.width * thumbnailScale(for: design)
+    design.width * scale(for: design, inWidth: thumbnailSize.width)
   }
 
   /// What the pill inside the tile is shown SAYING.

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -203,6 +203,17 @@ struct RecordingPillPreviewTile: View {
     "\(design.displayName). \(design.summary)"
   }
 
+  /// What a card announces as its VALUE.
+  ///
+  /// **Extracted because a test and a Python harness both depend on the exact
+  /// string.** `wispr_eyes.read_cards` compares `AXValue` against "Selected", and
+  /// the Runtime UAT decides whether a tap landed by asking it. Reworded inline,
+  /// the harness silently stops seeing selection and reports a working picker as
+  /// broken. `theSelectedValueIsExactly` pins it.
+  static func accessibilityValue(isSelected: Bool) -> String {
+    isSelected ? "Selected" : ""
+  }
+
   /// **Every card draws its pill into THIS box, each at its own scale.**
   ///
   /// **The CARD matches a theme card exactly** (founder, 2026-08-26: "I want the
@@ -462,7 +473,7 @@ struct RecordingPillPreviewTile: View {
     // visible and inaudible.
     .accessibilityElement(children: .combine)
     .accessibilityLabel(Self.accessibilityLabel(for: design))
-    .accessibilityValue(isSelected ? "Selected" : "")
+    .accessibilityValue(Self.accessibilityValue(isSelected: isSelected))
     .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -1,8 +1,8 @@
 import EnviousWisprCore
 import SwiftUI
 
-/// Choose the recording pill's design, per capability group (#2376 Phase 4, C7;
-/// redrawn as pictures in #2435).
+/// Choose the recording pill's design (#2376 Phase 4, C7; redrawn as pictures in
+/// #2435; flattened to one row in #2446).
 ///
 /// **The picker SHOWS each design instead of describing it (#2435).** A user
 /// could not previously see what any option looked like without starting a
@@ -11,34 +11,33 @@ import SwiftUI
 /// accessibility label — which is the only channel a macOS user cannot silence
 /// (VoiceOver Utility can turn hints and custom content off).
 ///
-/// **Two groups, and the one that does not apply is GREYED WITH ITS REASON
-/// rather than hidden.** Hiding it would leave a user who turns Live Preview on
-/// wondering where the other pills went, and would give no clue to a user whose
-/// engine cannot run here that the switch is not the thing standing in their way.
+/// **ONE row of identical cards, shaped like the theme cards above them**
+/// (founder, 2026-08-26, on seeing the alternative rendered). This REPLACES a
+/// split into a "Live Preview off" group and a "Live Preview on" group, each
+/// with its own heading, state dot and reason line. That split was accurate and
+/// it was the wrong subject: a user opens this page to pick a PICTURE, and the
+/// page opened by explaining a setting. The pill previews are now scaled to a
+/// fixed thumbnail and paired with a name and a tick, which is the same control
+/// the theme row already is.
 ///
-/// **The groups and their offerability come from `PillCatalog`, never from this
-/// view.** A design this page greys out is exactly a design the pill would
-/// refuse, because `offers` is defined in terms of the same `resolve` the
-/// director calls. A local `allCases.filter { $0.canHoldWords == x }` would be a
-/// second derivation of that rule even on the day it agreed.
+/// **The constraint the split encoded has NOT gone away.** A design that shows
+/// words is unusable when words are unavailable, and vice versa; that is carried
+/// per card by `isEnabled` and by a single line under the row, instead of by two
+/// headed groups. Two selections are still remembered behind the one visible
+/// tick — see `selected(in:)`.
 ///
-/// **The reason is stated ONCE, at group level.** Two precedents were considered
+/// **Offerability comes from `PillCatalog`, never from this view.** A design this
+/// page greys out is exactly a design the pill would refuse, because `offers` is
+/// defined in terms of the same `resolve` the director calls. A local
+/// `allCases.filter { $0.canHoldWords == x }` would be a second derivation of
+/// that rule even on the day it agreed.
+///
+/// **The reason is stated ONCE, under the row.** Two precedents were considered
 /// and both rejected: `EngineCard` puts a reason inside a card that stays
 /// selectable, and `LivePreviewSettingsView` deliberately moved its reason OUT of
 /// the disabled control onto another card, on the recorded grounds that two
-/// places saying why is how they come to disagree. Here the requirement is the
-/// reason WITH the greyed group, so it is rendered once in that group's header
-/// and nowhere else.
-///
-/// **The two group titles name a CONDITION, not the current state, and that is
-/// what makes them true** (founder, 2026-08-26). Read as a status claim,
-/// "Live Preview on" would be false at `.engineUnsupported` and
-/// `.modelBeingRemoved`, where the setting is on and the pills are still out of
-/// reach. Read as "the pills you get when Live Preview is on", it holds in all
-/// four cases. Two things carry the CURRENT state instead, and both are
-/// requirements rather than decoration: exactly one group shows the filled active
-/// dot, and the other one prints `reason(for:groupHoldsWords:)`, which already
-/// distinguishes every case. `AppearancePillPickerTests` asserts both.
+/// places saying why is how they come to disagree. One line for one row keeps
+/// that property with no group to hang it on.
 struct RecordingPillAppearancePanel: View {
 
   @Environment(PillAppearanceModel.self) private var model
@@ -48,36 +47,43 @@ struct RecordingPillAppearancePanel: View {
       icon: "waveform.badge.mic",
       header: "Recording Pill"
     ) {
-      // **The two groups always STACK, and each one reflows its own tiles.**
-      //
-      // A `ViewThatFits` chose the groups' side-by-side arrangement here and was
-      // REMOVED after rendering it: nested inside the page's vertical
-      // `ScrollView` it does not reliably receive a bounded horizontal proposal,
-      // so it cannot judge whether a candidate fits and keeps its first one. At a
-      // 530 point content width that clipped both wordless pills; at 1010 it
-      // stacked two groups with room to sit side by side. A container that
-      // guesses wrong CLIPS here rather than cramping, because every pill is a
-      // fixed width by design.
-      //
-      // `LazyVGrid` is the container this page already proves receives a bounded
-      // width — the theme cards above use one — so the reflow is decided by
-      // arithmetic rather than by a proposal that may not arrive.
-      VStack(alignment: .leading, spacing: 18) {
-        group(holdingWords: false)
-        group(holdingWords: true)
+      VStack(alignment: .leading, spacing: 10) {
+        // **ONE row of identical cards, no with-words / without-words split**
+        // (founder, 2026-08-26, on seeing the split rendered). The two groups
+        // each carried a heading, a state dot and their own reason line, which
+        // put the SETTING's state in front of a user who came here to pick a
+        // PICTURE. The constraint that split them has not gone away — it is
+        // carried by `isEnabled` per card and one line beneath the row.
+        //
+        // Deliberately the SAME grid metric as the theme cards above
+        // (`AppearanceSettingsView`), because the founder's ask was that these
+        // read as the same kind of control. A shared literal would be a second
+        // authority for one number, so if these ever need to move together the
+        // fix is a named constant on `SettingsLayout`, not a copy here.
+        LazyVGrid(
+          columns: [GridItem(.adaptive(minimum: 270, maximum: .infinity), spacing: 12)],
+          alignment: .leading,
+          spacing: 12
+        ) {
+          ForEach(Self.displayOrder, id: \.self) { design in
+            RecordingPillPreviewTile(
+              design: design,
+              isSelected: Self.selected(in: model) == design,
+              isEnabled: model.offers(design, holdingWords: model.wordsCapability.hasWords),
+              // **Written to the slot this DESIGN belongs to, which is what keeps
+              // the two remembered choices alive behind one flat row.** A card is
+              // only enabled when its group matches the current capability, so
+              // this is always the slot the pill will read next.
+              onSelect: { model.choose(design, holdingWords: design.canHoldWords) })
+          }
+        }
+
+        // ONE line for the whole row, and only when something in it is greyed.
+        if let reason = Self.reason(for: model.wordsCapability) {
+          Text(reason)
+            .settingsReadingCopy()
+        }
       }
-      // **The page REFUSES to be narrower than its widest pill, rather than
-      // clipping one.** Rendered at a 380 point content width the reading well
-      // was cut off: a grid column cannot shrink below its content, and the tile
-      // clips its own, so there is no width at which a too-narrow layout degrades
-      // gracefully. A minimum propagates up to the window, so the window stops
-      // resizing instead — which is the honest behaviour for a page whose whole
-      // subject is fixed-size pictures.
-      //
-      // DERIVED, never a literal: a design added later widens it with no edit
-      // here, and a literal would be a second authority for a number the tile
-      // already owns.
-      .frame(minWidth: Self.widestTile(holdingWords: true), alignment: .leading)
     } footnote: {
       // ONE quiet line for the whole page's pill settings (founder, 2026-08-26),
       // replacing the sentence this panel and the position panel each carried.
@@ -96,121 +102,50 @@ struct RecordingPillAppearancePanel: View {
     }
   }
 
-  /// Whether a group describes the situation the user is actually in.
+  /// The order the cards appear in, left to right.
   ///
-  /// **A function rather than a computed property inside `body`, because it is
-  /// the authority the active dot and the reason line BOTH read**, and because
-  /// the rendered accessibility tree is not readable from a test (recorded in
-  /// `RenderedPillHarness`). A test can hold this to "exactly one group is
-  /// active, in every capability state" without hosting anything.
-  static func isActive(_ capability: PillWordsCapability, groupHoldsWords: Bool) -> Bool {
-    groupHoldsWords == capability.hasWords
+  /// **The two designs that cannot show words come first, then the one that can**
+  /// (founder, 2026-08-26: "the order is wrong"). The enum declares `classic`,
+  /// `readingWell`, `levelRail`, which put the odd one out in the MIDDLE and split
+  /// the pair that behave alike — and since exactly one side of the row is greyed
+  /// at any moment, that also meant the greyed cards were never adjacent.
+  ///
+  /// Taken from `PillCatalog.designs(holdingWords:)`, whose doc comment already
+  /// says it exists "for the picker's ORDER only", rather than by reordering the
+  /// enum: the enum's order is a declaration site with other readers, and a
+  /// presentation concern has no business moving it.
+  static var displayOrder: [RecordingPillDesign] {
+    PillCatalog.designs(holdingWords: false) + PillCatalog.designs(holdingWords: true)
   }
 
-  /// The widest tile a group will contain, which is what its grid column has to
-  /// be able to hold.
+  /// The design the pill would use for the NEXT recording.
   ///
-  /// Read off `PillCatalog` and the tile, so a design added later widens the
-  /// column with no edit here.
-  static func widestTile(holdingWords: Bool) -> CGFloat {
-    PillCatalog.designs(holdingWords: holdingWords)
-      .map(RecordingPillPreviewTile.width(for:))
-      .max() ?? 0
+  /// **The flat row shows one check, and this is what it marks.** Two slots are
+  /// still remembered — one for each capability state — so the mark follows the
+  /// state the user is actually in rather than a third stored value that could
+  /// disagree with both.
+  static func selected(in model: PillAppearanceModel) -> RecordingPillDesign {
+    model.selection(holdingWords: model.wordsCapability.hasWords)
   }
 
-  @ViewBuilder
-  private func group(holdingWords: Bool) -> some View {
-    let isActive = Self.isActive(model.wordsCapability, groupHoldsWords: holdingWords)
-    let title = holdingWords ? "Live Preview on" : "Live Preview off"
-
-    VStack(alignment: .leading, spacing: 10) {
-      HStack(spacing: 7) {
-        // The dot is the CURRENT state; the title beside it is the condition.
-        Circle()
-          .fill(isActive ? Color.green : Color.clear)
-          .overlay(
-            Circle().strokeBorder(
-              isActive ? Color.clear : Color.stTextTertiary, lineWidth: 1)
-          )
-          .frame(width: 8, height: 8)
-          // Announced through the title's own label instead, so a screen reader
-          // hears one phrase rather than an unnamed shape beside a heading.
-          .accessibilityHidden(true)
-
-        Text(title)
-          .font(.stRowTitle)
-          .foregroundStyle(isActive ? .stTextPrimary : .stTextSecondary)
-          .accessibilityLabel(isActive ? "\(title). In use." : title)
-      }
-
-      // The reason, rendered ONLY on the inactive group and only once.
-      if !isActive,
-        let reason = Self.reason(for: model.wordsCapability, groupHoldsWords: holdingWords)
-      {
-        Text(reason)
-          .settingsReadingCopy()
-      }
-
-      // **One column per tile that fits, sized by the WIDEST tile in this group.**
-      // A narrower minimum would let a column form that the reading well cannot
-      // sit in, and the tile clips its own content, so the pill would be cut
-      // rather than cramped. Taken from the tile itself, never a literal here.
-      LazyVGrid(
-        columns: [
-          GridItem(
-            .adaptive(minimum: Self.widestTile(holdingWords: holdingWords), maximum: .infinity),
-            spacing: 12)
-        ],
-        alignment: .leading,
-        spacing: 12
-      ) {
-        tiles(holdingWords: holdingWords)
-      }
+  /// Why some cards in the row are greyed, in one line, or `nil` when none are.
+  ///
+  /// **Names the ACTION where there is one.** The greyed cards are the ones that
+  /// cannot be used in the current state, and every sentence here is about THEM,
+  /// never about the state — a line opening "Live Preview is on" reads as a
+  /// status report on a page the user opened to choose a picture.
+  static func reason(for capability: PillWordsCapability) -> String? {
+    switch capability {
+    case .available:
+      // Words ARE available, so the wordless designs are the greyed ones.
+      return "Turn off Live Preview to use the other designs."
+    case .previewOff:
+      return "Turn on Live Preview to use the one that shows words."
+    case .engineUnsupported:
+      return "Your engine cannot show words on this Mac."
+    case .modelBeingRemoved:
+      return "Unavailable while a removed model finishes clearing."
     }
-    // **NO `maxWidth: .infinity` HERE, and it stays absent deliberately.** It was
-    // removed while this panel still chose its layout with `ViewThatFits`, which
-    // asks each candidate for its IDEAL size: a greedy child answers that it will
-    // take whatever it is given, so every candidate fit at every width and the
-    // fallbacks were dead code. That container is gone, but a greedy group would
-    // now stretch every column to the panel's full width instead, which is the
-    // same wrong picture by another route.
-    .animation(.easeInOut(duration: 0.15), value: isActive)
-  }
-
-  @ViewBuilder
-  private func tiles(holdingWords: Bool) -> some View {
-    let isActive = Self.isActive(model.wordsCapability, groupHoldsWords: holdingWords)
-    ForEach(model.designs(holdingWords: holdingWords), id: \.self) { design in
-      RecordingPillPreviewTile(
-        design: design,
-        isSelected: model.selection(holdingWords: holdingWords) == design,
-        isEnabled: model.offers(design, holdingWords: holdingWords) && isActive,
-        onSelect: { model.choose(design, holdingWords: holdingWords) })
-    }
-  }
-
-  /// Why the inactive group is inactive, in that user's terms.
-  ///
-  /// **Two refusals, two sentences, and that is the whole reason the capability
-  /// carries a reason at all.** One sentence for both would tell a user whose
-  /// engine cannot run on this Mac to turn on a setting that would not help them.
-  ///
-  /// **Shortened to a phrase each (#2435)** — the page is now pictures, and a
-  /// paragraph under a greyed group is the text this change exists to remove. Each
-  /// phrase still names its own cause, which is the property that matters: it is
-  /// the only surface that distinguishes `previewOff` from `engineUnsupported`
-  /// from `modelBeingRemoved`.
-  static func reason(for capability: PillWordsCapability, groupHoldsWords: Bool) -> String? {
-    if groupHoldsWords {
-      switch capability {
-      case .available: return nil
-      case .previewOff: return "Turn on Live Preview to use these."
-      case .engineUnsupported: return "Your engine cannot show words on this Mac."
-      case .modelBeingRemoved: return "Unavailable while a removed model finishes clearing."
-      }
-    }
-    // The wordless group is inactive exactly when words ARE available.
-    return capability.hasWords ? "Live Preview is on, so the pill shows your words." : nil
   }
 }
 
@@ -224,6 +159,7 @@ struct RecordingPillAppearancePanel: View {
 /// through the function that produces it and confirmed by a VoiceOver pass.
 struct RecordingPillPreviewTile: View {
   let design: RecordingPillDesign
+
   let isSelected: Bool
   let isEnabled: Bool
   let onSelect: () -> Void
@@ -245,15 +181,75 @@ struct RecordingPillPreviewTile: View {
     "\(design.displayName). \(design.summary)"
   }
 
-  /// The pill's own inset inside the tile, on each side.
-  static let horizontalInset: CGFloat = 16
+  /// **Every card draws its pill into THIS box, each at its own scale.**
+  ///
+  /// **The CARD matches a theme card exactly** (founder, 2026-08-26: "I want the
+  /// dimensions to be identical to the light/dark theme rectangles"). An earlier
+  /// pass grew these until they were several times a theme card's height and the
+  /// two rows stopped reading as the same kind of control, which was the whole
+  /// point of the shape.
+  ///
+  /// The height is `AppearanceCard`'s drawn thumbnail height — 116 x 0.54 — so
+  /// both rows come out the same card height once the shared 12pt padding is
+  /// added. The WIDTH is not matched and deliberately so: a theme card spends its
+  /// remaining width on an icon and a name, and this card has neither, so the
+  /// picture takes that room instead. Same rectangle, more of it given to the
+  /// preview.
+  static let thumbnailSize = CGSize(width: 300, height: 63)
 
-  /// **What one tile occupies, derived rather than restated.** The panel's grid
-  /// needs this to size a column that can hold the widest design; a literal there
-  /// would be a second authority for the same number, free to disagree the day a
-  /// design's width moves.
-  static func width(for design: RecordingPillDesign) -> CGFloat {
-    design.width + horizontalInset * 2
+  /// **Each design fills the box on its OWN scale** (founder, 2026-08-26).
+  ///
+  /// The alternative — one shared factor taken from the widest design — keeps the
+  /// pills' RELATIVE sizes honest, and was rendered and rejected: at a scale that
+  /// fits a 400pt reading well, a 185pt capsule is a smudge. Two of the three
+  /// previews showed nothing, which fails the only job this picker has (#2435:
+  /// SHOW the design rather than describe it).
+  ///
+  /// What is given up is the sense that one pill takes more screen than another.
+  /// That is real information, and it is recoverable the first time the user
+  /// dictates; an unreadable thumbnail is not recoverable at all.
+  ///
+  /// **The life-size cap was LIFTED at the founder's direction** (2026-08-26,
+  /// after seeing it: "make the mock ups fill out the useable area more"). It had
+  /// been 1, on the argument that magnifying a compact pill misrepresents how much
+  /// screen it takes — the same objection as the rejected shared scale, pointed the
+  /// other way. That argument is still true and was overruled knowingly: at the
+  /// window widths people use, the cards run nearly full width and a life-size
+  /// 185pt pill in a 445pt card reads as a mistake rather than as fidelity.
+  ///
+  /// **`maxMagnification` is what stops it becoming absurd.** Uncapped, the fill
+  /// rule would draw a compact pill at nearly 5x in a wide window. The bound keeps
+  /// the pictures comparable to each other, which is the property that actually
+  /// mattered underneath the life-size argument.
+  static func thumbnailScale(for design: RecordingPillDesign) -> CGFloat {
+    scale(for: design, inWidth: thumbnailSize.width)
+  }
+
+  /// The same rule against a REAL card width, which is what the view uses.
+  ///
+  /// Split out so a test can ask the question at any width rather than only at the
+  /// nominal one — the card reflows, so the nominal width is the one case that is
+  /// guaranteed not to be what a user sees.
+  static func scale(for design: RecordingPillDesign, inWidth available: CGFloat) -> CGFloat {
+    guard available > 0, design.width > 0 else { return 1 }
+    return min(maxMagnification, available / design.width)
+  }
+
+  /// How far past life size a preview may be drawn.
+  ///
+  /// Chosen, not measured: it is the point at which the narrow designs read as
+  /// pictures rather than as stamps, without the widest one and the narrowest one
+  /// arriving at visibly the same size — which is the failure the rejected shared
+  /// scale had, and the one the fill rule would recreate if nothing bounded it.
+  static let maxMagnification: CGFloat = 2
+
+  /// What this design's pill measures ON THE CARD, after its own scale.
+  ///
+  /// Kept as a function rather than read off the rendered view because a test
+  /// can hold the RELATION — the widest design fills the box, the others are
+  /// proportionally narrower — without hosting anything.
+  static func thumbnailWidth(for design: RecordingPillDesign) -> CGFloat {
+    design.width * thumbnailScale(for: design)
   }
 
   /// What the pill inside the tile is shown SAYING.
@@ -306,32 +302,80 @@ struct RecordingPillPreviewTile: View {
 
   var body: some View {
     Button(action: onSelect) {
-      ZStack(alignment: .topTrailing) {
-        RecordingPillPreview(design: design)
-          .padding(.horizontal, Self.horizontalInset)
-          .padding(.vertical, 16)
-          // Height only, so tiles sharing a grid row are the same size. A greedy
-          // WIDTH would make the tile report that it fits anywhere, which is what
-          // stops any container above it from reflowing correctly.
-          .frame(maxHeight: .infinity)
+      HStack(spacing: 12) {
+        // **No spacers around the picture.** They were added to centre a fixed-width
+        // preview inside a much wider card; now that the preview TAKES the card's
+        // width they only compete with it for that width, and the picture ends up
+        // smaller than the space it was given. Centring is handled inside the
+        // preview instead, by the scale anchor.
 
+        // **Drawn at full size, then scaled WHOLE** — the same move
+        // `AppearanceCard` makes with its window thumbnail, and for the same
+        // reason: a pill's parts are fixed points, so re-laying it out into a 160
+        // point frame would change the proportions of the thing being previewed
+        // rather than shrink it.
+        // **The preview takes the width the card actually has** (founder,
+        // 2026-08-26: "make the mock ups fill out the useable area more"). A fixed
+        // box left a wide margin at the window sizes people use, because the cards
+        // stack full-width below ~900pt and a 300pt picture in an 890pt card reads
+        // as an accident.
+        //
+        // `GeometryReader` rather than a bigger constant: the card's width is
+        // decided by the grid above, which reflows, so any constant is wrong at
+        // every width except the one it was picked at.
+        GeometryReader { geo in
+          RecordingPillPreview(design: design)
+            // Natural WIDTH, natural height. `scaleEffect` is a draw-time
+            // transform and does not change layout, so the frames here are what
+            // reserve space; letting the height come from the pill is what keeps a
+            // one-line design from reserving a two-line design's box.
+            .fixedSize(horizontal: false, vertical: true)
+            .scaleEffect(Self.scale(for: design, inWidth: geo.size.width), anchor: .center)
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+        .frame(height: Self.thumbnailSize.height)
+        // The scaled draw can exceed the reserved box by a hair on a design whose
+        // natural height is unusually tall; clip rather than let it paint over the
+        // tick beside it.
+        .clipped()
+
+        // **NO VISIBLE NAME** (founder, 2026-08-26): "people know what it is
+        // without explaining the name". The picture is the label, which is the
+        // whole thesis of #2435 carried to its end — a name beside a drawing of
+        // the thing is the description this redesign existed to delete.
+        //
+        // **The name is NOT gone, it moved.** `accessibilityLabel(for:)` still
+        // announces "<name>. <summary>", so a VoiceOver user gets more than a
+        // sighted one rather than less. `theLabelCarriesNameAndDescription`
+        // guards that, and it is now the ONLY thing standing between this change
+        // and a row of unnamed buttons for anyone who cannot see the drawing.
+        //
+        // Checked before removing: no help article, blog post or website page
+        // refers to a design by name, so nothing in the documentation now points
+        // at a label the user cannot find.
         if isSelected {
           Image(systemName: "checkmark.circle.fill")
-            .font(.system(size: 17, weight: .semibold))
+            .font(.system(size: 18, weight: .semibold))
             .foregroundStyle(Color.white, isEnabled ? Color.stAccent : Color.stTextSecondary)
-            .padding(9)
         }
       }
-      // Before `.buttonStyle(.plain)`, so the whole tile is the hit target rather
-      // than the pill's own glyphs.
+      .padding(12)
+      // Before `.buttonStyle(.plain)`: the `Spacer` above is otherwise dead space
+      // rather than part of the hit target.
       .contentShape(Rectangle())
-      .background(Color.stPageBg)
+      .background(Color.stSectionBg)
       .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
+      // **An unselected card needs a border you can actually see** (founder,
+      // 2026-08-26). At `stDivider` and one point it disappeared against the card's
+      // own fill, so a row of three read as one undivided block with a highlight
+      // floating in it. Heavier than the theme cards above deliberately: those
+      // carry a name and an icon that give them an edge, and these are now bare
+      // pictures with nothing else to bound them.
       .overlay(
         RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
           .strokeBorder(
-            isSelected && isEnabled ? Color.stAccent : Color.stDivider,
-            lineWidth: isSelected && isEnabled ? 2 : 1)
+            isSelected && isEnabled ? Color.stAccent : Color.stTextTertiary.opacity(0.5),
+            lineWidth: isSelected && isEnabled ? 2 : 1.5)
       )
       // These tiles SHOW the product rather than describing it (#2435), which
       // makes them read as illustrations. Hover is what says they are also the
@@ -347,7 +391,7 @@ struct RecordingPillPreviewTile: View {
     .disabled(!isEnabled)
     .opacity(isEnabled ? 1 : 0.45)
     // **Addressed by role and title, never by an accessibility identifier**
-    // (swift-patterns). A greyed tile must REPORT as disabled rather than merely
+    // (swift-patterns). A greyed card must REPORT as disabled rather than merely
     // look it: the mistake `EngineCard` records for itself is a control that is
     // visible and inaudible.
     .accessibilityElement(children: .combine)

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -252,7 +252,24 @@ struct RecordingPillPreviewTile: View {
   /// guaranteed not to be what a user sees.
   static func scale(for design: RecordingPillDesign, inWidth available: CGFloat) -> CGFloat {
     guard available > 0, design.width > 0 else { return 1 }
-    return min(maxMagnification, available / design.width)
+    // **The card can be WIDER than the picture may safely grow**, because the
+    // card's HEIGHT is fixed at a theme card's and the pill's height scales with
+    // its width. At a single-column layout the reader is ~370pt, which scales the
+    // reading well to ~0.93x — and that pill's fixed 34pt header plus its well
+    // insets and text then exceed the 63pt box, so it is drawn clipped. Found by
+    // cloud review.
+    //
+    // Capping the width used for the scale is what closes it WITHOUT a per-design
+    // height table the view cannot measure. It also removes the gap that hid the
+    // defect: the scale is now the same at every card width at or above the
+    // nominal one, so a test taken at the nominal width describes what a user
+    // actually gets rather than the one case they never see.
+    //
+    // The cost, and it is the honest trade: at a wide card the picture stops
+    // growing and sits centred with margin either side. It could not have grown
+    // safely anyway.
+    let usable = min(available, thumbnailSize.width)
+    return min(maxMagnification, usable / design.width)
   }
 
   /// How far past life size a preview may be drawn.

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -135,8 +135,18 @@ struct RecordingPillAppearancePanel: View {
   /// still remembered — one for each capability state — so the mark follows the
   /// state the user is actually in rather than a third stored value that could
   /// disagree with both.
+  ///
+  /// **RESOLVED, not read raw.** Reading the slot directly returned whatever is
+  /// persisted, while the recording director puts the same value through
+  /// `PillDesignSelections.resolve` and SUBSTITUTES an incompatible one. A
+  /// downgrade or a hand-edited plist can leave a words-capable design in the
+  /// wordless slot, and the picker then ticked a card the next recording would
+  /// not use — and, since the Configure link keys off this, showed or hid the link
+  /// against the wrong design. Found by Codex review; it is the same root as
+  /// `offersCoupled`, which was routed through the catalog one round earlier while
+  /// this second site was missed.
   static func selected(in model: PillAppearanceModel) -> RecordingPillDesign {
-    model.selection(holdingWords: model.wordsCapability.hasWords)
+    model.resolvedSelection()
   }
 
   /// Why some cards in the row are greyed, in one line, or `nil` when none are.

--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -378,15 +378,29 @@ struct RecordingPillPreviewTile: View {
         // Checked before removing: no help article, blog post or website page
         // refers to a design by name, so nothing in the documentation now points
         // at a label the user cannot find.
-        if isSelected {
-          Image(systemName: "checkmark.circle.fill")
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(Color.white, isEnabled ? Color.stAccent : Color.stTextSecondary)
+        // **The tick's slot is reserved whether or not it is shown, and that is a
+        // correctness requirement rather than tidiness.** The preview's scale is
+        // computed from the width its `GeometryReader` is handed, so a tick that
+        // appears only when selected TAKES that width from the card it is on:
+        // selecting a design visibly shrank its own pill while the previous
+        // selection grew. Found by Codex review — invisible in a static render,
+        // because every render captures one selection and the effect is only
+        // legible as a change.
+        //
+        // An empty frame rather than an overlay, so the picture is never drawn
+        // underneath the tick.
+        ZStack {
+          if isSelected {
+            Image(systemName: "checkmark.circle.fill")
+              .font(.system(size: 18, weight: .semibold))
+              .foregroundStyle(Color.white, isEnabled ? Color.stAccent : Color.stTextSecondary)
+          }
         }
+        .frame(width: 18)
       }
       .padding(12)
-      // Before `.buttonStyle(.plain)`: the `Spacer` above is otherwise dead space
-      // rather than part of the hit target.
+      // Before `.buttonStyle(.plain)`: the reserved tick slot is otherwise dead
+      // space rather than part of the hit target.
       .contentShape(Rectangle())
       .background(Color.stSectionBg)
       .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -14,6 +14,28 @@ extension EnvironmentValues {
   }
 }
 
+/// A way for a page to send the user to ANOTHER page.
+///
+/// **Added for the Appearance page's link to Live Preview** (#2446). Picking the
+/// pill that shows words switches Live Preview on, and the user then needs
+/// somewhere to configure it — which lives on a different page. Threading a
+/// binding down through `AppearanceSettingsView` into a panel would put window
+/// navigation in the signature of every view in between; the environment is where
+/// this window already keeps `settingsPageSection`, one level up.
+///
+/// Defaults to a no-op rather than to `nil`, so a preview or a test that hosts a
+/// panel on its own gets a dead link instead of a crash.
+private struct SettingsNavigateKey: EnvironmentKey {
+  static let defaultValue: @MainActor (SettingsSection) -> Void = { _ in }
+}
+
+extension EnvironmentValues {
+  var settingsNavigate: @MainActor (SettingsSection) -> Void {
+    get { self[SettingsNavigateKey.self] }
+    set { self[SettingsNavigateKey.self] = newValue }
+  }
+}
+
 /// Sidebar navigation sections for the unified window.
 enum SettingsSection: String, CaseIterable, Identifiable {
   case history

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -279,6 +279,9 @@ struct UnifiedWindowView: View {
   ) -> some View {
     content()
       .environment(\.settingsPageSection, section)
+      // The only place `selectedSection` is in scope, so the only place this can
+      // be supplied without threading a binding through every page.
+      .environment(\.settingsNavigate) { selectedSection = $0 }
   }
 }
 

--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -55,7 +55,7 @@ struct AppearancePillPickerTests {
   @Test("the two groups between them offer every design")
   func groupsCoverEveryDesign() {
     let m = Self.model(.available)
-    let all = Set(m.designs(holdingWords: true) + m.designs(holdingWords: false))
+    let all = Set(PillCatalog.designs(holdingWords: true) + PillCatalog.designs(holdingWords: false))
     #expect(
       all == Set(RecordingPillDesign.allCases),
       "the picker lays out \(all.count) of \(RecordingPillDesign.allCases.count) designs")
@@ -72,22 +72,38 @@ struct AppearancePillPickerTests {
   /// array literal is not exhaustive over an enum, so adding `.modelBeingRemoved`
   /// compiled and left it unswept in four places at once: the compiler cannot see
   /// an omission from a list, only from a `switch`. Reading the authority instead
-  /// **Every capability state greys something, so every state says why.**
+  /// **A state explains itself EXACTLY when something in it is greyed.**
   ///
-  /// One row replaced two groups (#2446), which turns a per-group question into a
-  /// single invariant: exactly one side of the words divide is usable at a time,
-  /// so a card is always greyed and a reason is always owed. A `nil` here would be
-  /// a row with dead cards and no explanation.
-  @Test("every state explains its greyed cards", arguments: PillWordsCapability.allCases)
-  func everyStateCarriesAReason(capability: PillWordsCapability) {
+  /// Coupling the pill choice to Live Preview (founder, 2026-08-26) means a tap
+  /// now produces whatever state the design needs, so nothing is greyed in the two
+  /// states the switch controls — and a line there would be instructing the user to
+  /// do by hand what the tap already does. The other two are not about the switch,
+  /// stay greyed, and still owe a reason.
+  ///
+  /// Both directions asserted, so a future change that greys a card without
+  /// explaining it fails here, and so does one that leaves an orphaned sentence
+  /// under a row where everything is selectable.
+  @Test("a state explains itself exactly when it greys something",
+        arguments: PillWordsCapability.allCases)
+  func reasonAppearsExactlyWhenSomethingIsGreyed(capability: PillWordsCapability) throws {
     let reason = RecordingPillAppearancePanel.reason(for: capability)
-    let text = try! #require(reason, "\(capability) greys cards and says nothing about why")
+    let switchCanFixIt = capability == .available || capability == .previewOff
 
-    #expect(
-      !text.isEmpty, "\(capability) returns an empty reason, which renders as a blank line")
-    #expect(
-      !text.contains("—") && !text.contains("–"),
-      "\(capability) reason carries a dash: \(text)")
+    if switchCanFixIt {
+      #expect(
+        reason == nil,
+        """
+        \(capability) shows "\(reason ?? "")" while every card is selectable. Picking a \
+        design sets the switch itself, so this sentence tells the user to go and do what \
+        the tap already did.
+        """)
+    } else {
+      let text = try #require(reason, "\(capability) greys a card and says nothing about why")
+      #expect(!text.isEmpty, "\(capability) returns an empty reason, which renders as a blank line")
+      #expect(
+        !text.contains("—") && !text.contains("–"),
+        "\(capability) reason carries a dash: \(text)")
+    }
   }
 
   /// **The reason never opens by reporting the SETTING's state.**
@@ -99,28 +115,55 @@ struct AppearancePillPickerTests {
   /// PICTURES, and naming the action is what keeps it there.
   @Test("the reason is about the cards, not the setting", arguments: PillWordsCapability.allCases)
   func theReasonIsAboutTheCards(capability: PillWordsCapability) {
-    let text = try! #require(RecordingPillAppearancePanel.reason(for: capability))
+    // **Only the states that still HAVE a reason.** This used to require one from
+    // every state; coupling the pill choice to Live Preview removed the two the
+    // switch controls, and a `#require` here then aborted the whole run rather
+    // than reporting a result — which is why the sibling above now uses a
+    // throwing require.
+    guard let text = RecordingPillAppearancePanel.reason(for: capability) else { return }
 
     #expect(
       !text.hasPrefix("Live Preview is on"),
       "\(capability) opens by reporting the setting's state: \(text)")
+    #expect(
+      !text.lowercased().contains("turn on live preview")
+        && !text.lowercased().contains("turn off live preview"),
+      """
+      \(capability) tells the user to flip Live Preview by hand: "\(text)". Tapping a \
+      design does that now, so an instruction to go and do it is stale copy.
+      """)
   }
 
-  /// **Exactly one side of the divide is offerable at a time, and the row shows
-  /// its tick on that side.**
+  /// **A wordless design is ALWAYS pickable; a words-capable one needs words to be
+  /// possible here.**
   ///
-  /// This is the constraint the two groups used to make visible. Flattening the
-  /// row did not remove it, so it is asserted directly against the catalog rather
-  /// than against a heading that no longer exists.
-  @Test("one side is usable and the tick is on it", arguments: PillWordsCapability.allCases)
-  func theUsableSideCarriesTheSelection(capability: PillWordsCapability) {
-    let usable = RecordingPillDesign.allCases.filter {
-      PillCatalog.offers($0, capabilityHasWords: capability.hasWords)
+  /// This replaces "exactly one side is offerable at a time", which was true while
+  /// the capability GATED the choice. It now FOLLOWS the choice, so the only
+  /// remaining bar is whether the machine can produce words at all — something no
+  /// tap can change. Asserted per state so the two cases the switch cannot fix
+  /// stay closed.
+  @Test("a tap can reach any design the machine can actually run",
+        arguments: PillWordsCapability.allCases)
+  func couplingOpensEverythingTheMachineCanDo(capability: PillWordsCapability) {
+    let model = Self.model(capability)
+
+    for design in RecordingPillDesign.allCases where !design.canHoldWords {
+      #expect(
+        model.offersCoupled(design, capability: capability),
+        """
+        \(design) is greyed at \(capability), but turning Live Preview OFF always works, \
+        so no state can put a wordless design out of reach.
+        """)
     }
 
-    #expect(!usable.isEmpty, "\(capability) offers no design at all, so the row is entirely dead")
-    #expect(
-      usable.allSatisfy { $0.canHoldWords == capability.hasWords },
-      "\(capability) offers designs from both sides of the words divide: \(usable)")
+    let wordsArePossible = capability == .available || capability == .previewOff
+    for design in RecordingPillDesign.allCases where design.canHoldWords {
+      #expect(
+        model.offersCoupled(design, capability: capability) == wordsArePossible,
+        """
+        \(design) offerability at \(capability) does not match whether words are possible \
+        there. A tap sets the switch, but it cannot install an engine or finish a removal.
+        """)
+    }
   }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -22,11 +22,59 @@ struct AppearancePillPickerTests {
   init() { _ = NSApplication.shared }
 
   private static func model(_ capability: PillWordsCapability) -> PillAppearanceModel {
+    settingsAndModel(capability).1
+  }
+
+  /// Both halves, for a test that has to PERSIST a selection before reading it
+  /// back through the picker.
+  private static func settingsAndModel(
+    _ capability: PillWordsCapability
+  ) -> (SettingsManager, PillAppearanceModel) {
     let name = "ew.pillPickerTest." + UUID().uuidString
     let suite = UserDefaults(suiteName: name)!
     suite.removePersistentDomain(forName: name)
-    return PillAppearanceModel(
-      settings: SettingsManager(defaults: suite), capability: { capability })
+    let settings = SettingsManager(defaults: suite)
+    return (settings, PillAppearanceModel(settings: settings, capability: { capability }))
+  }
+
+  /// **The tick marks what the NEXT RECORDING will use, not what is stored.**
+  ///
+  /// The recording director puts both stored slots through
+  /// `PillDesignSelections.resolve`, which SUBSTITUTES a design the current
+  /// capability cannot render. The picker read the raw slot, so a words-capable
+  /// design sitting in the wordless slot — reachable by a downgrade or a
+  /// hand-edited plist, and the case `resolve`'s own mirror-direction guard exists
+  /// for — ticked a card the pill would not draw, and drove the Configure Live
+  /// Preview link off the wrong design.
+  ///
+  /// Found by Codex review. Same root as `offersCoupled`, which was routed through
+  /// the catalog a round earlier while this second site was missed — which is why
+  /// this asserts the RELATION to `resolve` rather than a specific design, so any
+  /// future divergence between the two fails here.
+  @Test("the tick marks the design the recorder would actually use")
+  func theTickFollowsTheResolvedDesign() {
+    for capability in PillWordsCapability.allCases {
+      let (settings, model) = Self.settingsAndModel(capability)
+
+      // The incompatible combination, persisted deliberately: a words-capable
+      // design in the wordless slot and vice versa.
+      settings.recordingPillDesignWithoutWords = .readingWell
+      settings.recordingPillDesignWithWords = .classic
+
+      let shown = RecordingPillAppearancePanel.selected(in: model)
+      let resolved = PillDesignSelections(
+        withoutWords: settings.recordingPillDesignWithoutWords,
+        withWords: settings.recordingPillDesignWithWords
+      ).resolve(capabilityHasWords: capability.hasWords).design
+
+      #expect(
+        shown == resolved,
+        """
+        at \(capability) the picker ticks \(shown) while the recorder would draw \
+        \(resolved). The tick is a promise about the next recording, so the two \
+        cannot be allowed to disagree.
+        """)
+    }
   }
 
   // MARK: - Offerability comes from the catalog, in both directions

--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -72,199 +72,55 @@ struct AppearancePillPickerTests {
   /// array literal is not exhaustive over an enum, so adding `.modelBeingRemoved`
   /// compiled and left it unswept in four places at once: the compiler cannot see
   /// an omission from a list, only from a `switch`. Reading the authority instead
-  /// means the next cause is swept by every case here on the day it is added.
-  @Test("no two refusals give the same reason")
-  func refusalsAreDistinguishable() throws {
-    let refusals = PillWordsCapability.allCases.filter { !$0.hasWords }
-    #expect(refusals.count >= 2, "control: there is more than one way to be refused")
-
-    var sentences: [PillWordsCapability: String] = [:]
-    for cause in refusals {
-      let sentence = try #require(
-        RecordingPillAppearancePanel.reason(for: cause, groupHoldsWords: true),
-        "\(cause) greys the with-words group and explains nothing")
-      #expect(!sentence.isEmpty)
-      sentences[cause] = sentence
-    }
-
-    #expect(
-      Set(sentences.values).count == refusals.count,
-      """
-      \(refusals.count) causes share \(Set(sentences.values).count) sentences, so at \
-      least one user is told the wrong thing about why their designs are greyed: \
-      \(sentences)
-      """)
-  }
-
-  /// **One property replacing two row tables, and it is a closed question: a group
-  /// carries a reason EXACTLY when it is inapplicable.** The applicable group must
-  /// carry none, so the sentence appears once on the page rather than twice; the
-  /// inapplicable one must always carry one, so nothing is greyed in silence.
-  /// Written as an if-and-only-if over the full cross-product because the two
-  /// halves were separate hand-written tables that could each be extended without
-  /// the other.
-  @Test(
-    "a group explains itself exactly when it is inapplicable",
-    arguments: PillWordsCapability.allCases, [true, false])
-  func onlyTheInapplicableGroupCarriesAReason(
-    capability: PillWordsCapability, groupHoldsWords: Bool
-  ) {
-    // The with-words group applies when words are available; the wordless group
-    // applies when they are not. So applicability IS this equality.
-    let isApplicable = (groupHoldsWords == capability.hasWords)
-    let reason = RecordingPillAppearancePanel.reason(
-      for: capability, groupHoldsWords: groupHoldsWords)
-
-    if isApplicable {
-      #expect(
-        reason == nil,
-        """
-        the \(groupHoldsWords ? "with-words" : "wordless") group applies at \
-        \(capability) and still explains a restriction that is not in force: \(reason!)
-        """)
-    } else {
-      #expect(
-        reason != nil,
-        "the \(groupHoldsWords ? "with-words" : "wordless") group is greyed at \(capability) and says nothing")
-      #expect(reason?.isEmpty == false, "\(capability) explains itself with an empty string")
-    }
-  }
-
-  /// House style: no em or en dashes in anything a user reads. Swept over the
-  /// authority for the same reason as above.
-  @Test("no user-facing string carries a dash")
-  func copyCarriesNoDashes() {
-    var strings = RecordingPillDesign.allCases.flatMap { [$0.displayName, $0.summary] }
-    for capability in PillWordsCapability.allCases {
-      for holdsWords in [true, false] {
-        if let r = RecordingPillAppearancePanel.reason(
-          for: capability, groupHoldsWords: holdsWords)
-        {
-          strings.append(r)
-        }
-      }
-    }
-    #expect(strings.count > RecordingPillDesign.allCases.count, "control: reasons were collected")
-    for s in strings {
-      #expect(!s.contains("\u{2014}"), "em dash in: \(s)")
-      #expect(!s.contains("\u{2013}"), "en dash in: \(s)")
-    }
-  }
-
-  /// **THE PAGE MUST BE INVALIDATED, not merely able to compute the right answer
-  /// if something else happens to ask it again** (cloud review round 4).
+  /// **Every capability state greys something, so every state says why.**
   ///
-  /// Every other input to `wordsCapability` is settings-backed, so a page reading
-  /// it registers a dependency and refreshes on its own. Model-removal
-  /// suppression is the exception: a private field on a coordinator that is not
-  /// `@Observable`, which the capability's guard returns on BEFORE any settings
-  /// read. During a drain the page therefore depends on nothing at all, and the
-  /// end of the drain cannot invalidate it — the removal sentence stays over
-  /// designs that are available again.
-  ///
-  /// Asserted with `withObservationTracking`, the mechanism SwiftUI itself uses,
-  /// so this fails if `wordsCapability` ever stops consuming the generation. That
-  /// discard in its body reads like tidying and IS the registration.
-  ///
-  /// Lives here rather than beside the coordinator because this suite already
-  /// builds a model with its own defaults suite; the capability suite has a
-  /// coordinator rig and no settings rig, and a second fixture for a state one
-  /// already stages is the cost worth not paying.
-  @Test("a reader of the capability is invalidated when the coordinator announces")
-  func aCapabilityReaderIsInvalidated() {
-    let model = Self.model(.available)
+  /// One row replaced two groups (#2446), which turns a per-group question into a
+  /// single invariant: exactly one side of the words divide is usable at a time,
+  /// so a card is always greyed and a reason is always owed. A `nil` here would be
+  /// a row with dead cards and no explanation.
+  @Test("every state explains its greyed cards", arguments: PillWordsCapability.allCases)
+  func everyStateCarriesAReason(capability: PillWordsCapability) {
+    let reason = RecordingPillAppearancePanel.reason(for: capability)
+    let text = try! #require(reason, "\(capability) greys cards and says nothing about why")
 
-    // A reference box because `onChange` is `@Sendable`. It fires synchronously on
-    // the mutating thread, which here is the main actor throughout.
-    final class Flag: @unchecked Sendable { var fired = false }
-    let flag = Flag()
-    withObservationTracking {
-      _ = model.wordsCapability
-    } onChange: {
-      flag.fired = true
+    #expect(
+      !text.isEmpty, "\(capability) returns an empty reason, which renders as a blank line")
+    #expect(
+      !text.contains("—") && !text.contains("–"),
+      "\(capability) reason carries a dash: \(text)")
+  }
+
+  /// **The reason never opens by reporting the SETTING's state.**
+  ///
+  /// The wording this replaced read "Live Preview is on, so the pill shows your
+  /// words." directly beneath a heading that said "Live Preview off", which the
+  /// founder rejected on sight. The heading is gone, but the failure mode is not
+  /// about the heading: a line on a picture-picking page should be about the
+  /// PICTURES, and naming the action is what keeps it there.
+  @Test("the reason is about the cards, not the setting", arguments: PillWordsCapability.allCases)
+  func theReasonIsAboutTheCards(capability: PillWordsCapability) {
+    let text = try! #require(RecordingPillAppearancePanel.reason(for: capability))
+
+    #expect(
+      !text.hasPrefix("Live Preview is on"),
+      "\(capability) opens by reporting the setting's state: \(text)")
+  }
+
+  /// **Exactly one side of the divide is offerable at a time, and the row shows
+  /// its tick on that side.**
+  ///
+  /// This is the constraint the two groups used to make visible. Flattening the
+  /// row did not remove it, so it is asserted directly against the catalog rather
+  /// than against a heading that no longer exists.
+  @Test("one side is usable and the tick is on it", arguments: PillWordsCapability.allCases)
+  func theUsableSideCarriesTheSelection(capability: PillWordsCapability) {
+    let usable = RecordingPillDesign.allCases.filter {
+      PillCatalog.offers($0, capabilityHasWords: capability.hasWords)
     }
 
-    #expect(!flag.fired, "control: nothing has changed yet")
-    model.capabilityDidChange()
+    #expect(!usable.isEmpty, "\(capability) offers no design at all, so the row is entirely dead")
     #expect(
-      flag.fired,
-      """
-      a reader of wordsCapability was not invalidated by an announced change, so \
-      the Appearance page renders whatever it computed last and corrects itself \
-      only on an unrelated redraw.
-      """)
-  }
-
-  @Test("choosing a design writes its own group and leaves the other alone")
-  func choosingWritesOneGroup() {
-    let m = Self.model(.previewOff)
-    let otherBefore = m.selection(holdingWords: true)
-
-    m.choose(.levelRail, holdingWords: false)
-
-    #expect(m.selection(holdingWords: false) == .levelRail)
-    #expect(
-      m.selection(holdingWords: true) == otherBefore,
-      "choosing a wordless design changed the with-words group's selection")
-  }
-
-  /// Every design carries a name and a sentence, so a design added later cannot
-  /// render as a blank card.
-  @Test("every design has copy", arguments: RecordingPillDesign.allCases)
-  func everyDesignHasCopy(design: RecordingPillDesign) {
-    #expect(!design.displayName.isEmpty, "\(design) has no name")
-    #expect(!design.summary.isEmpty, "\(design) has no description")
-  }
-
-  @Test("no two designs share a name")
-  func namesAreDistinct() {
-    let names = RecordingPillDesign.allCases.map(\.displayName)
-    #expect(Set(names).count == names.count, "two designs share a card title: \(names)")
-  }
-
-  // MARK: - The current state stays unmistakable (#2435)
-
-  /// **Product Outcome, and the reason the approved group titles are honest.**
-  ///
-  /// "Live Preview off" and "Live Preview on" name a CONDITION — the pills you get
-  /// when the setting is that way. Read instead as a claim about the CURRENT
-  /// state they would be false at `engineUnsupported` and `modelBeingRemoved`,
-  /// where the setting is on and the pills are still out of reach. What makes the
-  /// condition reading the one a user actually gets is that exactly one group
-  /// shows the filled dot and the other prints its own reason. Both are therefore
-  /// requirements, and this is the row that holds them.
-  ///
-  /// **It links the two surfaces rather than re-deriving either.** The dot reads
-  /// `isActive`; the greyed line reads `reason(for:groupHoldsWords:)`. That they
-  /// each behave correctly is asserted above; that they AGREE, in every
-  /// capability state, is what this asserts and nothing else does.
-  @Test(
-    "exactly one group is marked in use, and it is the one with nothing to explain",
-    arguments: PillWordsCapability.allCases)
-  func theDotAndTheReasonAgree(capability: PillWordsCapability) throws {
-    let active = [true, false].filter {
-      RecordingPillAppearancePanel.isActive(capability, groupHoldsWords: $0)
-    }
-
-    #expect(
-      active.count == 1,
-      """
-      \(capability) marks \(active.count) groups in use. The dot is the only thing on \
-      the page carrying the CURRENT state, so zero leaves a user unable to tell which \
-      pills they have and two tells them both.
-      """)
-    let live = try #require(active.first)
-
-    #expect(
-      RecordingPillAppearancePanel.reason(for: capability, groupHoldsWords: live) == nil,
-      "\(capability) marks a group in use and still explains why it is not")
-    #expect(
-      RecordingPillAppearancePanel.reason(for: capability, groupHoldsWords: !live)?.isEmpty
-        == false,
-      """
-      \(capability) greys a group without saying why. The title says only which \
-      CONDITION that group belongs to, so with no reason beside it there is nothing on \
-      the page that names what is actually wrong.
-      """)
+      usable.allSatisfy { $0.canHoldWords == capability.hasWords },
+      "\(capability) offers designs from both sides of the words divide: \(usable)")
   }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -76,15 +76,6 @@ struct RecordingPillTileTests {
     )
   }
 
-  /// **Every tile in one group draws the SAME rectangle, and the two groups draw
-  /// different ones.**
-  ///
-  /// This REPLACES an assertion that no two tiles shared a width, which pinned
-  /// the behaviour the founder rejected on sight: unequal boxes read as a ragged
-  /// set rather than as a row of pictures. The pill inside still keeps its own
-  /// true size — `thePreviewIsTheRealPillScaled` and `noPreviewIsMagnified` are
-  /// what hold that, and they are what would fail if normalising ever started
-  /// distorting the pill.
   /// **The pill inside the card is the REAL pill, and it fits its box.**
   ///
   /// REPLACES `tileHeightTracksTheLeaf` and `theReadingWellRendersTaller`, which
@@ -173,6 +164,35 @@ struct RecordingPillTileTests {
     #expect(
       abs(selected.height - unselected.height) < 0.01,
       "\(design) changes height on selection: \(unselected.height) -> \(selected.height)")
+  }
+
+  /// **The selected card's accessibility VALUE is exactly "Selected".**
+  ///
+  /// Not a style preference: `wispr_eyes.read_cards` compares `AXValue` against
+  /// that literal, and the Runtime UAT now decides whether a tap landed by asking
+  /// it. Reword this and the harness stops seeing selection at all — and it fails
+  /// toward reporting a working picker as broken, which is the direction that
+  /// wastes a person's afternoon.
+  ///
+  /// The empty string for unselected matters too: `read_cards` treats anything
+  /// other than "selected" as not-selected, so a placeholder like "Not selected"
+  /// would still read correctly, but a second SELECTED-ish word would not.
+  @Test("the selected value is exactly the string the harness reads")
+  func theSelectedValueIsExactly() {
+    // Assert the CONSTANT the view uses, so this fails if the literal moves.
+    let selectedValue = "Selected"
+
+    #expect(
+      RecordingPillPreviewTile.accessibilityValue(isSelected: true) == selectedValue,
+      """
+      the selected card announces \
+      "\(RecordingPillPreviewTile.accessibilityValue(isSelected: true))" rather than \
+      "\(selectedValue)". `wispr_eyes.read_cards` compares against that exact string, so the \
+      Runtime UAT would stop seeing any selection.
+      """)
+    #expect(
+      RecordingPillPreviewTile.accessibilityValue(isSelected: false).isEmpty,
+      "an unselected card announces a value, which read_cards may read as a selection")
   }
 
   @Test("every card in the row is the same size")

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -31,9 +31,11 @@ struct RecordingPillTileTests {
   ///
   /// **The width comes from the design's GROUP, exactly as the panel supplies
   /// it** — a tile measured at some other width is not the tile the user sees.
-  private static func tileSize(_ design: RecordingPillDesign) -> CGSize {
+  private static func tileSize(
+    _ design: RecordingPillDesign, isSelected: Bool = false
+  ) -> CGSize {
     let tile = RecordingPillPreviewTile(
-      design: design, isSelected: false, isEnabled: true, onSelect: {})
+      design: design, isSelected: isSelected, isEnabled: true, onSelect: {})
     let host = NSHostingView(rootView: AnyView(tile))
     let frame = NSRect(x: 0, y: 0, width: 1200, height: 600)
     let window = NSWindow(
@@ -136,6 +138,34 @@ struct RecordingPillTileTests {
       wordless one. The well carries a line of text the others do not, so it must be \
       taller; equal heights mean the well is rendering without its text.
       """)
+  }
+
+  /// **Selecting a card does not change its size.**
+  ///
+  /// Codex review found the tick taking width from the preview beside it, so
+  /// selecting a design shrank its own pill while the previous selection grew —
+  /// a wobble on every click. **No render could have caught it**: each render
+  /// captures one selection, and the defect exists only as a difference between
+  /// two, which is exactly why this is asserted rather than looked at.
+  ///
+  /// Written against the whole card rather than the tick, so any future control
+  /// added on selection is caught by the same row.
+  @Test("selecting a card does not resize it", arguments: RecordingPillDesign.allCases)
+  func selectionDoesNotResizeTheCard(design: RecordingPillDesign) {
+    let unselected = Self.tileSize(design, isSelected: false)
+    let selected = Self.tileSize(design, isSelected: true)
+
+    #expect(unselected.width > 0, "\(design) measured \(unselected): nothing rendered")
+    #expect(
+      abs(selected.width - unselected.width) < 0.01,
+      """
+      \(design) is \(unselected.width) unselected and \(selected.width) selected. The \
+      preview scales to the width it is handed, so a card that changes width on \
+      selection redraws its pill at a different size every time it is clicked.
+      """)
+    #expect(
+      abs(selected.height - unselected.height) < 0.01,
+      "\(design) changes height on selection: \(unselected.height) -> \(selected.height)")
   }
 
   @Test("every card in the row is the same size")

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -99,7 +99,11 @@ struct RecordingPillTileTests {
     arguments: RecordingPillDesign.allCases)
   func thePreviewIsTheRealPillScaled(design: RecordingPillDesign) throws {
     let leaf = try Self.leafHeight(design)
-    let drawn = leaf * RecordingPillPreviewTile.thumbnailScale(for: design)
+    // The SAME entry point the view calls, at the nominal box width. A separate
+    // `thumbnailScale(for:)` used to exist for tests to ask this; it was one more
+    // answer to a question the view already had an answer for, so it is gone.
+    let drawn = leaf * RecordingPillPreviewTile.scale(
+      for: design, inWidth: RecordingPillPreviewTile.thumbnailSize.width)
 
     #expect(leaf > 0, "\(design) leaf measured \(leaf), so the harness rendered nothing")
     #expect(

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -60,7 +60,6 @@ struct RecordingPillTileTests {
 
   // MARK: - The tile renders the real pill
 
-
   /// **The two wordless designs are the same height, because they are the same
   /// chrome.** A tile that routed one of them through the reading well's layout
   /// would differ here, and the difference is what no static mock could catch.
@@ -69,12 +68,13 @@ struct RecordingPillTileTests {
     let capsule = Self.tileSize(.classic).height
     let rail = Self.tileSize(.levelRail).height
 
-    #expect(capsule > 0 && rail > 0, "measured \(capsule)/\(rail): nothing rendered, which is not a pass")
+    #expect(
+      capsule > 0 && rail > 0, "measured \(capsule)/\(rail): nothing rendered, which is not a pass")
     #expect(
       capsule == rail,
-      "the capsule tile is \(capsule)pt and the level rail tile is \(rail)pt, so one of them is not the pill it claims")
+      "the capsule tile is \(capsule)pt and the level rail tile is \(rail)pt, so one of them is not the pill it claims"
+    )
   }
-
 
   /// **Every tile in one group draws the SAME rectangle, and the two groups draw
   /// different ones.**
@@ -97,23 +97,30 @@ struct RecordingPillTileTests {
   /// The oracle is still one the tile did not write — `RenderedPillHarness`
   /// measures the recording leaf directly, with no tile involved.
   @Test(
-    "the preview is the real pill, scaled to fit its box",
-    arguments: RecordingPillDesign.allCases)
-  func thePreviewIsTheRealPillScaled(design: RecordingPillDesign) throws {
+    "the preview is the real pill, scaled to fit its box at every card width",
+    arguments: RecordingPillDesign.allCases, [CGFloat(260), 300, 370, 520, 900])
+  func thePreviewIsTheRealPillScaled(design: RecordingPillDesign, width: CGFloat) throws {
     let leaf = try Self.leafHeight(design)
-    // The SAME entry point the view calls, at the nominal box width. A separate
-    // `thumbnailScale(for:)` used to exist for tests to ask this; it was one more
-    // answer to a question the view already had an answer for, so it is gone.
-    let drawn = leaf * RecordingPillPreviewTile.scale(
-      for: design, inWidth: RecordingPillPreviewTile.thumbnailSize.width)
+    // **Every width a card ACTUALLY gets, not just the nominal one.** The nominal
+    // width was the only case asserted, and cloud review found the defect at
+    // ~370pt — a single-column layout at the supported minimum window width,
+    // where the reading well scaled to ~0.93x and its fixed header plus insets
+    // overflowed the fixed box. The one width guaranteed NOT to be what a user
+    // sees was the one width under test. 260 is below the grid minimum and 900 is
+    // a wide single column, so the bound is exercised from both sides.
+    //
+    // The SAME entry point the view calls. A separate `thumbnailScale(for:)` used
+    // to exist for tests to ask this; it was one more answer to a question the
+    // view already had an answer for, so it is gone.
+    let drawn = leaf * RecordingPillPreviewTile.scale(for: design, inWidth: width)
 
     #expect(leaf > 0, "\(design) leaf measured \(leaf), so the harness rendered nothing")
     #expect(
       drawn <= RecordingPillPreviewTile.thumbnailSize.height + 0.5,
       """
       \(design) draws \(drawn) tall into a \
-      \(RecordingPillPreviewTile.thumbnailSize.height) box, so the pill is cut off. The \
-      card is a fixed height now, so nothing grows to accommodate it.
+      \(RecordingPillPreviewTile.thumbnailSize.height) box at a card width of \(width), so \
+      the pill is cut off. The card is a fixed height, so nothing grows to accommodate it.
       """)
   }
 
@@ -172,7 +179,8 @@ struct RecordingPillTileTests {
   func everyCardIsOneSize() {
     let sizes = RecordingPillDesign.allCases.map { Self.tileSize($0) }
 
-    #expect(sizes.allSatisfy { $0.width > 0 && $0.height > 0 }, "measured \(sizes): nothing rendered")
+    #expect(
+      sizes.allSatisfy { $0.width > 0 && $0.height > 0 }, "measured \(sizes): nothing rendered")
     #expect(
       Set(sizes.map(\.height)).count == 1,
       """
@@ -240,8 +248,9 @@ struct RecordingPillTileTests {
     let widestDesign = try! #require(widest, "no designs, so the row has no subject")
 
     #expect(
-      abs(RecordingPillPreviewTile.thumbnailWidth(for: widestDesign)
-        - RecordingPillPreviewTile.thumbnailSize.width) < 0.01,
+      abs(
+        RecordingPillPreviewTile.thumbnailWidth(for: widestDesign)
+          - RecordingPillPreviewTile.thumbnailSize.width) < 0.01,
       """
       the widest design draws \(RecordingPillPreviewTile.thumbnailWidth(for: widestDesign)) \
       into a \(RecordingPillPreviewTile.thumbnailSize.width) box. It should fill it: if it \
@@ -272,7 +281,6 @@ struct RecordingPillTileTests {
       "\(design) announces no description, leaving a blind user only a name for a picture")
   }
 
-
   // MARK: - What a screen reader gets
 
   /// **The words that left the screen have to arrive somewhere, and the LABEL is
@@ -290,7 +298,8 @@ struct RecordingPillTileTests {
   /// not readable from a test — measured 2026-08-25 and recorded in
   /// `RenderedPillHarness`. Those three are unchanged from the control this tile
   /// replaces and are confirmed by the VoiceOver pass in Live UAT.
-  @Test("every tile announces its name and what it looks like", arguments: RecordingPillDesign.allCases)
+  @Test(
+    "every tile announces its name and what it looks like", arguments: RecordingPillDesign.allCases)
   func theLabelCarriesNameAndDescription(design: RecordingPillDesign) {
     let label = RecordingPillPreviewTile.accessibilityLabel(for: design)
 
@@ -430,14 +439,19 @@ struct RecordingPillTileTests {
 
   /// The sample sentence is a real one, and the wordless designs get no words —
   /// which is what makes their tiles pictures of a capsule rather than of a well.
-  @Test("only a design that can hold words is shown holding any", arguments: RecordingPillDesign.allCases)
+  @Test(
+    "only a design that can hold words is shown holding any",
+    arguments: RecordingPillDesign.allCases)
   func onlyWordCapableDesignsAreShownWords(design: RecordingPillDesign) {
     switch RecordingPillPreviewTile.sampleDisplay(for: design) {
     case .text(let sentence):
-      #expect(design.canHoldWords, "\(design) cannot hold words and is drawn holding \"\(sentence)\"")
+      #expect(
+        design.canHoldWords, "\(design) cannot hold words and is drawn holding \"\(sentence)\"")
       #expect(!sentence.isEmpty, "\(design) is drawn holding an empty sentence")
     case .off:
-      #expect(!design.canHoldWords, "\(design) can hold words and is drawn empty, so its tile understates it")
+      #expect(
+        !design.canHoldWords,
+        "\(design) can hold words and is drawn empty, so its tile understates it")
     default:
       Issue.record("\(design) is sampled in a transient state, which is not an appearance")
     }
@@ -632,7 +646,8 @@ struct RecordingPillPreviewWiringTests {
 
     #expect(
       literal.literal.tokenKind == .keyword(.false),
-      "the settings tile passes animatesGlow: true, so every capsule tile runs a permanent two second pulse")
+      "the settings tile passes animatesGlow: true, so every capsule tile runs a permanent two second pulse"
+    )
   }
 
   /// **The seed and the provider must be the SAME expression**, which is the
@@ -657,7 +672,8 @@ struct RecordingPillPreviewWiringTests {
       "livePreviewProvider is not a literal closure, so this guard cannot compare the two")
     let onlyStatement = try #require(
       provider.statements.count == 1 ? provider.statements.first : nil,
-      "livePreviewProvider has \(provider.statements.count) statements; this guard reads a single expression")
+      "livePreviewProvider has \(provider.statements.count) statements; this guard reads a single expression"
+    )
     let returned = try #require(
       onlyStatement.item.as(ExprSyntax.self)?.as(DeclReferenceExprSyntax.self),
       "livePreviewProvider returns \(onlyStatement.item.trimmedDescription), not a plain reference")
@@ -726,7 +742,8 @@ struct RecordingPillPreviewWiringTests {
     let stateNames = Self.stateProperties(of: view)
     #expect(
       stateNames.count >= 4,
-      "found \(stateNames.count) @State properties, which is fewer than the four this view is known to hold: \(stateNames)")
+      "found \(stateNames.count) @State properties, which is fewer than the four this view is known to hold: \(stateNames)"
+    )
 
     let written = Self.namesAssignedOutsideInit(of: view).intersection(stateNames)
     #expect(

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -28,6 +28,9 @@ struct RecordingPillTileTests {
 
   /// The tile as the settings page builds it, measured unconstrained so it
   /// reports what it ideally wants.
+  ///
+  /// **The width comes from the design's GROUP, exactly as the panel supplies
+  /// it** — a tile measured at some other width is not the tile the user sees.
   private static func tileSize(_ design: RecordingPillDesign) -> CGSize {
     let tile = RecordingPillPreviewTile(
       design: design, isSelected: false, isEnabled: true, onSelect: {})
@@ -55,32 +58,6 @@ struct RecordingPillTileTests {
 
   // MARK: - The tile renders the real pill
 
-  /// **The strong one: the tile's height tracks the LEAF's height exactly.**
-  ///
-  /// Stated as a difference so the tile's own padding cancels out of both sides.
-  /// A tile that drew a placeholder, an empty box, or another design's chrome
-  /// would have a height unrelated to what the leaf reports for itself, and no
-  /// absolute constant is involved on either side.
-  @Test(
-    "each tile is as tall as the pill inside it",
-    arguments: [RecordingPillDesign.levelRail, RecordingPillDesign.readingWell])
-  func tileHeightTracksTheLeaf(design: RecordingPillDesign) throws {
-    let baseline = RecordingPillDesign.classic
-
-    let tileDelta = Self.tileSize(design).height - Self.tileSize(baseline).height
-    let leafDelta = try Self.leafHeight(design) - Self.leafHeight(baseline)
-
-    // Equality, with no tolerance: the tile's padding cancels algebraically from
-    // both sides of one in-process comparison, so a tolerance would only be a
-    // number nobody measured.
-    #expect(
-      tileDelta == leafDelta,
-      """
-      the \(design) tile is \(tileDelta)pt taller than the \(baseline) tile while the \
-      PILLS differ by \(leafDelta)pt. The tile is not sized by the pill it contains, so \
-      it is drawing something else.
-      """)
-  }
 
   /// **The two wordless designs are the same height, because they are the same
   /// chrome.** A tile that routed one of them through the reading well's layout
@@ -96,108 +73,171 @@ struct RecordingPillTileTests {
       "the capsule tile is \(capsule)pt and the level rail tile is \(rail)pt, so one of them is not the pill it claims")
   }
 
-  /// **The reading well ends up taller, which is a FINAL geometry outcome and not
-  /// a claim about the first frame.**
-  ///
-  /// This row was first named for `initialPreview:` seeding, and it cannot prove
-  /// that: the leaf's first asynchronous provider read can win before
-  /// `fittingSize` is sampled, so an unseeded tile measures tall here too. What
-  /// it does prove is that the design which shows your words renders visibly more
-  /// than one that cannot, which a placeholder-sized well would fail.
-  ///
-  /// The seeding has no rendered observable at all, so it is covered structurally
-  /// by `RecordingPillPreviewWiringTests` below.
-  @Test("the rendered reading well tile is taller than a wordless tile")
-  func theReadingWellRendersTaller() {
-    let well = Self.tileSize(.readingWell).height
-    let capsule = Self.tileSize(.classic).height
 
+  /// **Every tile in one group draws the SAME rectangle, and the two groups draw
+  /// different ones.**
+  ///
+  /// This REPLACES an assertion that no two tiles shared a width, which pinned
+  /// the behaviour the founder rejected on sight: unequal boxes read as a ragged
+  /// set rather than as a row of pictures. The pill inside still keeps its own
+  /// true size — `thePreviewIsTheRealPillScaled` and `noPreviewIsMagnified` are
+  /// what hold that, and they are what would fail if normalising ever started
+  /// distorting the pill.
+  /// **The pill inside the card is the REAL pill, and it fits its box.**
+  ///
+  /// REPLACES `tileHeightTracksTheLeaf` and `theReadingWellRendersTaller`, which
+  /// both required a card's height to track the pill inside it. The founder
+  /// replaced that layout with three identical cards on 2026-08-26, so a uniform
+  /// card can no longer report the pill's height and those two failed BY DESIGN.
+  /// They are obsolete rather than weakened: the fidelity they protected moves
+  /// onto the LEAF, which the tile does not size.
+  ///
+  /// The oracle is still one the tile did not write — `RenderedPillHarness`
+  /// measures the recording leaf directly, with no tile involved.
+  @Test(
+    "the preview is the real pill, scaled to fit its box",
+    arguments: RecordingPillDesign.allCases)
+  func thePreviewIsTheRealPillScaled(design: RecordingPillDesign) throws {
+    let leaf = try Self.leafHeight(design)
+    let drawn = leaf * RecordingPillPreviewTile.thumbnailScale(for: design)
+
+    #expect(leaf > 0, "\(design) leaf measured \(leaf), so the harness rendered nothing")
     #expect(
-      well > capsule,
+      drawn <= RecordingPillPreviewTile.thumbnailSize.height + 0.5,
       """
-      the reading well tile is \(well)pt against a \(capsule)pt capsule tile, so the \
-      design that shows your words as you speak is drawn no larger than one that cannot.
+      \(design) draws \(drawn) tall into a \
+      \(RecordingPillPreviewTile.thumbnailSize.height) box, so the pill is cut off. The \
+      card is a fixed height now, so nothing grows to accommodate it.
       """)
   }
 
-  /// Each design asks for its own width, so no two tiles are interchangeable.
-  @Test("no two tiles are the same width")
-  func tileWidthsAreDistinct() {
-    let widths = RecordingPillDesign.allCases.map { Self.tileSize($0).width }
-    #expect(widths.allSatisfy { $0 > 0 }, "measured \(widths): nothing rendered")
+  /// **The pill that shows words is still the TALLEST**, even though its card is
+  /// no longer taller than the others.
+  ///
+  /// A change that started drawing the well at a wordless pill's height would be
+  /// showing the user the wrong picture, and the equalised cards can no longer
+  /// catch it.
+  @Test("the pill that shows words is still the tallest")
+  func theReadingWellLeafIsTallest() throws {
+    let wordy = try RecordingPillDesign.allCases.filter(\.canHoldWords).map(Self.leafHeight)
+    let wordless = try RecordingPillDesign.allCases.filter { !$0.canHoldWords }.map(Self.leafHeight)
+
+    let tallestWordy = try #require(wordy.max(), "no design holds words")
+    let tallestWordless = try #require(wordless.max(), "no design is wordless")
+
     #expect(
-      Set(widths).count == widths.count,
-      "two tiles measured the same width \(widths), so the picker shows one design twice")
+      tallestWordy > tallestWordless,
+      """
+      a words-holding pill measured \(tallestWordy) against \(tallestWordless) for a \
+      wordless one. The well carries a line of text the others do not, so it must be \
+      taller; equal heights mean the well is rendering without its text.
+      """)
   }
 
-  /// **Every tile asks for its design's DECLARED width, and the excess over that
-  /// is one constant shared by all three.**
+  @Test("every card in the row is the same size")
+  func everyCardIsOneSize() {
+    let sizes = RecordingPillDesign.allCases.map { Self.tileSize($0) }
+
+    #expect(sizes.allSatisfy { $0.width > 0 && $0.height > 0 }, "measured \(sizes): nothing rendered")
+    #expect(
+      Set(sizes.map(\.height)).count == 1,
+      """
+      the cards measured heights \(sizes.map(\.height)). One row of identical cards was \
+      the founder's ask; a difference means a card is sized by the pill inside it rather \
+      than by the shared thumbnail box.
+      """)
+  }
+
+  /// **No tile is ever narrower than the pill it frames, plus its padding.**
   ///
   /// Cloud review on #2439 raised the reading well overflowing a narrow window.
-  /// This is the half that can be measured rather than argued: the tile's ideal
-  /// width is the design's own `width` plus a padding that does not vary by
-  /// design. Whether the containing window can ever be narrower than that is a
-  /// Live UAT row, and the horizontal scroll fallback is what keeps it from
-  /// clipping when it is.
-  @Test("a tile asks for its design's declared width plus a shared padding")
-  func tileWidthIsTheDesignWidthPlusOnePadding() {
-    let overheads = RecordingPillDesign.allCases.map {
-      Self.tileSize($0).width - $0.width
-    }
+  /// Normalising every tile in a group to that group's WIDEST can only ever add
+  /// width, never remove it — but that is an argument, and this is the
+  /// measurement, taken per design so a future group whose widest shrinks fails
+  /// here rather than by clipping a pill on screen.
+  ///
+  /// Whether the containing WINDOW can be narrower than the tile is a different
+  /// question, held by `thePanelRefusesToClipItsWidestPill` and a Live UAT row.
+  /// **No pill overflows the thumbnail box it is scaled into.**
+  ///
+  /// The shared scale is taken from the WIDEST design, so this can only fail if a
+  /// design's declared width stops being covered by that maximum — which is
+  /// exactly what a new, wider design would do if the scale were ever pinned to a
+  /// literal instead of derived.
+  @Test("no pill overflows its thumbnail", arguments: RecordingPillDesign.allCases)
+  func noPillOverflowsItsThumbnail(design: RecordingPillDesign) {
+    let drawn = RecordingPillPreviewTile.thumbnailWidth(for: design)
+    let box = RecordingPillPreviewTile.thumbnailSize.width
 
+    #expect(drawn > 0, "\(design) scaled to \(drawn), so nothing is drawn")
     #expect(
-      overheads.allSatisfy { $0 > 0 },
-      """
-      measured overheads \(overheads). A tile no wider than its design's declared width \
-      has no padding at all, which means the pill is touching the tile's border.
-      """)
+      drawn <= box + 0.01,
+      "\(design) draws \(drawn) into a \(box) box, so the pill is clipped")
+  }
+
+  /// **No pill is ever drawn LARGER than it appears in real life.**
+  ///
+  /// The previews were enlarged so a user can read them (founder, 2026-08-26), and
+  /// the narrow designs already fit the box at native size. Scaling them UP to
+  /// fill it would make a compact pill look bigger on this page than on screen —
+  /// the same misrepresentation as the rejected shared scale, pointed the other
+  /// way, and the one this cap exists to prevent.
+  @Test("no preview is magnified past the bound", arguments: RecordingPillDesign.allCases)
+  func noPreviewIsMagnifiedPastTheBound(design: RecordingPillDesign) {
+    // A card far wider than any pill, which is what the founder's window gives at
+    // the default size — the case the bound exists for.
+    let scale = RecordingPillPreviewTile.scale(for: design, inWidth: 2000)
+
+    #expect(scale > 0, "\(design) scales to \(scale), so nothing is drawn")
     #expect(
-      Set(overheads).count == 1,
+      scale <= RecordingPillPreviewTile.maxMagnification,
       """
-      the three tiles add \(overheads) to their designs' widths. They share one padding \
-      constant, so a difference means a tile is sized by something other than the pill \
-      inside it.
+      \(design) is drawn at \(scale)x against a bound of \
+      \(RecordingPillPreviewTile.maxMagnification)x. Unbounded, a wide window draws a \
+      compact pill at nearly 5x and the row stops being comparable.
       """)
   }
 
-  /// **The page refuses to be narrower than its widest pill.**
-  ///
-  /// Rendered at a 380 point content width the reading well was CUT OFF: a grid
-  /// column cannot shrink below its content and the tile clips its own, so there
-  /// is no width at which a too-narrow layout degrades gracefully. The panel
-  /// therefore carries a minimum that propagates to the window.
-  ///
-  /// Asserted as a RELATION against the tile's own width, so no point value is
-  /// frozen. What this does NOT prove is that the WINDOW honours it — that is a
-  /// Live UAT row, dragging the real window narrow.
-  @Test("the picker will not lay out narrower than its widest pill")
-  func thePanelRefusesToClipItsWidestPill() {
-    let widest = RecordingPillDesign.allCases
-      .filter(\.canHoldWords)
-      .map(RecordingPillPreviewTile.width(for:))
-      .max()
-    let required = try! #require(widest, "no design can hold words, so this guard has no subject")
+  /// **The widest design still fills the box**, so enlarging the previews did not
+  /// quietly leave the biggest one floating in margin.
+  @Test("the widest design fills the preview box")
+  func theWidestDesignFillsTheBox() {
+    let widest = RecordingPillDesign.allCases.max(by: { $0.width < $1.width })
+    let widestDesign = try! #require(widest, "no designs, so the row has no subject")
 
     #expect(
-      RecordingPillAppearancePanel.widestTile(holdingWords: true) == required,
+      abs(RecordingPillPreviewTile.thumbnailWidth(for: widestDesign)
+        - RecordingPillPreviewTile.thumbnailSize.width) < 0.01,
       """
-      the panel sizes its with-words column to \
-      \(RecordingPillAppearancePanel.widestTile(holdingWords: true)) while its widest tile \
-      needs \(required). A column narrower than its tile clips the pill, because the tile \
-      clips its own content.
+      the widest design draws \(RecordingPillPreviewTile.thumbnailWidth(for: widestDesign)) \
+      into a \(RecordingPillPreviewTile.thumbnailSize.width) box. It should fill it: if it \
+      does not, every other preview is smaller than it needed to be.
       """)
-
-    // And the wordless side, which has its own widest design.
-    let wordless = RecordingPillDesign.allCases
-      .filter { !$0.canHoldWords }
-      .map(RecordingPillPreviewTile.width(for:))
-      .max()
-    if let wordless {
-      #expect(
-        RecordingPillAppearancePanel.widestTile(holdingWords: false) == wordless,
-        "the wordless column is sized to something other than its widest tile")
-    }
   }
+
+  /// **The names came off the cards, so the ACCESSIBILITY label is now the only
+  /// thing naming a design to anyone who cannot see the drawing.**
+  ///
+  /// Before the visible names were removed a sighted user and a VoiceOver user both
+  /// got the name; now only one does, and this is what keeps it. A change that
+  /// trimmed the label to match the visible card would leave a row of buttons that
+  /// announce nothing distinguishable.
+  @Test(
+    "every design is still named to a screen reader", arguments: RecordingPillDesign.allCases)
+  func theNameSurvivesInTheAccessibilityLabel(design: RecordingPillDesign) {
+    let label = RecordingPillPreviewTile.accessibilityLabel(for: design)
+
+    #expect(
+      label.contains(design.displayName),
+      """
+      \(design) announces "\(label)", which does not carry its name. The card shows no \
+      name, so this label is the only place a screen reader can get one.
+      """)
+    #expect(
+      label.contains(design.summary),
+      "\(design) announces no description, leaving a blind user only a name for a picture")
+  }
+
 
   // MARK: - What a screen reader gets
 

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -108,10 +108,23 @@ def main():
     # presence/absence pair can falsify is the shape to stop writing here.
     #
     # What replaces them tests the behaviour that replaced the sentence.
+    # **Select it EXPLICITLY rather than assuming it is already selected.** The
+    # previous version sampled the baseline from whatever state the machine
+    # happened to be in, and this script finishes each run on Level Rail without
+    # restoring — so the second run in a row read the link as missing, captured a
+    # Level Rail pill under the key `readingWell`, and reported the coupling
+    # broken while it worked. It also failed that way for any user who simply
+    # prefers a wordless pill. Found by Codex review.
+    #
+    # Resolves through the ACCESSIBILITY label, since the cards carry no visible
+    # name; `tapped_readingWell` false means that label stopped naming the design,
+    # which is a real defect and not a harness quirk.
+    report["picker"]["tapped_readingWell"] = bool(w.tap("Reading Well"))
+    await_idle()
+
     before = ui_text()
     report["picker"]["configure_link_while_words_selected"] = CONFIGURE_LINK in before
 
-    # ---- Reading Well first: it is what is selected now, no toggle needed ----
     report["rows"]["readingWell"] = capture_design(pid, "readingWell")
 
     # ---- Live Preview is now turned off BY THE PICKER, not on its own tab ----
@@ -137,8 +150,15 @@ def main():
     w.tap("Appearance")
     after = ui_text()
     report["picker"]["configure_link_gone_after_wordless"] = CONFIGURE_LINK not in after
+    # Every tap that had to land is named here, so a run where the picker was
+    # never actually driven reports FALSE rather than inheriting a lucky starting
+    # state. Without this the whole verdict rests on a link being absent, which is
+    # also what a completely dead run looks like.
     report["picker"]["coupling_observed"] = bool(
-        report["picker"].get("configure_link_while_words_selected")
+        report["picker"].get("tapped_readingWell")
+        and report["picker"].get("tapped_classic")
+        and report["picker"].get("tapped_levelRail")
+        and report["picker"].get("configure_link_while_words_selected")
         and report["picker"]["configure_link_gone_after_wordless"]
     )
 

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -84,10 +84,11 @@ def capture_design(pid, name):
     return {"bounds": seen, "screenshot": str(shot) if seen else None}
 
 
-# The greyed group's reason line, verbatim from
-# `RecordingPillAppearancePanel.reason(for:)`. Two rows below read
-# it — one requires it present, one requires it gone — so it lives here once.
-GREYED_REASON = "Turn off Live Preview to use the other designs."
+# The link the panel shows ONLY while the words-showing design is the live
+# choice. It is the coupling's one visible consequence, which makes it the
+# oracle for it: this file's own docstring records Codex's ruling that a
+# defaults read-back is not evidence and the picker must be SEEN to change.
+CONFIGURE_LINK = "Configure Live Preview"
 
 
 def main():
@@ -98,39 +99,48 @@ def main():
     w.tap("Appearance")
     report["picker"]["appearance_open"] = "RECORDING PILL" in ui_text()
 
-    # The without-words group is greyed while Live Preview is on — Phase 4's own
-    # behaviour, and the reason it states is captured here as evidence.
+    # **The greyed-reason rows are GONE, not renamed.** They asserted a sentence
+    # the panel no longer renders in either Live Preview state: the presence half
+    # would have failed on correct behaviour, and the absence half would have
+    # passed vacuously. Found by Codex review on this branch — and it is the
+    # SECOND time this pair went stale, the first being when the wording changed
+    # rather than when it was deleted. A literal that only one side of a
+    # presence/absence pair can falsify is the shape to stop writing here.
     #
-    # ONE constant for both the presence and the absence check below. Held twice,
-    # the absence half passes for free the moment the copy changes and the string
-    # here goes stale: it then asserts that a sentence nobody renders is missing.
-    # That is the shape that made this row green against copy it had never seen.
+    # What replaces them tests the behaviour that replaced the sentence.
     before = ui_text()
-    report["picker"]["greyed_reason_present"] = GREYED_REASON in before
+    report["picker"]["configure_link_while_words_selected"] = CONFIGURE_LINK in before
 
     # ---- Reading Well first: it is what is selected now, no toggle needed ----
     report["rows"]["readingWell"] = capture_design(pid, "readingWell")
 
-    # ---- turn Live Preview OFF through its own tab ----
-    w.tap("Live Preview")
-    lp = ui_text()
-    report["picker"]["live_preview_tab"] = "Live Preview" in lp
-    for label in ("Show words as I speak", "Live Preview", "Enable Live Preview"):
-        try:
-            if w.tap(label):
-                report["picker"]["toggled_via"] = label
-                break
-        except Exception:  # noqa: BLE001
-            continue
-
-    w.tap("Appearance")
-    after = ui_text()
-    report["picker"]["greyed_cleared"] = GREYED_REASON not in after
-
+    # ---- Live Preview is now turned off BY THE PICKER, not on its own tab ----
+    #
+    # The trip to the Live Preview tab is deleted along with the toggle hunt it
+    # needed. That was the friction the founder named: a user who can SEE the
+    # design they want should not have to find a switch elsewhere to earn the
+    # click they already made. Tapping a wordless design is now the whole gesture,
+    # and driving it here is what proves it.
+    #
+    # The cards carry no visible name any more, so these labels resolve through
+    # the ACCESSIBILITY label, which still announces "<name>. <summary>". That is
+    # not incidental: if a rename ever broke it, this row goes red and a
+    # VoiceOver user loses the only name they had.
     for label, key in (("Capsule", "classic"), ("Level Rail", "levelRail")):
         tapped = w.tap(label)
         report["picker"][f"tapped_{key}"] = bool(tapped)
         report["rows"][key] = capture_design(pid, key)
+
+    # Both directions, so neither half can pass vacuously: the link was present
+    # above with the words design live, and must be gone now that a wordless one
+    # is. A run where the taps did nothing fails HERE rather than reporting green.
+    w.tap("Appearance")
+    after = ui_text()
+    report["picker"]["configure_link_gone_after_wordless"] = CONFIGURE_LINK not in after
+    report["picker"]["coupling_observed"] = bool(
+        report["picker"].get("configure_link_while_words_selected")
+        and report["picker"]["configure_link_gone_after_wordless"]
+    )
 
     (UAT / "geometry-ui.json").write_text(json.dumps(report, indent=2, default=str))
     print(json.dumps(report, indent=2, default=str)[:2200])

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -91,13 +91,44 @@ def capture_design(pid, name):
 CONFIGURE_LINK = "Configure Live Preview"
 
 
+class UATPreconditionFailed(RuntimeError):
+    """A state this run needs, which it could not establish."""
+
+
+def require(condition, what):
+    """Stop the run rather than record a value nothing established.
+
+    **Every field below used to be written whatever the app was doing.** Measured
+    2026-08-26 against a freshly launched build with NO Settings window open: the
+    report came back with `appearance_open: false` and the run CARRIED ON,
+    producing `tapped_readingWell: true`, `tapped_classic: true` and
+    `configure_link_gone_after_wordless: true` — three green-looking fields from a
+    run that never opened a window. Every `bounds` was null in the same report and
+    was recorded as data rather than as failure.
+
+    **`w.tap()` returning True does NOT mean the tap landed.** That is the half
+    that matters, because a guard built on tap results — which is exactly what
+    `coupling_observed` was — inherits the lie. The only trustworthy evidence is
+    the app's own rendered state, read back after the action.
+    """
+    if not condition:
+        raise UATPreconditionFailed(what)
+
+
 def main():
     pid = int(sys.argv[1])
     report = {"pid": pid, "rows": {}, "picker": {}}
 
     w.connect()
-    w.tap("Appearance")
-    report["picker"]["appearance_open"] = "RECORDING PILL" in ui_text()
+
+    # **The window has to EXIST before any of this means anything.** Nothing here
+    # opened Settings, and every check below silently assumed someone had.
+    require(w.tap("Appearance"), "could not reach the Appearance section")
+    await_idle()
+
+    appearance_open = "RECORDING PILL" in ui_text()
+    report["picker"]["appearance_open"] = appearance_open
+    require(appearance_open, "Appearance did not open — the Recording Pill panel is not on screen")
 
     # **The greyed-reason rows are GONE, not renamed.** They asserted a sentence
     # the panel no longer renders in either Live Preview state: the presence half
@@ -119,11 +150,16 @@ def main():
     # Resolves through the ACCESSIBILITY label, since the cards carry no visible
     # name; `tapped_readingWell` false means that label stopped naming the design,
     # which is a real defect and not a harness quirk.
-    report["picker"]["tapped_readingWell"] = bool(w.tap("Reading Well"))
+    w.tap("Reading Well")
     await_idle()
 
     before = ui_text()
     report["picker"]["configure_link_while_words_selected"] = CONFIGURE_LINK in before
+    # The link IS the evidence that the tap landed, so it is required rather than
+    # recorded. A tap result would not be: see `require`.
+    require(
+        report["picker"]["configure_link_while_words_selected"],
+        "selecting the words design did not produce the Configure Live Preview link")
 
     report["rows"]["readingWell"] = capture_design(pid, "readingWell")
 
@@ -140,9 +176,13 @@ def main():
     # not incidental: if a rename ever broke it, this row goes red and a
     # VoiceOver user loses the only name they had.
     for label, key in (("Capsule", "classic"), ("Level Rail", "levelRail")):
-        tapped = w.tap(label)
-        report["picker"][f"tapped_{key}"] = bool(tapped)
-        report["rows"][key] = capture_design(pid, key)
+        w.tap(label)
+        await_idle()
+        row = capture_design(pid, key)
+        report["rows"][key] = row
+        # A null bound is a failed capture, and recording it as data is how a dead
+        # run reported three designs it never saw.
+        require(row.get("bounds"), f"no bounds captured for {key} — the pill never rendered")
 
     # Both directions, so neither half can pass vacuously: the link was present
     # above with the words design live, and must be gone now that a wordless one
@@ -154,17 +194,27 @@ def main():
     # never actually driven reports FALSE rather than inheriting a lucky starting
     # state. Without this the whole verdict rests on a link being absent, which is
     # also what a completely dead run looks like.
-    report["picker"]["coupling_observed"] = bool(
-        report["picker"].get("tapped_readingWell")
-        and report["picker"].get("tapped_classic")
-        and report["picker"].get("tapped_levelRail")
-        and report["picker"].get("configure_link_while_words_selected")
-        and report["picker"]["configure_link_gone_after_wordless"]
-    )
+    # Both halves are now REQUIRED above and here, so reaching this line at all
+    # means the coupling was observed in both directions. The field stays for the
+    # report's readers; it is no longer what decides the verdict, because a value
+    # computed from tap results was exactly the thing that could not be trusted.
+    require(
+        report["picker"]["configure_link_gone_after_wordless"],
+        "the Configure Live Preview link survived selecting a wordless design")
+    report["picker"]["coupling_observed"] = True
 
     (UAT / "geometry-ui.json").write_text(json.dumps(report, indent=2, default=str))
     print(json.dumps(report, indent=2, default=str)[:2200])
 
 
 if __name__ == "__main__":
-    main()
+    # **A failed precondition EXITS NONZERO and writes no report.** The previous
+    # entrypoint let every failure become a JSON file full of plausible-looking
+    # fields, which is worse than no file: a caller reading it cannot tell a real
+    # result from a run that never opened a window. `validate-pr.sh` and any human
+    # reading the exit status now get an unambiguous answer.
+    try:
+        main()
+    except UATPreconditionFailed as failure:
+        print(f"UAT PRECONDITION FAILED: {failure}", file=sys.stderr)
+        sys.exit(2)

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -244,13 +244,30 @@ def main():
         # discards that — the same silent-empty shape as the reader this file just
         # had — so it is required rather than called.
         require(await_idle(), f"the recording before {label} never tore down")
-        before_tap = ui_text()
         w.tap(label)
         require(await_idle(), f"the app never went idle after tapping {label}")
+
+        # **Read WHICH CARD IS SELECTED, rather than diffing printed trees.**
+        #
+        # Two earlier versions of this check were wrong and the second is the
+        # instructive one. A whole-tree diff could differ for reasons unrelated to
+        # the tap — an overlay tearing down — and, worse, could be IDENTICAL for a
+        # real move: Capsule to Level Rail keeps both designs wordless, so the
+        # Configure link does not change and the only relevant difference is which
+        # button carries `AXValue == "Selected"`. It therefore fails on a working
+        # app and passes on a broken one, in different states. Found by the cloud
+        # review.
+        #
+        # `read_cards` is the harness's own reader for this exact question and asks
+        # the AX API instead of parsing text. The pill group was added to it for
+        # this, and the "Selected" string it compares against is pinned by
+        # `theSelectedValueIsExactly` — so this does not rest on a guessed format.
+        selected = w.read_cards("pill")
+        require(selected, f"read_cards found no pill cards after tapping {label}")
         require(
-            ui_text() != before_tap,
-            f"tapping {label} changed nothing on screen — the capture that follows would "
-            f"be the PREVIOUS design's geometry filed under {key}")
+            selected.get(label) is True,
+            f"tapping {label} did not select it (read {selected}) — the capture that "
+            f"follows would be the PREVIOUS design's geometry filed under {key}")
         row = capture_design(pid, key)
         report["rows"][key] = row
         # A null bound is a failed capture, and recording it as data is how a dead

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -94,7 +94,7 @@ def ui_text():
 
 def capture_design(pid, name):
     """One fresh recording, its bounds and a screenshot."""
-    await_idle()
+    require(await_idle(), f"the app never went idle before capturing {name}")
     rk.single_press_record_key()
     seen = await_visible(pid)
     shot = SHOTS / f"{name}.png"
@@ -157,7 +157,7 @@ def main():
     # **The window has to EXIST before any of this means anything.** Nothing here
     # opened Settings, and every check below silently assumed someone had.
     require(w.tap("Appearance"), "could not reach the Appearance section")
-    await_idle()
+    require(await_idle(), "the app never went idle after opening Appearance")
 
     tree = ui_text()
     appearance_open = "RECORDING PILL" in tree
@@ -194,7 +194,7 @@ def main():
     # name; `tapped_readingWell` false means that label stopped naming the design,
     # which is a real defect and not a harness quirk.
     w.tap("Reading Well")
-    await_idle()
+    require(await_idle(), "the app never went idle before selecting the words design")
 
     before = ui_text()
     report["picker"]["configure_link_while_words_selected"] = CONFIGURE_LINK in before
@@ -232,9 +232,21 @@ def main():
         # format could not be sampled, and a matcher grounded in nothing is how a
         # check comes to pass for the wrong reason. A no-op leaves the tree
         # byte-identical, which needs no format knowledge at all.
+        # **Wait for the PREVIOUS recording to tear down before sampling.**
+        # `capture_design` sends the stop key and returns without waiting, so the
+        # recording overlay can still be on screen here and then vanish during the
+        # `await_idle` below — making the two trees differ for a reason that has
+        # nothing to do with the tap. The check would pass while the tap did
+        # nothing, which is the exact false pass it was added to close. Found by
+        # the cloud review.
+        #
+        # `await_idle` returns False on timeout and every other call site here
+        # discards that — the same silent-empty shape as the reader this file just
+        # had — so it is required rather than called.
+        require(await_idle(), f"the recording before {label} never tore down")
         before_tap = ui_text()
         w.tap(label)
-        await_idle()
+        require(await_idle(), f"the app never went idle after tapping {label}")
         require(
             ui_text() != before_tap,
             f"tapping {label} changed nothing on screen — the capture that follows would "

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -84,6 +84,12 @@ def capture_design(pid, name):
     return {"bounds": seen, "screenshot": str(shot) if seen else None}
 
 
+# The greyed group's reason line, verbatim from
+# `RecordingPillAppearancePanel.reason(for:)`. Two rows below read
+# it — one requires it present, one requires it gone — so it lives here once.
+GREYED_REASON = "Turn off Live Preview to use the other designs."
+
+
 def main():
     pid = int(sys.argv[1])
     report = {"pid": pid, "rows": {}, "picker": {}}
@@ -94,10 +100,13 @@ def main():
 
     # The without-words group is greyed while Live Preview is on — Phase 4's own
     # behaviour, and the reason it states is captured here as evidence.
+    #
+    # ONE constant for both the presence and the absence check below. Held twice,
+    # the absence half passes for free the moment the copy changes and the string
+    # here goes stale: it then asserts that a sentence nobody renders is missing.
+    # That is the shape that made this row green against copy it had never seen.
     before = ui_text()
-    report["picker"]["greyed_reason_present"] = (
-        "Live Preview is on, so the pill shows your words" in before
-    )
+    report["picker"]["greyed_reason_present"] = GREYED_REASON in before
 
     # ---- Reading Well first: it is what is selected now, no toggle needed ----
     report["rows"]["readingWell"] = capture_design(pid, "readingWell")
@@ -116,9 +125,7 @@ def main():
 
     w.tap("Appearance")
     after = ui_text()
-    report["picker"]["greyed_cleared"] = (
-        "Live Preview is on, so the pill shows your words" not in after
-    )
+    report["picker"]["greyed_cleared"] = GREYED_REASON not in after
 
     for label, key in (("Capsule", "classic"), ("Level Rail", "levelRail")):
         tapped = w.tap(label)

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -135,9 +135,22 @@ def require(condition, what):
         raise UATPreconditionFailed(what)
 
 
+# The report path, named once because two places now touch it: the success write
+# and the invalidation below.
+REPORT = UAT / "geometry-ui.json"
+
+
 def main():
     pid = int(sys.argv[1])
     report = {"pid": pid, "rows": {}, "picker": {}}
+
+    # **A previous run's success must not survive this run.** The path is fixed,
+    # so a failing run used to exit leaving the last GOOD report on disk — and a
+    # reviewer or a script reading it cannot tell stale success from a current
+    # result. Deleted up front rather than only on failure, so a crash between
+    # here and the write also leaves nothing rather than something wrong.
+    # Found by Codex review.
+    REPORT.unlink(missing_ok=True)
 
     w.connect()
 
@@ -209,8 +222,23 @@ def main():
     # not incidental: if a rename ever broke it, this row goes red and a
     # VoiceOver user loses the only name they had.
     for label, key in (("Capsule", "classic"), ("Level Rail", "levelRail")):
+        # **The tap must CHANGE something before its capture is trusted.** If the
+        # Capsule tap silently no-ops, the next capture records Reading Well's
+        # geometry under the key `classic`; the later distinctness check still
+        # passes, because Level Rail did move. Found by Codex review.
+        #
+        # Compared as whole trees rather than by hunting a "Selected" marker: the
+        # picker was not on screen when this was written, so the marker's rendered
+        # format could not be sampled, and a matcher grounded in nothing is how a
+        # check comes to pass for the wrong reason. A no-op leaves the tree
+        # byte-identical, which needs no format knowledge at all.
+        before_tap = ui_text()
         w.tap(label)
         await_idle()
+        require(
+            ui_text() != before_tap,
+            f"tapping {label} changed nothing on screen — the capture that follows would "
+            f"be the PREVIOUS design's geometry filed under {key}")
         row = capture_design(pid, key)
         report["rows"][key] = row
         # A null bound is a failed capture, and recording it as data is how a dead
@@ -246,7 +274,7 @@ def main():
         "the Configure Live Preview link survived selecting a wordless design")
     report["picker"]["coupling_observed"] = True
 
-    (UAT / "geometry-ui.json").write_text(json.dumps(report, indent=2, default=str))
+    REPORT.write_text(json.dumps(report, indent=2, default=str))
     print(json.dumps(report, indent=2, default=str)[:2200])
 
 

--- a/Tests/RuntimeUAT/phase5_geometry_ui.py
+++ b/Tests/RuntimeUAT/phase5_geometry_ui.py
@@ -13,6 +13,8 @@ starts a fresh recording — the design is read once per fresh recording and hel
 Settings are snapshotted and restored through the same UI.
 """
 
+import contextlib
+import io
 import json
 import pathlib
 import subprocess
@@ -69,7 +71,25 @@ def await_visible(pid, timeout=8.0):
 
 
 def ui_text():
-    return str(w.see())
+    """The accessibility tree as TEXT, captured from what `see()` PRINTS.
+
+    **`see()` has no return statement — it prints and returns None** — so the
+    previous `str(w.see())` was the four-character string "None" on every call.
+    A presence check against it is always False and an absence check always True:
+    the absence direction merely loses information, the presence direction
+    MANUFACTURES evidence.
+
+    `uat-testing.md` FACT: uat-gotchas documents this verbatim, names the capture
+    below as the fix, and records that the row "already existed and was not read
+    first". It was not read first here either — the checks built on this reader
+    during #2446 were vacuous by construction, and the exit-2 "control" that
+    appeared to prove the script failed closed was this bug firing rather than the
+    precondition logic working.
+    """
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        w.see()
+    return buffer.getvalue()
 
 
 def capture_design(pid, name):
@@ -126,8 +146,18 @@ def main():
     require(w.tap("Appearance"), "could not reach the Appearance section")
     await_idle()
 
-    appearance_open = "RECORDING PILL" in ui_text()
+    tree = ui_text()
+    appearance_open = "RECORDING PILL" in tree
     report["picker"]["appearance_open"] = appearance_open
+
+    # **POSITIVE CONTROL on the same capture**, required by uat-testing.md
+    # FACT: uat-gotchas. Without it, "the panel is not on screen" and "the reader
+    # is broken" are the same observation — which is exactly the confusion that
+    # produced a confident wrong diagnosis on this branch.
+    report["picker"]["reader_alive"] = "PILL POSITION" in tree
+    require(
+        report["picker"]["reader_alive"],
+        "the AX reader returned nothing recognisable — instrument failure, not a product result")
     require(appearance_open, "Appearance did not open — the Recording Pill panel is not on screen")
 
     # **The greyed-reason rows are GONE, not renamed.** They asserted a sentence
@@ -162,6 +192,9 @@ def main():
         "selecting the words design did not produce the Configure Live Preview link")
 
     report["rows"]["readingWell"] = capture_design(pid, "readingWell")
+    require(
+        report["rows"]["readingWell"].get("bounds"),
+        "no bounds captured for readingWell — the pill never rendered")
 
     # ---- Live Preview is now turned off BY THE PICKER, not on its own tab ----
     #
@@ -183,6 +216,16 @@ def main():
         # A null bound is a failed capture, and recording it as data is how a dead
         # run reported three designs it never saw.
         require(row.get("bounds"), f"no bounds captured for {key} — the pill never rendered")
+
+    # **The two wordless designs must MEASURE DIFFERENTLY.** Non-null bounds only
+    # prove a pill rendered; if the Level Rail tap silently no-ops, the Capsule
+    # renders twice, both rows look valid, and the second is filed under the wrong
+    # name. uat-testing.md requires compared designs to prove they differ.
+    classic_bounds = report["rows"]["classic"].get("bounds")
+    rail_bounds = report["rows"]["levelRail"].get("bounds")
+    require(
+        classic_bounds != rail_bounds,
+        f"classic and levelRail measured identically ({classic_bounds}) — one tap did not land")
 
     # Both directions, so neither half can pass vacuously: the link was present
     # above with the words design live, and must be gone now that a wordless one

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -393,6 +393,12 @@ def read(label):
 _CARD_GROUPS = {
     "engine": ["Fast", "All Languages"],
     "style": ["Formal", "Standard", "Friendly"],
+    # The Appearance page's recording-pill cards. They carry NO visible text, so
+    # these keywords match the accessibility label alone — which is also the only
+    # thing naming a design to a VoiceOver user. `RecordingPillTileTests`
+    # asserts that label still carries the name, and `theSelectedValueIsExactly`
+    # pins the "Selected" value this reader compares against.
+    "pill": ["Capsule", "Reading Well", "Level Rail"],
 }
 
 def read_cards(group):


### PR DESCRIPTION
Closes #2452

The pill picker shipped in #2439 as two headed groups with state dots and per-group
reason lines. The founder opened it and rejected the shape: a user comes to this
page to pick a PICTURE, and the page opened by explaining a SETTING.

It is now one row of identical cards, the same grid and card geometry as the theme
row directly above it, with no split, no visible names, and a tap that sets Live
Preview to whatever the chosen design needs.

## What a user sees

- Three cards, same size, same shape as the theme cards. Each is the real pill,
  scaled to fill its card.
- No design names. The picture is the label. **The names moved rather than went**:
  `accessibilityLabel(for:)` still announces "<name>. <summary>", so a VoiceOver
  user now gets more than a sighted one. Checked before removing that no help
  article, blog post or website page refers to a design by name.
- Tapping any pill sets Live Preview. Tap the one with text underneath and it
  turns on; tap either of the others and it turns off. **The founder's framing is
  the justification**: *"they'll see the last one that has the text underneath it
  and they'll go, oh yeah, I want that. And they'll try to click it and it won't
  click and they'll get really annoyed."*
- Both bottom lines deleted, replaced by a "Configure Live Preview" link shown
  only while that design is the live choice.
- The two designs that cannot show words come first; the one that can comes last.

## The cost, stated because nothing in the UI states it

Picking a pill writes `livePreviewEnabled`. **This is the first thing in the app to
write that setting on the user's behalf** — until now only their own toggle did. A
confirm step was offered and declined: the pill IS the choice. So someone who
turned Live Preview on, then picks a compact pill because they prefer how it
looks, loses Live Preview silently.

Greying survives only where no tap can help — an engine that cannot run here, or a
model mid-removal — and those keep their reason line.

## Defects found on the way, all fixed

- **Selecting a card shrank its own preview.** The tick exists only on the selected
  card and took width from the preview beside it, whose scale is computed from that
  width. **No render could have caught it**: each render captures one selection and
  the defect exists only as a difference between two.
- **The tick could mark a design the recorder would not draw.** The picker read the
  raw persisted slot while the recording director resolves through
  `PillDesignSelections.resolve`. Reachable by a downgrade or a hand-edited plist.
  Same root as an offerability finding one round earlier — two sites answering one
  question, one routed through the authority and one not.
- **The Runtime UAT's AX reader returned the string `"None"` on every call**, so
  every check built on it was vacuous, and an exit-2 "control" I had reported as
  proof the script fails closed was that bug firing rather than the logic working.
  Pre-existing, documented verbatim in `uat-testing.md`, and not read before the
  script was touched.

Both new guards are proven by CONTROL rather than by a green run: the defect was
reintroduced, the test went red, the fix restored, and the file verified
byte-identical.

## Review

Four Codex rounds plus a class enumeration forced by the repeat-rounds gate. The
enumeration was redone after the confirming round returned new members — the first
version had been built from the findings already in hand, so it could only contain
variations on them.

**Round 4 returned zero findings in the production code** ("the production changes
and targeted Swift tests appear sound"); both remaining findings were in the
harness. That split is the evidence behind the recorded accept-with-rationale
choice: the product converged, the harness had not.

## Not fixed here, deliberately

`phase5_geometry_ui.py` still cannot OPEN Settings. It now fails honestly when
Settings is shut instead of publishing a dead run as data. Opening it belongs with
the harness entrypoint, not smuggled into a picker change.

## Evidence

- 7,086 tests green
- Approved in the running app by the founder before this was committed
- Dev build compiled clean at the pushed tree
