### PR TITLE
Pill Refactor Phase 6 C3: coalesced first-render gate

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -327,6 +327,19 @@ final class OverlayDirector {
     self.reducer = OverlayReducer(makeID: makeID)
   }
 
+  /// **The previous mechanism resolved a caller left waiting when the
+  /// director itself went away before its deferred first render fired —
+  /// `self` going `nil` inside a `[weak self]` scheduled block.** The gate
+  /// owns no relay to resolve on that path (`pendingFirstAcceptance` lives
+  /// here, not on the gate), so this director going away is the only place
+  /// left that can settle those callers. Preserves the old promise: a caller
+  /// hears `false` rather than nothing.
+  deinit {
+    MainActor.assumeIsolated {
+      pendingFirstAcceptance?.relays.forEach { $0.resolve(false) }
+    }
+  }
+
   var renderModel: OverlayRenderModel { model }
 
   // **`currentIntent` was DELETED** (#2292 C6). It was a PROJECTION invented so a

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -132,35 +132,25 @@ final class OverlayDirector {
   /// announces.
   private let announce: @MainActor (OverlayAnnouncement) -> Void
 
-  /// **ONE hosting view for THIS DIRECTOR's lifetime**, created lazily and
-  /// reused. The model is observable, so the same view re-renders rather than
-  /// being rebuilt — the SwiftUI half of the same claim the retained `NSPanel`
-  /// makes about the window. "For the app's lifetime" is a property of the
-  /// COMPOSITION ROOT holding the director, not something this file can promise.
-  ///
-  /// The view sends whole events and supplies the presentation's own ID; this
-  /// closure no longer looks one up. It used to read `reducer.state.current?.id`
-  /// at press time, which relabels a click on an outgoing pill with its
-  /// SUCCESSOR's identity — so the staleness check below passes it through and
-  /// the wrong pill's handler runs.
-  /// **Built on first use, and whether it HAS been built is load-bearing** —
-  /// which a `lazy var` cannot report, so the storage is explicit.
-  ///
-  /// Constructing this during the status-item menu dismiss animation is the
-  /// SIGABRT `deferFirstRender` exists to avoid, so "is it built yet" is the
-  /// exact condition the deferral keys on. A boolean set when a deferral was
-  /// SCHEDULED is a different fact and was wrong twice over: a second event
-  /// arriving before the queued block ran saw the flag already true and
-  /// constructed synchronously, and a deferred request dropped by its identity
-  /// gate left the flag true with nothing built, so the next presentation did
-  /// the same. Cloud review caught both in one finding.
-  private var builtRootView: NSView?
+  /// **ONE construction, however many presentations ask before it is ready**,
+  /// owned by `OverlayFirstRenderGate` rather than by a director-held flag.
+  /// `lazy var` is required, not stylistic: the closures below capture `self`,
+  /// and a stored property's initializer expression cannot — `self` is not
+  /// fully formed until every stored property is set, so construction is
+  /// deferred to first access, which is always after `init` completes.
+  private lazy var firstRenderGate = OverlayFirstRenderGate(
+    schedule: firstRenderSchedule,
+    construct: { [unowned self] in makeRootHostingView() },
+    didBecomeReady: { [weak self] root in
+      self?.commitLatestFirstRender(root)
+    })
 
-  private var rootHostingView: NSView {
-    if let builtRootView { return builtRootView }
+  /// Builds the retained root view. Called at most once per launch, from the
+  /// gate's own scheduled task — never directly.
+  private func makeRootHostingView() -> NSView {
     // #2377 Phase 6: DEBUG-only measurement of root construction, the cost this
-    // phase moves. Memoised above, so this runs once per launch and the marker
-    // is naturally a singleton.
+    // phase moves. The gate calls this once, so the marker is naturally a
+    // singleton.
     #if DEBUG
       let constructStart = OverlayFirstRenderMarkers.capture(.rootConstructStart)
     #endif
@@ -171,7 +161,6 @@ final class OverlayDirector {
     #if DEBUG
       let constructEnd = OverlayFirstRenderMarkers.capture(.rootConstructEnd)
     #endif
-    builtRootView = view
     #if DEBUG
       // HELD, not emitted. Writing here would put the marker's own cost inside
       // the keypress interval in the baseline bundle and outside it in the
@@ -188,20 +177,23 @@ final class OverlayDirector {
   /// Carries one `present` call's result from wherever that call terminates back
   /// to the caller — and is reachable from nothing else.
   ///
-  /// **NOT stored on the director, and that is the whole design.** A result held
-  /// in a director property belongs to whoever touched it last, and both ways of
-  /// managing that shipped a defect in turn: left armed, a recording resolved a
-  /// CARD's caller with the recording's outcome; flushed on entry, a request that
-  /// `admit` went on to REFUSE had already told a pending caller its card never
-  /// appeared — while that card rendered anyway, with buttons whose target its
-  /// presenter had never been told to record. A relay created by the call and
-  /// captured by that call's own deferred block cannot be reached by a later
-  /// transaction, so neither is expressible.
+  /// **Never resolved twice, and never resolved on the caller's behalf by a
+  /// LATER transaction.** A result held past its own call belongs to whoever
+  /// touched it last, and both ways of managing that shipped a defect in turn:
+  /// left armed, a recording resolved a CARD's caller with the recording's
+  /// outcome; flushed on entry, a request that `admit` went on to REFUSE had
+  /// already told a pending caller its card never appeared — while that card
+  /// rendered anyway, with buttons whose target its presenter had never been
+  /// told to record.
   ///
-  /// **SEVERAL DEFERRALS CAN BE PENDING AT ONCE**, which is why no single slot
-  /// could have been right: `builtRootView` is assigned inside `rootHostingView`,
-  /// reached only from `performRender`, so until some deferred block actually
-  /// renders, every presentation defers and queues its own block.
+  /// **Several relays CAN be pending at once for the SAME presentation id**,
+  /// held in `PendingFirstAcceptance.relays` while the first-render gate has
+  /// not yet constructed: two calls that both morph the one recording pill
+  /// before it has ever been drawn each get their own relay, and each must
+  /// hear the SAME verdict once the pill actually reaches the screen —
+  /// `onResult` promises exactly one answer describing whether the caller's
+  /// own presentation id was shown, and answering early or not at all is a
+  /// broken promise either way, not a simplification.
   ///
   /// One-shot: `resolve` after the first is a no-op, so a path that both rolls
   /// back and reports cannot report twice.
@@ -234,7 +226,8 @@ final class OverlayDirector {
   /// re-anchor or preserve the live frame, and it is the CALLER's fact.
   private var presentedID: PresentationID?
 
-  /// How the FIRST render reaches the next run loop.
+  /// How the FIRST render reaches the next run loop — the seam
+  /// `OverlayFirstRenderGate` schedules through.
   ///
   /// **A seam, not a branch, and the same shape `scheduler` already uses for
   /// expiry.** The production value is `DispatchQueue.main.async`, which is the
@@ -246,7 +239,12 @@ final class OverlayDirector {
   /// at its own call site: `Task` may execute immediately when already on the
   /// main actor, which is precisely the case that crashes. Written here because
   /// this is the line someone will try to modernise.
-  private let deferFirstRender: (@escaping () -> Void) -> Void
+  ///
+  /// A plain stored property, not `lazy`: it captures no `self`, so it needs
+  /// none of the deferred-construction treatment `firstRenderGate` requires,
+  /// and the gate reads it at ITS OWN `init`, which runs at first access —
+  /// after the director's `init` has already set this.
+  private let firstRenderSchedule: OverlayFirstRenderGate.Schedule
 
   private let position: () -> OverlayPillPosition
 
@@ -304,7 +302,7 @@ final class OverlayDirector {
     // installed and is not.
     selections: @escaping @MainActor () -> PillDesignSelections,
     makeID: @escaping () -> PresentationID = { PresentationID() },
-    deferFirstRender: @escaping (@escaping () -> Void) -> Void = { work in
+    firstRenderSchedule: @escaping OverlayFirstRenderGate.Schedule = { work in
       DispatchQueue.main.async(execute: work)
     },
     // A MECHANISM default, unlike the two above: production always wants the next
@@ -314,7 +312,7 @@ final class OverlayDirector {
       DispatchQueue.main.async(execute: work)
     }
   ) {
-    self.deferFirstRender = deferFirstRender
+    self.firstRenderSchedule = firstRenderSchedule
     self.selections = selections
     self.scheduleReconciliation = scheduleReconciliation
     self.host = host
@@ -731,6 +729,19 @@ final class OverlayDirector {
       case .inPanelNotice: self?.handle(.inPanelNoticeExpiryFired(id), binding: .none)
       }
     }
+    // **Which of `PillExpiryClock`'s three meanings this plan carries, kept
+    // explicit rather than folded into the returned closure.** `.unchanged`
+    // and `.cancel` both hand back an indistinguishable no-op — `.cancel`'s
+    // real effect already ran INSIDE `prepare` above — so a coalescing
+    // decision (preserve a still-pending arm vs. clear it vs. replace it)
+    // cannot be read back out of `armExpiry` itself; it has to travel
+    // alongside it. `PillExpiryClock.swift:66` owns which case means what.
+    let expiryUpdate: PendingExpiryUpdate
+    switch plan.expiryCommand {
+    case .unchanged: expiryUpdate = .preserve
+    case .cancel: expiryUpdate = .clear
+    case .arm: expiryUpdate = .replace(armExpiry)
+    }
 
     // **FAIL CLOSED: the recovery pill needs a payload the intent cannot carry.**
     // `OverlayIntent` is `Sendable` and the paste target is a pair of main-actor
@@ -799,54 +810,18 @@ final class OverlayDirector {
       // resolved notice copy and the providers reach the root together, so no
       // leaf can be built from a new presentation and an outgoing lock.
       model.publish(plan.presentation)
-      // **The announcement travels WITH the render**, so the deferred first
-      // presentation announces when it lands and a refused one never does.
-      let announceOnSuccess: () -> Void = { [weak self] in
-        armExpiry()
-        guard announcing, let announcement = plan.announcement else { return }
-        self?.announce(announcement)
-      }
-      let outcome = render(plan.presentation, onPresented: announceOnSuccess, relay: relay)
-      // The deferred branch holds the relay and resolves it when it lands;
-      // returning here must not resolve, or the caller hears a verdict before
-      // the host has been asked.
-      if outcome == .deferred { return }
-      if outcome == .refused {
-        // **A REFUSED PRESENTATION MUST NOT LEAVE AN OWNER BEHIND.** Clearing
-        // `presentedID` and the window says nothing to the reducer, the model,
-        // the binding or the armed expiry, all of which still name an occupant
-        // that is not on screen. Two consequences, both shipped defects rather
-        // than theory: `currentIntent` reads `reducer.state.current`, so the
-        // Bluetooth presenter's handshake confirms an invisible card and acts on
-        // its buttons; and `pipelineIntent` still holds the refused intent, so
-        // the dedup guard drops the RETRY as a repeat and the pill never
-        // recovers once a screen comes back.
-        //
-        // Rolled back through the same silent-dismiss path a real dismissal
-        // takes, so "nothing is on screen" has ONE definition rather than a
-        // second, partial one written here. Silent because nothing appeared:
-        // announcing a dismissal for a pill a VoiceOver user was never told
-        // about is a false statement in the other direction.
-        // **Rollback FIRST, then the verdict — and the ORDER is why this reads
-        // `presentedThisPlan` below.** The rollback dismisses through
-        // `apply(.hidden)`, which renders nil, which SUCCEEDS. Resolving on a
-        // bare render outcome therefore reported `.presented` for the very pill
-        // the host had just refused.
-        // **Rollback FIRST, then the verdict.** The rollback dismisses through
-        // `apply(.hidden)`, which renders nil, which SUCCEEDS — and it carries no
-        // relay, so it cannot answer for the presentation it is undoing. Reading
-        // a bare render outcome instead reported `.presented` for the very pill
-        // the host had just refused.
-        rollBackRefusedPresentation()
-        relay?.resolve(false)
-        // Nothing this plan installed survives, so an action addressed to it has
-        // no target. Delivering it would hit the assertion below on a state the
-        // rollback deliberately emptied.
-        return
-      }
-      // Only a plan that actually PUT SOMETHING ON SCREEN answers "presented".
-      // A `.hidden` plan reaches here too, and that is a dismissal.
-      if plan.presentation != nil { relay?.resolve(true) }
+      // **`render` now owns acceptance, refusal, rollback, expiry-start and
+      // announcement together — see `finishRender`.** `RenderSubmission` has
+      // only two cases because a QUEUED render and a REFUSED one both need the
+      // relay left to a LATER resolution and neither is this call's business:
+      // a queued render resolves when `commitLatestFirstRender` eventually
+      // runs, and a refused one is resolved by `finishRender` itself before
+      // this call returns. Only `.queued` needs this call to stop — a refusal
+      // has already rolled back and answered by the time control gets here.
+      let submission = render(
+        plan.presentation, relay: relay, expiryUpdate: expiryUpdate,
+        announcement: announcing ? plan.announcement : nil)
+      if submission == .queued { return }
     }
 
     // **A plan that changes NOTHING still announces, and that is shipped.**
@@ -939,22 +914,82 @@ final class OverlayDirector {
     return false
   }
 
-  /// Three outcomes, because a DEFERRED first render is neither of the other
-  /// two: nothing has been refused yet, and nothing is on screen yet. Collapsing
-  /// it into `true` announced a presentation the host had not accepted — the C8
-  /// defect reopening through the C15 deferral, caught by C8's own case.
-  enum RenderOutcome { case presented, refused, deferred }
+  /// `.queued` means no host verdict exists yet and `apply` must return.
+  /// `.completed` means this call has already hidden, or `finishRender` has
+  /// accepted or refused the host command and settled every relay.
+  private enum RenderSubmission {
+    case completed
+    case queued
+  }
+
+  /// **Which of `PillExpiryClock`'s three prepared meanings a coalescing
+  /// update carries.** `expiryClock.prepare` always returns a callable
+  /// closure, but `.unchanged`'s and `.cancel`'s are both indistinguishable
+  /// no-ops — see the comment where this is built, in `apply`. `.preserve`
+  /// and `.clear` collapse to the same "call nothing" outcome wherever there
+  /// is no PRIOR pending state to preserve FROM (the immediate, gate-ready
+  /// render path); they diverge only while coalescing an update onto an
+  /// already-pending first render.
+  private enum PendingExpiryUpdate {
+    case preserve
+    case clear
+    case replace(() -> Void)
+
+    var resolvedStart: (() -> Void)? {
+      guard case .replace(let start) = self else { return nil }
+      return start
+    }
+  }
+
+  /// **Everything a still-unbuilt first render owes once it lands**, coalesced
+  /// from however many presentations arrived while the gate had not yet
+  /// constructed. Typed because `.unchanged` must retain a previously prepared
+  /// arm, `.cancel` must clear it, and `.arm` must replace it.
+  private struct PendingFirstAcceptance {
+    let id: PresentationID
+    var relays: [PresentationRelay]
+    var expiryStart: (() -> Void)?
+    var announcement: OverlayAnnouncement?
+  }
+
+  /// The ONE slot for construction-pending presentations, keyed by id so a
+  /// same-id morph coalesces and a different-id supersession resolves the
+  /// outgoing owner `false`. `nil` whenever nothing is waiting on the gate —
+  /// which is always, once `firstRenderGate.readyRoot` exists.
+  private var pendingFirstAcceptance: PendingFirstAcceptance?
 
   @discardableResult
   private func render(
-    _ presentation: PillDefinition?, onPresented: @escaping () -> Void = {},
-    relay: PresentationRelay? = nil
-  ) -> RenderOutcome {
+    _ presentation: PillDefinition?,
+    relay: PresentationRelay? = nil,
+    expiryUpdate: PendingExpiryUpdate = .preserve,
+    announcement: OverlayAnnouncement? = nil
+  ) -> RenderSubmission {
     guard let presentation else {
+      // A `.hidden` plan still owes whatever was waiting on a construction
+      // that will now never show it — resolved here rather than left for
+      // `commitLatestFirstRender` to find later, so a caller hears its
+      // verdict as soon as the answer is known instead of whenever the gate
+      // next happens to fire.
+      //
+      // **Take the slot and settle every OTHER consequence before resolving
+      // any relay.** `resolve(false)` runs arbitrary caller code, and a
+      // reentrant `present` from inside that callback must see the hide
+      // already applied and the slot already empty — not this call's own
+      // stale view of either, which it would otherwise overwrite on return.
+      let detached = pendingFirstAcceptance?.relays ?? []
+      pendingFirstAcceptance = nil
       presentedID = nil
       host.hide()
-      onPresented()
-      return .presented
+      // **A dismissal still announces "Recording complete" and still owes
+      // whatever expiry command this plan carried** — `.hidden` has no
+      // presentation but is not exempt from either
+      // (`OverlayReducer.swift`'s own `OverlayPlan.announcement` doc comment
+      // states this explicitly, and `silentDismissalSaysNothing` proves it).
+      expiryUpdate.resolvedStart?()
+      if let announcement { announce(announcement) }
+      detached.forEach { $0.resolve(false) }
+      return .completed
     }
     // **THE FIRST PRESENTATION IS DEFERRED ONE RUN LOOP, AND THIS IS A CRASH
     // FIX RATHER THAN A COMPENSATION.** `MenuBarController.toggleRecordingAction`
@@ -977,56 +1012,141 @@ final class OverlayDirector {
     // view that already exists, and the shipped code was synchronous on that
     // path too. `DispatchQueue.main.async` rather than `Task`, for the reason
     // above, spelled out so it is not "modernised" back.
-    // Keyed on the VIEW, not on a flag: every presentation arriving before the
-    // view exists defers, however many that is. Each carries its own identity
-    // gate, so a superseded one drops and the live one constructs; a request
-    // cancelled that way leaves nothing built and the next one defers too.
-    if builtRootView == nil {
-      presentedID = presentation.id
-      let deferredID = presentation.id
-      relay?.markDeferred()
-      // Captured, not read from the director when the block fires: the result
-      // belongs to the call that scheduled this block, and a transaction that
-      // starts in between must not be able to reach it.
-      deferFirstRender { [weak self] in
-        guard let self else {
-          // The director went away before its own run loop turn. Nothing was
-          // drawn, and a caller left waiting forever is a once-per-launch
-          // allowance spent on a pill that never existed.
-          relay?.resolve(false)
-          return
-        }
-        // Identity gate, not a generation counter: a presentation superseded
-        // while we waited is dropped, and the one that replaced it does its own
-        // render. Same one-shot staleness rule `PresentationID` exists for.
-        guard self.reducer.state.current?.id == deferredID else {
-          // Superseded while we waited. The replacement does its own render, so
-          // this request never reached the screen and its caller must hear so.
-          relay?.resolve(false)
-          return
-        }
-        if self.performRender(presentation) {
-          onPresented()
-          relay?.resolve(true)
-        } else {
-          // Rollback FIRST, so a caller acting inside the callback sees an
-          // emptied slot rather than one still naming the pill it was refused.
-          self.rollBackRefusedPresentation()
-          relay?.resolve(false)
-        }
+    if let root = firstRenderGate.readyRoot {
+      return finishRender(
+        presentation, root: root, relays: relay.map { [$0] } ?? [],
+        expiryStart: expiryUpdate.resolvedStart, announcement: announcement)
+    }
+
+    coalescePendingFirstAcceptance(
+      id: presentation.id, relay: relay, expiryUpdate: expiryUpdate,
+      announcement: announcement)
+    firstRenderGate.scheduleIfNeeded()
+    return .queued
+  }
+
+  /// Folds a new presentation into whatever is already pending, per the
+  /// coalescing rule the render gate cannot own itself (it knows nothing of
+  /// presentation identity — see `OverlayFirstRenderGate`'s own doc comment):
+  /// a different id resolves the outgoing relays `false` and starts a fresh
+  /// slot; the same id keeps every relay accumulated so far, since each one
+  /// promises its own caller exactly one verdict once the SAME presentation
+  /// id actually reaches the screen.
+  private func coalescePendingFirstAcceptance(
+    id: PresentationID,
+    relay: PresentationRelay?,
+    expiryUpdate: PendingExpiryUpdate,
+    announcement: OverlayAnnouncement?
+  ) {
+    // Set before scheduling, not after: an injected IMMEDIATE scheduler can
+    // resolve this same call stack, and `present(_:onResult:)` reads
+    // `isDeferred` to decide whether the receipt exists yet to rebind to.
+    relay?.markDeferred()
+
+    if var pending = pendingFirstAcceptance, pending.id == id {
+      if let relay { pending.relays.append(relay) }
+      switch expiryUpdate {
+      case .preserve: break
+      case .clear: pending.expiryStart = nil
+      case .replace(let start): pending.expiryStart = start
       }
-      return .deferred
+      // A nil announcement does not erase one already pending; only a later
+      // non-nil announcement replaces it.
+      if let announcement { pending.announcement = announcement }
+      pendingFirstAcceptance = pending
+      return
     }
-    if performRender(presentation) {
-      onPresented()
-      return .presented
+
+    // **THE REPLACEMENT MUST BE INSTALLED BEFORE ANY OUTGOING RELAY RUNS.**
+    // `resolve(false)` calls arbitrary caller code synchronously, and a
+    // `.notPresented` callback presenting AGAIN is a real, reachable shape —
+    // that reentrant call reads `pendingFirstAcceptance` too. Resolving
+    // first would let it install its own slot, which this function would then
+    // silently clobber with its previously computed replacement.
+    let outgoing = pendingFirstAcceptance?.relays ?? []
+    let expiryStart: (() -> Void)?
+    switch expiryUpdate {
+    case .preserve, .clear: expiryStart = nil
+    case .replace(let start): expiryStart = start
     }
-    return .refused
+    pendingFirstAcceptance = PendingFirstAcceptance(
+      id: id, relays: relay.map { [$0] } ?? [], expiryStart: expiryStart,
+      announcement: announcement)
+
+    // The replacement is authoritative before arbitrary caller code runs.
+    outgoing.forEach { $0.resolve(false) }
+  }
+
+  /// The render gate's readiness callback: bind whatever is currently pending
+  /// to the just-built root, provided the presentation that pending state was
+  /// FOR is still the one actually published.
+  private func commitLatestFirstRender(_ root: NSView) {
+    // **Take the slot before resolving anything it holds** — same reentrancy
+    // reason as `coalescePendingFirstAcceptance` and `render`'s dismissal
+    // branch: `resolve(false)` runs arbitrary caller code, which must see an
+    // already-empty slot rather than one this function would otherwise
+    // overwrite on return.
+    guard let pending = pendingFirstAcceptance else { return }
+    pendingFirstAcceptance = nil
+
+    guard let presentation = model.state.presentation, pending.id == presentation.id else {
+      // Either nothing is on screen any more, or the pending id and the
+      // published one disagree — a presentation superseded while
+      // construction was in flight. The replacement (if any) does its own
+      // render through the now-ready gate; this stale slot only owes its
+      // own callers `false`.
+      pending.relays.forEach { $0.resolve(false) }
+      return
+    }
+    _ = finishRender(
+      presentation, root: root, relays: pending.relays,
+      expiryStart: pending.expiryStart, announcement: pending.announcement)
+  }
+
+  /// Host acceptance, refusal rollback, expiry start, announcement and every
+  /// retained relay's resolution — all in one place, so the queued path
+  /// (`commitLatestFirstRender`) and the immediate path (`render`, once the
+  /// gate is ready) run identically once a root view exists.
+  @discardableResult
+  private func finishRender(
+    _ presentation: PillDefinition, root: NSView, relays: [PresentationRelay],
+    expiryStart: (() -> Void)?, announcement: OverlayAnnouncement?
+  ) -> RenderSubmission {
+    if performRender(presentation, rootView: root) {
+      expiryStart?()
+      if let announcement { announce(announcement) }
+      relays.forEach { $0.resolve(true) }
+    } else {
+      // **A REFUSED PRESENTATION MUST NOT LEAVE AN OWNER BEHIND.** Clearing
+      // `presentedID` and the window says nothing to the reducer, the model,
+      // the binding or the armed expiry, all of which still name an occupant
+      // that is not on screen. Two consequences, both shipped defects rather
+      // than theory: `currentIntent` reads `reducer.state.current`, so the
+      // Bluetooth presenter's handshake confirms an invisible card and acts on
+      // its buttons; and `pipelineIntent` still holds the refused intent, so
+      // the dedup guard drops the RETRY as a repeat and the pill never
+      // recovers once a screen comes back.
+      //
+      // Rolled back through the same silent-dismiss path a real dismissal
+      // takes, so "nothing is on screen" has ONE definition rather than a
+      // second, partial one written here. Silent because nothing appeared:
+      // announcing a dismissal for a pill a VoiceOver user was never told
+      // about is a false statement in the other direction.
+      //
+      // **Rollback FIRST, then the verdict.** The rollback dismisses through
+      // `apply(.hidden)`, which renders nil, which SUCCEEDS — and it carries
+      // no relay, so it cannot answer for the presentation it is undoing.
+      // Resolving on a bare render outcome instead would report `true` for
+      // the very pill the host had just refused.
+      rollBackRefusedPresentation()
+      relays.forEach { $0.resolve(false) }
+    }
+    return .completed
   }
 
   /// The synchronous half, so the deferred first call and every later one run
   /// exactly the same code rather than two copies that can drift.
-  private func performRender(_ presentation: PillDefinition) -> Bool {
+  private func performRender(_ presentation: PillDefinition, rootView: NSView) -> Bool {
     // **`isFresh` means NOTHING IS SHOWING, not "a different occupant".** The
     // comment here used to say the opposite and the code matched it, which made
     // every recording -> processing -> warning step a fresh presentation: the
@@ -1093,7 +1213,7 @@ final class OverlayDirector {
         Self.isRecording(presentation) ? .recording : .other
       ) {
         host.present(
-          rootHostingView,
+          rootView,
           width: recordingGeometry.width,
           fixedHeight: recordingGeometry.fixedHeight,
           isFresh: isFresh,
@@ -1101,7 +1221,7 @@ final class OverlayDirector {
       }
     #else
       let presented = host.present(
-        rootHostingView,
+        rootView,
         width: recordingGeometry.width,
         fixedHeight: recordingGeometry.fixedHeight,
         isFresh: isFresh,
@@ -1159,7 +1279,7 @@ extension OverlayDirector: OverlayPresenting {
     _ request: PillRequest,
     onResult: @escaping (PillPresentationResult) -> Void
   ) -> PillReceipt? {
-    // Captured synchronously. `deferFirstRender` hands its block to
+    // Captured synchronously. `firstRenderSchedule` hands its block to
     // `DispatchQueue.main.async`, so it cannot run until this call stack
     // unwinds — the branches below are reached with the receipt already in hand
     // rather than racing it.

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayFirstRenderGate.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayFirstRenderGate.swift
@@ -1,0 +1,57 @@
+import AppKit
+
+/// Owns ONE deferred construction: schedule it once, build once, publish the
+/// result once — however many callers ask before it is ready.
+///
+/// **Construction readiness only.** This type never stores a presentation,
+/// an identity, or a queue of pending work — that is the Director's job,
+/// which lets a caller ask "is it ready yet" without also asking "for whom".
+///
+/// Setting `.scheduled` BEFORE invoking `schedule` is load-bearing: an
+/// immediate (synchronous) test scheduler would otherwise re-enter
+/// `scheduleIfNeeded()` from inside `schedule`'s own call, before `state` had
+/// recorded that a construction was already underway, and build twice.
+@MainActor
+final class OverlayFirstRenderGate {
+  typealias Schedule = (@escaping () -> Void) -> Void
+
+  private enum State {
+    case idle
+    case scheduled
+    case ready(NSView)
+  }
+
+  private let schedule: Schedule
+  private let construct: () -> NSView
+  private let didBecomeReady: (NSView) -> Void
+  private var state: State = .idle
+
+  init(
+    schedule: @escaping Schedule = {
+      DispatchQueue.main.async(execute: $0)
+    },
+    construct: @escaping () -> NSView,
+    didBecomeReady: @escaping (NSView) -> Void
+  ) {
+    self.schedule = schedule
+    self.construct = construct
+    self.didBecomeReady = didBecomeReady
+  }
+
+  var readyRoot: NSView? {
+    guard case .ready(let root) = state else { return nil }
+    return root
+  }
+
+  func scheduleIfNeeded() {
+    guard case .idle = state else { return }
+    state = .scheduled
+
+    schedule { [weak self] in
+      guard let self, case .scheduled = self.state else { return }
+      let root = self.construct()
+      self.state = .ready(root)
+      self.didBecomeReady(root)
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
@@ -69,7 +69,7 @@ struct LanguageChipExpiryOwnershipTests {
       announce: { _ in },
       livePreview: .disabled,
       grantAccessibility: {}, selections: { .shipped },
-      deferFirstRender: { $0() })
+      firstRenderSchedule: { $0() })
 
     d.present(
       .languageChip(

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
@@ -35,7 +35,7 @@ enum OverlayTestDouble {
       // Announcements go nowhere: a test that has not asked for a screen has not
       // asked for VoiceOver either, and the real post reaches the system.
       announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
-      deferFirstRender: { $0() })
+      firstRenderSchedule: { $0() })
   }
 
   /// The same director, with its fake host in hand for a test that needs to
@@ -45,7 +45,7 @@ enum OverlayTestDouble {
     return (
       OverlayDirector(
         host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped }, deferFirstRender: { $0() }),
+        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped }, firstRenderSchedule: { $0() }),
       host
     )
   }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -1106,6 +1106,41 @@ struct OverlayDirectorTests {
 
   // MARK: - A presentation result is delivered exactly once (PR #2370)
 
+  /// **A caller still waiting on its deferred first render must hear
+  /// `false` if the director itself goes away first, not nothing.** The
+  /// gate cannot resolve this on its own deallocation — the pending relays
+  /// live in the director's `pendingFirstAcceptance`, not on the gate — so
+  /// the director's own `deinit` is the only place left to settle them.
+  /// Cloud review caught this as a regression: the previous mechanism's
+  /// `[weak self]` scheduled block explicitly resolved `false` when `self`
+  /// had gone nil.
+  @Test("a caller waiting on a deferred first render hears false if the director deallocates first")
+  func directorDeallocationResolvesAPendingRelay() {
+    let deferral = Deferral()
+    var results: [PillPresentationResult] = []
+
+    do {
+      let host = RefusingWindowlessHost()
+      var d: OverlayDirector? = Self.deferrableDirector(host, deferral)
+      _ = d!.present(
+        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+        onResult: { results.append($0) })
+
+      #expect(results.isEmpty, "a verdict arrived before any render")
+      d = nil
+    }
+
+    #expect(
+      results == [.notPresented],
+      "a caller was left waiting forever when the director deallocated before its render fired")
+
+    // The gate's own scheduled block still exists (captured by `deferral`,
+    // independent of the director); firing it now must be a harmless no-op,
+    // not a second callback or a crash on the deallocated `self`.
+    deferral.fireAll()
+    #expect(results == [.notPresented], "firing a stale block after deinit reported a second time")
+  }
+
   /// **THE DEFECT: a receipt is not proof the pill was drawn.** `present`
   /// returns synchronously, and the FIRST presentation of a launch reaches the
   /// host a run loop later — so at the moment a receipt is handed back there is

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -6,1722 +6,1988 @@
 // the user gets, what the caller was handed back, or what the host was asked
 // for, all of which are production surface. 39 cases moved into the Release lane
 // with this line.
-  import AppKit
-  import EnviousWisprCore
-  import EnviousWisprPipeline
-  import Foundation
-  import Testing
+import AppKit
+import EnviousWisprCore
+import EnviousWisprPipeline
+import Foundation
+import Testing
 
-  @testable import EnviousWisprAppKit
+@testable import EnviousWisprAppKit
 
-  /// #2292 chunk C4b. The presentation transaction.
+/// #2292 chunk C4b. The presentation transaction.
+///
+/// **Product Outcome.** When these fail the user sees a pill dismissed by a
+/// timer belonging to a dictation that already ended, a button that does nothing
+/// because its handler was dropped, or an Undo that pastes the wrong transcript.
+///
+/// **No clock anywhere.** The scheduler is a seam: the test holds the armed work
+/// and fires it itself, so "the timer fired" is an event the test causes rather
+/// than something it waits for. `never-guess-when-the-subject-is-finished`
+/// forbids waiting on time; here there is nothing to wait for.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayDirectorTests {
+
+  init() { _ = NSApplication.shared }
+
+  /// Every host built by this suite, so each test can order its window out.
+  /// `NSApp` retains an ordered-in window, so without this the pills accumulate
+  /// on screen for the life of the xctest process — which is what put 34 of them
+  /// over the founder's terminal before he reported it.
   ///
-  /// **Product Outcome.** When these fail the user sees a pill dismissed by a
-  /// timer belonging to a dictation that already ended, a button that does nothing
-  /// because its handler was dropped, or an Undo that pastes the wrong transcript.
-  ///
-  /// **No clock anywhere.** The scheduler is a seam: the test holds the armed work
-  /// and fires it itself, so "the timer fired" is an event the test causes rather
-  /// than something it waits for. `never-guess-when-the-subject-is-finished`
-  /// forbids waiting on time; here there is nothing to wait for.
+  /// **Shared across the suite, which is only safe while no test here suspends.**
+  /// Every case is synchronous on the main actor, so two cannot interleave and
+  /// `closeAllWindows()` can never order out a sibling's window mid-test. Adding
+  /// an `async` case reopens that, and the symptom would be a flake rather than a
+  /// leak: the teardown is still total, it would just run early. If you add one,
+  /// hand each test its own host instead of registering it here.
+  private static nonisolated(unsafe) var hosts: [OverlayWindowHost] = []
+
+  /// Publishes a recording after release and requires provider defaults.
+  /// An empty frame alone cannot prove staged closures were cleared, because a
+  /// later recording could publish them again. Used by hide, replacement and refusal.
   @MainActor
-  @Suite(.tags(.productOutcome))
-  struct OverlayDirectorTests {
+  private static func expectReleasedProvidersDoNotReappear(_ model: OverlayRenderModel) {
+    let design = RecordingPillDesign.classic
+    model.publish(
+      PillDefinition(
+        id: PresentationID(rawValue: UUID()),
+        content: .recording(audioLevel: 0, isLocked: false, notice: nil, design: design),
+        expiry: .untilReplaced,
+        requestedWidth: .fixed(design.width),
+        reservesFixedHeight: design.reservedHeight))
+    #expect(
+      model.state.recording?.audioLevelProvider() == 0,
+      "the released dictation's level closure was staged and reappeared on the next pill")
+    #expect(
+      model.state.recording?.recordingElapsedProvider() == nil,
+      "the released dictation's elapsed clock was staged and reappeared on the next pill")
+  }
 
-    init() { _ = NSApplication.shared }
+  /// Recordings go through `presentRecording`, never `send`, because providers,
+  /// the resolved design and captured position must be installed in the same
+  /// operation that presents the pill. The director asserts on the wrong order,
+  /// so this helper is what keeps the suite expressing the right one.
+  private static func record(
+    _ d: OverlayDirector, level: Float = 0.2, preview: Bool = false,
+    locked: Bool = false,
+    elapsed: @escaping () -> TimeInterval? = { nil },
+    display: @escaping () -> LivePreviewDisplay = { .off },
+    // Only the two cases that exercise Live Preview pass one; every other
+    // caller records with the feature off and has no setting to flip.
+    previewSetting: PreviewSetting? = nil
+  ) {
+    previewSetting?.isEnabled = preview
+    previewSetting?.display = display
+    // **No `actions:` parameter, and nothing is lost.** A recording pill draws
+    // no buttons, so `PillRequest.recording` carries no callbacks — an action
+    // binding on a recording is unspellable rather than merely unused.
+    d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: level,
+          audioLevelProvider: { level },
+          recordingElapsedProvider: elapsed,
+          isLocked: locked)))
+  }
 
-    /// Every host built by this suite, so each test can order its window out.
-    /// `NSApp` retains an ordered-in window, so without this the pills accumulate
-    /// on screen for the life of the xctest process — which is what put 34 of them
-    /// over the founder's terminal before he reported it.
+  /// The same wiring as `director()` on a host that never draws, for a case
+  /// whose subject is a BUTTON rather than a window.
+  ///
+  /// The real host has no root to press through, and giving it one would be a
+  /// test hatch in shipping code. Every case using this asserts what a press
+  /// reached; none of them asks a question about a frame.
+  private static func pressableDirector(preview: PreviewSetting = PreviewSetting())
+    -> (OverlayDirector, WindowlessOverlayHost, Sink)
+  {
+    let sink = Sink()
+    let host = WindowlessOverlayHost()
+    let d = OverlayDirector(
+      host: host,
+      scheduler: .manual { _ in },
+      announce: { sink.announcements.append($0) },
+      livePreview: LivePreviewBridge(
+        recordingDidChange: { sink.recordingStates.append($0) },
+        isEnabledForGeometry: { preview.isEnabled },
+        // Derived from this fixture's own verdict, never typed beside it: a
+        // fixture stating both independently can contradict itself, and no
+        // assertion would catch it.
+        wordsCapability: { preview.isEnabled ? .available : .previewOff },
+        display: { preview.display() }),
+      grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+      selections: { .shipped },
+      firstRenderSchedule: { $0() })
+    return (d, host, sink)
+  }
+
+  /// **Teardown through `hide()`, the production surface** (#2292 C6). It used
+  /// to reach `panelForTesting`, a `#if DEBUG` accessor on the host, which is
+  /// what kept this whole suite out of the Release lane once the director's own
+  /// hatches were gone. `hide()` does strictly MORE than the old line did: it
+  /// orders the panel out AND releases the hosting view, so a hidden pill stops
+  /// polling the audio level instead of running invisibly for the rest of the
+  /// session.
+  /// A windowless host that can be told to refuse, so the refusal path needs no
+  /// screen state.
+  private final class RefusingWindowlessHost: OverlayWindowHosting {
+    var accepts = true
+    private(set) var presentCount = 0
+    private(set) var hideCount = 0
+
+    @discardableResult
+    func present(
+      _ view: NSView, width: OverlayWidth, fixedHeight: CGFloat?, isFresh: Bool,
+      position: OverlayPillPosition
+    ) -> Bool {
+      presentCount += 1
+      return accepts
+    }
+
+    func hide() { hideCount += 1 }
+    func resizeCurrentPresentation(to size: CGSize) {}
+    func repositionForActiveSpaceChange() {}
+  }
+
+  /// Holds the ONE scheduled construction so a test can fire it, which is the
+  /// only way to reach the window this whole class of defect lives in.
+  ///
+  /// **Still a queue in SHAPE, though production now schedules at most once
+  /// per director lifetime** (`OverlayFirstRenderGate.scheduleIfNeeded` is a
+  /// no-op once `.scheduled`). A one-slot fixture would silently drop a
+  /// SECOND block if the gate's own coalescing guard ever regressed and
+  /// scheduled twice — keeping the queue shape means that regression fails
+  /// LOUD, as an unexpectedly-non-empty `blocks` array, rather than
+  /// disappearing into a fixture that can hold only one answer.
+  private final class Deferral {
+    private var blocks: [() -> Void] = []
+    var fired = 0
+
+    var block: (() -> Void)? {
+      get { blocks.first }
+      set { if let newValue { blocks.append(newValue) } else { blocks = [] } }
+    }
+
+    /// Fire the oldest queued block, the way the main queue would.
+    func fire() {
+      guard !blocks.isEmpty else { return }
+      let next = blocks.removeFirst()
+      fired += 1
+      next()
+    }
+
+    /// Drain every queued block in the order they were scheduled.
+    func fireAll() { while !blocks.isEmpty { fire() } }
+  }
+
+  private static func deferrableDirector(
+    _ host: RefusingWindowlessHost, _ deferral: Deferral
+  ) -> OverlayDirector {
+    OverlayDirector(
+      host: host,
+      scheduler: .manual { _ in },
+      announce: { _ in },
+      livePreview: .disabled,
+      grantAccessibility: {}, selections: { .shipped },
+      firstRenderSchedule: { deferral.block = $0 })
+  }
+
+  private static func closeAllWindows() {
+    for h in hosts { h.hide() }
+    hosts.removeAll()
+  }
+
+  private final class Armed {
+    var work: OverlayScheduledWork?
+  }
+
+  private static let screen = ScreenGeometry(
+    id: ScreenID(rawValue: 1),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
+
+  private final class Sink {
+    var effects: [PillEffect] = []
+    /// Recording state as LIVE PREVIEW receives it (#2292 C2).
     ///
-    /// **Shared across the suite, which is only safe while no test here suspends.**
-    /// Every case is synchronous on the main actor, so two cannot interleave and
-    /// `closeAllWindows()` can never order out a sibling's window mid-test. Adding
-    /// an `async` case reopens that, and the symptom would be a flake rather than a
-    /// leak: the teardown is still total, it would just run early. If you add one,
-    /// hand each test its own host instead of registering it here.
-    private static nonisolated(unsafe) var hosts: [OverlayWindowHost] = []
+    /// This used to arrive as a `.recordingStateChanged` effect in `effects`,
+    /// routed to the preview by the composition root. The director now holds a
+    /// `LivePreviewBridge` and delivers it there directly, so a suite watching
+    /// only `effects` would see an empty list and read a working feature as a
+    /// dead one. Same signal, same ordering guarantee, different channel.
+    var recordingStates: [Bool] = []
+    /// The two buttons whose handler belongs to the APP. Captured so a guard
+    /// can prove they are BOUND — both were silently unbound by the cutover
+    /// and only a cloud review caught it, because an unbound button renders
+    /// perfectly and nothing fails.
+    var appActions: [PillAction] = []
+    /// The ORDER outputs left the director in. Effects must precede the
+    /// render, which is the shipped order and is load-bearing for Live
+    /// Preview's first frame.
+    var order: [String] = []
+    /// What a screen reader would have been told. Captured rather than
+    /// inferred: `NSAccessibility.post` returns nothing, so without this seam
+    /// the strongest available assertion is that the code which would have
+    /// posted was reached — a marker beside the subject rather than the
+    /// subject.
+    var announcements: [OverlayAnnouncement] = []
+  }
 
-    /// Publishes a recording after release and requires provider defaults.
-    /// An empty frame alone cannot prove staged closures were cleared, because a
-    /// later recording could publish them again. Used by hide, replacement and refusal.
-    @MainActor
-    private static func expectReleasedProvidersDoNotReappear(_ model: OverlayRenderModel) {
-      let design = RecordingPillDesign.classic
-      model.publish(
-        PillDefinition(
-          id: PresentationID(rawValue: UUID()),
-          content: .recording(audioLevel: 0, isLocked: false, notice: nil, design: design),
-          expiry: .untilReplaced,
-          requestedWidth: .fixed(design.width),
-          reservesFixedHeight: design.reservedHeight))
-      #expect(
-        model.state.recording?.audioLevelProvider() == 0,
-        "the released dictation's level closure was staged and reappeared on the next pill")
-      #expect(
-        model.state.recording?.recordingElapsedProvider() == nil,
-        "the released dictation's elapsed clock was staged and reappeared on the next pill")
-    }
+  /// Live Preview's enabled answer, held so a test can flip it BETWEEN
+  /// presentations (#2292 C2).
+  ///
+  /// The bridge is supplied at construction now and cannot be replaced, which
+  /// is the point of the chunk. That does not make the setting immutable: the
+  /// production bridge reads `coordinator.isEnabledForGeometry` live, and a
+  /// user toggling Live Preview mid-dictation changes what the next read
+  /// returns. This box is the same shape.
+  private final class PreviewSetting {
+    var isEnabled = false
+    var display: () -> LivePreviewDisplay = { .off }
+  }
 
-    /// Recordings go through `presentRecording`, never `send`, because providers,
-    /// the resolved design and captured position must be installed in the same
-    /// operation that presents the pill. The director asserts on the wrong order,
-    /// so this helper is what keeps the suite expressing the right one.
-    private static func record(
-      _ d: OverlayDirector, level: Float = 0.2, preview: Bool = false,
-      locked: Bool = false,
-      elapsed: @escaping () -> TimeInterval? = { nil },
-      display: @escaping () -> LivePreviewDisplay = { .off },
-      // Only the two cases that exercise Live Preview pass one; every other
-      // caller records with the feature off and has no setting to flip.
-      previewSetting: PreviewSetting? = nil
-    ) {
-      previewSetting?.isEnabled = preview
-      previewSetting?.display = display
-      // **No `actions:` parameter, and nothing is lost.** A recording pill draws
-      // no buttons, so `PillRequest.recording` carries no callbacks — an action
-      // binding on a recording is unspellable rather than merely unused.
-      d.present(
-        .recording(
-          RecordingPillInput(
-            audioLevel: level,
-            audioLevelProvider: { level },
-            recordingElapsedProvider: elapsed,
-            isLocked: locked)))
-    }
-
-    /// The same wiring as `director()` on a host that never draws, for a case
-    /// whose subject is a BUTTON rather than a window.
-    ///
-    /// The real host has no root to press through, and giving it one would be a
-    /// test hatch in shipping code. Every case using this asserts what a press
-    /// reached; none of them asks a question about a frame.
-    private static func pressableDirector(preview: PreviewSetting = PreviewSetting())
-      -> (OverlayDirector, WindowlessOverlayHost, Sink)
-    {
-      let sink = Sink()
-      let host = WindowlessOverlayHost()
-      let d = OverlayDirector(
-        host: host,
-        scheduler: .manual { _ in },
-        announce: { sink.announcements.append($0) },
-        livePreview: LivePreviewBridge(
-          recordingDidChange: { sink.recordingStates.append($0) },
-          isEnabledForGeometry: { preview.isEnabled },
-          // Derived from this fixture's own verdict, never typed beside it: a
-          // fixture stating both independently can contradict itself, and no
-          // assertion would catch it.
-          wordsCapability: { preview.isEnabled ? .available : .previewOff },
-          display: { preview.display() }),
-        grantAccessibility: { sink.appActions.append(.grantAccessibility) },
-        selections: { .shipped },
-        deferFirstRender: { $0() })
-      return (d, host, sink)
-    }
-
-    /// **Teardown through `hide()`, the production surface** (#2292 C6). It used
-    /// to reach `panelForTesting`, a `#if DEBUG` accessor on the host, which is
-    /// what kept this whole suite out of the Release lane once the director's own
-    /// hatches were gone. `hide()` does strictly MORE than the old line did: it
-    /// orders the panel out AND releases the hosting view, so a hidden pill stops
-    /// polling the audio level instead of running invisibly for the rest of the
-    /// session.
-    /// A windowless host that can be told to refuse, so the refusal path needs no
-    /// screen state.
-    private final class RefusingWindowlessHost: OverlayWindowHosting {
-      var accepts = true
-      private(set) var presentCount = 0
-      private(set) var hideCount = 0
-
-      @discardableResult
-      func present(
-        _ view: NSView, width: OverlayWidth, fixedHeight: CGFloat?, isFresh: Bool,
-        position: OverlayPillPosition
-      ) -> Bool {
-        presentCount += 1
-        return accepts
-      }
-
-      func hide() { hideCount += 1 }
-      func resizeCurrentPresentation(to size: CGSize) {}
-      func repositionForActiveSpaceChange() {}
-    }
-
-    /// Holds the deferred first renders so a test can fire them, which is the
-    /// only way to reach the window this whole class of defect lives in.
-    ///
-    /// **A QUEUE, not a slot, because production queues too.** `builtRootView` is
-    /// assigned inside `rootHostingView`, reached only from `performRender`, so
-    /// until some deferred block actually renders, every presentation defers and
-    /// schedules its own block. A one-slot fixture silently dropped all but the
-    /// last, which made the case the relay exists for unwritable — the fixture
-    /// would have reported coverage it did not have.
-    private final class Deferral {
-      private var blocks: [() -> Void] = []
-      var fired = 0
-
-      var block: (() -> Void)? {
-        get { blocks.first }
-        set { if let newValue { blocks.append(newValue) } else { blocks = [] } }
-      }
-
-      /// Fire the oldest queued block, the way the main queue would.
-      func fire() {
-        guard !blocks.isEmpty else { return }
-        let next = blocks.removeFirst()
-        fired += 1
-        next()
-      }
-
-      /// Drain every queued block in the order they were scheduled.
-      func fireAll() { while !blocks.isEmpty { fire() } }
-    }
-
-    private static func deferrableDirector(
-      _ host: RefusingWindowlessHost, _ deferral: Deferral
-    ) -> OverlayDirector {
-      OverlayDirector(
-        host: host,
-        scheduler: .manual { _ in },
-        announce: { _ in },
-        livePreview: .disabled,
-        grantAccessibility: {}, selections: { .shipped },
-        deferFirstRender: { deferral.block = $0 })
-    }
-
-    private static func closeAllWindows() {
-      for h in hosts { h.hide() }
-      hosts.removeAll()
-    }
-
-    private final class Armed {
-      var work: OverlayScheduledWork?
-    }
-
-    private static let screen = ScreenGeometry(
-      id: ScreenID(rawValue: 1),
-      frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
-      visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
-
-    private final class Sink {
-      var effects: [PillEffect] = []
-      /// Recording state as LIVE PREVIEW receives it (#2292 C2).
-      ///
-      /// This used to arrive as a `.recordingStateChanged` effect in `effects`,
-      /// routed to the preview by the composition root. The director now holds a
-      /// `LivePreviewBridge` and delivers it there directly, so a suite watching
-      /// only `effects` would see an empty list and read a working feature as a
-      /// dead one. Same signal, same ordering guarantee, different channel.
-      var recordingStates: [Bool] = []
-      /// The two buttons whose handler belongs to the APP. Captured so a guard
-      /// can prove they are BOUND — both were silently unbound by the cutover
-      /// and only a cloud review caught it, because an unbound button renders
-      /// perfectly and nothing fails.
-      var appActions: [PillAction] = []
-      /// The ORDER outputs left the director in. Effects must precede the
-      /// render, which is the shipped order and is load-bearing for Live
-      /// Preview's first frame.
-      var order: [String] = []
-      /// What a screen reader would have been told. Captured rather than
-      /// inferred: `NSAccessibility.post` returns nothing, so without this seam
-      /// the strongest available assertion is that the code which would have
-      /// posted was reached — a marker beside the subject rather than the
-      /// subject.
-      var announcements: [OverlayAnnouncement] = []
-    }
-
-    /// Live Preview's enabled answer, held so a test can flip it BETWEEN
-    /// presentations (#2292 C2).
-    ///
-    /// The bridge is supplied at construction now and cannot be replaced, which
-    /// is the point of the chunk. That does not make the setting immutable: the
-    /// production bridge reads `coordinator.isEnabledForGeometry` live, and a
-    /// user toggling Live Preview mid-dictation changes what the next read
-    /// returns. This box is the same shape.
-    private final class PreviewSetting {
-      var isEnabled = false
-      var display: () -> LivePreviewDisplay = { .off }
-    }
-
-    private static func director(
-      position: @escaping () -> OverlayPillPosition = { .bottom },
-      warningDismissed: @escaping () -> Bool = { false },
-      preview: PreviewSetting = PreviewSetting()
-    ) -> (OverlayDirector, Armed, Sink) {
-      let armed = Armed()
-      let sink = Sink()
-      // Real panels again: the director renders through a real host. Held so the
-      // caller can order the window out when the test ends.
-      let host = OverlayWindowHost(screens: { OverlayScreenResolver { screen } })
-      let d = OverlayDirector(
-        host: host,
-        position: position,
-        scheduler: .manual { armed.work = $0 },
-        announce: {
-          sink.announcements.append($0)
-          sink.order.append("announce")
+  private static func director(
+    position: @escaping () -> OverlayPillPosition = { .bottom },
+    warningDismissed: @escaping () -> Bool = { false },
+    preview: PreviewSetting = PreviewSetting()
+  ) -> (OverlayDirector, Armed, Sink) {
+    let armed = Armed()
+    let sink = Sink()
+    // Real panels again: the director renders through a real host. Held so the
+    // caller can order the window out when the test ends.
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { screen } })
+    let d = OverlayDirector(
+      host: host,
+      position: position,
+      scheduler: .manual { armed.work = $0 },
+      announce: {
+        sink.announcements.append($0)
+        sink.order.append("announce")
+      },
+      accessibilityEligibility: OverlayAccessibilityEligibility(
+        warningDismissed: warningDismissed),
+      livePreview: LivePreviewBridge(
+        recordingDidChange: {
+          sink.recordingStates.append($0)
+          // The SAME marker the effect sink writes: what this suite pins is
+          // that the preview learns of the recording before the window is
+          // drawn, and that property did not move when the channel did.
+          sink.order.append("effect")
         },
-        accessibilityEligibility: OverlayAccessibilityEligibility(
-          warningDismissed: warningDismissed),
-        livePreview: LivePreviewBridge(
-          recordingDidChange: {
-            sink.recordingStates.append($0)
-            // The SAME marker the effect sink writes: what this suite pins is
-            // that the preview learns of the recording before the window is
-            // drawn, and that property did not move when the channel did.
-            sink.order.append("effect")
-          },
-          isEnabledForGeometry: { preview.isEnabled },
-          // Derived from this fixture's own verdict, never typed beside it: a
-          // fixture stating both independently can contradict itself, and no
-          // assertion would catch it.
-          wordsCapability: { preview.isEnabled ? .available : .previewOff },
-          display: { preview.display() }),
-        grantAccessibility: { sink.appActions.append(.grantAccessibility) },
-        selections: { .shipped },
-        deferFirstRender: { $0() })
-      hosts.append(host)
-      return (d, armed, sink)
-    }
-
-    // MARK: - The clock starts when the pill is visible
-
-    /// **A dwell starts when the pill is ON SCREEN, not when the plan is applied**
-    /// (#2377 Phase 5, C2).
-    ///
-    /// `PillExpiryClockTests` proves the clock separates preparing from starting.
-    /// This proves the DIRECTOR uses that split: it must prepare at plan time and
-    /// start only from the successful-presentation callback, so a pill whose
-    /// first render is deferred spends none of its dwell before anything is
-    /// visible. Escape Recovery draws a countdown rail from this same dwell, so a
-    /// clock that starts early finishes early and the rail disagrees with the
-    /// pill it is drawn on.
-    ///
-    /// Both halves are asserted. The "nothing yet" half alone is satisfied by a
-    /// director that never arms at all.
-    @Test("a deferred timed pill arms no clock and publishes no dwell until it lands")
-    func aDeferredPillArmsNothingUntilItIsOnScreen() throws {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let armed = Armed()
-      let d = OverlayDirector(
-        host: host,
-        scheduler: .manual { armed.work = $0 },
-        announce: { _ in },
-        livePreview: .disabled,
-        grantAccessibility: {}, selections: { .shipped },
-        deferFirstRender: { deferral.block = $0 })
-
-      d.present(.warning(reason: .polishFailed))
-
-      #expect(armed.work == nil, "the clock armed before the pill reached the screen")
-      #expect(
-        d.renderModel.state.dwell == nil,
-        "a dwell was published before the pill reached the screen")
-
-      deferral.fire()
-
-      #expect(armed.work != nil, "the pill landed and no clock armed")
-      let window = try #require(
-        d.renderModel.state.dwell, "the pill landed and no dwell was published")
-      #expect(
-        window.id == d.renderModel.state.presentation?.id,
-        "the published dwell names a pill other than the one on screen")
-    }
-
-    // MARK: - Exactly one expiry
-
-    /// **The defect `PresentationID` exists to close.** Seven independently owned
-    /// staleness mechanisms in the shipped code each answered "is this deferred
-    /// work still valid" their own way, and nothing held them to the same answer.
-    @Test("a timer armed for a dismissed pill cannot dismiss its replacement")
-    func staleTimerCannotDismissTheLivePill() {
-      let (d, armed, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      d.present(.warning(reason: .polishFailed))
-      let staleTimer = try! #require(armed.work)
-
-      Self.record(d, level: 0.4)
-      let live = try! #require(d.renderModel.state.presentation?.id)
-
-      staleTimer.fire()
-
-      #expect(
-        d.renderModel.state.presentation?.id == live,
-        "a timer from a finished notice closed the live recording pill")
-    }
-
-    /// A new occupant REPLACES the armed expiry rather than leaving it running.
-    @Test("arming a new expiry cancels the previous one")
-    func armingReplacesTheArmedExpiry() {
-      let (d, armed, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      d.present(.warning(reason: .polishFailed))
-      let first = try! #require(armed.work)
-
-      d.present(.error(reason: .asrFailed))
-
-      #expect(first.isCancelled, "the previous pill's timer was left running")
-      #expect(armed.work !== first, "a second timer was armed without replacing the first")
-    }
-
-    /// A persistent presentation cancels rather than inheriting.
-    @Test("a persistent pill leaves no timer armed")
-    func persistentPillDisarms() {
-      let (d, armed, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      d.present(.warning(reason: .polishFailed))
-      let notice = try! #require(armed.work)
-
-      Self.record(d, level: 0.2)
-
-      // `isCancelled` on the schedule the director armed IS the observation —
-      // it is the object the director acted on, not a flag beside it. The
-      // `hasArmedExpiryForTesting` read that used to sit here asked the same
-      // question of a private field and could not fail while this one passed.
-      #expect(notice.isCancelled, "the notice's dwell survived the recording that replaced it")
-    }
-
-    /// The paired accepted case: a timed pill's OWN timer must still work, or
-    /// every guard above is satisfied by a director that never dismisses anything.
-    @Test("a pill's own timer dismisses it")
-    func ownTimerDismisses() {
-      let (d, armed, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      d.present(.warning(reason: .polishFailed))
-
-      try! #require(armed.work).fire()
-
-      #expect(d.renderModel.state.presentation == nil)
-    }
-
-    // MARK: - Exactly one action binding
-
-    // **`actionReachesItsOwner` was DELETED** (#2292 C5c). It installed a test
-    // observer through the generic ingress's `actions:` parameter, which no
-    // longer exists — an action's owner now arrives with the request, so the
-    // observer it used cannot be expressed. What it asserted, that a press
-    // reaches the owner bound with its own presentation, is asserted in BOTH
-    // lanes by `PillRequestParityTests.everyActionIsBound` across the five
-    // feature actions and by `grantIsBound` for the app-owned one.
-
-    /// **A binding must not outlive its pill.** The shipped panel keeps eight
-    /// handler closures alive for the app's lifetime whether or not the pill that
-    /// uses them is showing.
-    @Test("a binding is dropped when its pill is replaced")
-    func bindingDiesWithItsPill() throws {
-      let (d, host, _) = Self.pressableDirector()
-      var discards = 0
-
-      // A request that carries its OWN owner, so the observation is the callback
-      // the caller supplied rather than a test closure the ingress used to take.
-      let notice = try #require(d.present(.recoveryNotice(onDiscard: { discards += 1 })))
-
-      Self.record(d, level: 0.3)
-
-      // The press below IS the assertion: a binding that outlived its pill shows
-      // up as a callback firing for a pill nobody can see. The
-      // `hasActiveBindingForTesting` read that used to precede it asked about the
-      // field instead of the effect, and could not fail while the press passed.
-      try host.sendUserActionThroughRoot(.discardRecovery, for: notice)
-      #expect(discards == 0, "an action from a replaced pill reached its old handler")
-    }
-
-    /// **Replaced by construction.** There used to be a test that a `bind(for:)`
-    /// call naming a non-current pill was refused. That entry point is gone: a
-    /// request carries its own handler, so a binding for a presentation that is
-    /// not current cannot be expressed. The guard it provided is now a property of
-    /// the API rather than a runtime check — which is the better place for it, and
-    /// the reason the test is deleted rather than rewritten.
-    // MARK: - Payload custody
-
-    /// Custody ends with the pill. Otherwise a payload outlives the dictation it
-    /// belongs to and the next Undo could reach it.
-    ///
-    /// **Observed through a PRESS since C6.** "Is a payload held" is a field a
-    /// user cannot meet; what they can meet is Undo restoring a transcript from a
-    /// dictation they already finished with. Pressing the dismissed pill's own
-    /// receipt is how that would happen, so it is what the case does.
-    @Test("the payload is released when the pill goes")
-    func payloadIsReleasedWithThePill() throws {
-      let (d, host, _) = Self.pressableDirector()
-      let transcript = UUID()
-      var restored: [UUID] = []
-      let receipt = try #require(
-        d.present(
-          .escapeRecovery(
-            payload: CancelUndoPayload(
-              transcriptID: transcript, targetApp: nil, targetElement: nil),
-            onPaste: { restored.append($0.transcriptID) })))
-
-      d.dismissCurrent(.announced)
-      try host.sendUserActionThroughRoot(
-        .pasteEscapeRecovery(transcriptID: transcript), for: receipt)
-
-      #expect(
-        restored.isEmpty,
-        "a cancelled transcript outlived the pill offering to restore it")
-    }
-
-    /// Custody must end when ANOTHER pill takes the slot, not only when the slot
-    /// empties. Clearing it only on empty left a cancelled transcript held while a
-    /// different pill was showing.
-    @Test("the payload is released when a different pill replaces the recovery pill")
-    func payloadIsReleasedOnReplacement() throws {
-      let (d, host, _) = Self.pressableDirector()
-      let transcript = UUID()
-      var restored: [UUID] = []
-      let receipt = try #require(
-        d.present(
-          .escapeRecovery(
-            payload: CancelUndoPayload(
-              transcriptID: transcript, targetApp: nil, targetElement: nil),
-            onPaste: { restored.append($0.transcriptID) })))
-
-      Self.record(d, level: 0.3)
-      try host.sendUserActionThroughRoot(
-        .pasteEscapeRecovery(transcriptID: transcript), for: receipt)
-
-      #expect(
-        restored.isEmpty,
-        "a cancelled transcript was still held while a different pill was on screen")
-    }
-
-    /// **Undo must be bindable, and it was not.** Making the handler arrive with
-    /// the request broke this entry point outright: the pill appeared with nothing
-    /// bound, so the first press hit the invariant assertion. No test pressed the
-    /// button on a pill presented this way, so the suite could not see it.
-    ///
-    /// Since C4a the request carries `onPaste` and the director owns custody, so
-    /// this observes the PAYLOAD arriving rather than a raw action — which is the
-    /// thing a user's press has to produce.
-    @Test("the cancelled-transcript pill carries its Undo handler")
-    func escapeRecoveryCarriesItsHandler() throws {
-      let (d, host, _) = Self.pressableDirector()
-      let transcript = UUID()
-      var pressed: [PillAction] = []
-      let receipt = try #require(
-        d.present(
-          .escapeRecovery(
-            payload: CancelUndoPayload(
-              transcriptID: transcript, targetApp: nil, targetElement: nil),
-            onPaste: { _ in pressed.append(.pasteEscapeRecovery(transcriptID: transcript)) })))
-
-      try host.sendUserActionThroughRoot(
-        .pasteEscapeRecovery(transcriptID: transcript), for: receipt)
-
-      #expect(
-        pressed == [.pasteEscapeRecovery(transcriptID: transcript)],
-        "Undo was pressed and nothing was bound to it")
-    }
-
-    // **`morphPreservesItsBinding` was DELETED here** (#2292 C5b), and the reason
-    // is a real consequence of the typed boundary rather than a convenience.
-    //
-    // It proved that an audio-level tick — a same-id morph arriving many times a
-    // second — must not replace the live pill's action binding with the nothing
-    // that tick carried. Its vehicle was a RECORDING presented with an `actions:`
-    // closure and a synthetic `.discardRecovery` press.
-    //
-    // `PillRequest.recording` carries no callbacks, because a recording pill
-    // draws no buttons — so that vehicle cannot be built, and an action binding
-    // on a recording is now unspellable rather than merely unused. The only
-    // morphable presentation is the recording (`PillUpdate` targets exactly
-    // `.recordingLock` and `.inPanelNotice`), so there is no pill that both
-    // morphs AND carries a binding, and the defect this case described can no
-    // longer occur.
-    //
-    // **The production guard in `apply` stays and is now DEFENSIVE.** Keeping it
-    // costs a comparison; removing it would be a bet that no future request ever
-    // becomes both morphable and interactive. Flagged for the C5 review rather
-    // than decided here.
-
-    /// **A morph is not a fresh presentation, and the host needs that told to it.**
-
-    // MARK: - Rendering through the host
-
-    /// A fresh presentation re-anchors; a morph keeps the live frame. Getting it
-    /// wrong moves the pill on every audio tick.
-    @Test("a same-pill update is not presented as a fresh occupant")
-    func morphIsNotFresh() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      Self.record(d, level: 0.2)
-      let first = try! #require(d.renderModel.state.presentation?.id)
-
-      Self.record(d, level: 0.8)
-
-      #expect(
-        d.renderModel.state.presentation?.id == first,
-        "a metering update changed the presented occupant")
-    }
-
-    @Test("a genuinely new pill is a new occupant")
-    func replacementIsANewOccupant() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      Self.record(d, level: 0.2)
-      let first = try! #require(d.renderModel.state.presentation?.id)
-
-      d.present(.warning(reason: .polishFailed))
-
-      #expect(d.renderModel.state.presentation?.id != first)
-    }
-
-    /// Emptying the slot must release the recording providers, or a closure
-    /// reading a finished dictation outlives it.
-    @Test("hiding releases the recording providers and the occupant")
-    func hidingReleasesEverything() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      d.renderModel.setRecordingProviders(
-        audioLevel: { 0.9 }, recordingElapsed: { 12 }, livePreview: { .off },
-        design: .classic, position: .top, onContentHeightChange: { _ in })
-      Self.record(d, level: 0.2)
-
-      d.dismissCurrent(.announced)
-
-      #expect(d.renderModel.state.presentation == nil)
-      #expect(d.renderModel.state.recording == nil, "a provider outlived its dictation")
-      Self.expectReleasedProvidersDoNotReappear(d.renderModel)
-    }
-
-    /// **A REPLACEMENT ends a recording as surely as an empty slot does.** The
-    /// first version released the providers only when the presentation became
-    /// nil, so a finished dictation's closures were still being polled fifty times
-    /// a second behind whatever pill replaced it. The test above cannot see this:
-    /// it hides, which is the one path that already worked.
-    @Test("a pill that replaces the recording releases its providers too")
-    func replacingTheRecordingReleasesItsProviders() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      d.renderModel.setRecordingProviders(
-        audioLevel: { 0.9 }, recordingElapsed: { 12 }, livePreview: { .off },
-        design: .classic, position: .top, onContentHeightChange: { _ in })
-      Self.record(d, level: 0.2)
-
-      d.present(.processing(phase: .transcribing))
-
-      #expect(
-        d.renderModel.state.recording == nil,
-        "the finished dictation's level closure is still being polled behind the processing pill")
-      Self.expectReleasedProvidersDoNotReappear(d.renderModel)
-    }
-
-    /// A same-id morph is the SAME recording, so it keeps what it installed. This
-    /// is the paired accepted case for the rejection above: without it, "release
-    /// on any change" would also be satisfied by releasing on every audio tick,
-    /// which empties the meter mid-dictation.
-    ///
-    /// **Asserted as NOT-CLEARED rather than as a specific value**, because
-    /// `presentRecording` installs providers on every call by construction — a
-    /// tick legitimately replaces the level closure with the new level. What must
-    /// never happen is the release path running, which zeroes them.
-    ///
-    /// Every tick carries the elapsed provider too, at this boundary. An earlier
-    /// version of this comment said no tick does; that is true of the audio-level
-    /// PUSH and false of `presentRecording`, which takes the full provider set
-    /// each time — the distinction the atomic operation exists to enforce.
-    @Test("an audio tick does not release the recording's own providers")
-    func morphingTheRecordingKeepsItsProviders() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      Self.record(d, level: 0.2, elapsed: { 12 })
-
-      Self.record(d, level: 0.7, elapsed: { 12 })
-
-      #expect(
-        d.renderModel.state.recording?.audioLevelProvider() == 0.7,
-        "an audio tick emptied the meter it was reporting to")
-      #expect(
-        d.renderModel.state.recording?.recordingElapsedProvider() == 12,
-        "an audio tick dropped the elapsed clock it was handed")
-    }
-
-    /// **A morph keeps the DESIGN it was created with, whatever the setting now
-    /// says.** The shipped panel reads the preview setting once at creation and
-    /// its width is fixed for that panel's life, because an `NSPanel` cannot grow
-    /// mid-recording without a rebuild and a rebuild is the #930 flicker. So a
-    /// user toggling Live Preview mid-dictation must not resize the live pill —
-    /// which re-resolving the design on every tick would do.
-    @Test("toggling Live Preview mid-dictation does not resize the live pill")
-    func morphKeepsTheDesignItWasCreatedWith() {
-      let setting = PreviewSetting()
-      let (d, host, _) = Self.pressableDirector(preview: setting)
-      Self.record(d, level: 0.2, preview: false, previewSetting: setting)
-
-      // The setting flips, and the next tick reports it.
-      Self.record(d, level: 0.6, preview: true, previewSetting: setting)
-
-      // **Asserted on what the director ASKED FOR, not on the panel it got**
-      // (#2292 C6). The claim is about the director's arithmetic — it must
-      // preserve the accepted design on a tick. Reading an `NSPanel` frame to
-      // check that tested it through AppKit, which is why this case could only
-      // run in the Debug lane. Whether a panel honours the width it is handed is
-      // `OverlayWindowHostTests`' question.
-      #expect(
-        host.presented.map(\.width) == [.fixed(185), .fixed(185)],
-        "a mid-dictation settings change resized the live pill, which is the #930 rebuild flicker")
-    }
-
-    /// **The accessibility notice announces the SAME sentence whether or not the
-    /// toast is shown, and that is the whole reason it is one method.**
-    ///
-    /// The shipped panel posts the accessibility announcement BEFORE its
-    /// eligibility branch, so a VoiceOver user hears "Accessibility permission
-    /// needed for auto-paste" even on the runs where the toast is suppressed and
-    /// the clipboard hint is drawn instead. Routing the suppressed case through
-    /// `.pipeline(.clipboardFallback)` would say "Text copied to clipboard" — a
-    /// different sentence, and a silent change in what a blind user is told,
-    /// arriving inside a refactor.
-    ///
-    /// Paired ACCEPTED and SUPPRESSED cases, because a guard that only checked
-    /// the suppressed one would pass a version that never shows the toast at all.
-    @Test("the accessibility notice keeps its spoken sentence when the toast is suppressed")
-    func suppressedAccessibilityToastKeepsItsAnnouncement() {
-      let (shown, _, shownSink) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      shown.present(.accessibilityNotice)
-
-      guard case .notice(let toast)? = shown.renderModel.state.presentation?.content else {
-        Issue.record("expected a notice")
-        return
-      }
-      #expect(toast.kind == .accessibilityToast, "an eligible toast was not drawn")
-      #expect(
-        shownSink.announcements.map(\.text)
-          == [DictationNarrator.announcement(for: .accessibilityToast)])
-
-      // Suppressed because the user dismissed the standing warning — the real
-      // reason, driven through the real policy rather than a stubbed answer.
-      let (suppressed, _, suppressedSink) = Self.director(warningDismissed: { true })
-
-      suppressed.present(.accessibilityNotice)
-
-      guard case .notice(let fallback)? = suppressed.renderModel.state.presentation?.content else {
-        Issue.record("expected a notice")
-        return
-      }
-      #expect(
-        fallback.text == DictationNarrator.clipboardFallbackText,
-        "a suppressed toast did not fall back to the clipboard hint")
-      #expect(
-        suppressedSink.announcements.map(\.text)
-          == [DictationNarrator.announcement(for: .accessibilityToast)],
-        "the suppressed run announced the clipboard sentence, which tells a blind user something different from what the shipped app tells them")
-    }
-
-    /// **A duplicate push must cost nothing at all**, and "nothing" has three
-    /// parts: it must not spend the session's one showing, must not replace the
-    /// visible toast with the fallback, and must not announce a second time. The
-    /// shipped dedup guard drops an identical intent before any of that;
-    /// splitting the notice into two reductions had put the eligibility ask in
-    /// front of it.
-    ///
-    /// The spent-showing half is asserted through what the USER would see on a
-    /// later, genuine push rather than by counting calls: if the duplicate ate
-    /// the showing, that push draws the clipboard hint instead of the toast. A
-    /// counter would prove the same thing one layer further from the harm.
-    @Test("a duplicate accessibility push neither reclaims nor replaces the toast")
-    func duplicateAccessibilityPushIsACompleteNoOp() {
-      let (d, _, sink) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      d.present(.accessibilityNotice)
-      let first = d.renderModel.state.presentation?.id
-
-      d.present(.accessibilityNotice)
-
-      #expect(d.renderModel.state.presentation?.id == first, "a duplicate push replaced the toast")
-      #expect(sink.announcements.count == 1, "a duplicate push announced twice")
-      guard case .notice(let notice)? = d.renderModel.state.presentation?.content else {
-        Issue.record("expected the accessibility toast")
-        return
-      }
-      #expect(notice.kind == .accessibilityToast)
-
-      // A genuine LATER push, after something else has held the slot. The
-      // session's showing is already spent by the FIRST push, so this one
-      // correctly falls back — and it proves the duplicate did not spend a
-      // second one, because there is only ever one to spend.
-      d.present(.processing(phase: .transcribing))
-      d.present(.accessibilityNotice)
-      guard case .notice(let later)? = d.renderModel.state.presentation?.content else {
-        Issue.record("expected a notice")
-        return
-      }
-      #expect(
-        later.text == DictationNarrator.clipboardFallbackText,
-        "the session's one showing was not spent by the push that actually showed it")
-    }
-
-    /// **The suppressed toast is ONE transition, not two**, and the two things
-    /// that proves are invisible from the picture: the pipeline intent must read
-    /// `.accessibilityToast` even though the clipboard hint is what is drawn, and
-    /// the effect that ends the recording must survive.
-    ///
-    /// Reducing two intents and applying the second lost both — the state said
-    /// `.clipboardFallback`, so a real clipboard push would have been deduped
-    /// away, and `.recordingStateChanged(false)` was discarded, which is how
-    /// Live Preview learns the dictation ended.
-    @Test("a suppressed accessibility toast ends the recording and keeps its logical intent")
-    func suppressedAccessibilityToastPreservesTransitionState() {
-      let (d, _, sink) = Self.director(warningDismissed: { true })
-      defer { Self.closeAllWindows() }
-      Self.record(d)
-      sink.effects.removeAll()
-      sink.recordingStates.removeAll()
-      sink.announcements.removeAll()
-
-      d.present(.accessibilityNotice)
-
-      #expect(
-        sink.recordingStates == [false],
-        "Live Preview was never told the recording ended")
-      // **The "logical intent follows the DECISION, not the picture" claim moved
-      // to `OverlayReducerTests`** (#2292 C6). It is a statement about what the
-      // reducer commits, and it was read here through a director hatch; the
-      // reducer suite can assert it directly and in the Release lane. What this
-      // case keeps is the part a user meets: the picture is the clipboard
-      // fallback and the sentence spoken is still the accessibility one.
-      guard case .notice(let notice)? = d.renderModel.state.presentation?.content else {
-        Issue.record("expected the clipboard fallback")
-        return
-      }
-      #expect(notice.kind == .processing)
-      #expect(
-        sink.announcements.map(\.text)
-          == [DictationNarrator.announcement(for: .accessibilityToast)])
-    }
-
-    /// **The two app-level buttons must be BOUND.** Grant and Discard were
-    /// setGrantHandler / setDiscardRecoveryHandler on the deleted panel;
-    /// their setters went with the class and both presenting sites passed
-    /// `actions: nil`, so the buttons rendered and reached nobody. Nothing
-    /// failed, which is why a review found it and the suite did not.
-    // **`grantIsBound` was DELETED here** (#2292 C5c) and lives in
-    // `PillRequestParityTests`, which runs in the Release lane. This suite is
-    // `#if DEBUG` in its entirety, so the Debug-only copy was the weaker of two
-    // tests making one claim.
-
-    /// **Observed at the request's own callback since C4b.** There is no app
-    /// action sink any more: the router that owned it is deleted, so Discard
-    /// reaches the closure the presenting caller supplied and nowhere else.
-    // **`discardIsBound` was DELETED here** (#2292 C5c), for the same reason as
-    // `grantIsBound` above: `PillRequestParityTests.discardDismisses` asserts it
-    // in both lanes, and `discardRunsBeforeDismissal` adds the ordering half.
-
-    /// **A feature that OCCUPIES the slot has to say so.** The presenter used to
-    /// confirm its own card by asking `currentIntent` for `.bluetoothAwareness`
-    /// before acting on any button, and returning the bare pipeline intent —
-    /// which a feature never changes — left that handshake permanently failing
-    /// and every button on the card a no-op.
-    ///
-    /// **The projection is gone and the question is now asked of the screen**
-    /// (#2292 C6). Admission moved into `present` in C3, so no presenter reads an
-    /// intent any more; what remains is that the card must be the pill on screen
-    /// and must hold the slot against the next feature that asks. The
-    /// pipeline-intent half is a reducer claim and lives in `OverlayReducerTests`.
-    @Test("a Bluetooth card owns the slot it took")
-    func bluetoothCardReportsOwnership() throws {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      let receipt = try #require(
-        d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {})))
-
-      guard case .bluetoothAwareness? = d.renderModel.state.presentation?.content else {
-        Issue.record("the card is not the pill on screen")
-        return
-      }
-      #expect(d.isCurrent(receipt), "the card does not own the presentation it was issued")
-      #expect(
-        d.featureSlotIsAvailable == false,
-        "the card is up and the slot still reads free, so the next feature evicts it")
-    }
-
-    /// **The slot must report a chip as occupying it, exactly as it reports the
-    /// card.**
-    ///
-    /// Bluetooth was projected at the cutover and the chip was not — the same
-    /// omission twice, and only the first was found by review.
-    /// `LanguageSuggestionPresenter` guards `case .hidden` before showing a
-    /// chip, so with its own chip up it read the slot as free.
-    ///
-    /// **The pipeline-intent assertion this case used to carry was DELETED and
-    /// its claim was false** (#2292 C5c). It read "a feature must not change the
-    /// PIPELINE intent", which was true of the spelling this case used to send —
-    /// a feature request routed through the reducer's feature path, which never
-    /// touches `pipelineIntent`. That spelling was not the one production used
-    /// and C5c deleted it outright. The typed request travels as
-    /// `.pipeline(.passiveChip)` and SETS the pipeline intent, which is the whole
-    /// point: the language presenter arbitrates against exactly that.
-    /// `PillRequestParityTests.languageChip` owns the claim in its correct
-    /// direction, and the two contradicted each other until this one was fixed.
-    @Test("a language chip reports itself as the current intent")
-    func languageChipReportsOwnership() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-      let payload = LanguageChipPayload(
-        lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
-
-      d.present(.languageChip(payload: payload, onLock: {}, onDismiss: {}, onExpire: {}))
-
-      guard case .languageChip(let shown)? = d.renderModel.state.presentation?.content else {
-        Issue.record("the chip is not the pill on screen")
-        return
-      }
-      #expect(shown == payload, "a different chip reached the screen")
-      #expect(
-        d.featureSlotIsAvailable == false,
-        "the chip is up and the slot still reads free, so the next feature evicts it")
-    }
-
-    /// The non-member, pinned so it is not "fixed" later. Import status is the
-    /// one request with no matching `OverlayIntent`; the shipped panel did not
-    /// set `currentIntent` for it either, so reporting `.hidden` while a status
-    /// pill shows is preserved behaviour rather than a third omission.
-    @Test("an import status pill deliberately does not claim the intent")
-    func importStatusDoesNotClaimTheIntent() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      d.present(.importStatus(message: "Importing 3 recordings"))
-
-      #expect(d.renderModel.state.presentation != nil, "the status pill never took the slot")
-      #expect(
-        d.featureSlotIsAvailable,
-        "import status began BLOCKING other features, which the shipped panel never did")
-    }
-
-    /// **Effects run before the render.** The shipped
-    /// recordingIntentObserver fired at the top of `show(intent:)`, before the
-    /// announcement and before any panel work, so Live Preview has frozen its
-    /// geometry answer by the time the first frame is sized. Running effects last
-    /// can size that frame from the live setting instead.
-    @Test("an effect is delivered before the presentation is announced")
-    func effectsPrecedeTheAnnouncement() {
-      let (d, _, sink) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      Self.record(d)
-
-      #expect(
-        sink.order.first == "effect",
-        "the recording-intent effect arrived after the window was already being drawn")
-      #expect(sink.recordingStates == [true])
-    }
-
-    /// **The effect must beat the GEOMETRY READ, not merely the render.**
-    ///
-    /// `presentRecording` reads capability on its way to resolving a design, and
-    /// that read happens before `apply` is entered — so moving effects to the top
-    /// of `apply` fixed only half of it. `LivePreviewCoordinator` applies its
-    /// model-removal suppression inside `setRecording`, so a read that beats the
-    /// effect can select `.readingWell` for a pill whose preview is about to
-    /// resolve DISABLED: a preview-sized window with no preview in it.
-    ///
-    /// The probe is the provider itself. It answers true only AFTER the effect
-    /// has been delivered, so `canHoldWords` is true if and only if the ordering
-    /// is right. Asserting the ORDER directly would need a clock; this needs none.
-    ///
-    /// **The host must PRESENT for this probe to survive**, and it did not have
-    /// to before C7. The first version resolved no screen, so the presentation
-    /// was refused -- and the presentation asserted below outlived the refusal
-    /// only because refused presentations previously left their owner behind. Reading
-    /// state that should not exist is not a weaker test, it is a test of the
-    /// defect; with the rollback in place the same probe needs a real screen.
-    @Test("a recording's effect is delivered before its geometry is resolved")
-    func recordingEffectsPrecedeGeometry() {
-      var recordingStarted = false
-      let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } })
-      // **Both halves ride on the SAME bridge now** (#2292 C2), which states the
-      // ordering this case is about more directly than the old pair did: the
-      // recording signal and the geometry answer arrive together, so "did the
-      // signal land before the geometry was read" is a question about one value.
-      let d = OverlayDirector(
-        host: host,
-        announce: { _ in },
-        livePreview: LivePreviewBridge(
-          recordingDidChange: { if $0 { recordingStarted = true } },
-          isEnabledForGeometry: { recordingStarted },
-          wordsCapability: { recordingStarted ? .available : .previewOff },
-          display: { .off }),
-        grantAccessibility: {}, selections: { .shipped }, deferFirstRender: { $0() })
-      Self.hosts.append(host)
-      defer { Self.closeAllWindows() }
-
+        isEnabledForGeometry: { preview.isEnabled },
+        // Derived from this fixture's own verdict, never typed beside it: a
+        // fixture stating both independently can contradict itself, and no
+        // assertion would catch it.
+        wordsCapability: { preview.isEnabled ? .available : .previewOff },
+        display: { preview.display() }),
+      grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+      selections: { .shipped },
+      firstRenderSchedule: { $0() })
+    hosts.append(host)
+    return (d, armed, sink)
+  }
+
+  // MARK: - The clock starts when the pill is visible
+
+  /// **A dwell starts when the pill is ON SCREEN, not when the plan is applied**
+  /// (#2377 Phase 5, C2).
+  ///
+  /// `PillExpiryClockTests` proves the clock separates preparing from starting.
+  /// This proves the DIRECTOR uses that split: it must prepare at plan time and
+  /// start only from the successful-presentation callback, so a pill whose
+  /// first render is deferred spends none of its dwell before anything is
+  /// visible. Escape Recovery draws a countdown rail from this same dwell, so a
+  /// clock that starts early finishes early and the rail disagrees with the
+  /// pill it is drawn on.
+  ///
+  /// Both halves are asserted. The "nothing yet" half alone is satisfied by a
+  /// director that never arms at all.
+  @Test("a deferred timed pill arms no clock and publishes no dwell until it lands")
+  func aDeferredPillArmsNothingUntilItIsOnScreen() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let armed = Armed()
+    let d = OverlayDirector(
+      host: host,
+      scheduler: .manual { armed.work = $0 },
+      announce: { _ in },
+      livePreview: .disabled,
+      grantAccessibility: {}, selections: { .shipped },
+      firstRenderSchedule: { deferral.block = $0 })
+
+    d.present(.warning(reason: .polishFailed))
+
+    #expect(armed.work == nil, "the clock armed before the pill reached the screen")
+    #expect(
+      d.renderModel.state.dwell == nil,
+      "a dwell was published before the pill reached the screen")
+
+    deferral.fire()
+
+    #expect(armed.work != nil, "the pill landed and no clock armed")
+    let window = try #require(
+      d.renderModel.state.dwell, "the pill landed and no dwell was published")
+    #expect(
+      window.id == d.renderModel.state.presentation?.id,
+      "the published dwell names a pill other than the one on screen")
+  }
+
+  // MARK: - Exactly one expiry
+
+  /// **The defect `PresentationID` exists to close.** Seven independently owned
+  /// staleness mechanisms in the shipped code each answered "is this deferred
+  /// work still valid" their own way, and nothing held them to the same answer.
+  @Test("a timer armed for a dismissed pill cannot dismiss its replacement")
+  func staleTimerCannotDismissTheLivePill() {
+    let (d, armed, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    d.present(.warning(reason: .polishFailed))
+    let staleTimer = try! #require(armed.work)
+
+    Self.record(d, level: 0.4)
+    let live = try! #require(d.renderModel.state.presentation?.id)
+
+    staleTimer.fire()
+
+    #expect(
+      d.renderModel.state.presentation?.id == live,
+      "a timer from a finished notice closed the live recording pill")
+  }
+
+  /// A new occupant REPLACES the armed expiry rather than leaving it running.
+  @Test("arming a new expiry cancels the previous one")
+  func armingReplacesTheArmedExpiry() {
+    let (d, armed, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    d.present(.warning(reason: .polishFailed))
+    let first = try! #require(armed.work)
+
+    d.present(.error(reason: .asrFailed))
+
+    #expect(first.isCancelled, "the previous pill's timer was left running")
+    #expect(armed.work !== first, "a second timer was armed without replacing the first")
+  }
+
+  /// A persistent presentation cancels rather than inheriting.
+  @Test("a persistent pill leaves no timer armed")
+  func persistentPillDisarms() {
+    let (d, armed, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    d.present(.warning(reason: .polishFailed))
+    let notice = try! #require(armed.work)
+
+    Self.record(d, level: 0.2)
+
+    // `isCancelled` on the schedule the director armed IS the observation —
+    // it is the object the director acted on, not a flag beside it. The
+    // `hasArmedExpiryForTesting` read that used to sit here asked the same
+    // question of a private field and could not fail while this one passed.
+    #expect(notice.isCancelled, "the notice's dwell survived the recording that replaced it")
+  }
+
+  /// The paired accepted case: a timed pill's OWN timer must still work, or
+  /// every guard above is satisfied by a director that never dismisses anything.
+  @Test("a pill's own timer dismisses it")
+  func ownTimerDismisses() {
+    let (d, armed, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    d.present(.warning(reason: .polishFailed))
+
+    try! #require(armed.work).fire()
+
+    #expect(d.renderModel.state.presentation == nil)
+  }
+
+  // MARK: - Exactly one action binding
+
+  // **`actionReachesItsOwner` was DELETED** (#2292 C5c). It installed a test
+  // observer through the generic ingress's `actions:` parameter, which no
+  // longer exists — an action's owner now arrives with the request, so the
+  // observer it used cannot be expressed. What it asserted, that a press
+  // reaches the owner bound with its own presentation, is asserted in BOTH
+  // lanes by `PillRequestParityTests.everyActionIsBound` across the five
+  // feature actions and by `grantIsBound` for the app-owned one.
+
+  /// **A binding must not outlive its pill.** The shipped panel keeps eight
+  /// handler closures alive for the app's lifetime whether or not the pill that
+  /// uses them is showing.
+  @Test("a binding is dropped when its pill is replaced")
+  func bindingDiesWithItsPill() throws {
+    let (d, host, _) = Self.pressableDirector()
+    var discards = 0
+
+    // A request that carries its OWN owner, so the observation is the callback
+    // the caller supplied rather than a test closure the ingress used to take.
+    let notice = try #require(d.present(.recoveryNotice(onDiscard: { discards += 1 })))
+
+    Self.record(d, level: 0.3)
+
+    // The press below IS the assertion: a binding that outlived its pill shows
+    // up as a callback firing for a pill nobody can see. The
+    // `hasActiveBindingForTesting` read that used to precede it asked about the
+    // field instead of the effect, and could not fail while the press passed.
+    try host.sendUserActionThroughRoot(.discardRecovery, for: notice)
+    #expect(discards == 0, "an action from a replaced pill reached its old handler")
+  }
+
+  /// **Replaced by construction.** There used to be a test that a `bind(for:)`
+  /// call naming a non-current pill was refused. That entry point is gone: a
+  /// request carries its own handler, so a binding for a presentation that is
+  /// not current cannot be expressed. The guard it provided is now a property of
+  /// the API rather than a runtime check — which is the better place for it, and
+  /// the reason the test is deleted rather than rewritten.
+  // MARK: - Payload custody
+
+  /// Custody ends with the pill. Otherwise a payload outlives the dictation it
+  /// belongs to and the next Undo could reach it.
+  ///
+  /// **Observed through a PRESS since C6.** "Is a payload held" is a field a
+  /// user cannot meet; what they can meet is Undo restoring a transcript from a
+  /// dictation they already finished with. Pressing the dismissed pill's own
+  /// receipt is how that would happen, so it is what the case does.
+  @Test("the payload is released when the pill goes")
+  func payloadIsReleasedWithThePill() throws {
+    let (d, host, _) = Self.pressableDirector()
+    let transcript = UUID()
+    var restored: [UUID] = []
+    let receipt = try #require(
       d.present(
-        .recording(
-          RecordingPillInput(
-            audioLevel: 0,
-            audioLevelProvider: { 0 },
-            recordingElapsedProvider: { nil },
-            isLocked: false)))
+        .escapeRecovery(
+          payload: CancelUndoPayload(
+            transcriptID: transcript, targetApp: nil, targetElement: nil),
+          onPaste: { restored.append($0.transcriptID) })))
 
-      // **Reads the DESIGN since #2375 C3b**, which is the same question one
-      // authority later: the layout bundle it used to read is gone, and what the
-      // pill can hold is now a property of the design the transaction captured.
-      #expect(
-        d.renderModel.state.presentation?.recordingDesign?.canHoldWords == true,
-        "geometry was resolved before the effect that freezes its input")
+    d.dismissCurrent(.announced)
+    try host.sendUserActionThroughRoot(
+      .pasteEscapeRecovery(transcriptID: transcript), for: receipt)
+
+    #expect(
+      restored.isEmpty,
+      "a cancelled transcript outlived the pill offering to restore it")
+  }
+
+  /// Custody must end when ANOTHER pill takes the slot, not only when the slot
+  /// empties. Clearing it only on empty left a cancelled transcript held while a
+  /// different pill was showing.
+  @Test("the payload is released when a different pill replaces the recovery pill")
+  func payloadIsReleasedOnReplacement() throws {
+    let (d, host, _) = Self.pressableDirector()
+    let transcript = UUID()
+    var restored: [UUID] = []
+    let receipt = try #require(
+      d.present(
+        .escapeRecovery(
+          payload: CancelUndoPayload(
+            transcriptID: transcript, targetApp: nil, targetElement: nil),
+          onPaste: { restored.append($0.transcriptID) })))
+
+    Self.record(d, level: 0.3)
+    try host.sendUserActionThroughRoot(
+      .pasteEscapeRecovery(transcriptID: transcript), for: receipt)
+
+    #expect(
+      restored.isEmpty,
+      "a cancelled transcript was still held while a different pill was on screen")
+  }
+
+  /// **Undo must be bindable, and it was not.** Making the handler arrive with
+  /// the request broke this entry point outright: the pill appeared with nothing
+  /// bound, so the first press hit the invariant assertion. No test pressed the
+  /// button on a pill presented this way, so the suite could not see it.
+  ///
+  /// Since C4a the request carries `onPaste` and the director owns custody, so
+  /// this observes the PAYLOAD arriving rather than a raw action — which is the
+  /// thing a user's press has to produce.
+  @Test("the cancelled-transcript pill carries its Undo handler")
+  func escapeRecoveryCarriesItsHandler() throws {
+    let (d, host, _) = Self.pressableDirector()
+    let transcript = UUID()
+    var pressed: [PillAction] = []
+    let receipt = try #require(
+      d.present(
+        .escapeRecovery(
+          payload: CancelUndoPayload(
+            transcriptID: transcript, targetApp: nil, targetElement: nil),
+          onPaste: { _ in pressed.append(.pasteEscapeRecovery(transcriptID: transcript)) })))
+
+    try host.sendUserActionThroughRoot(
+      .pasteEscapeRecovery(transcriptID: transcript), for: receipt)
+
+    #expect(
+      pressed == [.pasteEscapeRecovery(transcriptID: transcript)],
+      "Undo was pressed and nothing was bound to it")
+  }
+
+  // **`morphPreservesItsBinding` was DELETED here** (#2292 C5b), and the reason
+  // is a real consequence of the typed boundary rather than a convenience.
+  //
+  // It proved that an audio-level tick — a same-id morph arriving many times a
+  // second — must not replace the live pill's action binding with the nothing
+  // that tick carried. Its vehicle was a RECORDING presented with an `actions:`
+  // closure and a synthetic `.discardRecovery` press.
+  //
+  // `PillRequest.recording` carries no callbacks, because a recording pill
+  // draws no buttons — so that vehicle cannot be built, and an action binding
+  // on a recording is now unspellable rather than merely unused. The only
+  // morphable presentation is the recording (`PillUpdate` targets exactly
+  // `.recordingLock` and `.inPanelNotice`), so there is no pill that both
+  // morphs AND carries a binding, and the defect this case described can no
+  // longer occur.
+  //
+  // **The production guard in `apply` stays and is now DEFENSIVE.** Keeping it
+  // costs a comparison; removing it would be a bet that no future request ever
+  // becomes both morphable and interactive. Flagged for the C5 review rather
+  // than decided here.
+
+  /// **A morph is not a fresh presentation, and the host needs that told to it.**
+
+  // MARK: - Rendering through the host
+
+  /// A fresh presentation re-anchors; a morph keeps the live frame. Getting it
+  /// wrong moves the pill on every audio tick.
+  @Test("a same-pill update is not presented as a fresh occupant")
+  func morphIsNotFresh() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    Self.record(d, level: 0.2)
+    let first = try! #require(d.renderModel.state.presentation?.id)
+
+    Self.record(d, level: 0.8)
+
+    #expect(
+      d.renderModel.state.presentation?.id == first,
+      "a metering update changed the presented occupant")
+  }
+
+  @Test("a genuinely new pill is a new occupant")
+  func replacementIsANewOccupant() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    Self.record(d, level: 0.2)
+    let first = try! #require(d.renderModel.state.presentation?.id)
+
+    d.present(.warning(reason: .polishFailed))
+
+    #expect(d.renderModel.state.presentation?.id != first)
+  }
+
+  /// Emptying the slot must release the recording providers, or a closure
+  /// reading a finished dictation outlives it.
+  @Test("hiding releases the recording providers and the occupant")
+  func hidingReleasesEverything() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    d.renderModel.setRecordingProviders(
+      audioLevel: { 0.9 }, recordingElapsed: { 12 }, livePreview: { .off },
+      design: .classic, position: .top, onContentHeightChange: { _ in })
+    Self.record(d, level: 0.2)
+
+    d.dismissCurrent(.announced)
+
+    #expect(d.renderModel.state.presentation == nil)
+    #expect(d.renderModel.state.recording == nil, "a provider outlived its dictation")
+    Self.expectReleasedProvidersDoNotReappear(d.renderModel)
+  }
+
+  /// **A REPLACEMENT ends a recording as surely as an empty slot does.** The
+  /// first version released the providers only when the presentation became
+  /// nil, so a finished dictation's closures were still being polled fifty times
+  /// a second behind whatever pill replaced it. The test above cannot see this:
+  /// it hides, which is the one path that already worked.
+  @Test("a pill that replaces the recording releases its providers too")
+  func replacingTheRecordingReleasesItsProviders() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    d.renderModel.setRecordingProviders(
+      audioLevel: { 0.9 }, recordingElapsed: { 12 }, livePreview: { .off },
+      design: .classic, position: .top, onContentHeightChange: { _ in })
+    Self.record(d, level: 0.2)
+
+    d.present(.processing(phase: .transcribing))
+
+    #expect(
+      d.renderModel.state.recording == nil,
+      "the finished dictation's level closure is still being polled behind the processing pill")
+    Self.expectReleasedProvidersDoNotReappear(d.renderModel)
+  }
+
+  /// A same-id morph is the SAME recording, so it keeps what it installed. This
+  /// is the paired accepted case for the rejection above: without it, "release
+  /// on any change" would also be satisfied by releasing on every audio tick,
+  /// which empties the meter mid-dictation.
+  ///
+  /// **Asserted as NOT-CLEARED rather than as a specific value**, because
+  /// `presentRecording` installs providers on every call by construction — a
+  /// tick legitimately replaces the level closure with the new level. What must
+  /// never happen is the release path running, which zeroes them.
+  ///
+  /// Every tick carries the elapsed provider too, at this boundary. An earlier
+  /// version of this comment said no tick does; that is true of the audio-level
+  /// PUSH and false of `presentRecording`, which takes the full provider set
+  /// each time — the distinction the atomic operation exists to enforce.
+  @Test("an audio tick does not release the recording's own providers")
+  func morphingTheRecordingKeepsItsProviders() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    Self.record(d, level: 0.2, elapsed: { 12 })
+
+    Self.record(d, level: 0.7, elapsed: { 12 })
+
+    #expect(
+      d.renderModel.state.recording?.audioLevelProvider() == 0.7,
+      "an audio tick emptied the meter it was reporting to")
+    #expect(
+      d.renderModel.state.recording?.recordingElapsedProvider() == 12,
+      "an audio tick dropped the elapsed clock it was handed")
+  }
+
+  /// **A morph keeps the DESIGN it was created with, whatever the setting now
+  /// says.** The shipped panel reads the preview setting once at creation and
+  /// its width is fixed for that panel's life, because an `NSPanel` cannot grow
+  /// mid-recording without a rebuild and a rebuild is the #930 flicker. So a
+  /// user toggling Live Preview mid-dictation must not resize the live pill —
+  /// which re-resolving the design on every tick would do.
+  @Test("toggling Live Preview mid-dictation does not resize the live pill")
+  func morphKeepsTheDesignItWasCreatedWith() {
+    let setting = PreviewSetting()
+    let (d, host, _) = Self.pressableDirector(preview: setting)
+    Self.record(d, level: 0.2, preview: false, previewSetting: setting)
+
+    // The setting flips, and the next tick reports it.
+    Self.record(d, level: 0.6, preview: true, previewSetting: setting)
+
+    // **Asserted on what the director ASKED FOR, not on the panel it got**
+    // (#2292 C6). The claim is about the director's arithmetic — it must
+    // preserve the accepted design on a tick. Reading an `NSPanel` frame to
+    // check that tested it through AppKit, which is why this case could only
+    // run in the Debug lane. Whether a panel honours the width it is handed is
+    // `OverlayWindowHostTests`' question.
+    #expect(
+      host.presented.map(\.width) == [.fixed(185), .fixed(185)],
+      "a mid-dictation settings change resized the live pill, which is the #930 rebuild flicker")
+  }
+
+  /// **The accessibility notice announces the SAME sentence whether or not the
+  /// toast is shown, and that is the whole reason it is one method.**
+  ///
+  /// The shipped panel posts the accessibility announcement BEFORE its
+  /// eligibility branch, so a VoiceOver user hears "Accessibility permission
+  /// needed for auto-paste" even on the runs where the toast is suppressed and
+  /// the clipboard hint is drawn instead. Routing the suppressed case through
+  /// `.pipeline(.clipboardFallback)` would say "Text copied to clipboard" — a
+  /// different sentence, and a silent change in what a blind user is told,
+  /// arriving inside a refactor.
+  ///
+  /// Paired ACCEPTED and SUPPRESSED cases, because a guard that only checked
+  /// the suppressed one would pass a version that never shows the toast at all.
+  @Test("the accessibility notice keeps its spoken sentence when the toast is suppressed")
+  func suppressedAccessibilityToastKeepsItsAnnouncement() {
+    let (shown, _, shownSink) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    shown.present(.accessibilityNotice)
+
+    guard case .notice(let toast)? = shown.renderModel.state.presentation?.content else {
+      Issue.record("expected a notice")
+      return
     }
+    #expect(toast.kind == .accessibilityToast, "an eligible toast was not drawn")
+    #expect(
+      shownSink.announcements.map(\.text)
+        == [DictationNarrator.announcement(for: .accessibilityToast)])
 
