### PR TITLE
fix(pipeline): stop stray periods and dots corrupting spoken web addresses

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -708,18 +708,37 @@ public struct InverseTextNormalizer: Sendable {
   // written narrower. A standalone "H"/"h" immediately followed by "slash slash" has no such
   // established alternate producer in the corpus, so it stays a safe, narrow fix.
   //
-  // Cloud review (PR #2463): unanchored, this also rewrote ordinary technical dictation with
-  // no URL intent at all ("the variable H slash slash is malformed" -> "...https slash
-  // slash..."). A zero-width lookahead requiring what FOLLOWS to actually be a host
-  // (spoken "host dot tld" or already-joined "host.tld") closes that — "is malformed" matches
-  // neither shape, so that sentence is left untouched, while a real address still qualifies.
+  // Cloud review (PR #2463), round 1: unanchored, this also rewrote ordinary technical
+  // dictation with no URL intent at all ("the variable H slash slash is malformed" ->
+  // "...https slash slash..."). A zero-width lookahead requiring what FOLLOWS to actually be
+  // a host (spoken "host dot tld" or already-joined "host.tld") closed that specific case.
+  //
+  // Cloud review, round 2: the follows-a-host guard alone is insufficient — a constructed
+  // sentence can put a REAL domain right after an unrelated "H" ("the variable H slash slash
+  // example.com is malformed"), satisfying the lookahead while still meaning something else
+  // entirely. The follows-a-host check answers "is what's AFTER this shaped like a URL"; it
+  // has nothing to say about what PRECEDES it, which is exactly where the ambiguity lives — a
+  // bare single letter is ONLY unambiguous as a truncated "https" at the very start of the
+  // utterance, matching how a real truncated protocol prefix actually arrives (nothing spoken
+  // before it), never buried mid-sentence after other words. Checked in the callback (this
+  // file's established pattern for a preceding-context guard, see `isBareURLUtterance` below):
+  // requiring nothing but whitespace before the match closes this round's case too, since
+  // "the variable " precedes "H" there.
   private func normalizeGarbledHTTPSPrefix(_ t: String) -> String {
     let hostChain = #"(?:"# + Self.urlHostLabelPat + #"\.)*"# + Self.urlHostLabelPat
     let tldAlt = Self.lowerRiskURLTLDAlt + #"|"# + Self.commonWordURLTLDAlt
     let urlAhead =
       #"(?=\s+"# + hostChain + #"\s+dot\s+(?:"# + tldAlt + #")\b|\s+"# + hostChain
       + #"\.(?:"# + tldAlt + #")\b)"#
-    return reSub(#"\b[Hh]\s+slash\s+slash\b"# + urlAhead, t) { _ in "https slash slash" }
+    return reSub(#"\b[Hh]\s+slash\s+slash\b"# + urlAhead, t) { m in
+      let start = m.result.range.location
+      guard
+        start == 0
+          || m.ns.substring(with: NSRange(location: 0, length: start))
+            .trimmingCharacters(in: .whitespaces).isEmpty
+      else { return nil }
+      return "https slash slash"
+    }
   }
 
   // #2315: the recognizer's own end-of-utterance period lands right after a bare spoken URL

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -689,7 +689,67 @@ public struct InverseTextNormalizer: Sendable {
   /// points are needed). `emails(_:)` runs first, so any domain it already converted to
   /// `name@host.tld` is excluded here via a negative lookbehind on `@` — a trailing
   /// "slash word" after an email is NOT a URL path.
+  // #2315: both ASR backends can transcribe a spoken "https" prefix as a lone letter
+  // ("H slash slash example.com") instead of the word. Not recovered by
+  // `precededByProtocolPrefix` below, since that guard only RECOGNIZES an existing "https"/
+  // "http" prefix to refuse a bad partial match — it has nothing to say about a truncated one.
+  // This runs BEFORE spokenPat/joinedPat so a corrected "https slash slash" prefix reaches
+  // downstream (LLM polish) as clean, recognizable text instead of the garbled original.
+  //
+  // Scoped to exactly this one shape, not "any bare protocol connector with https missing" —
+  // this repo's own oracle corpus (`parity.jsonl`) establishes a well-tested, DIFFERENT
+  // producer for a dropped "https": the recognizer spells it out letter-by-letter
+  // ("h t t p colon slash slash..."), which already carries its own oracle-verified handling
+  // elsewhere in this file. A same-shaped "bare colon slash slash" normalizer here would have
+  // no way to distinguish that established shape from a genuinely https-less utterance (the
+  // spelled letters are separated by ordinary word-boundary whitespace, so a same-length
+  // lookbehind for the contiguous word "http" cannot see them) — measured against the oracle,
+  // it collided with 44 existing "h t t p colon slash slash" rows before this comment was
+  // written narrower. A standalone "H"/"h" immediately followed by "slash slash" has no such
+  // established alternate producer in the corpus, so it stays a safe, narrow fix.
+  private func normalizeGarbledHTTPSPrefix(_ t: String) -> String {
+    reSub(#"\b[Hh]\s+slash\s+slash\b"#, t) { _ in "https slash slash" }
+  }
+
+  // #2315: the recognizer's own end-of-utterance period lands right after a bare spoken URL
+  // ("https slash facebook dot com.") indistinguishable, at the ITN layer, from a real sentence
+  // period on a URL that happens to end a real sentence ("I visited facebook.com."). And a
+  // trailing "dot"/"dot." word can survive a conversion untouched, on either the spoken-word
+  // ("facebook dot com dot.") or ASR-pre-joined ("www.facebook.com dot.") shape, because neither
+  // existing pass ever inspects text after a match it already accepted.
+  //
+  // Both are handled by ONE optional trailer group appended to the end of each pattern below
+  // (`(?<trailer>...)`), never a post-hoc window check: `reSub` only rewrites the exact matched
+  // span and copies everything else through verbatim, so a trailing period or stray "dot" is
+  // only actually CONSUMED if it is part of the match itself. The trailer only ever matches
+  // right at true end-of-string, so a real following sentence or a genuine mid-utterance
+  // continuation ("facebook.com dot five percent off") is never part of the match and is left
+  // completely untouched.
+  //
+  // `trailerSuffix` turns whichever trailer this match captured into what to append: a stray
+  // "dot"/"dot." is always the recognizer's own artifact (nobody ends a real sentence with the
+  // literal word "dot"), so it always folds to a period. A literal "." only folds away when the
+  // WHOLE utterance was nothing but the spoken URL (`isBareURLUtterance`) — otherwise it is a
+  // real sentence period and is put back exactly as it was.
+  private static let urlTrailerPat = #"(?<trailer>\s*dot\.?\s*$|\.\s*$)?"#
+  private func trailerSuffix(_ m: Match) -> String {
+    guard let trailer = m.g("trailer"), !trailer.isEmpty else { return "" }
+    if firstMatch(#"dot\.?\s*$"#, trailer) != nil { return "." }
+    return isBareURLUtterance(m) ? "" : "."
+  }
+
+  // Whether the text BEFORE a match is nothing but whitespace and bare protocol-prefix words —
+  // i.e. the entire utterance IS the spoken URL, so a trailing period is the recognizer's own
+  // artifact rather than real sentence punctuation the user dictated around the address.
+  private func isBareURLUtterance(_ m: Match) -> Bool {
+    let start = m.result.range.location
+    guard start > 0 else { return true }
+    let lead = m.ns.substring(with: NSRange(location: 0, length: start))
+    return firstMatch(#"^\s*(?:https?\s*:?\s*)?(?:slash\s*){0,2}$"#, lead) != nil
+  }
+
   private func urls(_ t: String) -> String {
+    let t = normalizeGarbledHTTPSPrefix(t)
     func withPath(_ base: String, _ path: String?) -> String {
       var s = base
       if let path, !path.isEmpty {
@@ -797,7 +857,7 @@ public struct InverseTextNormalizer: Sendable {
     let spokenPat =
       #"(?<![@a-z0-9.-])\b(?<host>(?:"# + Self.urlHostLabelPat + #"\.)*"#
       + Self.urlHostLabelPat + #")\s+dot\s+(?<tld>"# + Self.lowerRiskURLTLDAlt + #")\b"#
-      + #"(?<path>(?:\s+slash\s+"# + Self.urlPathSegmentPat + #")*)"#
+      + #"(?<path>(?:\s+slash\s+"# + Self.urlPathSegmentPat + #")*)"# + Self.urlTrailerPat
     var result = reSub(spokenPat, t) { m in
       // followedByUnsupportedContinuation only applies once a path is actually being
       // converted: with an EMPTY path (this pass's is optional, `*`), the host.tld
@@ -810,7 +870,7 @@ public struct InverseTextNormalizer: Sendable {
         !precededByProtocolPrefix(m), !precededByUnresolvedConnector(m),
         !precededBySpacedAtSign(m), !(hasPath && followedByUnsupportedContinuation(m))
       else { return nil }
-      return withPath("\(m.g("host") ?? "").\(m.g("tld") ?? "")", m.g("path"))
+      return withPath("\(m.g("host") ?? "").\(m.g("tld") ?? "")", m.g("path")) + trailerSuffix(m)
     }
 
     // Pass 2: recognizer already pre-joined the host into `word.tld`; only a trailing
@@ -848,14 +908,40 @@ public struct InverseTextNormalizer: Sendable {
       + Self.urlHostLabelPat + #"\.(?:"# + Self.lowerRiskURLTLDAlt + #"))"#
       + #"|(?<domain2>(?:"# + Self.urlHostLabelPat + #"\.)*"# + Self.urlHostLabelPat
       + #"\.(?:"# + Self.commonWordURLTLDAlt + #")))"#
-      + #"(?<path>(?:\s+slash\s+"# + Self.urlPathSegmentPat + #")+)"#
+      + #"(?<path>(?:\s+slash\s+"# + Self.urlPathSegmentPat + #")+)"# + Self.urlTrailerPat
     result = reSub(joinedPat, result) { m in
       guard
         !precededByProtocolPrefix(m), !precededByUnresolvedConnector(m),
         !precededBySpacedAtSign(m), !followedByUnsupportedContinuation(m)
       else { return nil }
       let domain = m.g("domain") ?? m.g("domain2") ?? ""
-      return withPath(domain, m.g("path"))
+      return withPath(domain, m.g("path")) + trailerSuffix(m)
+    }
+
+    // Pass 3 (#2315): a bare, already-correct `host.tld` with NO path — deliberately outside
+    // joinedPat's scope above, since that pattern requires >=1 path segment precisely so an
+    // ordinary mid-sentence "example.com" is left untouched — immediately followed by a stray
+    // trailing "dot"/"dot." WORD and nothing else before end-of-string. Never touches the
+    // domain itself, only strips what the recognizer glued on after it.
+    //
+    // WORD-ONLY trailer, deliberately narrower than `Self.urlTrailerPat` (no bare "."
+    // alternative): passes 1/2 above already run this SAME text and, via their own trailer
+    // group, correctly decide whether a literal "." they matched should stay or go — a bare
+    // "." is real, ordinary sentence punctuation on an ALREADY-CORRECT domain (nothing to
+    // fix), never an artifact this pass exists to clean up. Matching it too would re-scan
+    // pass 1/2's OWN just-emitted period on their own output and re-run the bare-utterance
+    // check a second time with a different lead context, silently overturning their decision
+    // — measured: "facebook dot com dot" correctly became "facebook.com." in pass 1, then
+    // this pass matched the trailing "." it had just added and stripped it right back off.
+    let bareTrailerPat =
+      #"(?<![@a-z0-9.-])\b(?<domain>(?:"# + Self.urlHostLabelPat + #"\.)*"# + Self.urlHostLabelPat
+      + #"\.(?:"# + Self.lowerRiskURLTLDAlt + #"|"# + Self.commonWordURLTLDAlt + #"))"#
+      + #"(?<trailer>\s*dot\.?\s*$)"#
+    result = reSub(bareTrailerPat, result) { m in
+      guard
+        !precededByProtocolPrefix(m), !precededByUnresolvedConnector(m), !precededBySpacedAtSign(m)
+      else { return nil }
+      return (m.g("domain") ?? "") + trailerSuffix(m)
     }
 
     return result

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -707,8 +707,19 @@ public struct InverseTextNormalizer: Sendable {
   // it collided with 44 existing "h t t p colon slash slash" rows before this comment was
   // written narrower. A standalone "H"/"h" immediately followed by "slash slash" has no such
   // established alternate producer in the corpus, so it stays a safe, narrow fix.
+  //
+  // Cloud review (PR #2463): unanchored, this also rewrote ordinary technical dictation with
+  // no URL intent at all ("the variable H slash slash is malformed" -> "...https slash
+  // slash..."). A zero-width lookahead requiring what FOLLOWS to actually be a host
+  // (spoken "host dot tld" or already-joined "host.tld") closes that — "is malformed" matches
+  // neither shape, so that sentence is left untouched, while a real address still qualifies.
   private func normalizeGarbledHTTPSPrefix(_ t: String) -> String {
-    reSub(#"\b[Hh]\s+slash\s+slash\b"#, t) { _ in "https slash slash" }
+    let hostChain = #"(?:"# + Self.urlHostLabelPat + #"\.)*"# + Self.urlHostLabelPat
+    let tldAlt = Self.lowerRiskURLTLDAlt + #"|"# + Self.commonWordURLTLDAlt
+    let urlAhead =
+      #"(?=\s+"# + hostChain + #"\s+dot\s+(?:"# + tldAlt + #")\b|\s+"# + hostChain
+      + #"\.(?:"# + tldAlt + #")\b)"#
+    return reSub(#"\b[Hh]\s+slash\s+slash\b"# + urlAhead, t) { _ in "https slash slash" }
   }
 
   // #2315: the recognizer's own end-of-utterance period lands right after a bare spoken URL

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -742,7 +742,13 @@ public struct InverseTextNormalizer: Sendable {
   // literal word "dot"), so it always folds to a period. A literal "." only folds away when the
   // WHOLE utterance was nothing but the spoken URL (`isBareURLUtterance`) — otherwise it is a
   // real sentence period and is put back exactly as it was.
-  private static let urlTrailerPat = #"(?<trailer>\s*dot\.?\s*$|\.\s*$)?"#
+  //
+  // `\s+` (not `\s*`) before the "dot" word (cloud review, PR #2463): a real trailing "dot"
+  // is always a distinct spoken/ITN token, separated from the domain by whitespace — requiring
+  // at least one space rules out this group ever splitting a glued, unrelated identifier like
+  // "example.comdot" into a domain plus a bogus trailer. The bare-period alternative needs no
+  // such guard: a literal "." is punctuation, not a word, so it never has this ambiguity.
+  private static let urlTrailerPat = #"(?<trailer>\s+dot\.?\s*$|\.\s*$)?"#
   private func trailerSuffix(_ m: Match) -> String {
     guard let trailer = m.g("trailer"), !trailer.isEmpty else { return "" }
     if firstMatch(#"dot\.?\s*$"#, trailer) != nil { return "." }
@@ -944,10 +950,15 @@ public struct InverseTextNormalizer: Sendable {
     // check a second time with a different lead context, silently overturning their decision
     // — measured: "facebook dot com dot" correctly became "facebook.com." in pass 1, then
     // this pass matched the trailing "." it had just added and stripped it right back off.
+    //
+    // `\s+` (not `\s*`, cloud review PR #2463): without a required space, the TLD alternation
+    // has no trailing `\b` of its own, so this could split a glued, unrelated identifier like
+    // "example.comdot" into a domain plus a bogus trailer — a real trailing "dot" word is
+    // always separated from the domain by whitespace, so requiring one costs nothing genuine.
     let bareTrailerPat =
       #"(?<![@a-z0-9.-])\b(?<domain>(?:"# + Self.urlHostLabelPat + #"\.)*"# + Self.urlHostLabelPat
       + #"\.(?:"# + Self.lowerRiskURLTLDAlt + #"|"# + Self.commonWordURLTLDAlt + #"))"#
-      + #"(?<trailer>\s*dot\.?\s*$)"#
+      + #"(?<trailer>\s+dot\.?\s*$)"#
     result = reSub(bareTrailerPat, result) { m in
       guard
         !precededByProtocolPrefix(m), !precededByUnresolvedConnector(m), !precededBySpacedAtSign(m)

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -311,6 +311,9 @@ struct InverseTextNormalizerParityTests {
       // Boundary (see note above): a cleanly-heard "https slash slash" prefix already blocks
       // dot-conversion today, independent of this fix — documented, not asserted as fixed.
       ("https slash slash facebook dot com.", "https slash slash facebook dot com."),
+      // Fix 2 (negative, cloud review PR #2463): a glued, unrelated identifier ending in "dot"
+      // with no whitespace before it must not be split into a domain plus a bogus trailer.
+      ("visit example.comdot", "visit example.comdot"),
       // Regression guard (#2257-era): the letter-spelled "h t t p" shape must still leave an
       // unrelated trailing "dot s m" continuation untouched — this fix must not reopen it.
       (

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -308,6 +308,13 @@ struct InverseTextNormalizerParityTests {
       (
         "the variable H slash slash is malformed", "the variable H slash slash is malformed"
       ),
+      // Fix 3 (negative, round 2, cloud review PR #2463): a real domain right after an
+      // unrelated "H" mid-sentence still must not be rewritten — the ambiguity is about what
+      // PRECEDES "H", not just what follows it.
+      (
+        "the variable H slash slash example.com is malformed",
+        "the variable H slash slash example.com is malformed"
+      ),
       // Boundary (see note above): a cleanly-heard "https slash slash" prefix already blocks
       // dot-conversion today, independent of this fix — documented, not asserted as fixed.
       ("https slash slash facebook dot com.", "https slash slash facebook dot com."),

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -259,4 +259,60 @@ struct InverseTextNormalizerParityTests {
   func codexFindingRegressions(input: String, expected: String) {
     #expect(InverseTextNormalizer().normalize(input, spokenPunctuation: true) == expected)
   }
+
+  // #2315: spoken web addresses come out broken — trailing periods, a stray trailing "dot"
+  // word, and a garbled "https" prefix. Each row demonstrates one fix; the regression-guard
+  // row confirms the fix does not reopen the #2257-era "dot s m" bug the file's own comment
+  // on `spokenPat` warns about.
+  //
+  // Expected values are ITN-ONLY output (this test calls `normalize(_:)` directly, not the
+  // full pipeline): ITN converts spoken dot/slash into real punctuation and strips the
+  // recognizer's own trailing-period/stray-dot artifacts, but it does not materialize a
+  // spoken "slash slash" protocol connector into "://" — that reconstruction is LLM polish's
+  // job downstream, unchanged by this fix.
+  //
+  // KNOWN, PRE-EXISTING, OUT-OF-SCOPE BOUNDARY: a domain immediately preceded by "slash" —
+  // as in a spoken "https slash slash" protocol prefix — never reaches spokenPat/joinedPat's
+  // conversion at all. `precededByUnresolvedConnector` (this file, unrelated to and unchanged
+  // by this fix) already treats "slash" as one of its dangling-connector-word signals and
+  // refuses the WHOLE match, so the host/tld dot-conversion this PR adds trailer handling to
+  // never fires there either — the last two rows below document this AS-IS rather than
+  // asserting the aspirational fully-cleaned form. Changing that guard's established
+  // "slash" membership is a separate, larger decision (it exists to avoid a worse dangling
+  // partial conversion) and is out of scope here.
+  @Test(
+    "#2315 spoken web addresses: trailing period, stray dot, garbled https prefix",
+    .bug("https://github.com/saurabhav88/EnviousWispr/issues/2315", "spoken web address cleanup"),
+    arguments: [
+      // Fix 1: a bare URL-only utterance's recognizer-added period is dropped.
+      ("facebook dot com.", "facebook.com"),
+      // Fix 1 (negative): the identical trailing period on a real sentence is kept.
+      ("I visited facebook dot com.", "I visited facebook.com."),
+      // Fix 2: a stray trailing "dot"/"dot." word survives a spoken-shape conversion.
+      ("facebook dot com dot.", "facebook.com."),
+      ("facebook dot com dot", "facebook.com."),
+      // Fix 2, ASR-pre-joined bare-domain shape (no path — outside joinedPat's own scope,
+      // handled by the dedicated bare-trailer pass).
+      ("www.facebook.com dot.", "www.facebook.com."),
+      // Fix 2 (negative): a real mid-utterance continuation after the domain must not be
+      // swallowed into the address (the "5%" is separate, pre-existing percent conversion,
+      // unrelated to and unaffected by this fix).
+      ("facebook.com dot five percent off", "facebook.com dot 5% off"),
+      // Fix 3: a garbled "H slash slash" (truncated "https") is normalized to the full word,
+      // reaching polish as unambiguous text instead of a dangling "H" — see the boundary
+      // note above for why the domain itself stays dot-unconverted here.
+      ("H slash slash facebook dot com", "https slash slash facebook dot com"),
+      // Boundary (see note above): a cleanly-heard "https slash slash" prefix already blocks
+      // dot-conversion today, independent of this fix — documented, not asserted as fixed.
+      ("https slash slash facebook dot com.", "https slash slash facebook dot com."),
+      // Regression guard (#2257-era): the letter-spelled "h t t p" shape must still leave an
+      // unrelated trailing "dot s m" continuation untouched — this fix must not reopen it.
+      (
+        "h t t p colon slash slash w w w dot o u r d a i l y n e w s dot com dot s m",
+        "h t t p: slash slash w w w dot o u r d a i l y n e w s.com dot s m"
+      ),
+    ])
+  func issue2315SpokenURLCleanup(input: String, expected: String) {
+    #expect(InverseTextNormalizer().normalize(input, spokenPunctuation: true) == expected)
+  }
 }

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerParityTests.swift
@@ -302,6 +302,12 @@ struct InverseTextNormalizerParityTests {
       // reaching polish as unambiguous text instead of a dangling "H" — see the boundary
       // note above for why the domain itself stays dot-unconverted here.
       ("H slash slash facebook dot com", "https slash slash facebook dot com"),
+      // Fix 3 (negative, cloud review PR #2463): "H slash slash" with no URL-shaped
+      // continuation is ordinary technical dictation, not a truncated https, and must be
+      // left untouched.
+      (
+        "the variable H slash slash is malformed", "the variable H slash slash is malformed"
+      ),
       // Boundary (see note above): a cleanly-heard "https slash slash" prefix already blocks
       // dot-conversion today, independent of this fix — documented, not asserted as fixed.
       ("https slash slash facebook dot com.", "https slash slash facebook dot com."),


### PR DESCRIPTION
## Summary
- Drop the recognizer's own end-of-utterance period on a bare spoken-URL dictation, while keeping a genuine sentence period ("I visited facebook.com.") intact
- Fold a stray leftover "dot"/"dot." word into a real period after a host.tld conversion, on both the spoken-word and ASR-pre-joined domain shapes
- Normalize a garbled "H slash slash" (truncated "https") into the recognizable word, so it reaches LLM polish as clean text

Fixes #2315. Part of epic #2316.

Root cause and scope: see `docs/feature-requests/issue-2315-2026-08-26-spoken-url-cleanup.md`. Notably out of scope for this PR — documented, not silently dropped: a domain immediately preceded by a spoken "https slash slash" protocol prefix doesn't reach dot-conversion at all today, because the pre-existing `precededByUnresolvedConnector` guard already refuses that shape (unrelated to and unchanged by this fix). Decoder-level ASR vocabulary biasing for both engines is tracked as a separate follow-up.

## Test plan
- [x] New `@Test` cases in `InverseTextNormalizerParityTests.swift` covering all three fixes plus negatives (real-sentence period kept, mid-utterance continuation not swallowed) and the #2257-era regression guard
- [x] Full `scripts/xcode-test.sh` (no filter): 7097 tests, `Debug lane verdict: PASS`
- [x] Live UAT this session confirmed the underlying garbling live against the shipped default (Parakeet) backend before writing the fix
