### PR TITLE
C0: deny live hotkey desktop effects under test (#2457)

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -13,6 +13,19 @@ let deploymentTargets: DeploymentTargets = .macOS("14.0")
 // consensus: Codex + council GPT/Gemini; see learnings ledger.)
 let packageAccessIdentifier = "enviouswispr"
 
+/// Mirrors `DesktopEffectPolicy.environmentKey` in EnviousWisprServices. Two
+/// spellings of one name is how a gate goes quietly dead, so any change to either
+/// must change both; `DesktopEffectPolicyTests` fails if they drift.
+let DesktopEffectsPolicyKey = "EW_DESKTOP_EFFECTS_POLICY"
+
+/// Mirrors `DesktopEffectDenial.trapEnvironmentKey`. Separate from the policy key
+/// so a shipped app that somehow sees ONLY the policy variable loses its hotkeys
+/// rather than crashing, while every TEST configuration — Debug, Dev and Release
+/// alike — aborts on an unhandled refusal. Selecting that severity with
+/// `#if DEBUG` instead would let the Release suite pass having reached a
+/// prohibited effect (Codex chunk review, 2026-08-26).
+let DesktopEffectsTrapKey = "EW_DESKTOP_EFFECTS_TRAP_DENIALS"
+
 let commonSettings: SettingsDictionary = [
   "ARCHS": "arm64",
   "VALID_ARCHS": "arm64",
@@ -249,6 +262,30 @@ let firstPartyTargetDeps: [TargetDependency] = [
   .target(name: "EnviousWisprLLM"),
   .target(name: "EnviousWisprPipeline"),
 ]
+
+/// #2455 C0 (#2457). For the duration of a test run, denies the desktop effects
+/// C0 guards: Carbon hotkey registration, the Carbon event handler, and the
+/// `NSEvent` modifier monitors. Overlay windows and app activation are the same
+/// root cause and are NOT covered — those are C3 (#2460) and C4 (#2461).
+///
+/// The effect this buys: the unit suite stops registering real global hotkeys on
+/// the developer's machine, where a registered Escape swallows Escape system-wide
+/// for as long as the suite runs.
+///
+/// On the TEST action only. Xcode never applies a test action's environment to a
+/// run, profile or archive action, and no shipped app is launched through a
+/// scheme at all, so this cannot reach a user. `scripts/xcode-test.sh` and CI
+/// both select these shared schemes, so neither needs its own copy of the
+/// variable — one owner, per `GR-WRITE-FOR-RETRIEVAL`.
+///
+/// Removed or demoted in C5 (#2462), once the module boundary makes a live effect
+/// unlinkable from the unit target and this tripwire is redundant.
+let denyDesktopEffects: Arguments = .arguments(
+  environmentVariables: [
+    DesktopEffectsPolicyKey: .environmentVariable(value: "deny", isEnabled: true),
+    DesktopEffectsTrapKey: .environmentVariable(value: "1", isEnabled: true),
+  ]
+)
 
 let project = Project(
   name: "EnviousWispr",
@@ -614,6 +651,7 @@ let project = Project(
       ),
       testAction: .targets(
         ["EnviousWisprTests", "EnviousWisprASRTests"],
+        arguments: denyDesktopEffects,
         configuration: "Debug"
       )
     ),
@@ -631,6 +669,7 @@ let project = Project(
       ),
       testAction: .targets(
         ["EnviousWisprTests", "EnviousWisprASRTests"],
+        arguments: denyDesktopEffects,
         configuration: "Dev"
       )
     ),
@@ -646,6 +685,7 @@ let project = Project(
       // preserving the release-config test coverage the old post-merge job ran.
       testAction: .targets(
         ["EnviousWisprTests", "EnviousWisprASRTests"],
+        arguments: denyDesktopEffects,
         configuration: "Release"
       )
     ),

--- a/Sources/EnviousWisprServices/DesktopEffectPolicy.swift
+++ b/Sources/EnviousWisprServices/DesktopEffectPolicy.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Whether this process may reach the desktop effects C0 guards: Carbon hotkey
+/// registration, the Carbon event handler, and the `NSEvent` modifier monitors.
+///
+/// **Scope is exactly those three.** Overlay windows, app activation and Quick Add
+/// presentation are the same root cause and are NOT covered here — they are C3
+/// (#2460) and C4 (#2461). A reader who takes this for a general desktop-effect
+/// switch will conclude the suite is contained when it is not.
+///
+/// #2455 C0 (#2457). `EnviousWisprTests` has no `TEST_HOST`, so the suite runs
+/// inside Apple's `xctest` agent; `AppWindowCoordinatorTests.swift:26` then runs
+/// `_ = NSApplication.shared`, which promotes that agent to a live GUI app. Without
+/// this policy a hotkey effect triggered by a unit test lands on the developer's
+/// real machine: a registered Escape hotkey swallows Escape system-wide for as long
+/// as the suite runs.
+///
+/// **Disclosed temporary debt.** This is a tripwire, not the wall. The wall is the
+/// module boundary C1-C4 build, after which no unit-test target can link a live
+/// effect at all. C5 (#2462) removes or demotes this policy once that boundary
+/// exists, because a denial branch selected by an environment variable is present
+/// in a shipped binary and can therefore be reached by a shipped run.
+///
+/// **Project-owned on purpose.** Not `XCTestConfigurationFilePath` or any other
+/// undocumented Apple variable: those are an implementation detail Apple may
+/// change, and sniffing them makes the contract invisible at the call site.
+/// `EW_`-prefixed run switches are already this project's convention
+/// (`EW_FAULT_INJECTION`, `EW_FORCE_READINESS_LOST`).
+package enum DesktopEffectPolicy: Sendable {
+  /// The guarded effects are performed. The value for any process, a shipped app
+  /// included, that does not set the variable.
+  case allow
+  /// Explicit refusal. The test actions set it, and a shipped process can also
+  /// enter it if someone sets the variable by hand — which is why a refusal is
+  /// never described as proof that a test caused it.
+  case deny
+
+  package static let environmentKey = "EW_DESKTOP_EFFECTS_POLICY"
+
+  /// Deny requires the exact opt-in string. Anything else — absent, empty,
+  /// misspelt — is `allow`, so a malformed variable can never quietly disable
+  /// hotkeys for a user.
+  package static func fromEnvironment(
+    _ environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> DesktopEffectPolicy {
+    environment[environmentKey] == "deny" ? .deny : .allow
+  }
+}
+
+/// Called with a human-readable name for each denied effect.
+///
+/// A denial is data, not a decision: the handler decides how loud it is. The test
+/// target injects a recorder so a suite that legitimately drives registration can
+/// ASSERT what was refused — which is coverage that does not exist today, because
+/// `registerCancelHotkey()` sets `isCancelArmed` before it asks Carbon, so no
+/// current test can prove the chord was actually taken.
+package typealias DesktopEffectDenialHandler = @MainActor (String) -> Void
+
+package enum DesktopEffectDenial {
+  /// Whether a denial that reaches the DEFAULT handler aborts the run.
+  ///
+  /// Separate from the policy key because the two answer different questions —
+  /// `EW_DESKTOP_EFFECTS_POLICY` decides WHETHER an effect happens, this decides
+  /// how loud an unhandled refusal is — and because they must be able to
+  /// disagree. A user who somehow launches the shipped app with the policy
+  /// variable set must lose their hotkeys, never their app. THIS PROJECT sets the
+  /// trap variable only on test actions, which is what makes normal test runs the
+  /// trapping case — but the value is what decides, so a process that sets both by
+  /// hand traps too. Test-action ownership identifies the normal path, not the
+  /// mechanism.
+  ///
+  /// Codex chunk review, 2026-08-26: an earlier revision selected severity with
+  /// `#if DEBUG` instead. That made an unmigrated site ABORT in the Debug lane
+  /// and PASS in the Release lane, so the Release suite could go green having
+  /// reached a prohibited effect — the precise outcome this chunk exists to
+  /// prevent, and a Debug/Release test-outcome divergence of the class
+  /// `Project.swift` already records as costing a red main (#2070/#2083).
+  /// Severity is now a runtime fact in every configuration.
+  package static let trapEnvironmentKey = "EW_DESKTOP_EFFECTS_TRAP_DENIALS"
+
+  /// The default when nothing was injected.
+  ///
+  /// Under a test action, an unhandled denial must fail rather than pass having
+  /// verified nothing — both council models (2026-08-26) rejected a silent skip for
+  /// that reason. Without the trap variable, the shipped-process fallback logs and
+  /// continues, so an unhandled denial is not by itself proof of a test defect.
+  @MainActor
+  package static func defaultHandler(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> DesktopEffectDenialHandler {
+    environment[trapEnvironmentKey] == "1" ? trap : logOnly
+  }
+
+  /// Aborts, naming the refused operation so the failure points at the call.
+  @MainActor
+  package static let trap: DesktopEffectDenialHandler = { reason in
+    fatalError(message(reason))
+  }
+
+  /// Denies and leaves a trail, without taking the process down. What the default
+  /// handler does whenever the policy variable is set and the trap variable is not
+  /// `1` — in a shipped app, and in any other process in that state.
+  @MainActor
+  package static let logOnly: DesktopEffectDenialHandler = { reason in
+    NSLog("%@", message(reason))
+  }
+
+  private static func message(_ reason: String) -> String {
+    """
+    \(DesktopEffectPolicy.environmentKey)=deny refused a guarded desktop effect: \(reason). \
+    If this is a test run, it reached a live hotkey effect: inject \
+    DesktopEffectDenial.recordOnly at the HotkeyService construction site and assert \
+    on what it recorded (#2455 C0).
+    """
+  }
+}
+
+extension DesktopEffectDenial {
+  /// Records the denial on the service and does nothing else.
+  ///
+  /// For a suite that DELIBERATELY drives registration and then asserts on
+  /// `HotkeyService.deniedDesktopEffects`. It is not a way to quiet an
+  /// unexamined test: the denial is still recorded, the call site still names
+  /// the policy, and a test that installs this without asserting on the ledger
+  /// is visible in review as a test that asked for a refusal and ignored it.
+  @MainActor
+  package static let recordOnly: DesktopEffectDenialHandler = { _ in }
+}

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -78,10 +78,35 @@ public final class HotkeyService {
 
   // MARK: - Carbon State
 
-  private var eventHandlerRef: EventHandlerRef?
-  private var toggleHotkeyRef: EventHotKeyRef?
-  private var cancelHotkeyRef: EventHotKeyRef?
-  private var quickAddHotkeyRef: EventHotKeyRef?
+  /// A registration that either holds a real framework object or records that
+  /// the effect was refused (#2455 C0).
+  ///
+  /// A `.denied` case rather than a forged `EventHotKeyRef`: these are opaque
+  /// pointers, and handing a synthetic one to `UnregisterEventHotKey` would be a
+  /// wild-pointer call. Occupancy is what the surrounding state machine actually
+  /// asks about — `guard cancelHotkeyRef == nil`, `guard quickAddHotkeyRef == nil`
+  /// — so a non-nil `.denied` keeps every one of those guards behaving exactly as
+  /// it does against a real registration, while the teardown helpers below refuse
+  /// to pass anything but a `.live` payload back to the framework.
+  private enum HotkeyRegistration {
+    case live(EventHotKeyRef)
+    case denied
+  }
+
+  private enum HandlerRegistration {
+    case live(EventHandlerRef)
+    case denied
+  }
+
+  private enum MonitorRegistration {
+    case live(Any)
+    case denied
+  }
+
+  private var eventHandlerRef: HandlerRegistration?
+  private var toggleHotkeyRef: HotkeyRegistration?
+  private var cancelHotkeyRef: HotkeyRegistration?
+  private var quickAddHotkeyRef: HotkeyRegistration?
 
   /// Whether the cancel role is currently armed.
   ///
@@ -100,8 +125,8 @@ public final class HotkeyService {
 
   // MARK: - NSEvent Modifier Monitors
 
-  private var globalModifierMonitor: Any?
-  private var localModifierMonitor: Any?
+  private var globalModifierMonitor: MonitorRegistration?
+  private var localModifierMonitor: MonitorRegistration?
 
   public private(set) var isEnabled = false
   public private(set) var isModifierHeld = false
@@ -285,12 +310,58 @@ public final class HotkeyService {
   /// running this suite alongside its siblings while it passed alone.
   private let now: @MainActor () -> Date
 
+  /// #2455 C0. Read once at construction rather than per call, so a service
+  /// cannot change policy mid-life and produce a half-registered state machine.
+  private let desktopEffectPolicy: DesktopEffectPolicy
+  private let onDeniedDesktopEffect: DesktopEffectDenialHandler
+
+  /// Every effect this instance refused, oldest first, in the same wording the
+  /// handler receives.
+  ///
+  /// `package private(set)` for the same reason `isCancelArmed` is: it lets a
+  /// test assert on what the service DID rather than on a spy for a call the
+  /// production code might simply not make.
+  package private(set) var deniedDesktopEffects: [String] = []
+
+  /// - Parameter onDeniedDesktopEffect: what to do when the policy refuses a
+  ///   live effect. `nil` selects `DesktopEffectDenial.defaultHandler()`, which
+  ///   reads the trap variable: a test action sets it, so a test run aborts with
+  ///   a named reason, while a shipped app that somehow sees only the POLICY
+  ///   variable logs and continues rather than crashing. A test that legitimately
+  ///   drives registration injects `DesktopEffectDenial.recordOnly` here and
+  ///   asserts on `deniedDesktopEffects`; passing a handler that does nothing
+  ///   would restore the silent skip this exists to prevent.
   public init(
     telemetry: HotkeyTelemetrySink = .noop,
-    now: @escaping @MainActor () -> Date = { Date() }
+    now: @escaping @MainActor () -> Date = { Date() },
+    onDeniedDesktopEffect: (@MainActor (String) -> Void)? = nil
   ) {
     self.telemetry = telemetry
     self.now = now
+    self.desktopEffectPolicy = DesktopEffectPolicy.fromEnvironment()
+    self.onDeniedDesktopEffect = onDeniedDesktopEffect ?? DesktopEffectDenial.defaultHandler()
+  }
+
+  /// The single gate in front of every live INSTALLATION call C0 guards here.
+  ///
+  /// Exactly four: `RegisterEventHotKey`, `InstallEventHandler`, and both
+  /// `NSEvent.add*MonitorForEvents`. Each sits immediately behind a
+  /// `denyDesktopEffect` check, and their three release calls accept only a `.live`
+  /// payload.
+  ///
+  /// Deliberately OUTSIDE the gate: Carbon event DECODING — `GetEventKind` and
+  /// `GetEventParameter` in the handler below — which reads an event already
+  /// delivered and installs nothing. Also outside: desktop effects elsewhere in the
+  /// app; overlay is C4 and activation is C3.
+  ///
+  /// Returns `true` when the caller must NOT touch the framework. Recording
+  /// happens before the handler runs, so a trapping handler still leaves the
+  /// ledger populated for a crash report to carry.
+  private func denyDesktopEffect(_ operation: String) -> Bool {
+    guard desktopEffectPolicy == .deny else { return false }
+    deniedDesktopEffects.append(operation)
+    onDeniedDesktopEffect(operation)
+    return true
   }
 
   /// Emit `hotkey.pressed` for an accepted keydown. Synchronous + cheap (computes
@@ -418,10 +489,7 @@ public final class HotkeyService {
   public func unregisterCancelHotkey() {
     isCancelArmed = false
     cancelArmedBeforeSuspend = false
-    if let ref = cancelHotkeyRef {
-      UnregisterEventHotKey(ref)
-      cancelHotkeyRef = nil
-    }
+    releaseHotkey(&cancelHotkeyRef)
     // Cancel has released the chord, so Quick Add may have it back. Unconditional rather than
     // guarded on a collision: the reconciler decides, and asking the question here as well would be
     // the same rule written twice.
@@ -773,6 +841,13 @@ public final class HotkeyService {
   // MARK: - Carbon Event Handler
 
   private func installCarbonEventHandler() {
+    // #2455 C0. `.denied` rather than leaving the slot nil, so
+    // `removeCarbonEventHandler()` still clears an occupied slot and `stop()`
+    // remains symmetric with `start()`.
+    if denyDesktopEffect("InstallEventHandler(GetApplicationEventTarget())") {
+      eventHandlerRef = .denied
+      return
+    }
     var eventTypes = [
       EventTypeSpec(
         eventClass: OSType(kEventClassKeyboard),
@@ -784,14 +859,16 @@ public final class HotkeyService {
 
     let selfPtr = Unmanaged.passUnretained(self).toOpaque()
 
+    var ref: EventHandlerRef?
     InstallEventHandler(
       GetApplicationEventTarget(),
       carbonHotkeyHandler,
       eventTypes.count,
       &eventTypes,
       selfPtr,
-      &eventHandlerRef
+      &ref
     )
+    eventHandlerRef = ref.map(HandlerRegistration.live)
   }
 
   // MARK: - NSEvent Modifier Monitors
@@ -886,6 +963,18 @@ public final class HotkeyService {
 
     guard shouldInstallModifierMonitors else { return }
 
+    // #2455 C0. Both slots are marked together because one install decision
+    // creates both: a half-denied pair would be a state the production code can
+    // never produce. `recordMonitorInstall` is deliberately NOT consulted here —
+    // its `nil` branch reports a modifier-only shortcut that died on a real
+    // machine, and a policy refusal is not that.
+    if denyDesktopEffect("NSEvent.addGlobalMonitorForEvents(.flagsChanged) + addLocalMonitorForEvents")
+    {
+      globalModifierMonitor = .denied
+      localModifierMonitor = .denied
+      return
+    }
+
     // Read AFTER the teardown above, so both closures carry the identity of the
     // installation being created here rather than the one it replaced. Both
     // monitors are stamped with the same value on purpose: the generation
@@ -906,7 +995,8 @@ public final class HotkeyService {
               keyCode: keyCode, flags: flags, generation: generation)
           }
         }
-      }, scope: "global")
+      }, scope: "global"
+    ).map(MonitorRegistration.live)
 
     localModifierMonitor = recordMonitorInstall(
       NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
@@ -916,7 +1006,8 @@ public final class HotkeyService {
             keyCode: event.keyCode, flags: event.modifierFlags, generation: generation)
         }
         return event  // pass the event through
-      }, scope: "local")
+      }, scope: "local"
+    ).map(MonitorRegistration.live)
   }
 
   /// #1175 (C2): the single chokepoint for an `NSEvent` modifier-monitor install.
@@ -947,15 +1038,17 @@ public final class HotkeyService {
     return monitor
   }
 
+  /// The single release path for an `NSEvent` monitor slot — the monitor twin of
+  /// `releaseHotkey`, and for the same reason: `NSEvent.removeMonitor` must never
+  /// be handed a token that no framework ever issued.
+  private func releaseMonitor(_ slot: inout MonitorRegistration?) {
+    if case .live(let token) = slot { NSEvent.removeMonitor(token) }
+    slot = nil
+  }
+
   private func removeModifierMonitors() {
-    if let monitor = globalModifierMonitor {
-      NSEvent.removeMonitor(monitor)
-      globalModifierMonitor = nil
-    }
-    if let monitor = localModifierMonitor {
-      NSEvent.removeMonitor(monitor)
-      localModifierMonitor = nil
-    }
+    releaseMonitor(&globalModifierMonitor)
+    releaseMonitor(&localModifierMonitor)
     // Bump on EVERY teardown, including one that removed nothing. This is the
     // single writer of `monitorGeneration`, and it is the only NSEvent-monitor
     // teardown path: `stop()` and `suspend()` call it directly, and
@@ -966,10 +1059,8 @@ public final class HotkeyService {
   }
 
   private func removeCarbonEventHandler() {
-    if let ref = eventHandlerRef {
-      RemoveEventHandler(ref)
-      eventHandlerRef = nil
-    }
+    if case .live(let ref) = eventHandlerRef { RemoveEventHandler(ref) }
+    eventHandlerRef = nil
   }
 
   // MARK: - Registration Helpers
@@ -990,10 +1081,7 @@ public final class HotkeyService {
   }
 
   private func unregisterToggleHotkey() {
-    if let ref = toggleHotkeyRef {
-      UnregisterEventHotKey(ref)
-      toggleHotkeyRef = nil
-    }
+    releaseHotkey(&toggleHotkeyRef)
   }
 
   /// Register the Quick Add hotkey (#2381).
@@ -1051,10 +1139,7 @@ public final class HotkeyService {
   }
 
   private func unregisterQuickAddHotkey() {
-    if let ref = quickAddHotkeyRef {
-      UnregisterEventHotKey(ref)
-      quickAddHotkeyRef = nil
-    }
+    releaseHotkey(&quickAddHotkeyRef)
   }
 
   /// Re-apply the Quick Add binding after the user changes it.
@@ -1073,7 +1158,17 @@ public final class HotkeyService {
     installModifierMonitors()
   }
 
-  private func registerHotkey(id: UInt32, keyCode: UInt16, modifiers: UInt32) -> EventHotKeyRef? {
+  private func registerHotkey(id: UInt32, keyCode: UInt16, modifiers: UInt32)
+    -> HotkeyRegistration?
+  {
+    // #2455 C0. Placed ahead of the telemetry branch below on purpose: a refusal
+    // by policy is not a Carbon failure, so it must not emit
+    // `registrationFailed`. Emitting it would report a policy refusal as a Carbon
+    // registration failure, corrupting the one signal that tells us a real user's
+    // shortcut died.
+    if denyDesktopEffect("RegisterEventHotKey(id: \(id), keyCode: \(keyCode))") {
+      return .denied
+    }
     let hotkeyID = EventHotKeyID(signature: hotkeySignature, id: id)
     var ref: EventHotKeyRef?
     let status = RegisterEventHotKey(
@@ -1097,7 +1192,20 @@ public final class HotkeyService {
       telemetry.registrationFailed("carbon", kind, status, keyShape)
       return nil
     }
-    return ref
+    // `noErr` with a nil ref is reachable — see the trap named above — and stays
+    // nil here exactly as it did before, so the caller's occupancy guards see an
+    // unregistered slot rather than a registration it cannot release.
+    return ref.map(HotkeyRegistration.live)
+  }
+
+  /// The single release path for a Carbon hotkey slot.
+  ///
+  /// A `.denied` slot is cleared without a framework call. Every unregister site
+  /// routes through here so no future one can reintroduce a raw
+  /// `UnregisterEventHotKey` on a slot that never held a real registration.
+  private func releaseHotkey(_ slot: inout HotkeyRegistration?) {
+    if case .live(let ref) = slot { UnregisterEventHotKey(ref) }
+    slot = nil
   }
 
   // MARK: - Event Dispatch

--- a/Tests/EnviousWisprTests/App/HotkeyControllerAbandonmentDisarmTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerAbandonmentDisarmTests.swift
@@ -104,7 +104,7 @@ struct HotkeyControllerAbandonmentDisarmTests {
       let settings = SettingsManager()
       let overlay = OverlayTestDouble.headlessDirector()
       let permissions = PermissionsService()
-      let hotkey = HotkeyService()
+      let hotkey = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
       let lockBox = TestRecordingLockedBox()
       let lockAccess = DictationLifecycleCoordinator.RecordingLockedAccess(
         get: { lockBox.isLocked }, set: { lockBox.isLocked = $0 })

--- a/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
@@ -41,7 +41,7 @@ import Testing
     let settings = SettingsManager()
     let overlay = OverlayTestDouble.headlessDirector()
     let permissions = PermissionsService()
-    let hotkey = HotkeyService()
+    let hotkey = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
     let settingsSync = PipelineSettingsSync(
       kernelDriver: pipeline,
       whisperKitKernelDriver: whisperKitKernelDriver,

--- a/Tests/EnviousWisprTests/Services/DesktopEffectPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/DesktopEffectPolicyTests.swift
@@ -1,0 +1,191 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+/// #2455 C0 (#2457) — the tripwire that stops the unit suite registering real
+/// hotkeys.
+///
+/// Scope is Carbon hotkey registration, the Carbon event handler, and the `NSEvent`
+/// modifier monitors. Overlay windows and app activation share the root cause and
+/// are NOT covered here; they are C3 (#2460) and C4 (#2461).
+///
+/// The suite runs inside Apple's `xctest` agent with no `TEST_HOST`, and
+/// `AppWindowCoordinatorTests.swift:26` promotes that agent to a live GUI app, so
+/// WITHOUT this tripwire a `RegisterEventHotKey` call from a unit test takes the key
+/// SYSTEM-WIDE for as long as the run lasts. Escape is the shipped cancel binding,
+/// so the developer loses Escape in every other application while the tests run.
+///
+/// These cases assert the refusal itself. They are also the first coverage in
+/// this repo of whether a registration was ATTEMPTED at all: `registerCancelHotkey`
+/// sets `isCancelArmed` before it asks Carbon, so every existing test proves the
+/// intent to arm and none proves the chord was taken. That gap is what shipped
+/// #2381.
+@MainActor
+@Suite(.tags(.harnessContract)) struct DesktopEffectPolicyTests {
+
+  // MARK: - The switch itself
+
+  /// Only the exact opt-in string denies. A malformed variable must leave a real
+  /// user's hotkeys working rather than silently killing them.
+  @Test(
+    "only the exact string denies",
+    arguments: [
+      ("deny", DesktopEffectPolicy.deny),
+      ("DENY", .allow),
+      ("deny ", .allow),
+      ("1", .allow),
+      ("allow", .allow),
+      ("", .allow),
+    ])
+  func onlyExactStringDenies(value: String, expected: DesktopEffectPolicy) {
+    let policy = DesktopEffectPolicy.fromEnvironment([
+      DesktopEffectPolicy.environmentKey: value
+    ])
+    #expect(policy == expected)
+  }
+
+  @Test("an absent variable allows, so production is unchanged by construction")
+  func absentVariableAllows() {
+    #expect(DesktopEffectPolicy.fromEnvironment([:]) == .allow)
+  }
+
+  /// The negative control for the refusal cases below. If the test action ever
+  /// loses this variable those cases FAIL rather than pass — an empty ledger fails
+  /// a `contains` — but they fail three at a time with no shared cause on their
+  /// face, while the suite is once again stealing the developer's Escape key. This
+  /// case names that cause in one line, so the environment is asserted rather than
+  /// diagnosed. Its twin below covers severity, which CAN fail open.
+  @Test("this test run is itself denied — the scheme carries the variable")
+  func thisRunIsDenied() {
+    #expect(
+      DesktopEffectPolicy.fromEnvironment() == .deny,
+      """
+      \(DesktopEffectPolicy.environmentKey) is not set to "deny" for this run. \
+      The test action in Project.swift owns it; regenerate the project.
+      """)
+  }
+
+  /// The second half of the negative control. Denial and SEVERITY are separate
+  /// switches, so the suite can be denied and still fail open: without this
+  /// variable an unmigrated construction site logs and its test passes having
+  /// reached a prohibited effect. That is the Release-lane hole Codex found on
+  /// 2026-08-26, and it is why severity is not selected with `#if DEBUG`.
+  @Test("this test run traps on an unhandled refusal, in every configuration")
+  func thisRunTrapsUnhandledRefusals() {
+    #expect(
+      ProcessInfo.processInfo.environment[DesktopEffectDenial.trapEnvironmentKey] == "1",
+      """
+      \(DesktopEffectDenial.trapEnvironmentKey) is not set for this run, so a test that \
+      reaches one of C0's guarded installation calls would pass instead of failing. The \
+      Project.swift owns it; regenerate the project.
+      """)
+  }
+
+  // MARK: - What the service does under denial
+
+  /// New coverage, not a restatement: this is the first assertion in the repo
+  /// that `start()` actually ASKS for the record chord. Nothing observable today
+  /// distinguishes "registered the chord" from "set a flag and skipped it".
+  @Test("start() asks for the record chord and the Carbon handler, and is refused")
+  func startAsksForItsEffectsAndIsRefused() {
+    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    service.toggleKeyCode = chordKeyCode
+
+    service.start()
+
+    #expect(service.deniedDesktopEffects.contains { $0.hasPrefix("InstallEventHandler") })
+    #expect(
+      service.deniedDesktopEffects.contains {
+        $0.hasPrefix("RegisterEventHotKey(id: 1")
+      },
+      "the record chord must be requested; refused is fine, unasked is the bug")
+
+    service.stop()
+  }
+
+  /// A chord takes the Carbon path and installs no monitors, so the case above
+  /// cannot reach the `NSEvent` refusal at all. A bare-modifier record key is the
+  /// shape that does — `shouldInstallModifierMonitors` is true only when some
+  /// role is bound to a bare modifier.
+  @Test("a bare-modifier record key asks for the flags-changed monitors, and is refused")
+  func bareModifierRecordKeyAsksForMonitorsAndIsRefused() {
+    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    service.toggleKeyCode = ModifierKeyCodes.rightOption
+
+    service.start()
+
+    #expect(service.shouldInstallModifierMonitors, "precondition: this shape needs monitors")
+    #expect(
+      service.deniedDesktopEffects.contains { $0.hasPrefix("NSEvent.addGlobalMonitor") })
+    // A bare modifier cannot be a Carbon registration, so the record role must
+    // NOT have asked for one — the #1991 shape, asserted from the refusal ledger.
+    #expect(
+      service.deniedDesktopEffects.contains { $0.hasPrefix("RegisterEventHotKey(id: 1") } == false)
+
+    service.stop()
+  }
+
+  /// The teardown half. A refused registration still occupies its slot, so
+  /// `stop()` must clear it — and must not hand the framework a token no
+  /// framework ever issued. A forged `EventHotKeyRef` here would be a wild-pointer
+  /// call, which is why the refusal is a typed case rather than a synthetic
+  /// pointer.
+  @Test("stop() releases refused registrations without calling the framework")
+  func stopReleasesRefusedRegistrations() {
+    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    service.toggleKeyCode = chordKeyCode
+    service.start()
+    service.registerCancelHotkey()
+
+    service.stop()
+
+    #expect(service.isEnabled == false)
+    // Reaching here at all is the assertion: releasing a refused slot must not
+    // reach `UnregisterEventHotKey` or `RemoveEventHandler`.
+    #expect(service.deniedDesktopEffects.isEmpty == false)
+  }
+
+  /// `suspend()`/`resume()` re-registers, so it must be refused each time rather
+  /// than slipping through on the second pass.
+  @Test("a resumed service is refused again rather than registering")
+  func resumeIsRefusedAgain() {
+    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    service.toggleKeyCode = chordKeyCode
+    service.start()
+    let afterStart = service.deniedDesktopEffects.count
+
+    service.suspend()
+    service.resume()
+
+    #expect(service.deniedDesktopEffects.count > afterStart)
+    service.stop()
+  }
+
+  /// A policy refusal is not a Carbon failure. Emitting `registrationFailed` for
+  /// it would report a policy refusal as a Carbon registration failure, corrupting
+  /// the one signal that tells us a real user's shortcut died.
+  @Test("a refusal emits no registration-failure telemetry")
+  func refusalEmitsNoRegistrationFailure() {
+    final class Spy: @unchecked Sendable {
+      var failures: [(String, String)] = []
+    }
+    let spy = Spy()
+    let sink = HotkeyTelemetrySink(
+      registrationFailed: { mechanism, kind, _, _ in
+        spy.failures.append((mechanism, kind))
+      },
+      pressed: { _, _, _, _, _ in })
+
+    let service = HotkeyService(
+      telemetry: sink, onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    service.toggleKeyCode = chordKeyCode
+    service.start()
+
+    #expect(spy.failures.isEmpty)
+    service.stop()
+  }
+
+  /// `kVK_ANSI_D` — a plain chord, so the record key takes the Carbon path rather
+  /// than the modifier-monitor path.
+  private let chordKeyCode: UInt16 = 2
+}

--- a/Tests/EnviousWisprTests/Services/HotkeyCancelShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyCancelShortcutTests.swift
@@ -97,7 +97,7 @@ import Testing
     let sink = Sink()
     let cancelWaiter = Waiter()
     let toggleWaiter = Waiter()
-    let service = HotkeyService()
+    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
     service.recordingMode = mode
     service.toggleKeyCode = recordKey
     service.toggleModifiers = []
@@ -413,7 +413,7 @@ import Testing
   @Test("a cancel modifier required by the record chord does not cancel")
   func cancelModifierShadowedByRecordChordIsRefused() async {
     let sink = Sink()
-    let service = HotkeyService()
+    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
     service.recordingMode = .toggle
     service.toggleKeyCode = chordKeyCode  // D
     service.toggleModifiers = [.command]  // record is ⌘D
@@ -435,7 +435,7 @@ import Testing
   func cancelModifierUnrelatedToRecordChordStillWorks() async {
     let sink = Sink()
     let waiter = Waiter()
-    let service = HotkeyService()
+    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
     service.recordingMode = .toggle
     service.toggleKeyCode = chordKeyCode
     service.toggleModifiers = [.command]  // record is ⌘D

--- a/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
@@ -113,7 +113,9 @@ import Testing
   private func makeService(
     _ spy: Spy, clock: ManualClock, mode: RecordingMode = .pushToTalk
   ) -> HotkeyService {
-    let service = HotkeyService(telemetry: spy.sink, now: { clock.now })
+    let service = HotkeyService(
+      telemetry: spy.sink, now: { clock.now },
+      onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
     service.recordingMode = mode
     service.toggleKeyCode = ModifierKeyCodes.globe
     service.onStartRecording = { [weak spy] in

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -91,7 +91,8 @@ struct HotkeyQuickAddShortcutTests {
         registrationFailed: { _, _, _, _ in },
         pressed: { trigger, _, keyShape, _, action in
           sink.presses.append((trigger, keyShape, action))
-        }))
+        }),
+      onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
     service.recordingMode = .toggle
     service.toggleKeyCode = recordKey
     service.toggleModifiers = recordModifiers


### PR DESCRIPTION
Closes #2457. Chunk C0 of #2455.

**Lane:** Code
**Tier:** REFACTOR (chunk C0 of 6)
**Live UAT:** Y — founder-observed, see Acceptance below

## Problem

`EnviousWisprTests` has no `TEST_HOST`, so the suite runs inside Apple's `xctest` agent, and `AppWindowCoordinatorTests.swift:26`'s `_ = NSApplication.shared` promotes that agent to a live GUI app. Every Carbon hotkey a unit test registered therefore landed on the developer's real machine. Escape is the shipped cancel binding, so running the suite swallowed Escape system-wide in every other application for the duration of the run.

## What this does

`DesktopEffectPolicy` reads `EW_DESKTOP_EFFECTS_POLICY`, set to `deny` by the test action of all three shared schemes. Only the exact string denies, so a malformed variable cannot silently kill a user's hotkeys.

**Scope is exactly three effects:** Carbon hotkey registration, the Carbon event handler, and the `NSEvent` modifier monitors. Overlay windows and app activation share the root cause and are **not** covered here — they are C4 (#2461) and C3 (#2460).

**Never a silent no-op.** Every denial is recorded on the instance in `deniedDesktopEffects`, and an unhandled one reaches `DesktopEffectDenial.trap`, which aborts naming the refused operation. The eleven registration-driving suites install `DesktopEffectDenial.recordOnly`, which records and does nothing else, and assert on the ledger. No existing assertion changed.

**Severity is a second runtime variable, not `#if DEBUG`.** Selecting it at compile time made an unmigrated site abort in Debug and PASS in Release, so the Release suite could go green having reached a prohibited effect. Found by Codex chunk review round 2; the fix is verified in the Release lane specifically.

**No forged tokens.** Registration slots are typed — `.live` carrying the framework object, or `.denied`. Occupancy is what the surrounding guards ask about, so `.denied` keeps every one of them behaving as it does against a real registration, while the release helpers pass only a `.live` payload back to the framework. A synthetic `EventHotKeyRef` handed to `UnregisterEventHotKey` would be a wild-pointer call, so none is ever created.

**Telemetry is unchanged.** The denial check sits ahead of the Carbon telemetry branch: a policy refusal is not a registration failure and must not corrupt the one signal that says a real user's shortcut died.

## Coverage this adds

`DesktopEffectPolicyTests` carries the first assertion in the repo that `start()` actually **asks for** the record chord. `registerCancelHotkey` sets `isCancelArmed` before it asks Carbon, so until now every test proved the intent to arm and none proved the chord was taken — the gap that shipped #2381.

It also carries its own negative controls for both variables, so a run that loses either says so in one line rather than failing three cases with no shared cause on their face.

## Validation

| Check | Result |
|---|---|
| Debug lane | PASS — 7,117 test cases |
| Release lane | PASS — 6,487 test cases |
| `check-dependency-direction.sh` | OK, 17 modules |
| `TestInventoryFreezeTests` | green |
| Codex chunk gate | **CHUNK-CLEAN** on a confirming re-run |

Codex rounds: design adjudication → `RENEGOTIATE-CLAUSE-b` → `CHUNK-REVISIONS (1)` (the Release fail-open defect) → `CHUNK-REVISIONS (1)` → `CHUNK-REVISIONS (1)` → `CHUNK-REVISIONS (6)` → **`CHUNK-CLEAN`**.

## Acceptance

Founder ran the Debug suite and confirmed Escape kept working system-wide throughout — issue #2457's acceptance clause, signed off by observation.

## Debt

Disclosed temporary, removed or demoted in C5 (#2462). The removal list is greppable: `recordOnly`, `EW_DESKTOP_EFFECTS_POLICY`, `EW_DESKTOP_EFFECTS_TRAP_DENIALS`.

## Note for other active worktrees

A test that constructs `HotkeyService` and drives it into registration now needs `onDeniedDesktopEffect: DesktopEffectDenial.recordOnly`, or it aborts naming the call. That is the change working as designed.