-    /// **A dictation ending announces; a chip dismissal must not.**
-    ///
-    /// The shipped `hide()` and `show(intent: .hidden)` are different operations
-    /// and the difference is audible. `LanguageSuggestionPresenter.hideOverlay`
-    /// depends on the silent one, with a comment added by a prior review round
-    /// saying exactly that — and nothing anywhere expressed it as a property
-    /// until now, so a cutover could have collapsed the two and made every chip
-    /// dismissal announce a recording that did not just finish.
-    @Test("dismissing silently says nothing, while ending a dictation announces")
-    func silentDismissalSaysNothing() {
-      let (loud, _, loudSink) = Self.director()
-      defer { Self.closeAllWindows() }
-      Self.record(loud)
-      loudSink.announcements.removeAll()
+    // Suppressed because the user dismissed the standing warning — the real
+    // reason, driven through the real policy rather than a stubbed answer.
+    let (suppressed, _, suppressedSink) = Self.director(warningDismissed: { true })
 
-      loud.dismissCurrent(.announced)
+    suppressed.present(.accessibilityNotice)
 
-      #expect(
-        loudSink.announcements.map(\.text) == ["Recording complete"],
-        "ending a dictation stopped announcing completion")
-
-      let (quiet, _, quietSink) = Self.director()
-      Self.record(quiet)
-      quietSink.announcements.removeAll()
-
-      quiet.dismissCurrent(.silent)
-
-      #expect(
-        quietSink.announcements.isEmpty,
-        "a silent dismissal announced a completed recording that never happened")
-      #expect(
-        quiet.renderModel.state.presentation == nil,
-        "the silent dismissal did not actually empty the slot")
+    guard case .notice(let fallback)? = suppressed.renderModel.state.presentation?.content else {
+      Issue.record("expected a notice")
+      return
     }
+    #expect(
+      fallback.text == DictationNarrator.clipboardFallbackText,
+      "a suppressed toast did not fall back to the clipboard hint")
+    #expect(
+      suppressedSink.announcements.map(\.text)
+        == [DictationNarrator.announcement(for: .accessibilityToast)],
+      "the suppressed run announced the clipboard sentence, which tells a blind user something different from what the shipped app tells them"
+    )
+  }
 
-    /// The announcement is POSTED, not merely computed. The reducer's own guard
-    /// proves the plan carries one; this proves the director acts on it.
-    @Test("presenting a recording announces it")
-    func presentingAnnounces() {
-      let (d, _, sink) = Self.director()
-      defer { Self.closeAllWindows() }
+  /// **A duplicate push must cost nothing at all**, and "nothing" has three
+  /// parts: it must not spend the session's one showing, must not replace the
+  /// visible toast with the fallback, and must not announce a second time. The
+  /// shipped dedup guard drops an identical intent before any of that;
+  /// splitting the notice into two reductions had put the eligibility ask in
+  /// front of it.
+  ///
+  /// The spent-showing half is asserted through what the USER would see on a
+  /// later, genuine push rather than by counting calls: if the duplicate ate
+  /// the showing, that push draws the clipboard hint instead of the toast. A
+  /// counter would prove the same thing one layer further from the harm.
+  @Test("a duplicate accessibility push neither reclaims nor replaces the toast")
+  func duplicateAccessibilityPushIsACompleteNoOp() {
+    let (d, _, sink) = Self.director()
+    defer { Self.closeAllWindows() }
 
-      Self.record(d)
+    d.present(.accessibilityNotice)
+    let first = d.renderModel.state.presentation?.id
 
-      #expect(
-        sink.announcements.map(\.text) == ["Recording started"],
-        "the director computed an announcement and never posted it")
-      #expect(sink.announcements.first?.isHighPriority == true)
+    d.present(.accessibilityNotice)
+
+    #expect(d.renderModel.state.presentation?.id == first, "a duplicate push replaced the toast")
+    #expect(sink.announcements.count == 1, "a duplicate push announced twice")
+    guard case .notice(let notice)? = d.renderModel.state.presentation?.content else {
+      Issue.record("expected the accessibility toast")
+      return
     }
+    #expect(notice.kind == .accessibilityToast)
 
-    /// **The lock is part of the presentation TRANSACTION, not a later morph.**
-    /// The reducer's born-locked rule exists for this, and the shipped
-    /// `show(intent:isRecordingLocked:)` takes both in one call. Before this, the
-    /// caller had to remember a second `send(.lockStateChanged(_:))`, and
-    /// forgetting it lost hands-free lock with nothing to say so.
-    @Test("a recording is born with the lock value from its presentation transaction")
-    func recordingIsBornLocked() {
-      let (d, _, _) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      Self.record(d, locked: true)
-
-      guard case .recording(_, let locked, _, _)? = d.renderModel.state.presentation?.content else {
-        Issue.record("expected a recording presentation")
-        return
-      }
-      #expect(locked, "the recording rendered unlocked before a later lock morph")
+    // A genuine LATER push, after something else has held the slot. The
+    // session's showing is already spent by the FIRST push, so this one
+    // correctly falls back — and it proves the duplicate did not spend a
+    // second one, because there is only ever one to spend.
+    d.present(.processing(phase: .transcribing))
+    d.present(.accessibilityNotice)
+    guard case .notice(let later)? = d.renderModel.state.presentation?.content else {
+      Issue.record("expected a notice")
+      return
     }
+    #expect(
+      later.text == DictationNarrator.clipboardFallbackText,
+      "the session's one showing was not spent by the push that actually showed it")
+  }
 
-    /// **One position per presentation, not two reads of a provider.** The
-    /// recording transaction captures the anchored edge when the pill is composed;
-    /// the host used to re-read it, allowing composition and placement against
-    /// different edges.
-    ///
-    /// Counting READS rather than comparing edges, because the defect is the
-    /// second read itself — a test that compared two positions would pass
-    /// whenever the provider happened to answer the same twice.
-    @Test("recording position is resolved once for composition and placement")
-    func recordingPositionIsResolvedOnce() {
-      var reads = 0
-      let (d, _, _) = Self.director(position: {
-        reads += 1
-        return reads == 1 ? .bottom : .top
+  /// **The suppressed toast is ONE transition, not two**, and the two things
+  /// that proves are invisible from the picture: the pipeline intent must read
+  /// `.accessibilityToast` even though the clipboard hint is what is drawn, and
+  /// the effect that ends the recording must survive.
+  ///
+  /// Reducing two intents and applying the second lost both — the state said
+  /// `.clipboardFallback`, so a real clipboard push would have been deduped
+  /// away, and `.recordingStateChanged(false)` was discarded, which is how
+  /// Live Preview learns the dictation ended.
+  @Test("a suppressed accessibility toast ends the recording and keeps its logical intent")
+  func suppressedAccessibilityToastPreservesTransitionState() {
+    let (d, _, sink) = Self.director(warningDismissed: { true })
+    defer { Self.closeAllWindows() }
+    Self.record(d)
+    sink.effects.removeAll()
+    sink.recordingStates.removeAll()
+    sink.announcements.removeAll()
+
+    d.present(.accessibilityNotice)
+
+    #expect(
+      sink.recordingStates == [false],
+      "Live Preview was never told the recording ended")
+    // **The "logical intent follows the DECISION, not the picture" claim moved
+    // to `OverlayReducerTests`** (#2292 C6). It is a statement about what the
+    // reducer commits, and it was read here through a director hatch; the
+    // reducer suite can assert it directly and in the Release lane. What this
+    // case keeps is the part a user meets: the picture is the clipboard
+    // fallback and the sentence spoken is still the accessibility one.
+    guard case .notice(let notice)? = d.renderModel.state.presentation?.content else {
+      Issue.record("expected the clipboard fallback")
+      return
+    }
+    #expect(notice.kind == .processing)
+    #expect(
+      sink.announcements.map(\.text)
+        == [DictationNarrator.announcement(for: .accessibilityToast)])
+  }
+
+  /// **The two app-level buttons must be BOUND.** Grant and Discard were
+  /// setGrantHandler / setDiscardRecoveryHandler on the deleted panel;
+  /// their setters went with the class and both presenting sites passed
+  /// `actions: nil`, so the buttons rendered and reached nobody. Nothing
+  /// failed, which is why a review found it and the suite did not.
+  // **`grantIsBound` was DELETED here** (#2292 C5c) and lives in
+  // `PillRequestParityTests`, which runs in the Release lane. This suite is
+  // `#if DEBUG` in its entirety, so the Debug-only copy was the weaker of two
+  // tests making one claim.
+
+  /// **Observed at the request's own callback since C4b.** There is no app
+  /// action sink any more: the router that owned it is deleted, so Discard
+  /// reaches the closure the presenting caller supplied and nowhere else.
+  // **`discardIsBound` was DELETED here** (#2292 C5c), for the same reason as
+  // `grantIsBound` above: `PillRequestParityTests.discardDismisses` asserts it
+  // in both lanes, and `discardRunsBeforeDismissal` adds the ordering half.
+
+  /// **A feature that OCCUPIES the slot has to say so.** The presenter used to
+  /// confirm its own card by asking `currentIntent` for `.bluetoothAwareness`
+  /// before acting on any button, and returning the bare pipeline intent —
+  /// which a feature never changes — left that handshake permanently failing
+  /// and every button on the card a no-op.
+  ///
+  /// **The projection is gone and the question is now asked of the screen**
+  /// (#2292 C6). Admission moved into `present` in C3, so no presenter reads an
+  /// intent any more; what remains is that the card must be the pill on screen
+  /// and must hold the slot against the next feature that asks. The
+  /// pipeline-intent half is a reducer claim and lives in `OverlayReducerTests`.
+  @Test("a Bluetooth card owns the slot it took")
+  func bluetoothCardReportsOwnership() throws {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    let receipt = try #require(
+      d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {})))
+
+    guard case .bluetoothAwareness? = d.renderModel.state.presentation?.content else {
+      Issue.record("the card is not the pill on screen")
+      return
+    }
+    #expect(d.isCurrent(receipt), "the card does not own the presentation it was issued")
+    #expect(
+      d.featureSlotIsAvailable == false,
+      "the card is up and the slot still reads free, so the next feature evicts it")
+  }
+
+  /// **The slot must report a chip as occupying it, exactly as it reports the
+  /// card.**
+  ///
+  /// Bluetooth was projected at the cutover and the chip was not — the same
+  /// omission twice, and only the first was found by review.
+  /// `LanguageSuggestionPresenter` guards `case .hidden` before showing a
+  /// chip, so with its own chip up it read the slot as free.
+  ///
+  /// **The pipeline-intent assertion this case used to carry was DELETED and
+  /// its claim was false** (#2292 C5c). It read "a feature must not change the
+  /// PIPELINE intent", which was true of the spelling this case used to send —
+  /// a feature request routed through the reducer's feature path, which never
+  /// touches `pipelineIntent`. That spelling was not the one production used
+  /// and C5c deleted it outright. The typed request travels as
+  /// `.pipeline(.passiveChip)` and SETS the pipeline intent, which is the whole
+  /// point: the language presenter arbitrates against exactly that.
+  /// `PillRequestParityTests.languageChip` owns the claim in its correct
+  /// direction, and the two contradicted each other until this one was fixed.
+  @Test("a language chip reports itself as the current intent")
+  func languageChipReportsOwnership() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+    let payload = LanguageChipPayload(
+      lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
+
+    d.present(.languageChip(payload: payload, onLock: {}, onDismiss: {}, onExpire: {}))
+
+    guard case .languageChip(let shown)? = d.renderModel.state.presentation?.content else {
+      Issue.record("the chip is not the pill on screen")
+      return
+    }
+    #expect(shown == payload, "a different chip reached the screen")
+    #expect(
+      d.featureSlotIsAvailable == false,
+      "the chip is up and the slot still reads free, so the next feature evicts it")
+  }
+
+  /// The non-member, pinned so it is not "fixed" later. Import status is the
+  /// one request with no matching `OverlayIntent`; the shipped panel did not
+  /// set `currentIntent` for it either, so reporting `.hidden` while a status
+  /// pill shows is preserved behaviour rather than a third omission.
+  @Test("an import status pill deliberately does not claim the intent")
+  func importStatusDoesNotClaimTheIntent() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    d.present(.importStatus(message: "Importing 3 recordings"))
+
+    #expect(d.renderModel.state.presentation != nil, "the status pill never took the slot")
+    #expect(
+      d.featureSlotIsAvailable,
+      "import status began BLOCKING other features, which the shipped panel never did")
+  }
+
+  /// **Effects run before the render.** The shipped
+  /// recordingIntentObserver fired at the top of `show(intent:)`, before the
+  /// announcement and before any panel work, so Live Preview has frozen its
+  /// geometry answer by the time the first frame is sized. Running effects last
+  /// can size that frame from the live setting instead.
+  @Test("an effect is delivered before the presentation is announced")
+  func effectsPrecedeTheAnnouncement() {
+    let (d, _, sink) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    Self.record(d)
+
+    #expect(
+      sink.order.first == "effect",
+      "the recording-intent effect arrived after the window was already being drawn")
+    #expect(sink.recordingStates == [true])
+  }
+
+  /// **The effect must beat the GEOMETRY READ, not merely the render.**
+  ///
+  /// `presentRecording` reads capability on its way to resolving a design, and
+  /// that read happens before `apply` is entered — so moving effects to the top
+  /// of `apply` fixed only half of it. `LivePreviewCoordinator` applies its
+  /// model-removal suppression inside `setRecording`, so a read that beats the
+  /// effect can select `.readingWell` for a pill whose preview is about to
+  /// resolve DISABLED: a preview-sized window with no preview in it.
+  ///
+  /// The probe is the provider itself. It answers true only AFTER the effect
+  /// has been delivered, so `canHoldWords` is true if and only if the ordering
+  /// is right. Asserting the ORDER directly would need a clock; this needs none.
+  ///
+  /// **The host must PRESENT for this probe to survive**, and it did not have
+  /// to before C7. The first version resolved no screen, so the presentation
+  /// was refused -- and the presentation asserted below outlived the refusal
+  /// only because refused presentations previously left their owner behind. Reading
+  /// state that should not exist is not a weaker test, it is a test of the
+  /// defect; with the rollback in place the same probe needs a real screen.
+  @Test("a recording's effect is delivered before its geometry is resolved")
+  func recordingEffectsPrecedeGeometry() {
+    var recordingStarted = false
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } })
+    // **Both halves ride on the SAME bridge now** (#2292 C2), which states the
+    // ordering this case is about more directly than the old pair did: the
+    // recording signal and the geometry answer arrive together, so "did the
+    // signal land before the geometry was read" is a question about one value.
+    let d = OverlayDirector(
+      host: host,
+      announce: { _ in },
+      livePreview: LivePreviewBridge(
+        recordingDidChange: { if $0 { recordingStarted = true } },
+        isEnabledForGeometry: { recordingStarted },
+        wordsCapability: { recordingStarted ? .available : .previewOff },
+        display: { .off }),
+      grantAccessibility: {}, selections: { .shipped }, firstRenderSchedule: { $0() })
+    Self.hosts.append(host)
+    defer { Self.closeAllWindows() }
+
+    d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0,
+          audioLevelProvider: { 0 },
+          recordingElapsedProvider: { nil },
+          isLocked: false)))
+
+    // **Reads the DESIGN since #2375 C3b**, which is the same question one
+    // authority later: the layout bundle it used to read is gone, and what the
+    // pill can hold is now a property of the design the transaction captured.
+    #expect(
+      d.renderModel.state.presentation?.recordingDesign?.canHoldWords == true,
+      "geometry was resolved before the effect that freezes its input")
+  }
+
+  /// **A dictation ending announces; a chip dismissal must not.**
+  ///
+  /// The shipped `hide()` and `show(intent: .hidden)` are different operations
+  /// and the difference is audible. `LanguageSuggestionPresenter.hideOverlay`
+  /// depends on the silent one, with a comment added by a prior review round
+  /// saying exactly that — and nothing anywhere expressed it as a property
+  /// until now, so a cutover could have collapsed the two and made every chip
+  /// dismissal announce a recording that did not just finish.
+  @Test("dismissing silently says nothing, while ending a dictation announces")
+  func silentDismissalSaysNothing() {
+    let (loud, _, loudSink) = Self.director()
+    defer { Self.closeAllWindows() }
+    Self.record(loud)
+    loudSink.announcements.removeAll()
+
+    loud.dismissCurrent(.announced)
+
+    #expect(
+      loudSink.announcements.map(\.text) == ["Recording complete"],
+      "ending a dictation stopped announcing completion")
+
+    let (quiet, _, quietSink) = Self.director()
+    Self.record(quiet)
+    quietSink.announcements.removeAll()
+
+    quiet.dismissCurrent(.silent)
+
+    #expect(
+      quietSink.announcements.isEmpty,
+      "a silent dismissal announced a completed recording that never happened")
+    #expect(
+      quiet.renderModel.state.presentation == nil,
+      "the silent dismissal did not actually empty the slot")
+  }
+
+  /// The announcement is POSTED, not merely computed. The reducer's own guard
+  /// proves the plan carries one; this proves the director acts on it.
+  @Test("presenting a recording announces it")
+  func presentingAnnounces() {
+    let (d, _, sink) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    Self.record(d)
+
+    #expect(
+      sink.announcements.map(\.text) == ["Recording started"],
+      "the director computed an announcement and never posted it")
+    #expect(sink.announcements.first?.isHighPriority == true)
+  }
+
+  /// **The lock is part of the presentation TRANSACTION, not a later morph.**
+  /// The reducer's born-locked rule exists for this, and the shipped
+  /// `show(intent:isRecordingLocked:)` takes both in one call. Before this, the
+  /// caller had to remember a second `send(.lockStateChanged(_:))`, and
+  /// forgetting it lost hands-free lock with nothing to say so.
+  @Test("a recording is born with the lock value from its presentation transaction")
+  func recordingIsBornLocked() {
+    let (d, _, _) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    Self.record(d, locked: true)
+
+    guard case .recording(_, let locked, _, _)? = d.renderModel.state.presentation?.content else {
+      Issue.record("expected a recording presentation")
+      return
+    }
+    #expect(locked, "the recording rendered unlocked before a later lock morph")
+  }
+
+  /// **One position per presentation, not two reads of a provider.** The
+  /// recording transaction captures the anchored edge when the pill is composed;
+  /// the host used to re-read it, allowing composition and placement against
+  /// different edges.
+  ///
+  /// Counting READS rather than comparing edges, because the defect is the
+  /// second read itself — a test that compared two positions would pass
+  /// whenever the provider happened to answer the same twice.
+  @Test("recording position is resolved once for composition and placement")
+  func recordingPositionIsResolvedOnce() {
+    var reads = 0
+    let (d, _, _) = Self.director(position: {
+      reads += 1
+      return reads == 1 ? .bottom : .top
+    })
+    defer { Self.closeAllWindows() }
+
+    Self.record(d)
+
+    #expect(
+      reads == 1,
+      "the host re-read a position already captured by the recording transaction")
+  }
+
+  /// **The obligation `OverlayContent.recording` recorded, discharged.** The
+  /// non-preview pill reserves a fixed 92-point interaction frame; the Live
+  /// Preview variant is content-sized from its first frame so it does not
+  /// visibly snap once the real height is measured. The reducer cannot decide
+  /// this — preview arrives as a provider, not an event — so the director does.
+  ///
+  /// **Asserted on the ARGUMENT since C6, which is the thing under test.** The
+  /// earlier version read the resulting `NSPanel` frame on the stated grounds
+  /// that "a panel 92 points tall is the reserved frame". That is true and it
+  /// measured the director's decision through AppKit, which forced a real
+  /// window and kept the case out of the Release lane. A windowless host
+  /// records the reserved height and the requested width verbatim; whether a
+  /// panel honours them is `OverlayWindowHostTests`' question and it owns it.
+  @Test("Live Preview makes the recording pill content-sized, and only Live Preview")
+  func previewLayoutDropsTheReservedFrame() throws {
+    let fixedSetting = PreviewSetting()
+    let (fixed, fixedHost, _) = Self.pressableDirector(preview: fixedSetting)
+    Self.record(fixed, level: 0.2, preview: false, previewSetting: fixedSetting)
+    let compact = try #require(fixedHost.presented.last)
+
+    let previewSetting = PreviewSetting()
+    let (preview, previewHost, _) = Self.pressableDirector(preview: previewSetting)
+    Self.record(preview, level: 0.2, preview: true, previewSetting: previewSetting)
+    let wide = try #require(previewHost.presented.last)
+
+    #expect(
+      compact.fixedHeight == 92,
+      "the non-preview recording pill lost its reserved 92-point frame")
+    #expect(
+      wide.fixedHeight == nil,
+      "the Live Preview pill reserved a frame instead of sizing to its content")
+    // **The WIDTH is the half that is easy to miss.** The shipped site reads
+    // `showsPreview ? previewPillWidth : 185` — 400 against 185 — so carrying
+    // only the height still renders a preview pill at under half its size.
+    #expect(
+      compact.width == .fixed(185), "the non-preview recording pill lost its 185-point width")
+    #expect(
+      wide.width == .fixed(400), "the Live Preview pill did not take its 400-point width")
+  }
+
+  // MARK: - A presentation result is delivered exactly once (PR #2370)
+
+  /// **THE DEFECT: a receipt is not proof the pill was drawn.** `present`
+  /// returns synchronously, and the FIRST presentation of a launch reaches the
+  /// host a run loop later — so at the moment a receipt is handed back there is
+  /// nothing truthful it can say about a host call that has not happened.
+  ///
+  /// REPRODUCIBLE: the app is a login item and the Bluetooth card is requested
+  /// from `reconcile(trigger: .launch)`, so it is the request most likely to BE
+  /// that first presentation. If the host then refuses for want of a screen
+  /// while the display wakes, the old code spent a once-per-launch allowance on
+  /// a card nobody saw and recorded a `shown` that never happened.
+  @Test("a deferred presentation the host refuses reports notPresented")
+  func deferredRefusalReportsNotPresented() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    host.accepts = false
+    var results: [PillPresentationResult] = []
+
+    let receipt = d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { result in
+        results.append(result)
+        // **Rollback-before-callback, checked FROM INSIDE the callback
+        // itself** — not merely after `deferral.fire()` returns, which would
+        // also pass if the callback ran first and the rollback happened
+        // later in the same turn. The caller's own code must see the
+        // rollback already applied.
+        #expect(
+          d.renderModel.state.presentation == nil,
+          "the callback ran before the refusal's rollback emptied the model")
+        #expect(
+          d.featureSlotIsAvailable, "the callback ran before the refusal's rollback freed the slot")
       })
-      defer { Self.closeAllWindows() }
 
-      Self.record(d)
+    // The receipt IS handed back — admission succeeded — and no result has been
+    // delivered yet, because the host has not been asked.
+    #expect(receipt != nil, "admission was refused, so this case never reaches its subject")
+    #expect(results.isEmpty, "a verdict was delivered before the host was asked")
 
-      #expect(
-        reads == 1,
-        "the host re-read a position already captured by the recording transaction")
-    }
+    deferral.fire()
 
-    /// **The obligation `OverlayContent.recording` recorded, discharged.** The
-    /// non-preview pill reserves a fixed 92-point interaction frame; the Live
-    /// Preview variant is content-sized from its first frame so it does not
-    /// visibly snap once the real height is measured. The reducer cannot decide
-    /// this — preview arrives as a provider, not an event — so the director does.
-    ///
-    /// **Asserted on the ARGUMENT since C6, which is the thing under test.** The
-    /// earlier version read the resulting `NSPanel` frame on the stated grounds
-    /// that "a panel 92 points tall is the reserved frame". That is true and it
-    /// measured the director's decision through AppKit, which forced a real
-    /// window and kept the case out of the Release lane. A windowless host
-    /// records the reserved height and the requested width verbatim; whether a
-    /// panel honours them is `OverlayWindowHostTests`' question and it owns it.
-    @Test("Live Preview makes the recording pill content-sized, and only Live Preview")
-    func previewLayoutDropsTheReservedFrame() throws {
-      let fixedSetting = PreviewSetting()
-      let (fixed, fixedHost, _) = Self.pressableDirector(preview: fixedSetting)
-      Self.record(fixed, level: 0.2, preview: false, previewSetting: fixedSetting)
-      let compact = try #require(fixedHost.presented.last)
+    #expect(results == [.notPresented], "a refused card was reported as presented")
+    #expect(d.renderModel.state.presentation == nil, "a refused card is still published")
+    #expect(d.featureSlotIsAvailable, "the refused card still holds the slot")
+  }
 
-      let previewSetting = PreviewSetting()
-      let (preview, previewHost, _) = Self.pressableDirector(preview: previewSetting)
-      Self.record(preview, level: 0.2, preview: true, previewSetting: previewSetting)
-      let wide = try #require(previewHost.presented.last)
+  /// The paired accepted case. Without it, "reports notPresented" is also
+  /// satisfied by a director that reports notPresented for everything.
+  @Test("a deferred presentation the host accepts reports presented, once")
+  func deferredAcceptanceReportsPresentedOnce() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    var results: [PillPresentationResult] = []
 
-      #expect(
-        compact.fixedHeight == 92,
-        "the non-preview recording pill lost its reserved 92-point frame")
-      #expect(
-        wide.fixedHeight == nil,
-        "the Live Preview pill reserved a frame instead of sizing to its content")
-      // **The WIDTH is the half that is easy to miss.** The shipped site reads
-      // `showsPreview ? previewPillWidth : 185` — 400 against 185 — so carrying
-      // only the height still renders a preview pill at under half its size.
-      #expect(
-        compact.width == .fixed(185), "the non-preview recording pill lost its 185-point width")
-      #expect(
-        wide.width == .fixed(400), "the Live Preview pill did not take its 400-point width")
-    }
-
-    // MARK: - A presentation result is delivered exactly once (PR #2370)
-
-    /// **THE DEFECT: a receipt is not proof the pill was drawn.** `present`
-    /// returns synchronously, and the FIRST presentation of a launch reaches the
-    /// host a run loop later — so at the moment a receipt is handed back there is
-    /// nothing truthful it can say about a host call that has not happened.
-    ///
-    /// REPRODUCIBLE: the app is a login item and the Bluetooth card is requested
-    /// from `reconcile(trigger: .launch)`, so it is the request most likely to BE
-    /// that first presentation. If the host then refuses for want of a screen
-    /// while the display wakes, the old code spent a once-per-launch allowance on
-    /// a card nobody saw and recorded a `shown` that never happened.
-    @Test("a deferred presentation the host refuses reports notPresented")
-    func deferredRefusalReportsNotPresented() {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      host.accepts = false
-      var results: [PillPresentationResult] = []
-
-      let receipt = d.present(
-        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-        onResult: { results.append($0) })
-
-      // The receipt IS handed back — admission succeeded — and no result has been
-      // delivered yet, because the host has not been asked.
-      #expect(receipt != nil, "admission was refused, so this case never reaches its subject")
-      #expect(results.isEmpty, "a verdict was delivered before the host was asked")
-
-      deferral.fire()
-
-      #expect(results == [.notPresented], "a refused card was reported as presented")
-      #expect(d.renderModel.state.presentation == nil, "a refused card is still published")
-      #expect(d.featureSlotIsAvailable, "the refused card still holds the slot")
-    }
-
-    /// The paired accepted case. Without it, "reports notPresented" is also
-    /// satisfied by a director that reports notPresented for everything.
-    @Test("a deferred presentation the host accepts reports presented, once")
-    func deferredAcceptanceReportsPresentedOnce() throws {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      var results: [PillPresentationResult] = []
-
-      let receipt = try #require(
-        d.present(
-          .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-          onResult: { results.append($0) }))
-      #expect(results.isEmpty, "a verdict was delivered before the host was asked")
-
-      deferral.fire()
-
-      #expect(results == [.presented(receipt)], "the accepted card was not reported once")
-      guard case .bluetoothAwareness? = d.renderModel.state.presentation?.content else {
-        Issue.record("the accepted card never reached the screen")
-        return
-      }
-    }
-
-    /// **A REQUEST THAT IS REFUSED ANSWERS FOR ITSELF AND FOR NOTHING ELSE.**
-    /// The card is still waiting for its run loop when a second feature asks for
-    /// the slot and is turned away. The card is untouched by that: it still
-    /// renders, and its owner must still be told, because the owner is what
-    /// records the receipt the buttons are dispatched through.
-    ///
-    /// REPRODUCIBLE: a launch-time reconcile defers the card, a second feature
-    /// request arrives in the same run-loop turn and is refused for want of the
-    /// slot the card itself holds. Resolving the pending caller on the way in put
-    /// a VISIBLE Bluetooth card on screen with dead buttons and no `.shown` — the
-    /// user sees a tip they cannot dismiss, and the dashboard says they were
-    /// never shown one.
-    @Test
-    func aRefusedRequestLeavesAPendingDeferralsResultIntact() throws {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      var cardResults: [PillPresentationResult] = []
-      var refusedResults: [PillPresentationResult] = []
-
-      let receipt = try #require(
-        d.present(
-          .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-          onResult: { cardResults.append($0) }))
-
-      // A second feature asks while the card holds the slot, and is refused.
-      let refused = d.present(.importStatus(message: "Imported 3 words"),
-                              onResult: { refusedResults.append($0) })
-
-      #expect(refused == nil, "the second feature was admitted, so this case never reaches its subject")
-      #expect(refusedResults == [.notPresented], "the refused caller was not told it was refused")
-      #expect(cardResults.isEmpty, "the refused request answered on the pending card's behalf")
-
-      deferral.fire()
-
-      #expect(
-        cardResults == [.presented(receipt)],
-        "the card rendered but its owner was never told, so its buttons have no target")
-      guard case .bluetoothAwareness? = d.renderModel.state.presentation?.content else {
-        Issue.record("the card never reached the screen")
-        return
-      }
-    }
-
-    /// The paired case: a request that IS admitted supersedes the pending one,
-    /// and the pending caller hears `.notPresented` from its own deferred block.
-    /// Without this, the case above is satisfied by a director that simply never
-    /// reports supersession.
-    @Test
-    func anAdmittedRequestStillSupersedesAPendingDeferral() {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      var cardResults: [PillPresentationResult] = []
-
+    let receipt = try #require(
       d.present(
         .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-        onResult: { cardResults.append($0) })
-
-      // A recording outranks a feature, so this one IS admitted.
-      Self.record(d, level: 0.3)
-      deferral.fire()
-
-      #expect(
-        cardResults == [.notPresented],
-        "a card that lost the slot before rendering was reported as presented")
-    }
-
-    /// **TWO DEFERRALS IN FLIGHT AT ONCE, EACH ANSWERING ITS OWN CALLER.** This
-    /// is the case no single slot could ever have got right, and it is not exotic:
-    /// nothing is built until a deferred block actually renders, so every
-    /// presentation arriving before that queues its own.
-    @Test
-    func twoQueuedDeferralsEachAnswerTheirOwnCaller() throws {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      var cardResults: [PillPresentationResult] = []
-      var noticeResults: [PillPresentationResult] = []
-
-      d.present(
-        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-        onResult: { cardResults.append($0) })
-      // A pipeline pill outranks the feature, so this one IS admitted — and it
-      // defers too, because nothing has rendered yet.
-      let notice = try #require(
-        d.present(.clipboardFallback, onResult: { noticeResults.append($0) }))
-
-      #expect(cardResults.isEmpty && noticeResults.isEmpty, "a verdict arrived before any render")
-
-      deferral.fireAll()
-
-      #expect(
-        cardResults == [.notPresented],
-        "the superseded card was reported through the wrong transaction's verdict")
-      #expect(
-        noticeResults == [.presented(notice)],
-        "the pill that actually rendered was not reported to its own caller")
-    }
-
-    /// Exactly once, on the path that has the most terminals to get it wrong: the
-    /// host refuses, which rolls back through a dismissal that itself renders
-    /// successfully. Reading a bare render outcome reported that dismissal as the
-    /// presentation's own success.
-    @Test
-    func aRefusedDeferralReportsExactlyOnce() {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      host.accepts = false
-      var results: [PillPresentationResult] = []
-
-      d.present(
-        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-        onResult: { results.append($0) })
-
-      deferral.fireAll()
-      // Firing again must add nothing: the queue is drained and the relay spent.
-      deferral.fireAll()
-
-      #expect(results == [.notPresented], "the refused card was reported \(results.count) times")
-    }
-
-    /// A deferred presentation superseded before it renders never reached the
-    /// screen, and its caller must hear that rather than nothing at all — a
-    /// silent path is what leaves a once-per-launch allowance spent forever.
-    @Test("a deferred presentation superseded before rendering reports notPresented")
-    func supersededDeferralReportsNotPresented() {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      var results: [PillPresentationResult] = []
-
-      d.present(
-        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-        onResult: { results.append($0) })
-
-      // A recording takes the slot while the card is still waiting to render.
-      Self.record(d, level: 0.3)
-      deferral.fire()
-
-      #expect(results == [.notPresented], "a superseded card was reported as presented")
-    }
-
-    /// The ordinary path, which is every presentation after the first: no
-    /// deferral, one result, delivered before `present` returns.
-    @Test("an immediate presentation reports presented exactly once")
-    func immediatePresentationReportsPresentedOnce() throws {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-
-      // Spend the deferral on a first presentation, so the next one is
-      // synchronous — then clear the slot, or the card is refused at admission
-      // and this case never reaches the immediate render it is about.
-      d.present(.engineReady)
-      deferral.fire()
-      d.dismissCurrent(.silent)
-
-      var results: [PillPresentationResult] = []
-      let receipt = try #require(
-        d.present(
-          .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-          onResult: { results.append($0) }))
-
-      #expect(deferral.fired == 1, "the second presentation deferred, so this is not the immediate path")
-      #expect(results == [.presented(receipt)], "the immediate path did not report exactly one result")
-    }
-
-    /// Admission refusal is the fourth terminal and the only one that also
-    /// returns nil. A caller that hears nothing here would keep an allowance
-    /// pending forever waiting for a verdict that never arrives.
-    @Test("a request refused at admission reports notPresented and returns nil")
-    func admissionRefusalReportsNotPresented() {
-      let host = RefusingWindowlessHost()
-      let deferral = Deferral()
-      let d = Self.deferrableDirector(host, deferral)
-      Self.record(d, level: 0.3)
-      deferral.fire()
-
-      var results: [PillPresentationResult] = []
-      let receipt = d.present(
-        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
-        onResult: { results.append($0) })
-
-      #expect(receipt == nil, "a recording holds the slot, so the card is refused")
-      #expect(results == [.notPresented], "an admission refusal delivered no verdict")
-    }
-
-    // MARK: - Fail closed (#2292 C19)
-
-    // **`escapeRecoveryWithoutPayloadFailsClosed` was DELETED** (#2292 C5c), and
-    // its own comment names the reason it can go: it was "preserved because a
-    // bare call still COMPILES". It does not. The one route to that presentation
-    // is `present(.escapeRecovery(payload:onPaste:))`, whose payload is not
-    // optional, so an offer to Paste with no target behind it is no longer a
-    // shape anyone can write. The rule it protected became a property of the API,
-    // which is the stronger place for it.
-
-    // MARK: - The first render is deferred one run loop (#2292 C15)
-
-    /// **A crash fix, asserted through the production deferral rather than the
-    /// synchronous double the other cases use.**
-    ///
-    /// `MenuBarController.toggleRecordingAction` reaches the director while the
-    /// status-item menu dismiss animation is still running, and building the
-    /// `NSHostingView` during it causes a re-entrant `NSWindow` layout cycle and
-    /// SIGABRT. The deleted panel deferred every creation with
-    /// `DispatchQueue.main.async` and carried that reason in a comment.
-    ///
-    /// The barrier below is a SIGNAL, not a clock: a continuation enqueued
-    /// behind the deferred work resumes only after it has run, so this waits on
-    /// the subject rather than on time.
-    @Test("the first presentation reaches the window on the NEXT run loop")
-    func firstRenderIsDeferred() async {
-      let host = WindowlessOverlayHost()
-      // The production `deferFirstRender` — the default — is the subject here.
-      let d = OverlayDirector(
-        host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
-
-      d.present(.warning(reason: .polishFailed))
-      #expect(
-        host.presented.isEmpty,
-        "the first presentation reached the window synchronously — this is the menu-dismiss crash")
-
-      await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
-
-      #expect(host.presented.count == 1, "the deferred first presentation never arrived")
-      #expect(host.isShowing, "the deferred presentation did not leave the window showing")
-    }
-
-    /// **A first request that is SUPERSEDED must leave the deferral armed.**
-    ///
-    /// The first version of this fix set a "deferred once" flag when the work was
-    /// SCHEDULED. Two paths then reopened the crash: another event arriving
-    /// before the queued block ran saw the flag set and built the view
-    /// synchronously, and a request dropped by its own identity gate left the
-    /// flag set with nothing built, so the next presentation did the same.
-    /// Cloud review caught both; keying on whether the view EXISTS closes both.
-    @Test("a superseded first request leaves the next one still deferred")
-    func supersededFirstRequestKeepsDeferring() async {
-      let host = WindowlessOverlayHost()
-      let d = OverlayDirector(
-        host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
-
-      // First request, deferred. A second replaces it before the run loop turns,
-      // so the first drops on its identity gate and builds nothing.
-      d.present(.warning(reason: .polishFailed))
-      d.present(.processing(phase: .transcribing))
-      #expect(host.presented.isEmpty, "a presentation reached the window synchronously")
-
-      await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
-
-      #expect(
-        host.presented.count == 1,
-        "the superseded request drew, or the live one never did")
-      #expect(host.isShowing, "nothing ended up on screen after the run loop turned")
-    }
-
-    /// The pair: only the FIRST is deferred. Every later presentation morphs a
-    /// view that already exists, so deferring them all would add a frame of
-    /// latency to every transition for a crash window that has closed.
-    @Test("a later presentation is not deferred")
-    func laterRendersAreSynchronous() async {
-      let host = WindowlessOverlayHost()
-      let d = OverlayDirector(
-        host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
-      d.present(.warning(reason: .polishFailed))
-      await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
-
-      d.present(.processing(phase: .transcribing))
-
-      #expect(
-        host.presented.count == 2,
-        "a later presentation was deferred too, costing a frame on every transition")
-    }
-
-    // MARK: - A dictation is ONE presentation, however its content changes (#2292 C12)
-
-    /// **#2195, arriving through the identity gate rather than the placement
-    /// value.** `OverlayWindowHostTests` already proves the host keeps a dragged
-    /// pill when told `isFresh: false`, and it does. Nothing tested what the
-    /// DIRECTOR passes, and the director passed `presentedID != presentation.id`
-    /// — true for every occupant change, because the reducer mints a new
-    /// `PresentationID` for each one.
-    ///
-    /// So a dragged pill snapped back to centre the moment the recording became
-    /// processing, with the host, the placement value and the whole host suite
-    /// behaving perfectly. The rule it broke is written down:
-    /// `pill-position-behavior.md` RULE: continuing-panel-vs-fresh-panel.
-    /// **Asserted on `isFresh` since C6, which is the value this case is about.**
-    /// Its own paragraph says so: the host was already proven to keep a dragged
-    /// pill when told `isFresh: false` (`OverlayWindowHostTests` :106), and
-    /// nothing tested what the DIRECTOR passes. Reading the resulting panel
-    /// origin proved the director's flag through AppKit's placement arithmetic,
-    /// which needed a real window and kept the case out of the Release lane. The
-    /// windowless host records the flag itself.
-    @Test("a dragged pill keeps its place when the recording becomes processing")
-    func draggedPillSurvivesAContentChange() throws {
-      let (d, host, _) = Self.pressableDirector()
-      Self.record(d, level: 0.2)
-
-      d.present(.processing(phase: .transcribing))
-
-      // **The LAST value is the subject.** The first presentation of a
-      // director's life is reported `isFresh: false` because the deferred
-      // first-render path sets `presentedID` before it renders, so
-      // `presentedID == nil` is already false by the time freshness is computed.
-      // That is a property of first render, not of this transition, and pinning
-      // it here would make this case fail for a reason it is not about.
-      #expect(
-        host.presented.last?.isFresh == false,
-        """
-        the director called the content change a FRESH presentation, so a dragged \
-        pill snaps back to centre — #2195 through the director
-        """)
-    }
-
-    /// The paired case, without which the guard above is satisfied by a director
-    /// that never marks anything fresh. A pill appearing when NOTHING is showing
-    /// is genuinely new and must centre, drag history or not.
-    @Test("a pill appearing after the overlay was hidden is marked fresh again")
-    func hiddenThenShownRecentres() {
-      let (d, host, _) = Self.pressableDirector()
-      Self.record(d, level: 0.2)
-
-      d.dismissCurrent(.announced)
-      Self.record(d, level: 0.2)
-
-      #expect(
-        host.presented.last?.isFresh == true,
-        """
-        a pill raised after the overlay emptied was called CONTINUING, so it inherits \
-        a drag from a dictation that is over
-        """)
-    }
-
-    // MARK: - A feature that takes the slot is spoken (#2292 C8)
-
-    /// **The Bluetooth card appeared in silence, and it is the worst case for
-    /// that.** Every other pill is transient; this one persists until it is
-    /// dismissed, so a VoiceOver user got no signal at all that the overlay had
-    /// changed and no later event to infer it from.
-    ///
-    /// The shipped `apply(intent:)` has a `.bluetoothAwareness` arm posting
-    /// `DictationNarrator`'s sentence at MEDIUM priority, and the wiring reached
-    /// it by calling `show(intent: .bluetoothAwareness)`. The cutover routed the
-    /// card through `reduceFeature`, the one presenting plan that carried no
-    /// announcement, and nothing failed.
-    @Test("a Bluetooth card is announced at medium priority")
-    func bluetoothCardIsAnnounced() {
-      let (d, _, sink) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
-
-      #expect(sink.announcements.count == 1, "the card appeared and said nothing")
-      #expect(
-        sink.announcements.first?.isHighPriority == false,
-        "the card interrupted at high priority; the shipped arm posts medium")
-      #expect(
-        sink.announcements.first?.text == DictationNarrator.announcement(for: .bluetoothAwareness),
-        "the card announced something other than the narrator's sentence")
-    }
-
-    /// **The same defect, the same line, the second feature.** The review named
-    /// the Bluetooth card; the language chip goes through `reduceFeature` too and
-    /// the shipped switch has a `.passiveChip` arm posting at medium. Fixing one
-    /// and leaving the other would ship half a repair.
-    @Test("a language chip is announced at medium priority")
-    func languageChipIsAnnounced() {
-      let (d, _, sink) = Self.director()
-      defer { Self.closeAllWindows() }
-      let payload = LanguageChipPayload(
-        lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
-
-      d.present(.languageChip(payload: payload, onLock: {}, onDismiss: {}, onExpire: {}))
-
-      #expect(sink.announcements.count == 1, "the chip appeared and said nothing")
-      #expect(
-        sink.announcements.first?.isHighPriority == false,
-        "the chip interrupted at high priority; the shipped arm posts medium")
-    }
-
-    /// **Import status is silent, and that is the shipped behaviour rather than
-    /// an omission.** It is the one request with no matching `OverlayIntent`, so
-    /// the shipped switch has no arm for it. Asserted so a later reading of
-    /// "features announce" cannot quietly add one.
-    @Test("an import status pill stays silent, as it shipped")
-    func importStatusIsNotAnnounced() {
-      let (d, _, sink) = Self.director()
-      defer { Self.closeAllWindows() }
-
-      d.present(.importStatus(message: "Importing 3 recordings"))
-
-      #expect(
-        d.renderModel.state.presentation != nil, "the status pill never took the slot")
-      #expect(
-        sink.announcements.isEmpty,
-        "import status announced, which the shipped panel never did")
-    }
-
-    /// **A refused presentation must not be announced**, which is why the post
-    /// moved behind the render rather than staying where the shipped panel put
-    /// it. Announcing first makes the sentence unconditional, so a card the host
-    /// refuses is still spoken — and told to the one user who has no other way
-    /// to discover it is not there.
-    @Test("a refused presentation says nothing")
-    func refusedPresentationIsNotAnnounced() {
-      let (d, sink, _) = Self.refusingDirectorWithSink({ false })
-      defer { Self.closeAllWindows() }
-
-      d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
-
-      #expect(
-        sink.announcements.isEmpty,
-        "a card that never reached the screen was announced as though it had")
-      #expect(d.featureSlotIsAvailable, "the C7 rollback did not run")
-    }
-
-    // MARK: - A refused presentation leaves no owner behind (#2292 C7)
-
-    /// A director whose host refuses every presentation until `screenAvailable`
-    /// is flipped.
-    ///
-    /// **The resolver is re-read on every `present`**, which is what makes the
-    /// retry testable: the same director refuses, then succeeds, with nothing
-    /// rebuilt in between. A second director would prove only that a fresh one
-    /// works, which was never in doubt.
-    /// **Captures the armed expiry since C6.** The rollback case needs to fire
-    /// whatever timer a refused presentation left behind, and it cannot: this rig
-    /// used the LIVE scheduler, so an armed dwell was unreachable and the only
-    /// way to ask about one was a Boolean hatch reading `armedExpiry != nil`.
-    /// A captured schedule can be FIRED, which turns "is a timer armed" into
-    /// "does the timer take the successor down" — the thing a user would meet.
-    private static func refusingDirectorWithSink(_ screenAvailable: @escaping () -> Bool)
-      -> (OverlayDirector, Sink, Armed)
-    {
-      let sink = Sink()
-      let armed = Armed()
-      let host = OverlayWindowHost(
-        screens: { OverlayScreenResolver { screenAvailable() ? screen : nil } })
-      let d = OverlayDirector(
-        host: host,
-        scheduler: .manual { armed.work = $0 },
-        announce: { sink.announcements.append($0) },
-        livePreview: .disabled,
-        grantAccessibility: { sink.appActions.append(.grantAccessibility) },
-        selections: { .shipped },
-        deferFirstRender: { $0() })
-      hosts.append(host)
-      return (d, sink, armed)
-    }
-
-    /// **Clearing the window is not the same as releasing the slot.**
-    ///
-    /// `OverlayWindowHost.present` refuses on two causes — no screen, and a
-    /// presentation it cannot size — and both leave through the same `guard`, so
-    /// one of them proves the director's half of the contract. The host suite
-    /// owns the pair; this owns what the director does with a `false`.
-    ///
-    /// The first version cleared `presentedID` and hid the window, which reads
-    /// like a rollback and is not one: the reducer, the render model, the
-    /// binding and the armed expiry all still named an occupant that was never
-    /// drawn.
-    ///
-    /// **Asserted through CONSEQUENCES since C6**, because the internal markers
-    /// this used to read are gone and most of them had none on their own: nobody
-    /// can press a button on a pill that was never drawn, and an internal id
-    /// nobody reads cannot hurt a user. What DOES reach a person is the slot —
-    /// a refused card that keeps holding it means every later feature is refused
-    /// for the rest of the session, which is the failure this case exists for.
-    ///
-    /// **The armed-timer half is deliberately NOT re-asserted here**, and the
-    /// reason is worth stating because the obvious attempt does not work. Firing
-    /// "the armed work" after presenting a successor fires the SUCCESSOR'S OWN
-    /// dwell, which correctly dismisses it — a test that cannot pass. Firing the
-    /// timer captured before the successor tests nothing when the rollback is
-    /// correct, because there is no timer to fire. The property that actually
-    /// matters — a timer armed for one presentation cannot dismiss another — is
-    /// scoped by `PresentationID` and owned by
-    /// `staleTimerCannotDismissTheLivePill`, which proves it for every armed
-    /// timer including this one.
-    @Test("a refused presentation leaves nothing claiming the slot")
-    func refusedPresentationReleasesEverything() {
-      let (d, _, _) = Self.refusingDirectorWithSink({ false })
-      defer { Self.closeAllWindows() }
-
-      d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
-
-      #expect(d.renderModel.state.presentation == nil, "a refused card was published anyway")
-      #expect(
-        d.featureSlotIsAvailable,
-        "the refused card still holds the slot, so every later feature is refused too")
-    }
-
-    /// **The dedup guard is what turns a refusal into a PERMANENT failure.**
-    ///
-    /// A repeated intent is dropped as a no-op, by design — it is the guard that
-    /// stops an audio tick re-arming a dwell. But a refusal that leaves
-    /// `pipelineIntent` holding the refused intent makes the retry look like
-    /// that repeat, so the pill never comes back once a screen returns. The
-    /// user-visible shape: unplug the external display mid-dictation, plug it
-    /// back in, and the overlay is gone for the rest of the session.
-    @Test("the same intent presents on retry after a refusal")
-    func refusedIntentRetriesSuccessfully() {
-      var hasScreen = false
-      let (d, _, _) = Self.refusingDirectorWithSink({ hasScreen })
-      defer { Self.closeAllWindows() }
-
-      d.present(.warning(reason: .polishFailed))
-      #expect(d.renderModel.state.presentation == nil, "the refusal did not take")
-
-      hasScreen = true
-      d.present(.warning(reason: .polishFailed))
-
-      #expect(
-        d.renderModel.state.presentation != nil,
-        "the retry was deduplicated against the intent the refusal left behind")
-    }
-
-    /// **A recording's providers are polled ~50 times a second**, so leaving
-    /// them installed for a pill that was refused means a finished dictation's
-    /// closures run behind an empty screen for the rest of the session. Same
-    /// lifetime rule as a replaced recording, arriving through the refusal path
-    /// instead.
-    @Test("a refused recording releases its providers and its lock survives")
-    func refusedRecordingReleasesProviders() {
-      let (d, _, _) = Self.refusingDirectorWithSink({ false })
-      defer { Self.closeAllWindows() }
-
-      d.present(
-        .recording(
-          RecordingPillInput(
-            audioLevel: 0.5,
-            audioLevelProvider: { 0.5 },
-            recordingElapsedProvider: { 3 },
-            isLocked: true)))
-
-      #expect(d.renderModel.state.presentation == nil, "a refused recording was published anyway")
-      // Asserted through the FRAME rather than a test-only flag: a refused
-      // recording that left its providers reachable would leave a recording
-      // frame published, and that frame is the only thing a leaf can poll.
-      #expect(
-        d.renderModel.state.recording == nil,
-        "a refused recording's providers are still reachable to poll")
-      Self.expectReleasedProvidersDoNotReappear(d.renderModel)
-      // **The lock is NOT part of the rollback, and that claim moved to the
-      // reducer suite** (#2292 C6). It outlives any one presentation by design,
-      // so a refused frame must not silently unlock a hands-free session that is
-      // still running — but the lock is only OBSERVABLE where it is drawn, and
-      // every recording request carries its own lock flag, so a later pill
-      // reports what that call asked for rather than what survived. There is no
-      // rendered observation of this property at the director level.
-      //
-      // `OverlayReducerTests.lockWithoutRecordingIsRemembered` asserts it where
-      // it is real: the lock is remembered with NO pill showing, which is the
-      // same state a refusal leaves. That case runs in the Release lane.
+        onResult: { results.append($0) }))
+    #expect(results.isEmpty, "a verdict was delivered before the host was asked")
+
+    deferral.fire()
+
+    #expect(results == [.presented(receipt)], "the accepted card was not reported once")
+    guard case .bluetoothAwareness? = d.renderModel.state.presentation?.content else {
+      Issue.record("the accepted card never reached the screen")
+      return
     }
   }
+
+  /// **A REQUEST THAT IS REFUSED ANSWERS FOR ITSELF AND FOR NOTHING ELSE.**
+  /// The card is still waiting for its run loop when a second feature asks for
+  /// the slot and is turned away. The card is untouched by that: it still
+  /// renders, and its owner must still be told, because the owner is what
+  /// records the receipt the buttons are dispatched through.
+  ///
+  /// REPRODUCIBLE: a launch-time reconcile defers the card, a second feature
+  /// request arrives in the same run-loop turn and is refused for want of the
+  /// slot the card itself holds. Resolving the pending caller on the way in put
+  /// a VISIBLE Bluetooth card on screen with dead buttons and no `.shown` — the
+  /// user sees a tip they cannot dismiss, and the dashboard says they were
+  /// never shown one.
+  @Test
+  func aRefusedRequestLeavesAPendingDeferralsResultIntact() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    var cardResults: [PillPresentationResult] = []
+    var refusedResults: [PillPresentationResult] = []
+
+    let receipt = try #require(
+      d.present(
+        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+        onResult: { cardResults.append($0) }))
+
+    // A second feature asks while the card holds the slot, and is refused.
+    let refused = d.present(
+      .importStatus(message: "Imported 3 words"),
+      onResult: { refusedResults.append($0) })
+
+    #expect(
+      refused == nil, "the second feature was admitted, so this case never reaches its subject")
+    #expect(refusedResults == [.notPresented], "the refused caller was not told it was refused")
+    #expect(cardResults.isEmpty, "the refused request answered on the pending card's behalf")
+
+    deferral.fire()
+
+    #expect(
+      cardResults == [.presented(receipt)],
+      "the card rendered but its owner was never told, so its buttons have no target")
+    guard case .bluetoothAwareness? = d.renderModel.state.presentation?.content else {
+      Issue.record("the card never reached the screen")
+      return
+    }
+  }
+
+  /// The paired case: a request that IS admitted supersedes the pending one,
+  /// and the pending caller hears `.notPresented` from its own deferred block.
+  /// Without this, the case above is satisfied by a director that simply never
+  /// reports supersession.
+  @Test
+  func anAdmittedRequestStillSupersedesAPendingDeferral() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    var cardResults: [PillPresentationResult] = []
+
+    d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { cardResults.append($0) })
+
+    // A recording outranks a feature, so this one IS admitted.
+    Self.record(d, level: 0.3)
+    deferral.fire()
+
+    #expect(
+      cardResults == [.notPresented],
+      "a card that lost the slot before rendering was reported as presented")
+  }
+
+  /// **A DIFFERENT-ID SUPERSESSION RESOLVES ITS OUTGOING CALLER IMMEDIATELY,
+  /// NOT WHEN CONSTRUCTION EVENTUALLY COMPLETES.** Nothing is built until the
+  /// gate's one scheduled block runs, so a second, different presentation
+  /// arriving first coalesces onto the pending slot — and the card that slot
+  /// used to hold must hear it lost the slot as soon as that decision is
+  /// made, not lazily on an unrelated construction's schedule.
+  @Test
+  func twoQueuedDeferralsEachAnswerTheirOwnCaller() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    var cardResults: [PillPresentationResult] = []
+    var noticeResults: [PillPresentationResult] = []
+
+    d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { cardResults.append($0) })
+
+    #expect(cardResults.isEmpty, "a verdict arrived before any render")
+
+    // A pipeline pill outranks the feature, so this one IS admitted — and it
+    // defers too, because nothing has rendered yet.
+    let notice = try #require(
+      d.present(.clipboardFallback, onResult: { noticeResults.append($0) }))
+
+    #expect(
+      cardResults == [.notPresented],
+      "a different-id supersession must resolve the outgoing owner immediately")
+    #expect(noticeResults.isEmpty, "a verdict arrived before any render")
+
+    deferral.fireAll()
+
+    #expect(
+      cardResults == [.notPresented],
+      "the superseded card was reported through the wrong transaction's verdict")
+    #expect(
+      noticeResults == [.presented(notice)],
+      "the pill that actually rendered was not reported to its own caller")
+  }
+
+  /// **A SAME-ID coalescing must retain EVERY caller's relay, not just the
+  /// first.** Two audio-level ticks for one ongoing recording share one
+  /// presentation id — `presentRecording`'s own `.morphed` branch says so —
+  /// and each is a real `present(_:onResult:)` call with its own completion.
+  /// `onResult` promises exactly one answer per call, so losing the second
+  /// caller's relay to "retain the original" would leave it waiting forever;
+  /// both must hear the SAME verdict once the ONE coalesced construction
+  /// actually lands.
+  @Test
+  func twoSameIDCallsBeforeReadinessBothHearTheSingleVerdict() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    var firstResults: [PillPresentationResult] = []
+    var secondResults: [PillPresentationResult] = []
+
+    let firstReceipt = try #require(
+      d.present(
+        .recording(
+          RecordingPillInput(
+            audioLevel: 0.2, audioLevelProvider: { 0.2 },
+            recordingElapsedProvider: { nil }, isLocked: false)),
+        onResult: { firstResults.append($0) }))
+    let secondReceipt = try #require(
+      d.present(
+        .recording(
+          RecordingPillInput(
+            audioLevel: 0.4, audioLevelProvider: { 0.4 },
+            recordingElapsedProvider: { nil }, isLocked: false)),
+        onResult: { secondResults.append($0) }))
+
+    #expect(
+      firstResults.isEmpty && secondResults.isEmpty, "a verdict arrived before any render")
+    #expect(
+      firstReceipt.presentationID == secondReceipt.presentationID,
+      "two ticks of the SAME recording minted two different presentation ids")
+
+    deferral.fireAll()
+
+    #expect(host.presentCount == 1, "two same-id ticks produced more than one host command")
+    #expect(
+      firstResults == [.presented(firstReceipt)],
+      "the first caller never heard the single coalesced construction land")
+    #expect(
+      secondResults == [.presented(secondReceipt)],
+      "the second caller's relay was dropped rather than retained")
+    guard case .recording(let level, _, _, _)? = d.renderModel.state.presentation?.content else {
+      Issue.record("the recording never reached the published frame")
+      return
+    }
+    #expect(
+      level == 0.4,
+      "the published frame carries the FIRST tick's level, not the latest one the user spoke")
+  }
+
+  /// The refusing twin: both callers must hear the SAME refusal, not just the
+  /// original.
+  @Test
+  func twoSameIDCallsBeforeReadinessBothHearARefusal() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    host.accepts = false
+    var firstResults: [PillPresentationResult] = []
+    var secondResults: [PillPresentationResult] = []
+
+    d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0.2, audioLevelProvider: { 0.2 },
+          recordingElapsedProvider: { nil }, isLocked: false)),
+      onResult: { firstResults.append($0) })
+    d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0.4, audioLevelProvider: { 0.4 },
+          recordingElapsedProvider: { nil }, isLocked: false)),
+      onResult: { secondResults.append($0) })
+
+    deferral.fireAll()
+
+    #expect(host.presentCount == 1, "two same-id ticks produced more than one host command")
+    #expect(firstResults == [.notPresented], "the first caller did not hear the shared refusal")
+    #expect(secondResults == [.notPresented], "the second caller did not hear the shared refusal")
+  }
+
+  /// **The real AppKit surface, not the windowless fake's call count.** Every
+  /// other same-id row above counts calls into `RefusingWindowlessHost`; this
+  /// one asks the actual `OverlayWindowHost` what it told a real `NSPanel` to
+  /// do, so a bug that produced one FAKE-host call but two real
+  /// `orderFrontRegardless` commands — a shape none of the windowless rows
+  /// above could ever see — still fails here.
+  @Test("two same-id updates before readiness issue exactly one real orderFrontRegardless")
+  func twoSameIDUpdatesIssueExactlyOneRealHostCommand() {
+    let recorder = OverlayPanelCommandRecorder()
+    let host = OverlayWindowHost(
+      screens: { OverlayScreenResolver { Self.screen } }, panelFactory: recorder.makeFactory())
+    let deferral = Deferral()
+    let d = OverlayDirector(
+      host: host, scheduler: .manual { _ in }, announce: { _ in }, livePreview: .disabled,
+      grantAccessibility: {}, selections: { .shipped },
+      firstRenderSchedule: { deferral.block = $0 })
+    defer { recorder.panel?.orderOut(nil) }
+
+    Self.record(d, level: 0.2)
+    Self.record(d, level: 0.4)
+
+    deferral.fireAll()
+
+    let orderFrontCount = recorder.commands.reduce(into: 0) { count, command in
+      if case .orderFrontRegardless = command { count += 1 }
+    }
+    #expect(
+      orderFrontCount == 1,
+      "two same-id updates issued \(orderFrontCount) real orderFrontRegardless commands")
+  }
+
+  /// **Nothing announces or arms before the gate fires, and coalescing an
+  /// `.unchanged` update onto an armed `.arm` must not lose the arm.** A
+  /// recording presents (its own announcement pending), then an in-panel
+  /// notice arms a timed dismiss on the SAME id, then an audio tick —
+  /// `.unchanged` — arrives before any of this has rendered. `.unchanged`
+  /// must PRESERVE the pending expiry start, not silently drop it.
+  @Test("a same-id notice arm survives a later unchanged tick, and nothing fires early")
+  func recordingThenTimedNoticeThenUnchangedTickPreservesTheArm() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    var announcements: [OverlayAnnouncement] = []
+    let d = OverlayDirector(
+      host: host, scheduler: .manual { _ in }, announce: { announcements.append($0) },
+      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
+      firstRenderSchedule: { deferral.block = $0 })
+
+    Self.record(d, level: 0.2)
+    d.update(.inPanelNotice(.autoStopUnavailable, dismissAfter: 4.0))
+    Self.record(d, level: 0.4)
+
+    #expect(announcements.isEmpty, "an announcement fired before the gate ever ran")
+    #expect(d.renderModel.state.dwell == nil, "a dwell was published before anything rendered")
+
+    deferral.fireAll()
+
+    #expect(
+      announcements.map(\.text) == ["Recording started"],
+      "coalescing must not duplicate or drop the recording's own announcement")
+    let dwell = d.renderModel.state.dwell
+    #expect(dwell != nil, "the `.arm` from the in-panel notice was lost under a later `.unchanged`")
+    #expect(dwell?.seconds == 4.0, "the armed dwell does not match the notice's own dismiss time")
+  }
+
+  /// The paired case: `.cancel` on a same-id update MUST clear a previously
+  /// armed expiry, not merely leave it alone like `.unchanged` does.
+  @Test("a same-id notice cancel clears a previously armed dwell")
+  func recordingThenTimedNoticeThenCancelClearsTheArm() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = OverlayDirector(
+      host: host, scheduler: .manual { _ in }, announce: { _ in },
+      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
+      firstRenderSchedule: { deferral.block = $0 })
+
+    Self.record(d, level: 0.2)
+    d.update(.inPanelNotice(.autoStopUnavailable, dismissAfter: 4.0))
+    // A persistent notice cancels the timed one before either ever rendered.
+    d.update(.inPanelNotice(.approachingCap, dismissAfter: nil))
+
+    deferral.fireAll()
+
+    #expect(
+      d.renderModel.state.dwell == nil,
+      "a `.cancel` coalesced onto a pending `.arm` left a dwell armed anyway")
+  }
+
+  /// **A REENTRANT `present` from inside a supersession callback must not be
+  /// silently overwritten by the outer call finishing its own bookkeeping
+  /// after the reentrant call already installed its own slot.** `resolve`
+  /// runs arbitrary caller code, and presenting again from inside it is a
+  /// real, reachable shape.
+  @Test("a reentrant present from inside a supersession callback is not clobbered")
+  func reentrantPresentDuringASupersessionCallbackIsNotClobbered() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    var aResults: [PillPresentationResult] = []
+    var bResults: [PillPresentationResult] = []
+    var cResults: [PillPresentationResult] = []
+    var cReceipt: PillReceipt?
+
+    d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { result in
+        aResults.append(result)
+        // Reentrant, synchronous, from inside B's own admission call: a
+        // pipeline event always replaces whatever the pipeline last showed,
+        // so C supersedes B here — before B's own `present` call returns.
+        cReceipt = d.present(.warning(reason: .polishFailed), onResult: { cResults.append($0) })
+      })
+
+    let bReceipt = d.present(.clipboardFallback, onResult: { bResults.append($0) })
+
+    #expect(bReceipt != nil, "B was refused, so this case never reaches its subject")
+    #expect(aResults == [.notPresented], "A's own refusal callback did not fire exactly once")
+    let unwrappedCReceipt = try #require(cReceipt, "the reentrant C call was not admitted")
+
+    deferral.fireAll()
+
+    #expect(aResults == [.notPresented], "A was reported more than once")
+    #expect(bResults == [.notPresented], "B was superseded by the reentrant C but not told")
+    #expect(
+      cResults == [.presented(unwrappedCReceipt)],
+      "C, the reentrant presentation, never reached the screen")
+  }
+
+  /// **A dismissal before the gate ever fires must still let the ONE
+  /// construction complete** — the gate has no cancel, by design (its own
+  /// doc comment: "schedule it once, build once") — but that one completed
+  /// construction must never reach the host, since nothing was showing by
+  /// the time it landed. The proof that only ONE construction happened,
+  /// not zero and not two, is that the NEXT presentation is synchronous.
+  @Test(
+    "dismissing before the gate fires presents nothing, and the next presentation is synchronous")
+  func dismissalBeforeReadinessPresentsNothingAndLeavesTheGateReady() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+
+    d.present(.warning(reason: .polishFailed))
+    d.dismissCurrent(.silent)
+
+    deferral.fireAll()
+
+    #expect(
+      host.presentCount == 0,
+      "the one construction the gate always completes reached the host after a dismissal")
+    #expect(deferral.fired == 1, "more than one construction ran for a single director lifetime")
+
+    d.present(.warning(reason: .polishFailed))
+
+    #expect(
+      host.presentCount == 1,
+      "a presentation after the gate is ready deferred again instead of rendering synchronously")
+    #expect(deferral.fired == 1, "the second presentation scheduled a SECOND construction")
+  }
+
+  /// Exactly once, on the path that has the most terminals to get it wrong: the
+  /// host refuses, which rolls back through a dismissal that itself renders
+  /// successfully. Reading a bare render outcome reported that dismissal as the
+  /// presentation's own success.
+  @Test
+  func aRefusedDeferralReportsExactlyOnce() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    host.accepts = false
+    var results: [PillPresentationResult] = []
+
+    d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { results.append($0) })
+
+    deferral.fireAll()
+    // Firing again must add nothing: the queue is drained and the relay spent.
+    deferral.fireAll()
+
+    #expect(results == [.notPresented], "the refused card was reported \(results.count) times")
+  }
+
+  /// A deferred presentation superseded before it renders never reached the
+  /// screen, and its caller must hear that rather than nothing at all — a
+  /// silent path is what leaves a once-per-launch allowance spent forever.
+  @Test("a deferred presentation superseded before rendering reports notPresented")
+  func supersededDeferralReportsNotPresented() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    var results: [PillPresentationResult] = []
+
+    d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { results.append($0) })
+
+    // A recording takes the slot while the card is still waiting to render.
+    Self.record(d, level: 0.3)
+    deferral.fire()
+
+    #expect(results == [.notPresented], "a superseded card was reported as presented")
+  }
+
+  /// The ordinary path, which is every presentation after the first: no
+  /// deferral, one result, delivered before `present` returns.
+  @Test("an immediate presentation reports presented exactly once")
+  func immediatePresentationReportsPresentedOnce() throws {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+
+    // Spend the deferral on a first presentation, so the next one is
+    // synchronous — then clear the slot, or the card is refused at admission
+    // and this case never reaches the immediate render it is about.
+    d.present(.engineReady)
+    deferral.fire()
+    d.dismissCurrent(.silent)
+
+    var results: [PillPresentationResult] = []
+    let receipt = try #require(
+      d.present(
+        .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+        onResult: { results.append($0) }))
+
+    #expect(
+      deferral.fired == 1, "the second presentation deferred, so this is not the immediate path")
+    #expect(
+      results == [.presented(receipt)], "the immediate path did not report exactly one result")
+  }
+
+  /// Admission refusal is the fourth terminal and the only one that also
+  /// returns nil. A caller that hears nothing here would keep an allowance
+  /// pending forever waiting for a verdict that never arrives.
+  @Test("a request refused at admission reports notPresented and returns nil")
+  func admissionRefusalReportsNotPresented() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+    Self.record(d, level: 0.3)
+    deferral.fire()
+
+    var results: [PillPresentationResult] = []
+    let receipt = d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { results.append($0) })
+
+    #expect(receipt == nil, "a recording holds the slot, so the card is refused")
+    #expect(results == [.notPresented], "an admission refusal delivered no verdict")
+  }
+
+  // MARK: - Fail closed (#2292 C19)
+
+  // **`escapeRecoveryWithoutPayloadFailsClosed` was DELETED** (#2292 C5c), and
+  // its own comment names the reason it can go: it was "preserved because a
+  // bare call still COMPILES". It does not. The one route to that presentation
+  // is `present(.escapeRecovery(payload:onPaste:))`, whose payload is not
+  // optional, so an offer to Paste with no target behind it is no longer a
+  // shape anyone can write. The rule it protected became a property of the API,
+  // which is the stronger place for it.
+
+  // MARK: - The first render is deferred one run loop (#2292 C15)
+
+  /// **A crash fix, asserted through the production deferral rather than the
+  /// synchronous double the other cases use.**
+  ///
+  /// `MenuBarController.toggleRecordingAction` reaches the director while the
+  /// status-item menu dismiss animation is still running, and building the
+  /// `NSHostingView` during it causes a re-entrant `NSWindow` layout cycle and
+  /// SIGABRT. The deleted panel deferred every creation with
+  /// `DispatchQueue.main.async` and carried that reason in a comment.
+  ///
+  /// The barrier below is a SIGNAL, not a clock: a continuation enqueued
+  /// behind the deferred work resumes only after it has run, so this waits on
+  /// the subject rather than on time.
+  @Test("the first presentation reaches the window on the NEXT run loop")
+  func firstRenderIsDeferred() async {
+    let host = WindowlessOverlayHost()
+    // The production `firstRenderSchedule` — the default — is the subject here.
+    let d = OverlayDirector(
+      host: host, announce: { _ in },
+      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
+
+    d.present(.warning(reason: .polishFailed))
+    #expect(
+      host.presented.isEmpty,
+      "the first presentation reached the window synchronously — this is the menu-dismiss crash")
+
+    await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
+
+    #expect(host.presented.count == 1, "the deferred first presentation never arrived")
+    #expect(host.isShowing, "the deferred presentation did not leave the window showing")
+  }
+
+  /// **A first request that is SUPERSEDED must leave the deferral armed.**
+  ///
+  /// The first version of this fix set a "deferred once" flag when the work was
+  /// SCHEDULED. Two paths then reopened the crash: another event arriving
+  /// before the queued block ran saw the flag set and built the view
+  /// synchronously, and a request dropped by its own identity gate left the
+  /// flag set with nothing built, so the next presentation did the same.
+  /// Cloud review caught both; keying on whether the view EXISTS closes both.
+  @Test("a superseded first request leaves the next one still deferred")
+  func supersededFirstRequestKeepsDeferring() async {
+    let host = WindowlessOverlayHost()
+    let d = OverlayDirector(
+      host: host, announce: { _ in },
+      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
+
+    // First request, deferred. A second replaces it before the run loop turns,
+    // so the first drops on its identity gate and builds nothing.
+    d.present(.warning(reason: .polishFailed))
+    d.present(.processing(phase: .transcribing))
+    #expect(host.presented.isEmpty, "a presentation reached the window synchronously")
+
+    await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
+
+    #expect(
+      host.presented.count == 1,
+      "the superseded request drew, or the live one never did")
+    #expect(host.isShowing, "nothing ended up on screen after the run loop turned")
+  }
+
+  /// The pair: only the FIRST is deferred. Every later presentation morphs a
+  /// view that already exists, so deferring them all would add a frame of
+  /// latency to every transition for a crash window that has closed.
+  @Test("a later presentation is not deferred")
+  func laterRendersAreSynchronous() async {
+    let host = WindowlessOverlayHost()
+    let d = OverlayDirector(
+      host: host, announce: { _ in },
+      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
+    d.present(.warning(reason: .polishFailed))
+    await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
+
+    d.present(.processing(phase: .transcribing))
+
+    #expect(
+      host.presented.count == 2,
+      "a later presentation was deferred too, costing a frame on every transition")
+  }
+
+  // MARK: - A dictation is ONE presentation, however its content changes (#2292 C12)
+
+  /// **#2195, arriving through the identity gate rather than the placement
+  /// value.** `OverlayWindowHostTests` already proves the host keeps a dragged
+  /// pill when told `isFresh: false`, and it does. Nothing tested what the
+  /// DIRECTOR passes, and the director passed `presentedID != presentation.id`
+  /// — true for every occupant change, because the reducer mints a new
+  /// `PresentationID` for each one.
+  ///
+  /// So a dragged pill snapped back to centre the moment the recording became
+  /// processing, with the host, the placement value and the whole host suite
+  /// behaving perfectly. The rule it broke is written down:
+  /// `pill-position-behavior.md` RULE: continuing-panel-vs-fresh-panel.
+  /// **Asserted on `isFresh` since C6, which is the value this case is about.**
+  /// Its own paragraph says so: the host was already proven to keep a dragged
+  /// pill when told `isFresh: false` (`OverlayWindowHostTests` :106), and
+  /// nothing tested what the DIRECTOR passes. Reading the resulting panel
+  /// origin proved the director's flag through AppKit's placement arithmetic,
+  /// which needed a real window and kept the case out of the Release lane. The
+  /// windowless host records the flag itself.
+  @Test("a dragged pill keeps its place when the recording becomes processing")
+  func draggedPillSurvivesAContentChange() throws {
+    let (d, host, _) = Self.pressableDirector()
+    Self.record(d, level: 0.2)
+
+    d.present(.processing(phase: .transcribing))
+
+    // The first presentation is fresh because nothing is showing. This case
+    // asserts only the later recording-to-processing continuation.
+    #expect(
+      host.presented.last?.isFresh == false,
+      """
+      the director called the content change a FRESH presentation, so a dragged \
+      pill snaps back to centre — #2195 through the director
+      """)
+  }
+
+  /// The paired case, without which the guard above is satisfied by a director
+  /// that never marks anything fresh. A pill appearing when NOTHING is showing
+  /// is genuinely new and must centre, drag history or not.
+  @Test("a pill appearing after the overlay was hidden is marked fresh again")
+  func hiddenThenShownRecentres() {
+    let (d, host, _) = Self.pressableDirector()
+    Self.record(d, level: 0.2)
+
+    d.dismissCurrent(.announced)
+    Self.record(d, level: 0.2)
+
+    #expect(
+      host.presented.last?.isFresh == true,
+      """
+      a pill raised after the overlay emptied was called CONTINUING, so it inherits \
+      a drag from a dictation that is over
+      """)
+  }
+
+  // MARK: - A feature that takes the slot is spoken (#2292 C8)
+
+  /// **The Bluetooth card appeared in silence, and it is the worst case for
+  /// that.** Every other pill is transient; this one persists until it is
+  /// dismissed, so a VoiceOver user got no signal at all that the overlay had
+  /// changed and no later event to infer it from.
+  ///
+  /// The shipped `apply(intent:)` has a `.bluetoothAwareness` arm posting
+  /// `DictationNarrator`'s sentence at MEDIUM priority, and the wiring reached
+  /// it by calling `show(intent: .bluetoothAwareness)`. The cutover routed the
+  /// card through `reduceFeature`, the one presenting plan that carried no
+  /// announcement, and nothing failed.
+  @Test("a Bluetooth card is announced at medium priority")
+  func bluetoothCardIsAnnounced() {
+    let (d, _, sink) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
+
+    #expect(sink.announcements.count == 1, "the card appeared and said nothing")
+    #expect(
+      sink.announcements.first?.isHighPriority == false,
+      "the card interrupted at high priority; the shipped arm posts medium")
+    #expect(
+      sink.announcements.first?.text == DictationNarrator.announcement(for: .bluetoothAwareness),
+      "the card announced something other than the narrator's sentence")
+  }
+
+  /// **The same defect, the same line, the second feature.** The review named
+  /// the Bluetooth card; the language chip goes through `reduceFeature` too and
+  /// the shipped switch has a `.passiveChip` arm posting at medium. Fixing one
+  /// and leaving the other would ship half a repair.
+  @Test("a language chip is announced at medium priority")
+  func languageChipIsAnnounced() {
+    let (d, _, sink) = Self.director()
+    defer { Self.closeAllWindows() }
+    let payload = LanguageChipPayload(
+      lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
+
+    d.present(.languageChip(payload: payload, onLock: {}, onDismiss: {}, onExpire: {}))
+
+    #expect(sink.announcements.count == 1, "the chip appeared and said nothing")
+    #expect(
+      sink.announcements.first?.isHighPriority == false,
+      "the chip interrupted at high priority; the shipped arm posts medium")
+  }
+
+  /// **Import status is silent, and that is the shipped behaviour rather than
+  /// an omission.** It is the one request with no matching `OverlayIntent`, so
+  /// the shipped switch has no arm for it. Asserted so a later reading of
+  /// "features announce" cannot quietly add one.
+  @Test("an import status pill stays silent, as it shipped")
+  func importStatusIsNotAnnounced() {
+    let (d, _, sink) = Self.director()
+    defer { Self.closeAllWindows() }
+
+    d.present(.importStatus(message: "Importing 3 recordings"))
+
+    #expect(
+      d.renderModel.state.presentation != nil, "the status pill never took the slot")
+    #expect(
+      sink.announcements.isEmpty,
+      "import status announced, which the shipped panel never did")
+  }
+
+  /// **A refused presentation must not be announced**, which is why the post
+  /// moved behind the render rather than staying where the shipped panel put
+  /// it. Announcing first makes the sentence unconditional, so a card the host
+  /// refuses is still spoken — and told to the one user who has no other way
+  /// to discover it is not there.
+  @Test("a refused presentation says nothing")
+  func refusedPresentationIsNotAnnounced() {
+    let (d, sink, _) = Self.refusingDirectorWithSink({ false })
+    defer { Self.closeAllWindows() }
+
+    d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
+
+    #expect(
+      sink.announcements.isEmpty,
+      "a card that never reached the screen was announced as though it had")
+    #expect(d.featureSlotIsAvailable, "the C7 rollback did not run")
+  }
+
+  // MARK: - A refused presentation leaves no owner behind (#2292 C7)
+
+  /// A director whose host refuses every presentation until `screenAvailable`
+  /// is flipped.
+  ///
+  /// **The resolver is re-read on every `present`**, which is what makes the
+  /// retry testable: the same director refuses, then succeeds, with nothing
+  /// rebuilt in between. A second director would prove only that a fresh one
+  /// works, which was never in doubt.
+  /// **Captures the armed expiry since C6.** The rollback case needs to fire
+  /// whatever timer a refused presentation left behind, and it cannot: this rig
+  /// used the LIVE scheduler, so an armed dwell was unreachable and the only
+  /// way to ask about one was a Boolean hatch reading `armedExpiry != nil`.
+  /// A captured schedule can be FIRED, which turns "is a timer armed" into
+  /// "does the timer take the successor down" — the thing a user would meet.
+  private static func refusingDirectorWithSink(_ screenAvailable: @escaping () -> Bool)
+    -> (OverlayDirector, Sink, Armed)
+  {
+    let sink = Sink()
+    let armed = Armed()
+    let host = OverlayWindowHost(
+      screens: { OverlayScreenResolver { screenAvailable() ? screen : nil } })
+    let d = OverlayDirector(
+      host: host,
+      scheduler: .manual { armed.work = $0 },
+      announce: { sink.announcements.append($0) },
+      livePreview: .disabled,
+      grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+      selections: { .shipped },
+      firstRenderSchedule: { $0() })
+    hosts.append(host)
+    return (d, sink, armed)
+  }
+
+  /// **Clearing the window is not the same as releasing the slot.**
+  ///
+  /// `OverlayWindowHost.present` refuses on two causes — no screen, and a
+  /// presentation it cannot size — and both leave through the same `guard`, so
+  /// one of them proves the director's half of the contract. The host suite
+  /// owns the pair; this owns what the director does with a `false`.
+  ///
+  /// The first version cleared `presentedID` and hid the window, which reads
+  /// like a rollback and is not one: the reducer, the render model, the
+  /// binding and the armed expiry all still named an occupant that was never
+  /// drawn.
+  ///
+  /// **Asserted through CONSEQUENCES since C6**, because the internal markers
+  /// this used to read are gone and most of them had none on their own: nobody
+  /// can press a button on a pill that was never drawn, and an internal id
+  /// nobody reads cannot hurt a user. What DOES reach a person is the slot —
+  /// a refused card that keeps holding it means every later feature is refused
+  /// for the rest of the session, which is the failure this case exists for.
+  ///
+  /// **The armed-timer half is deliberately NOT re-asserted here**, and the
+  /// reason is worth stating because the obvious attempt does not work. Firing
+  /// "the armed work" after presenting a successor fires the SUCCESSOR'S OWN
+  /// dwell, which correctly dismisses it — a test that cannot pass. Firing the
+  /// timer captured before the successor tests nothing when the rollback is
+  /// correct, because there is no timer to fire. The property that actually
+  /// matters — a timer armed for one presentation cannot dismiss another — is
+  /// scoped by `PresentationID` and owned by
+  /// `staleTimerCannotDismissTheLivePill`, which proves it for every armed
+  /// timer including this one.
+  @Test("a refused presentation leaves nothing claiming the slot")
+  func refusedPresentationReleasesEverything() {
+    let (d, _, _) = Self.refusingDirectorWithSink({ false })
+    defer { Self.closeAllWindows() }
+
+    d.present(.bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
+
+    #expect(d.renderModel.state.presentation == nil, "a refused card was published anyway")
+    #expect(
+      d.featureSlotIsAvailable,
+      "the refused card still holds the slot, so every later feature is refused too")
+  }
+
+  /// **The dedup guard is what turns a refusal into a PERMANENT failure.**
+  ///
+  /// A repeated intent is dropped as a no-op, by design — it is the guard that
+  /// stops an audio tick re-arming a dwell. But a refusal that leaves
+  /// `pipelineIntent` holding the refused intent makes the retry look like
+  /// that repeat, so the pill never comes back once a screen returns. The
+  /// user-visible shape: unplug the external display mid-dictation, plug it
+  /// back in, and the overlay is gone for the rest of the session.
+  @Test("the same intent presents on retry after a refusal")
+  func refusedIntentRetriesSuccessfully() {
+    var hasScreen = false
+    let (d, _, _) = Self.refusingDirectorWithSink({ hasScreen })
+    defer { Self.closeAllWindows() }
+
+    d.present(.warning(reason: .polishFailed))
+    #expect(d.renderModel.state.presentation == nil, "the refusal did not take")
+
+    hasScreen = true
+    d.present(.warning(reason: .polishFailed))
+
+    #expect(
+      d.renderModel.state.presentation != nil,
+      "the retry was deduplicated against the intent the refusal left behind")
+  }
+
+  /// **A recording's providers are polled ~50 times a second**, so leaving
+  /// them installed for a pill that was refused means a finished dictation's
+  /// closures run behind an empty screen for the rest of the session. Same
+  /// lifetime rule as a replaced recording, arriving through the refusal path
+  /// instead.
+  @Test("a refused recording releases its providers and its lock survives")
+  func refusedRecordingReleasesProviders() {
+    let (d, _, _) = Self.refusingDirectorWithSink({ false })
+    defer { Self.closeAllWindows() }
+
+    d.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0.5,
+          audioLevelProvider: { 0.5 },
+          recordingElapsedProvider: { 3 },
+          isLocked: true)))
+
+    #expect(d.renderModel.state.presentation == nil, "a refused recording was published anyway")
+    // Asserted through the FRAME rather than a test-only flag: a refused
+    // recording that left its providers reachable would leave a recording
+    // frame published, and that frame is the only thing a leaf can poll.
+    #expect(
+      d.renderModel.state.recording == nil,
+      "a refused recording's providers are still reachable to poll")
+    Self.expectReleasedProvidersDoNotReappear(d.renderModel)
+    // **The lock is NOT part of the rollback, and that claim moved to the
+    // reducer suite** (#2292 C6). It outlives any one presentation by design,
+    // so a refused frame must not silently unlock a hands-free session that is
+    // still running — but the lock is only OBSERVABLE where it is drawn, and
+    // every recording request carries its own lock flag, so a later pill
+    // reports what that call asked for rather than what survived. There is no
+    // rendered observation of this property at the director level.
+    //
+    // `OverlayReducerTests.lockWithoutRecordingIsRemembered` asserts it where
+    // it is real: the lock is remembered with NO pill showing, which is the
+    // same state a refusal leaves. That case runs in the Release lane.
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayFirstRenderGateTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayFirstRenderGateTests.swift
@@ -1,0 +1,136 @@
+import AppKit
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// `OverlayFirstRenderGate` in isolation — no `OverlayDirector` involved.
+/// The Director's own use of this type is proved separately, in its own
+/// integration suite; this suite exists so the coalescing property holds
+/// even before there is a Director to coalesce FOR.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayFirstRenderGateTests {
+
+  /// A one-slot manual scheduler: `schedule` captures the work instead of
+  /// running it, so the test controls exactly when the gate's "next turn"
+  /// fires — the same seam production uses `DispatchQueue.main.async` for.
+  final class ManualScheduler {
+    private(set) var queued: [() -> Void] = []
+
+    func schedule(_ work: @escaping () -> Void) {
+      queued.append(work)
+    }
+
+    func fireAll() {
+      let work = queued
+      queued.removeAll()
+      for item in work { item() }
+    }
+  }
+
+  @Test("many pre-ready calls schedule exactly once")
+  func repeatedSchedulingEnqueuesOnce() {
+    let scheduler = ManualScheduler()
+    var constructionCount = 0
+
+    let gate = OverlayFirstRenderGate(
+      schedule: scheduler.schedule,
+      construct: {
+        constructionCount += 1
+        return NSView()
+      },
+      didBecomeReady: { _ in })
+
+    gate.scheduleIfNeeded()
+    gate.scheduleIfNeeded()
+    gate.scheduleIfNeeded()
+
+    #expect(scheduler.queued.count == 1, "three calls before readiness must enqueue one block")
+    #expect(constructionCount == 0, "construction has not run until the scheduled block fires")
+
+    scheduler.fireAll()
+
+    #expect(constructionCount == 1, "the scheduled block constructs exactly once")
+  }
+
+  @Test("readyRoot is nil before construction and the SAME instance after")
+  func readyRootPublishesOnce() {
+    let scheduler = ManualScheduler()
+    let constructed = NSView()
+
+    let gate = OverlayFirstRenderGate(
+      schedule: scheduler.schedule,
+      construct: { constructed },
+      didBecomeReady: { _ in })
+
+    #expect(gate.readyRoot == nil, "no construction has happened yet")
+
+    gate.scheduleIfNeeded()
+    #expect(gate.readyRoot == nil, "scheduled, not yet built")
+
+    scheduler.fireAll()
+    #expect(gate.readyRoot === constructed, "the exact constructed instance, not a copy")
+  }
+
+  @Test("didBecomeReady fires exactly once, with the constructed root")
+  func readinessCallbackFiresOnce() {
+    let scheduler = ManualScheduler()
+    let constructed = NSView()
+    var readyCallCount = 0
+    var receivedRoot: NSView?
+
+    let gate = OverlayFirstRenderGate(
+      schedule: scheduler.schedule,
+      construct: { constructed },
+      didBecomeReady: { root in
+        readyCallCount += 1
+        receivedRoot = root
+      })
+
+    gate.scheduleIfNeeded()
+    gate.scheduleIfNeeded()
+    scheduler.fireAll()
+
+    #expect(readyCallCount == 1)
+    #expect(receivedRoot === constructed)
+
+    // TWIN: scheduling again once ready is a no-op — this is what lets the
+    // Director call `scheduleIfNeeded()` unconditionally on every pre-ready
+    // presentation without worrying whether it already fired.
+    gate.scheduleIfNeeded()
+    #expect(scheduler.queued.isEmpty, "already ready — nothing new to schedule")
+    #expect(readyCallCount == 1, "readiness does not fire again")
+  }
+
+  @Test("state is scheduled before an immediate scheduler can re-enter")
+  func immediateSchedulerCannotReenterAndDoubleBuild() {
+    // The load-bearing property the type's own doc comment states: setting
+    // `.scheduled` BEFORE invoking `schedule` means a reentrant call arriving
+    // WHILE the scheduler closure is still running its first invocation
+    // — before `work()` has ever executed, so state has had no chance to
+    // reach `.ready` — is already a no-op.
+    var scheduleCallCount = 0
+    var constructionCount = 0
+    var gate: OverlayFirstRenderGate!
+
+    gate = OverlayFirstRenderGate(
+      schedule: { work in
+        scheduleCallCount += 1
+        if scheduleCallCount == 1 {
+          gate.scheduleIfNeeded()
+          work()
+        }
+      },
+      construct: {
+        constructionCount += 1
+        return NSView()
+      },
+      didBecomeReady: { _ in })
+
+    gate.scheduleIfNeeded()
+
+    #expect(scheduleCallCount == 1, "the reentrant call must not enqueue a second block")
+    #expect(
+      constructionCount == 1, "reentrant scheduling during construction must not double-build")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
@@ -50,7 +50,7 @@ struct OverlayHostingContractTests {
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
       selections: { .shipped },
-      deferFirstRender: { $0() })
+      firstRenderSchedule: { $0() })
 
     d.present(.warning(reason: .polishFailed))
 
@@ -100,7 +100,7 @@ struct OverlayHostingParityTests {
     OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
       selections: { .shipped },
-      deferFirstRender: { $0() })
+      firstRenderSchedule: { $0() })
   }
 
   @Test("both hosts report a presentation they accepted")

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
@@ -131,11 +131,13 @@ struct OverlayRetainedWindowTests {
   /// the crash fix with the compensation, and four local review rounds passed it
   /// — cloud review caught it as a P1.
   ///
-  /// **`deferFirstRender` is that fix, restored under a name this guard does not
-  /// ban.** It is not an evasion: the banned name meant per-presentation pending
-  /// creation with a cancel handle, and this defers exactly once for the lifetime
-  /// of a director. Naming it differently is what keeps the guard honest about
-  /// which idea is actually forbidden.
+  /// **`OverlayFirstRenderGate` is that fix, restored under a name this guard
+  /// does not ban.** It is not an evasion: the banned name meant per-presentation
+  /// pending creation with a cancel handle, and the gate schedules at most once
+  /// for the lifetime of a director, coalescing every later presentation onto
+  /// that one construction rather than queuing a cancel handle per arrival.
+  /// Naming it differently is what keeps the guard honest about which idea is
+  /// actually forbidden.
   ///
   /// **Named rather than derived, and that is a real weakness of this guard**:
   /// it cannot recognise the same idea under a different word. It is a tripwire
@@ -223,7 +225,7 @@ struct OverlayRetainedWindowBehaviourTests {
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
       selections: { .shipped },
-      deferFirstRender: { $0() })
+      firstRenderSchedule: { $0() })
     defer { recorder.panel?.orderOut(nil) }
 
     d.present(.processing(phase: .polishing))
@@ -254,7 +256,7 @@ struct OverlayRetainedWindowBehaviourTests {
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
       selections: { .shipped },
-      deferFirstRender: { $0() })
+      firstRenderSchedule: { $0() })
     defer { recorder.panel?.orderOut(nil) }
 
     for _ in 0..<4 {

--- a/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
@@ -85,7 +85,7 @@ struct PillRequestParityTests {
           grantSawPresentation = director.renderModel.state.presentation != nil
         },
         selections: { .shipped },
-        deferFirstRender: { $0() })
+        firstRenderSchedule: { $0() })
     }
 
   }

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
@@ -67,7 +67,7 @@ struct RecordingDirectorCaptureTests {
         counts.selections += 1
         return selections
       },
-      deferFirstRender: { $0() },
+      firstRenderSchedule: { $0() },
       scheduleReconciliation: scheduleReconciliation)
   }
 
@@ -325,7 +325,7 @@ struct RecordingDirectorCaptureTests {
         display: { .off }),
       grantAccessibility: {},
       selections: { .shipped },
-      deferFirstRender: { $0() })
+      firstRenderSchedule: { $0() })
 
     Self.record(d)
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
@@ -77,7 +77,7 @@ struct RecordingReconciliationTests {
         display: { .off }),
       grantAccessibility: {},
       selections: selections,
-      deferFirstRender: { $0() },
+      firstRenderSchedule: { $0() },
       scheduleReconciliation: { queue.schedule($0) })
   }
 


### PR DESCRIPTION
## Summary
- Replaces the per-presentation deferred-closure first-render mechanism
  (`builtRootView`, `deferFirstRender`, the three-case `RenderOutcome`, the
  ad-hoc `deferredID` identity gate) with `OverlayFirstRenderGate`: one
  scheduled construction per director lifetime, however many presentations
  arrive before it lands.
- Adds a typed `PendingFirstAcceptance` slot that coalesces same-id updates
  (retaining every caller's relay) and resolves a superseded id's callers as
  soon as that decision is made, rather than lazily when an unrelated
  construction eventually completes.
- Closes Phase 6 finding #6 per `docs/plans/pill-system-refactor-plan.md`
  (main checkout) — the gate reads one latest atomic state instead of
  retaining or ordering presentation closures.

## Test plan
- [x] `scripts/xcode-test.sh --release` — Debug 6,897 tests / Release 6,267
      tests, both `TEST SUCCEEDED`, zero failures, 3 pre-existing known
      issues unchanged
- [x] Chunk 1 (standalone gate) and chunk 2 (Director integration) each
      independently reached CHUNK-CLEAN with Codex, including a real
      reentrancy defect Codex caught and a fix verified with a mutation
      control (temporarily reintroduced the bug, confirmed the new test
      caught it, restored byte-identical)
- [x] Live UAT: `Tests/RuntimeUAT/measure_overlay_first_render.py --smoke`
      against a fresh rebuild — `SMOKE_PASS`, cold launch with no crash,
      clean keypress-to-overlay measurement (~104ms first press)

Part of #2377.
