### PR TITLE
Pill Refactor Phase 6 C4: idle-prewarm root construction, benchmark-proven

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -145,6 +145,27 @@ final class OverlayDirector {
       self?.commitLatestFirstRender(root)
     })
 
+  /// Requests root construction at the next main run-loop idle turn, ahead
+  /// of any real presentation (#2377 Phase 6 C4). Registers an idle observer
+  /// and returns immediately — construction happens later, when that
+  /// observer fires. A no-op if the gate is already scheduled or ready,
+  /// whichever caller got there first: `firstRenderGate`'s own idle-state
+  /// guard is what makes that safe, not anything here.
+  ///
+  /// `idleScheduler` is a MECHANISM default, the same shape as
+  /// `firstRenderSchedule`/`scheduleReconciliation` above: production always
+  /// wants a real `CFRunLoopObserver`, which a synchronous unit test cannot
+  /// observe firing without spinning the actual run loop. A test substitutes
+  /// a manual scheduler here; the one production call site
+  /// (`WisprBootstrapper.applicationDidFinishLaunching()`) stays a bare,
+  /// zero-argument `recordingOverlay.prewarmFirstRender()`.
+  func prewarmFirstRender(
+    idleScheduler: @escaping OverlayFirstRenderGate.Schedule =
+      OverlayFirstRenderGate.idleScheduler()
+  ) {
+    firstRenderGate.scheduleIfNeeded(using: idleScheduler)
+  }
+
   /// Builds the retained root view. Called at most once per launch, from the
   /// gate's own scheduled task — never directly.
   private func makeRootHostingView() -> NSView {

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayFirstRenderGate.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayFirstRenderGate.swift
@@ -43,15 +43,44 @@ final class OverlayFirstRenderGate {
     return root
   }
 
-  func scheduleIfNeeded() {
+  /// `scheduleOverride` lets a caller supply a DIFFERENT scheduling primitive
+  /// for this one call while every other caller keeps using the instance's
+  /// own default. Idle prewarm is the one caller that needs this: it wants
+  /// the main run loop's `.beforeWaiting` boundary (`idleScheduler()` below),
+  /// while demand-driven rendering keeps the constructor's `schedule`
+  /// (`DispatchQueue.main.async` in production) unchanged — that default is
+  /// load-bearing for the menu-dismiss crash fix and must not move.
+  func scheduleIfNeeded(using scheduleOverride: Schedule? = nil) {
     guard case .idle = state else { return }
     state = .scheduled
 
-    schedule { [weak self] in
+    (scheduleOverride ?? schedule) { [weak self] in
       guard let self, case .scheduled = self.state else { return }
       let root = self.construct()
       self.state = .ready(root)
       self.didBecomeReady(root)
+    }
+  }
+}
+
+extension OverlayFirstRenderGate {
+  /// A one-shot `Schedule` that fires when the main run loop next reaches
+  /// `.beforeWaiting` — the plan's literal "first idle main-run-loop turn",
+  /// as opposed to `DispatchQueue.main.async`'s "next queue turn", which can
+  /// still be contending with whatever async launch work the app itself
+  /// queued (recovery scan, expired-pending sweep, and anything
+  /// `AppLifecycleCoordinator.runDidFinishLaunching()` starts).
+  ///
+  /// `repeats: false` in `CFRunLoopObserverCreateWithHandler` invalidates the
+  /// observer after its first fire, so it costs nothing to leave registered
+  /// beyond that — there is no manual removal to forget.
+  static func idleScheduler() -> Schedule {
+    { work in
+      let observer = CFRunLoopObserverCreateWithHandler(
+        kCFAllocatorDefault, CFRunLoopActivity.beforeWaiting.rawValue,
+        false, 0
+      ) { _, _ in work() }
+      CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -102,6 +102,13 @@ public final class WisprBootstrapper {
   /// app-lifetime (a weak-only hold would dealloc and silently stop emitting).
   let settingsChangeTelemetry: SettingsChangeTelemetry
 
+  /// #2377 Phase 6 C4: the app-lifetime overlay owner, previously a local
+  /// only. Storing it here is what lets `applicationDidFinishLaunching()`
+  /// call `recordingOverlay.prewarmFirstRender()` — the +1 stored property
+  /// is the plan's named cost (ceiling 39 -> 40, Bible entry in
+  /// EnviousWisprAppCeilingsTests).
+  let recordingOverlay: OverlayDirector
+
   public init() {
     // ===== Subsystem construction (epic #763) =====
     // `EnviousWisprApp` is the composition root: every subsystem is constructed
@@ -533,6 +540,12 @@ public final class WisprBootstrapper {
           withoutWords: settings.recordingPillDesignWithoutWords,
           withWords: settings.recordingPillDesignWithWords)
       })
+    // #2377 Phase 6 C4: stored immediately so `applicationDidFinishLaunching()`
+    // can reach it later. Every use below this line keeps reading the bare
+    // `recordingOverlay` identifier, which still resolves to this same local —
+    // Swift resolves an unqualified name to the innermost declaration in
+    // scope, and the local shadows the property for the rest of `init`.
+    self.recordingOverlay = recordingOverlay
 
     // #2376 C7: the Appearance page's window onto the pill. Built HERE because
     // this is where the live-preview bridge already is, so the picker reads the
@@ -1255,6 +1268,13 @@ public final class WisprBootstrapper {
     // survives, so it is safe whenever it runs. Chaining it was tried and cloud
     // review refuted both halves. Bound by `EscapeRecoveryDiskExpiryTests`.
     Task { await transcriptCoordinator.sweepExpiredPending() }
+    // #2377 Phase 6 C4: registers a one-shot idle observer and returns
+    // immediately — root construction happens later, at the main run loop's
+    // next `.beforeWaiting`, not here. No outer `DispatchQueue.main.async`:
+    // that would add a second hop without establishing idleness, which is
+    // the whole reason this call exists instead of the demand-driven path's
+    // existing `DispatchQueue.main.async` default.
+    recordingOverlay.prewarmFirstRender()
   }
 
   public func applicationDidBecomeActive() {

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -2025,4 +2025,107 @@ struct OverlayDirectorTests {
     // it is real: the lock is remembered with NO pill showing, which is the
     // same state a refusal leaves. That case runs in the Release lane.
   }
+
+  // MARK: - Idle prewarm (#2377 Phase 6 C4)
+  //
+  // `OverlayFirstRenderGateTests` proves the gate's own `scheduleIfNeeded(using:)`
+  // override and both race directions in isolation. These four prove the
+  // DIRECTOR wires `prewarmFirstRender(idleScheduler:)` into that same gate
+  // correctly — no second construction path, no synchronous build, and both
+  // scheduler-race outcomes resolve through the full present()/renderModel
+  // surface, not just the gate's internal state.
+
+  @Test("prewarmFirstRender registers work asynchronously; nothing constructs before it fires")
+  func prewarmRegistersAsynchronously() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let prewarmDeferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+
+    d.prewarmFirstRender(idleScheduler: { prewarmDeferral.block = $0 })
+
+    #expect(prewarmDeferral.fired == 0, "prewarm registers work but does not run it synchronously")
+    #expect(host.presentCount == 0, "nothing was constructed or presented yet")
+  }
+
+  @Test("repeated prewarmFirstRender calls schedule and build at most once")
+  func repeatedPrewarmCallsBuildOnce() {
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let prewarmDeferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+
+    d.prewarmFirstRender(idleScheduler: { prewarmDeferral.block = $0 })
+    d.prewarmFirstRender(idleScheduler: { prewarmDeferral.block = $0 })
+    d.prewarmFirstRender(idleScheduler: { prewarmDeferral.block = $0 })
+    prewarmDeferral.fireAll()
+
+    #expect(prewarmDeferral.fired == 1, "only one block was ever queued across three calls")
+
+    // A real presentation afterward finds the root already built — it
+    // resolves on the SAME turn, with no `deferral.fire()` needed, which is
+    // only true if construction already happened via prewarm.
+    var results: [PillPresentationResult] = []
+    let receipt = d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { results.append($0) })
+    #expect(receipt != nil)
+    #expect(results.count == 1, "the presentation resolved immediately, without deferral.fire()")
+  }
+
+  @Test("prewarmFirstRender after a real presentation already scheduled is a no-op")
+  func prewarmAfterDemandDrivenAlreadyScheduledIsANoOp() {
+    // Race direction 1: demand-driven wins. Prewarm arriving second must
+    // never touch its own scheduler — the gate is already `.scheduled`.
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let prewarmDeferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+
+    var results: [PillPresentationResult] = []
+    let receipt = d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { results.append($0) })
+    #expect(receipt != nil)
+    #expect(deferral.fired == 0, "not yet fired")
+
+    d.prewarmFirstRender(idleScheduler: { prewarmDeferral.block = $0 })
+    #expect(
+      prewarmDeferral.block == nil,
+      "prewarm's scheduler never receives work — demand-driven already claimed .scheduled")
+
+    deferral.fire()
+    #expect(results.count == 1, "the presentation commits via the scheduler that won the race")
+  }
+
+  @Test("a real presentation before prewarm fires still commits once, via the prewarm scheduler")
+  func earlyPresentationBeforePrewarmFiresStillCommitsOnce() {
+    // Race direction 2, the mirror: prewarm wins. A presentation arriving
+    // before the prewarm scheduler fires must coalesce and wait for it — the
+    // demand-driven scheduler must never receive work either.
+    let host = RefusingWindowlessHost()
+    let deferral = Deferral()
+    let prewarmDeferral = Deferral()
+    let d = Self.deferrableDirector(host, deferral)
+
+    d.prewarmFirstRender(idleScheduler: { prewarmDeferral.block = $0 })
+
+    var results: [PillPresentationResult] = []
+    let receipt = d.present(
+      .bluetoothAwareness(onAcknowledge: {}, onClose: {}, onOpenSettings: {}),
+      onResult: { results.append($0) })
+    #expect(receipt != nil)
+    #expect(results.isEmpty, "not yet built — waiting on the prewarm scheduler's fire")
+    #expect(
+      deferral.fired == 0,
+      "the demand-driven scheduler must never receive work: prewarm already scheduled")
+
+    prewarmDeferral.fireAll()
+
+    #expect(results.count == 1, "the presentation commits exactly once, via the prewarm scheduler")
+    guard case .bluetoothAwareness? = d.renderModel.state.presentation?.content else {
+      Issue.record("the presentation never reached the screen")
+      return
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayFirstRenderGateTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayFirstRenderGateTests.swift
@@ -133,4 +133,108 @@ struct OverlayFirstRenderGateTests {
     #expect(
       constructionCount == 1, "reentrant scheduling during construction must not double-build")
   }
+
+  // MARK: - scheduleIfNeeded(using:) override (#2377 Phase 6 C4)
+
+  @Test("a per-call scheduler override is used instead of the constructor's default")
+  func overrideSchedulerIsUsedWhenSupplied() {
+    let defaultScheduler = ManualScheduler()
+    let overrideScheduler = ManualScheduler()
+    var constructionCount = 0
+
+    let gate = OverlayFirstRenderGate(
+      schedule: defaultScheduler.schedule,
+      construct: {
+        constructionCount += 1
+        return NSView()
+      },
+      didBecomeReady: { _ in })
+
+    gate.scheduleIfNeeded(using: overrideScheduler.schedule)
+
+    #expect(defaultScheduler.queued.isEmpty, "the default scheduler must not be invoked")
+    #expect(overrideScheduler.queued.count == 1, "the override scheduler receives the work")
+
+    overrideScheduler.fireAll()
+    #expect(constructionCount == 1, "the override scheduler's fire constructs exactly once")
+  }
+
+  @Test("omitting the override preserves the exact prior default-scheduler behavior")
+  func noOverridePreservesTheDefaultScheduler() {
+    // TWIN of the override test: production's existing demand-driven call
+    // sites pass no argument at all, and this proves that call shape still
+    // reaches the constructor's own `schedule` unchanged — the default
+    // parameter must not silently redirect every caller.
+    let defaultScheduler = ManualScheduler()
+    var constructionCount = 0
+
+    let gate = OverlayFirstRenderGate(
+      schedule: defaultScheduler.schedule,
+      construct: {
+        constructionCount += 1
+        return NSView()
+      },
+      didBecomeReady: { _ in })
+
+    gate.scheduleIfNeeded()
+
+    #expect(defaultScheduler.queued.count == 1, "the bare call reaches the default scheduler")
+    defaultScheduler.fireAll()
+    #expect(constructionCount == 1)
+  }
+
+  @Test("demand-driven scheduling first makes a later prewarm call a no-op")
+  func demandDrivenFirstMakesPrewarmANoOp() {
+    // Race direction 1 (plan §5/§7): the default scheduler wins, the
+    // override scheduler never receives anything, and construction still
+    // happens exactly once via the WINNING scheduler's fire.
+    let defaultScheduler = ManualScheduler()
+    let overrideScheduler = ManualScheduler()
+    var constructionCount = 0
+
+    let gate = OverlayFirstRenderGate(
+      schedule: defaultScheduler.schedule,
+      construct: {
+        constructionCount += 1
+        return NSView()
+      },
+      didBecomeReady: { _ in })
+
+    gate.scheduleIfNeeded()  // demand-driven, wins the race
+    gate.scheduleIfNeeded(using: overrideScheduler.schedule)  // prewarm, arrives second
+
+    #expect(defaultScheduler.queued.count == 1)
+    #expect(overrideScheduler.queued.isEmpty, "the loser's scheduler is never invoked")
+
+    defaultScheduler.fireAll()
+    #expect(constructionCount == 1, "construction happens exactly once, via the winner")
+  }
+
+  @Test("prewarm scheduling first makes a later demand-driven call a no-op")
+  func prewarmFirstMakesDemandDrivenANoOp() {
+    // Race direction 2 (plan §5/§7): the mirror image — the override
+    // scheduler wins, the default scheduler never receives anything.
+    let defaultScheduler = ManualScheduler()
+    let overrideScheduler = ManualScheduler()
+    var constructionCount = 0
+    var readyCallCount = 0
+
+    let gate = OverlayFirstRenderGate(
+      schedule: defaultScheduler.schedule,
+      construct: {
+        constructionCount += 1
+        return NSView()
+      },
+      didBecomeReady: { _ in readyCallCount += 1 })
+
+    gate.scheduleIfNeeded(using: overrideScheduler.schedule)  // prewarm, wins the race
+    gate.scheduleIfNeeded()  // demand-driven, arrives second (an early keypress)
+
+    #expect(overrideScheduler.queued.count == 1)
+    #expect(defaultScheduler.queued.isEmpty, "the loser's scheduler is never invoked")
+
+    overrideScheduler.fireAll()
+    #expect(constructionCount == 1, "construction happens exactly once, via the winner")
+    #expect(readyCallCount == 1, "readiness fires exactly once regardless of which side won")
+  }
 }

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -172,13 +172,19 @@ import Testing
   ///   `bulkImportEnrichmentCoordinator`, the app-lifetime owner of the durable
   ///   pending-word drain and Cancel/checkpoint sequencing. The approved #1701
   ///   plan §3b/§10 places this sibling of `contactsImportCoordinator` here.
+  /// - 39 → 40 in #2377 Phase 6 C4 (2026-08-26): App-owned `recordingOverlay`,
+  ///   previously a local only. Idle-prewarm needs `applicationDidFinishLaunching()`
+  ///   to reach the director after construction, and the approved plan
+  ///   (`docs/feature-requests/issue-2377-2026-08-26-phase6-c4-idle-prewarm.md`
+  ///   §3 step 4) places the app-lifetime overlay owner here rather than on
+  ///   `AppLifecycleCoordinator`, which gains no overlay dependency.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 39,
+      count <= 40,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 39. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 40. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.

--- a/Tests/RuntimeUAT/measure_overlay_first_render.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render.py
@@ -134,6 +134,17 @@ BLOCKED_AMBIGUOUS_OVERLAY = "BLOCKED_AMBIGUOUS_OVERLAY"
 # policy, not a first-render fault, so it gets its own verdict rather than
 # reusing `BLOCKED_WRONG_PRESENTATION` or `BLOCKED_LAUNCH`.
 BLOCKED_ENGINE_NOT_READY = "BLOCKED_ENGINE_NOT_READY"
+# A launched executable's identity (bundle id, executable path, or SHA-256)
+# did not match the identity pinned for its arm before pair 1, or the
+# post-run re-hash did not match the pinned value (#2377, C4). Never a
+# BENCHMARK_FAIL: a rebuild mid-run means the sixty launches are not all
+# measuring the same two builds, which is a question the run cannot answer,
+# not a regression it found.
+BLOCKED_IDENTITY_DRIFT = "BLOCKED_IDENTITY_DRIFT"
+# The pinned baseline and prewarmed identities share an executable path or a
+# hash (#2377, C4). A regression measured between one build and itself is not
+# evidence the optimization does anything — it proves nothing either way.
+BLOCKED_IDENTICAL_ARMS = "BLOCKED_IDENTICAL_ARMS"
 
 Identity = namedtuple("Identity", "bundle_id executable_path sha256")
 Marker = namedtuple("Marker", "run pid bundle event ticks window intent index")
@@ -395,9 +406,12 @@ def smoke_verdict(result):
     return SMOKE_PASS if result.verdict == OK else result.verdict
 
 
-def final_verdict_and_detail(result, timing):
-    """The SINGLE place that decides `smoke()`'s outcome once a launch's
-    marker adjudication AND a keypress measurement both exist.
+def result_and_timing_verdict(result, timing):
+    """The SINGLE place that decides a launch's outcome once its marker
+    adjudication AND a keypress measurement both exist — shared by
+    `final_verdict_and_detail` (smoke) and the benchmark's per-side verdict,
+    so a later edit to the priority order affects both callers rather than
+    silently diverging between them.
 
     `timing` is checked FIRST (#2377, C1 repair): it is the
     SPECIFIC diagnosis from the actual keypress measurement — AX
@@ -408,12 +422,25 @@ def final_verdict_and_detail(result, timing):
     true-but-less-informative `BLOCKED_MISSING_MARKER` for the SAME run,
     masking the real reason behind a verdict that reads like an app defect
     rather than an unavailable precondition.
+
+    Returns bare `OK` on success, never `SMOKE_PASS` — that relabeling means
+    "one launch, nothing to compare," which only `smoke()`'s caller wants;
+    the benchmark's per-side verdict has no use for it.
     """
     if timing["verdict"] != OK:
         return timing["verdict"], timing["detail"]
     if result.verdict != OK:
         return result.verdict, result.detail
-    return smoke_verdict(result), result.detail
+    return OK, result.detail
+
+
+def final_verdict_and_detail(result, timing):
+    """`smoke()`'s outcome: `result_and_timing_verdict`'s bare `OK` becomes
+    `SMOKE_PASS`; every blocked verdict passes through unchanged."""
+    verdict, detail = result_and_timing_verdict(result, timing)
+    if verdict == OK:
+        return smoke_verdict(result), detail
+    return verdict, detail
 
 
 # ------------------------------------------------------- the overlay endpoint
@@ -746,6 +773,7 @@ def adjudicate_benchmark(pairs, budget=PLAN_BUDGET, pair_count=PAIR_COUNT):
 
     a_launch = [p.a.sample.launch_ms for p in pairs]
     b_launch = [p.b.sample.launch_ms for p in pairs]
+    a_root = [p.a.sample.root_ms for p in pairs]
     b_root = [p.b.sample.root_ms for p in pairs]
     a_key = [p.a_keypress.keypress_ms for p in pairs]
     b_key = [p.b_keypress.keypress_ms for p in pairs]
@@ -771,6 +799,9 @@ def adjudicate_benchmark(pairs, budget=PLAN_BUDGET, pair_count=PAIR_COUNT):
         "launch_median_a_ms": median(a_launch),
         "launch_median_b_ms": median(b_launch),
         "launch_median_regression_ms": launch_regression,
+        # `a` (baseline) never triggers early construction, so its root p95
+        # is diagnostic evidence only — the budget applies to `b` alone.
+        "root_p95_a_ms": nearest_rank(a_root, 95),
         "root_p95_b_ms": root_p95,
         "keypress_p95_a_ms": nearest_rank(a_key, 95),
         "keypress_p95_b_ms": nearest_rank(b_key, 95),
@@ -1277,43 +1308,22 @@ def launch_with_markers(bundle_path, *, marker_dir, ready_timeout_s=30.0):
             "marker_path": marker_path, "process": proc}
 
 
-def smoke(bundle_path, *, out_dir):
-    """One bundle, one launch, one press: does the instrument produce a receipt?
+def _drive_one_launch(bundle_path, *, out_dir):
+    """One cold launch, one press, the raw pieces — no verdict, no JSON shape.
 
-    Returns a JSON-serialisable dict whose `verdict` is `SMOKE_PASS` or a
-    `BLOCKED_` reason. It is never `BENCHMARK_PASS` — one bundle has nothing to
-    be compared against.
+    Shared by `smoke()` and `run_benchmark()` so both execute the identical
+    crash-avoidance and timing sequence. The callers add only their own
+    pre-launch gates, adjudication, and receipt shape.
+
+    Returns a dict of raw pieces: `launched`, `resolved`, `timing`, `result`,
+    `timebase`, `engine_ready_wait_ms`, `failure`, `engine_not_ready`,
+    `screen_locked_before_press`, `screen_locked_pre_press` (the state dict,
+    for the caller's receipt). Never raises for an ordinary launch failure —
+    that is carried in `failure`; an exception here means the launch attempt
+    itself could not even be started (e.g. `launch_with_markers` itself
+    raised), which the caller turns into `BLOCKED_LAUNCH`.
     """
-    out = {"kind": "smoke", "bundle": str(bundle_path),
-           "hardware": hardware_identity()}
-
-    # The screen lock is checked BEFORE occupancy, because it costs nothing and
-    # invalidates the run whatever the slot looks like.
-    lock = screen_lock_state()
-    blocked_reason = screen_lock_block(lock)
-    out["screen_locked"] = lock
-    if blocked_reason:
-        out["verdict"] = BLOCKED_SCREEN_LOCKED
-        out["detail"] = blocked_reason
-        return out
-
-    # Occupancy: REFUSE rather than choose. Every dev bundle on this machine is
-    # named the same, so picking one of two instances silently retargets the
-    # measurement at somebody else's build.
-    instances = running_instances()
-    if instances:
-        out["verdict"] = BLOCKED_OCCUPANCY
-        out["detail"] = ("EnviousWispr is already running and this measurement needs a "
-                         "cold launch it owns: " +
-                         ", ".join(f"pid {p} at {x}" for p, x in sorted(instances.items())))
-        return out
-
-    try:
-        launched = launch_with_markers(bundle_path, marker_dir=out_dir)
-    except Exception as exc:
-        out["verdict"] = BLOCKED_LAUNCH
-        out["detail"] = f"{type(exc).__name__}: {exc}"
-        return out
+    launched = launch_with_markers(bundle_path, marker_dir=out_dir)
 
     resolved = None
     timing = None
@@ -1323,6 +1333,7 @@ def smoke(bundle_path, *, out_dir):
     engine_ready_wait_ms = None
     engine_not_ready = False
     screen_locked_before_press = None
+    screen_locked_pre_press = None
     try:
         # Inside the reaped region, not before it. `mach_timebase()` loads a
         # native symbol and can raise; raising here with the app already launched
@@ -1344,15 +1355,15 @@ def smoke(bundle_path, *, out_dir):
         # Re-check the screen lock immediately before the press (#2377, C1
         # repair). The launch and engine-readiness waits above can together
         # run for up to ~60s — wide enough for the screen to lock AFTER the
-        # check at the top of this function, which the
-        # initial check cannot see. A press sent into a locked screen
-        # invalidates the run for the same reason that initial check exists;
-        # checked here, not inside `measure_keypress_to_overlay`, so it
-        # shares the SAME verdict and receipt field as the initial check
-        # rather than inventing a second meaning for the same fact.
+        # caller's initial check, which that check cannot see. A press sent
+        # into a locked screen invalidates the run for the same reason the
+        # initial check exists; checked here, not inside
+        # `measure_keypress_to_overlay`, so it shares the SAME verdict and
+        # receipt field as the initial check rather than inventing a second
+        # meaning for the same fact.
         pre_press_lock = screen_lock_state()
         pre_press_blocked = screen_lock_block(pre_press_lock)
-        out["screen_locked_pre_press"] = pre_press_lock
+        screen_locked_pre_press = pre_press_lock
         press_permitted = engine_ready and not pre_press_blocked
 
         # Gated through `measure_after_engine_ready` rather than an inline
@@ -1386,62 +1397,381 @@ def smoke(bundle_path, *, out_dir):
     finally:
         reap(launched["process"])
 
-    out.update({
+    return {
+        "launched": launched, "resolved": resolved, "timing": timing,
+        "result": result, "timebase": timebase,
+        "engine_ready_wait_ms": engine_ready_wait_ms, "failure": failure,
+        "engine_not_ready": engine_not_ready,
+        "screen_locked_before_press": screen_locked_before_press,
+        "screen_locked_pre_press": screen_locked_pre_press,
+    }
+
+
+def _launch_receipt_fields(piece):
+    """The fields every launch receipt shares, keyed off `_drive_one_launch`'s
+    raw pieces. `smoke()` and `run_benchmark()` both call this so a field
+    added to one receipt shape is not silently absent from the other."""
+    launched = piece["launched"]
+    resolved = piece["resolved"]
+    result = piece["result"]
+    return {
         "run_id": launched["run_id"],
         "pid": launched["pid"],
         "marker_path": str(launched["marker_path"]),
         "requested_identity": launched["requested"]._asdict(),
         "resolved_identity": resolved._asdict() if resolved else None,
-        "timebase": timebase,
-        "engine_ready_wait_ms": engine_ready_wait_ms,
-        "keypress": timing,
-        "detail": failure or (result.detail if result else ""),
+        "timebase": piece["timebase"],
+        "engine_ready_wait_ms": piece["engine_ready_wait_ms"],
+        "keypress": piece["timing"],
+        "detail": piece["failure"] or (result.detail if result else ""),
         "sample": result.sample._asdict() if result and result.sample else None,
-    })
-    if engine_not_ready:
-        out["verdict"] = BLOCKED_ENGINE_NOT_READY
-        out["detail"] = (
-            f"no complete {ENGINE_READY} marker for run {launched['run_id']} "
-            f"within the warm-up wait; a keypress sent now would race "
-            f"ColdPressGuard (#879)")
-        return out
-    if screen_locked_before_press:
+    }
+
+
+def _launch_verdict(piece):
+    """`(verdict, detail)` for one driven launch, or `(None, None)` if the
+    launch reached a real result and the caller must derive its own verdict
+    from `piece["result"]` / `piece["timing"]` (via `final_verdict_and_detail`
+    for smoke, or the benchmark's own per-side OK/blocked check)."""
+    if piece["engine_not_ready"]:
+        launched = piece["launched"]
+        return (BLOCKED_ENGINE_NOT_READY,
+               f"no complete {ENGINE_READY} marker for run {launched['run_id']} "
+               f"within the warm-up wait; a keypress sent now would race "
+               f"ColdPressGuard (#879)")
+    if piece["screen_locked_before_press"]:
+        return (BLOCKED_SCREEN_LOCKED, piece["screen_locked_before_press"])
+    if piece["failure"] is not None:
+        return (BLOCKED_LAUNCH, piece["failure"])
+    return (None, None)
+
+
+def smoke(bundle_path, *, out_dir):
+    """One bundle, one launch, one press: does the instrument produce a receipt?
+
+    Returns a JSON-serialisable dict whose `verdict` is `SMOKE_PASS` or a
+    `BLOCKED_` reason. It is never `BENCHMARK_PASS` — one bundle has nothing to
+    be compared against.
+    """
+    out = {"kind": "smoke", "bundle": str(bundle_path),
+           "hardware": hardware_identity()}
+
+    # The screen lock is checked BEFORE occupancy, because it costs nothing and
+    # invalidates the run whatever the slot looks like.
+    lock = screen_lock_state()
+    blocked_reason = screen_lock_block(lock)
+    out["screen_locked"] = lock
+    if blocked_reason:
         out["verdict"] = BLOCKED_SCREEN_LOCKED
-        out["detail"] = screen_locked_before_press
+        out["detail"] = blocked_reason
         return out
-    if failure is not None:
+
+    # Occupancy: REFUSE rather than choose. Every dev bundle on this machine is
+    # named the same, so picking one of two instances silently retargets the
+    # measurement at somebody else's build.
+    instances = running_instances()
+    if instances:
+        out["verdict"] = BLOCKED_OCCUPANCY
+        out["detail"] = ("EnviousWispr is already running and this measurement needs a "
+                         "cold launch it owns: " +
+                         ", ".join(f"pid {p} at {x}" for p, x in sorted(instances.items())))
+        return out
+
+    try:
+        piece = _drive_one_launch(bundle_path, out_dir=out_dir)
+    except Exception as exc:
         out["verdict"] = BLOCKED_LAUNCH
+        out["detail"] = f"{type(exc).__name__}: {exc}"
         return out
-    out["verdict"], out["detail"] = final_verdict_and_detail(result, timing)
+
+    out["screen_locked_pre_press"] = piece["screen_locked_pre_press"]
+    out.update(_launch_receipt_fields(piece))
+    verdict, detail = _launch_verdict(piece)
+    if verdict is not None:
+        out["verdict"], out["detail"] = verdict, detail
+        return out
+    out["verdict"], out["detail"] = final_verdict_and_detail(piece["result"], piece["timing"])
+    return out
+
+
+def _pin_identity(bundle_path, label):
+    """A bundle's identity, read once before the run starts. Raises with a
+    label naming WHICH arm failed, since `bundle_identity` alone cannot say."""
+    try:
+        return bundle_identity(bundle_path)
+    except Exception as exc:
+        raise RuntimeError(
+            f"cannot pin the {label} bundle's identity: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _identity_matches(pinned, observed):
+    """Whole-identity equality — bundle id, executable path, AND hash all
+    three, because any one of them changing means the run stopped measuring
+    the bundle it started with."""
+    return (pinned.bundle_id == observed.bundle_id
+            and pinned.executable_path == observed.executable_path
+            and pinned.sha256 == observed.sha256)
+
+
+def _benchmark_side_verdict(piece):
+    """One side's `(verdict, detail)` — the launch-level block (engine not
+    ready, screen locked, launch failure) if there is one, else the shared
+    `result_and_timing_verdict` a benchmark side has no reason to duplicate."""
+    verdict, detail = _launch_verdict(piece)
+    if verdict is not None:
+        return verdict, detail
+    return result_and_timing_verdict(piece["result"], piece["timing"])
+
+
+def run_benchmark(baseline_bundle, prewarmed_bundle, *, pairs=PAIR_COUNT, out_dir):
+    """`pairs` alternating cold-launch pairs, baseline (A) vs prewarmed (B),
+    adjudicated against the plan's three binding budgets.
+
+    Returns a JSON-serialisable dict whose `verdict` is `BENCHMARK_PASS`,
+    `BENCHMARK_FAIL`, or a `BLOCKED_<reason>`. Every launch is driven through
+    `_drive_one_launch` — the exact sequence `smoke()` uses — so this runner
+    adds no second launch path, only the pairing, identity pinning, and
+    adjudication `smoke()` has no need for.
+
+    **No top-up, and this function stops at the FIRST bad side, never
+    launching that pair's other side.** A rejected sample blocks the run
+    rather than being replaced, because replacing it would select for
+    launches that happened to produce clean evidence — and continuing to
+    spend real cold launches on a run that can no longer reach a valid
+    `pairs`-pair set burns exactly the evidence this discipline exists to
+    protect.
+    """
+    out = {"kind": "benchmark", "baseline_bundle": str(baseline_bundle),
+           "prewarmed_bundle": str(prewarmed_bundle), "pairs_requested": pairs,
+           "hardware": hardware_identity(), "schedule": [],
+           "pair_receipts": []}
+
+    # The plan's three budgets are binding at exactly PAIR_COUNT pairs. A
+    # shorter run has no statistical claim on a p95, and PAIR_COUNT=0 would
+    # reach `nearest_rank` on an empty sample.
+    if pairs != PAIR_COUNT:
+        out["verdict"] = BLOCKED_INCOMPLETE_PAIRS
+        out["detail"] = (f"{pairs} pairs requested; the binding benchmark "
+                         f"requires exactly {PAIR_COUNT}")
+        return out
+    out["schedule"] = paired_schedule(pairs)
+
+    lock = screen_lock_state()
+    blocked_reason = screen_lock_block(lock)
+    out["screen_locked_start"] = lock
+    if blocked_reason:
+        out["verdict"] = BLOCKED_SCREEN_LOCKED
+        out["detail"] = blocked_reason
+        return out
+
+    instances = running_instances()
+    if instances:
+        out["verdict"] = BLOCKED_OCCUPANCY
+        out["detail"] = ("EnviousWispr is already running and this measurement needs a "
+                         "cold launch it owns: " +
+                         ", ".join(f"pid {p} at {x}" for p, x in sorted(instances.items())))
+        return out
+
+    try:
+        pinned = {"A": _pin_identity(baseline_bundle, "baseline"),
+                 "B": _pin_identity(prewarmed_bundle, "prewarmed")}
+    except Exception as exc:
+        out["verdict"] = BLOCKED_IDENTITY_DRIFT
+        out["detail"] = str(exc)
+        return out
+
+    out["pinned_identity"] = {side: identity._asdict() for side, identity in pinned.items()}
+
+    # Comparing a build with itself proves nothing. Path OR hash matching is
+    # enough to block — either alone means the two arms are not the two
+    # builds this benchmark exists to tell apart.
+    if (pinned["A"].executable_path == pinned["B"].executable_path
+            or pinned["A"].sha256 == pinned["B"].sha256):
+        out["verdict"] = BLOCKED_IDENTICAL_ARMS
+        out["detail"] = ("baseline and candidate resolve to the same executable "
+                         "or executable hash; comparing one build with itself "
+                         "cannot prove the optimization")
+        return out
+
+    bundle_for = {"A": baseline_bundle, "B": prewarmed_bundle}
+    schedule = out["schedule"]
+    completed = []
+
+    for i, order in enumerate(schedule):
+        pair_receipt = {"index": i, "order": order, "sides": {}}
+        sides = {}
+        pair_blocked = None  # (verdict, detail) if this pair cannot continue
+
+        for side in order:
+            # Re-checked before EVERY launch, not only before pair 0: a peer
+            # app appearing mid-run could answer the same global hotkey a
+            # launch triggers, and a run spanning up to 60 launches is wide
+            # enough for that to happen well after the initial check.
+            mid_run_instances = running_instances()
+            if mid_run_instances:
+                pair_blocked = (
+                    BLOCKED_OCCUPANCY,
+                    f"pair {i} side {side}: EnviousWispr appeared before this "
+                    "launch: " + ", ".join(
+                        f"pid {p} at {x}" for p, x in sorted(mid_run_instances.items())))
+                break
+
+            try:
+                piece = _drive_one_launch(bundle_for[side], out_dir=out_dir)
+            except Exception as exc:
+                pair_blocked = (BLOCKED_LAUNCH, f"pair {i} side {side}: "
+                               f"{type(exc).__name__}: {exc}")
+                break
+
+            side_receipt = _launch_receipt_fields(piece)
+            side_receipt.update({
+                "arm": side, "bundle": str(bundle_for[side]),
+                "screen_locked_pre_press": piece["screen_locked_pre_press"],
+            })
+
+            observed = piece["launched"]["requested"]
+            if not _identity_matches(pinned[side], observed):
+                side_receipt["verdict"] = BLOCKED_IDENTITY_DRIFT
+                side_receipt["detail"] = (
+                    f"launched identity drifted from the identity pinned "
+                    f"before pair 0 (pinned sha256={pinned[side].sha256}, "
+                    f"observed sha256={observed.sha256}) — the bundle was "
+                    f"likely rebuilt mid-run")
+                pair_receipt["sides"][side] = side_receipt
+                pair_blocked = (BLOCKED_IDENTITY_DRIFT, side_receipt["detail"])
+                break
+
+            verdict, detail = _benchmark_side_verdict(piece)
+            side_receipt["verdict"], side_receipt["detail"] = verdict, detail
+            pair_receipt["sides"][side] = side_receipt
+
+            if verdict != OK:
+                pair_blocked = (
+                    BLOCKED_INCOMPLETE_PAIRS,
+                    f"pair {i} side {side} is {verdict}: {detail}. "
+                    "The run stopped without top-up.")
+                break
+
+            sides[side] = {
+                "verdict": verdict, "detail": detail,
+                # `run_id` comes from the LAUNCH, independent of whether
+                # `result.sample` exists — deriving it from the sample
+                # instead would make `adjudicate_benchmark`'s cross-check
+                # pass by construction rather than by actually verifying the
+                # keypress and the launch describe the same run.
+                "run_id": piece["launched"]["run_id"],
+                "sample": piece["result"].sample if piece["result"] else None,
+                "keypress": piece["timing"],
+            }
+
+        out["pair_receipts"].append(pair_receipt)
+
+        if pair_blocked:
+            out["pairs_attempted"] = i + 1
+            out["pairs_completed"] = len(completed)
+            out["verdict"], out["detail"] = pair_blocked
+            return out
+
+        completed.append(Pair(
+            order=order,
+            a=LaunchResult(verdict=sides["A"]["verdict"], detail=sides["A"]["detail"],
+                          sample=sides["A"]["sample"]),
+            b=LaunchResult(verdict=sides["B"]["verdict"], detail=sides["B"]["detail"],
+                          sample=sides["B"]["sample"]),
+            a_keypress=KeypressSample(
+                run=sides["A"]["run_id"],
+                keypress_ms=(sides["A"]["keypress"] or {}).get("keypress_ms")),
+            b_keypress=KeypressSample(
+                run=sides["B"]["run_id"],
+                keypress_ms=(sides["B"]["keypress"] or {}).get("keypress_ms")),
+        ))
+
+    out["pairs_attempted"] = len(schedule)
+    out["pairs_completed"] = len(completed)
+
+    # Re-hash both executables after the last pair (#2377): per-launch
+    # identity checks above prove each launched PROCESS matched its pinned
+    # identity at THAT moment, but not that the bundle on disk stayed the
+    # same for the whole run — a rebuild landing between the last launch and
+    # this check would be invisible to every check already run.
+    try:
+        final = {"A": _pin_identity(baseline_bundle, "baseline"),
+                "B": _pin_identity(prewarmed_bundle, "prewarmed")}
+    except Exception as exc:
+        out["verdict"] = BLOCKED_IDENTITY_DRIFT
+        out["detail"] = f"post-run re-hash failed: {type(exc).__name__}: {exc}"
+        return out
+    out["final_identity"] = {side: identity._asdict() for side, identity in final.items()}
+    for side in ("A", "B"):
+        if not _identity_matches(pinned[side], final[side]):
+            out["verdict"] = BLOCKED_IDENTITY_DRIFT
+            out["detail"] = (
+                f"side {side}'s executable changed between pair 0 and the "
+                f"post-run re-hash (pinned sha256={pinned[side].sha256}, "
+                f"final sha256={final[side].sha256}) — the bundle was rebuilt "
+                f"during the run")
+            return out
+
+    result = adjudicate_benchmark(completed, pair_count=pairs)
+    out["verdict"] = result.verdict
+    out["detail"] = result.detail
+    out["measured"] = result.measured
     return out
 
 
 def main(argv):
     import argparse
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--smoke", action="store_true",
-                    help="one bundle, one launch; proves the instrument, not the latency")
-    ap.add_argument("--bundle", help="path to an EnviousWispr .app")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--smoke", action="store_true",
+                      help="one bundle, one launch; proves the instrument, not the latency")
+    mode.add_argument("--benchmark", action="store_true",
+                      help="the 30-pair paired comparison against the plan's three budgets")
+    ap.add_argument("--bundle", help="path to an EnviousWispr .app (--smoke)")
+    ap.add_argument("--baseline-bundle", help="the unmodified baseline .app (--benchmark)")
+    ap.add_argument("--prewarmed-bundle", help="the idle-prewarm candidate .app (--benchmark)")
+    ap.add_argument("--pairs", type=int, default=None,
+                    help=f"pair count for --benchmark (must be exactly {PAIR_COUNT})")
     ap.add_argument("--out-dir", default=None,
                     help="where the receipt and marker file are written")
     args = ap.parse_args(argv)
 
-    if not args.smoke:
-        ap.error("only --smoke is implemented in P6-C1; "
-                 "the 30-pair benchmark run belongs to C4, after a final candidate exists")
-    if not args.bundle:
-        ap.error("--smoke needs --bundle")
+    if args.smoke:
+        if not args.bundle:
+            ap.error("--smoke needs --bundle")
+        if args.baseline_bundle or args.prewarmed_bundle or args.pairs is not None:
+            ap.error("--smoke accepts only --bundle and --out-dir")
+        out_dir = pathlib.Path(args.out_dir or (pathlib.Path.cwd() / ".validation" /
+                                                "runs" / "2377-p6c1-smoke"))
+        out_dir.mkdir(parents=True, exist_ok=True)
+        receipt = smoke(args.bundle, out_dir=out_dir)
+        path = out_dir / "overlay-first-render-smoke.json"
+        path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+        print(f"\nreceipt: {path}")
+        print(f"VERDICT: {receipt['verdict']}")
+        return 0 if receipt["verdict"] == SMOKE_PASS else 1
+
+    if not args.baseline_bundle or not args.prewarmed_bundle:
+        ap.error("--benchmark needs both --baseline-bundle and --prewarmed-bundle")
+    if args.bundle:
+        ap.error("--benchmark does not accept --bundle")
+    pair_count = PAIR_COUNT if args.pairs is None else args.pairs
+    if pair_count != PAIR_COUNT:
+        ap.error(f"--pairs must be exactly {PAIR_COUNT}")
 
     out_dir = pathlib.Path(args.out_dir or (pathlib.Path.cwd() / ".validation" /
-                                            "runs" / "2377-p6c1-smoke"))
+                                            "runs" / "2377-p6c4-benchmark"))
     out_dir.mkdir(parents=True, exist_ok=True)
-    receipt = smoke(args.bundle, out_dir=out_dir)
-    path = out_dir / "overlay-first-render-smoke.json"
+    receipt = run_benchmark(args.baseline_bundle, args.prewarmed_bundle,
+                            pairs=pair_count, out_dir=out_dir)
+    path = out_dir / "overlay-first-render-benchmark.json"
     path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
     print(json.dumps(receipt, indent=2, sort_keys=True))
     print(f"\nreceipt: {path}")
     print(f"VERDICT: {receipt['verdict']}")
-    return 0 if receipt["verdict"] == SMOKE_PASS else 1
+    return 0 if receipt["verdict"] == BENCHMARK_PASS else 1
 
 
 if __name__ == "__main__":

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -1208,116 +1208,144 @@ def test_measure_after_engine_ready_gates_the_keypress_by_call_count():
     expect("calling the thunk exactly once", calls["n"], 1)
 
 
-def _smoke_body(source):
-    """`smoke()`'s own body text, isolated by its full definition signature —
-    never a bare function name, which would match a call site instead (the
-    same "found the wrong twin" class the AX-identifier order check hit
-    before it anchored on `final class OverlayWindowHost`).
+def _function_body(source, name, next_name):
+    """One named function's own body text, isolated by its full definition
+    signature — never a bare function name, which would match a call site
+    instead (the same "found the wrong twin" class the AX-identifier order
+    check hit before it anchored on `final class OverlayWindowHost`).
+
+    Bound to exactly ONE function: a wide span covering several functions
+    lets a required literal in an UNUSED sibling satisfy the check without
+    the function actually under test containing it. `next_name` is the
+    following top-level `def` that ends this one's body — pass the real next
+    function so the span is exact, not a lowest-common-denominator boundary
+    shared by every caller.
     """
-    start = source.find("\ndef smoke(bundle_path")
-    end = source.find("\ndef main(argv)", start) if start >= 0 else -1
+    start = source.find(f"\ndef {name}(")
+    end = source.find(f"\ndef {next_name}(", start) if start >= 0 else -1
     if start < 0 or end < 0:
         return None
     return source[start:end]
 
 
 def test_smoke_routes_its_keypress_measurement_through_the_readiness_gate():
-    """A CALLER-CONTRACT row (#2377, C1 repair): the
-    previous test proved `measure_after_engine_ready` behaves correctly in
-    isolation, which says nothing about whether `smoke()` still CALLS it —
-    replacing the live call with a direct `measure_keypress_to_overlay()`
-    would leave that test green. This binds the exact live shape instead.
+    """A CALLER-CONTRACT row (#2377, C1 repair): the previous test proved
+    `measure_after_engine_ready` behaves correctly
+    in isolation, which says nothing about whether the live sequence still
+    CALLS it — replacing a live call with a direct measurement would leave
+    that test green. This binds the exact live shape across the three
+    functions that now share the sequence: `_drive_one_launch` (the
+    readiness gate and screen-lock capture), `_launch_verdict` (the
+    pre-press-lock verdict return), and `smoke` (the call graph tying them
+    together plus the final adjudicator).
     """
     real_source = pathlib.Path(m.__file__).read_text()
-    body = _smoke_body(real_source)
-    if body is None:
-        FAILURES.append("could not isolate smoke()'s body by source markers")
+
+    drive_body = _function_body(real_source, "_drive_one_launch", "_launch_receipt_fields")
+    if drive_body is None:
+        FAILURES.append("could not isolate _drive_one_launch()'s body")
         return
 
-    ready_idx = body.find("await_engine_ready(")
+    ready_idx = drive_body.find("await_engine_ready(")
     if ready_idx < 0:
-        FAILURES.append("smoke() does not call await_engine_ready")
+        FAILURES.append("_drive_one_launch() does not call await_engine_ready")
         return
     # Bound to THIS call, not merely present anywhere in the function — the
     # keyword must appear before the call's own closing paren is reached.
-    call_end = body.find(")", ready_idx)
-    if 'proc=launched["process"]' not in body[ready_idx:call_end + 1]:
+    call_end = drive_body.find(")", ready_idx)
+    if 'proc=launched["process"]' not in drive_body[ready_idx:call_end + 1]:
         FAILURES.append(
-            "smoke()'s await_engine_ready call does not pass "
+            "_drive_one_launch()'s await_engine_ready call does not pass "
             'proc=launched["process"] — a crash during warm-up would wait '
             "out the full timeout instead of being detected")
 
     # `press_permitted` must be derived from BOTH facts — engine readiness
     # AND a screen-lock recheck taken AFTER the readiness wait (cloud review
     # P1, #2377 C1 repair): the launch and readiness waits can together run
-    # long enough for the screen to lock after the function's initial check,
+    # long enough for the screen to lock after the caller's initial check,
     # which that initial check cannot see.
-    if "pre_press_lock = screen_lock_state()" not in body:
-        FAILURES.append("smoke() does not re-check the screen lock before the press")
+    if "pre_press_lock = screen_lock_state()" not in drive_body:
+        FAILURES.append("_drive_one_launch() does not re-check the screen lock before the press")
     required_permit = "press_permitted = engine_ready and not pre_press_blocked"
-    if required_permit not in body:
+    if required_permit not in drive_body:
         FAILURES.append(
-            "smoke() does not derive press_permitted from BOTH engine "
-            "readiness and the pre-press screen-lock recheck")
+            "_drive_one_launch() does not derive press_permitted from BOTH "
+            "engine readiness and the pre-press screen-lock recheck")
 
     required_gate = "\n".join((
         "        timing = measure_after_engine_ready(",
         "            press_permitted,",
         "            lambda: measure_keypress_to_overlay(",
     ))
-    gate_idx = body.find(required_gate)
+    gate_idx = drive_body.find(required_gate)
     if gate_idx < 0:
         FAILURES.append(
-            "smoke() does not route its keypress measurement through "
-            "press_permitted")
+            "_drive_one_launch() does not route its keypress measurement "
+            "through press_permitted")
     elif gate_idx < ready_idx:
         FAILURES.append(
-            "smoke() gates the keypress measurement BEFORE awaiting "
-            "readiness — the readiness result it gates on would be stale")
+            "_drive_one_launch() gates the keypress measurement BEFORE "
+            "awaiting readiness — the readiness result it gates on would be stale")
 
-    # `final_verdict_and_detail` must actually be the live adjudicator, not
-    # just a correctly-behaving function nobody calls (round-two finding on
-    # this same review): restoring the old inline result-first ordering
-    # would leave the isolated priority test green.
-    required_final_adjudication = (
-        'out["verdict"], out["detail"] = '
-        "final_verdict_and_detail(result, timing)")
-    if required_final_adjudication not in body:
-        FAILURES.append(
-            "smoke() bypasses the timing-first final verdict adjudicator")
-
-    # The screen-lock recheck must both CAPTURE the block and RETURN its
-    # promised verdict — two separate live blocks, so each is bound on its
-    # own rather than inferred from the other.
+    # CAPTURE lives in `_drive_one_launch`.
     required_screen_capture = "\n".join((
         "        elif pre_press_blocked:",
         "            screen_locked_before_press = pre_press_blocked",
     ))
-    required_screen_verdict = "\n".join((
-        "    if screen_locked_before_press:",
-        "        out[\"verdict\"] = BLOCKED_SCREEN_LOCKED",
-        "        out[\"detail\"] = screen_locked_before_press",
-        "        return out",
-    ))
+    if required_screen_capture not in drive_body:
+        FAILURES.append("_drive_one_launch() discards the pre-press lock block")
+
+    # RETURN of that block's promised verdict lives in `_launch_verdict` —
+    # bound separately, on ITS OWN function body, so each is proven rather
+    # than inferred from the other.
+    verdict_body = _function_body(real_source, "_launch_verdict", "smoke")
+    if verdict_body is None:
+        FAILURES.append("could not isolate _launch_verdict()'s body")
+    else:
+        required_screen_verdict = "\n".join((
+            '    if piece["screen_locked_before_press"]:',
+            '        return (BLOCKED_SCREEN_LOCKED, piece["screen_locked_before_press"])',
+        ))
+        if required_screen_verdict not in verdict_body:
+            FAILURES.append("_launch_verdict() does not return the pre-press lock verdict")
+
+    # `smoke()` must actually CALL `_drive_one_launch`, `_launch_receipt_fields`,
+    # `_launch_verdict`, and the final adjudicator — the call graph itself,
+    # not merely text that happens to exist in one of the three functions.
+    # A wide span covering all three would let this pass with NO caller
+    # actually wiring the pieces together.
+    smoke_body = _function_body(real_source, "smoke", "_pin_identity")
+    if smoke_body is None:
+        FAILURES.append("could not isolate smoke()'s body")
+        return
+    required_final_adjudication = (
+        'out["verdict"], out["detail"] = '
+        'final_verdict_and_detail(piece["result"], piece["timing"])')
     for required, message in (
-        (required_screen_capture, "smoke() discards the pre-press lock block"),
-        (required_screen_verdict, "smoke() does not return the pre-press lock verdict"),
+        ("_drive_one_launch(bundle_path, out_dir=out_dir)",
+         "smoke() does not call _drive_one_launch"),
+        ("_launch_receipt_fields(piece)",
+         "smoke() does not call _launch_receipt_fields"),
+        ("_launch_verdict(piece)", "smoke() does not call _launch_verdict"),
+        (required_final_adjudication,
+         "smoke() bypasses the timing-first final verdict adjudicator"),
     ):
-        if required not in body:
+        if required not in smoke_body:
             FAILURES.append(message)
 
-    # CONTROL: the same check, run against a synthetic source where the live
-    # call is replaced by a direct measurement, must actually fail — proof
-    # this row is not vacuously true. Never touches the real file.
+    # CONTROL: a synthetic `smoke()` whose body calls a direct measurement
+    # instead of `_drive_one_launch` must actually fail this test's own
+    # call-graph check — proof it is not vacuously true. Never touches the
+    # real file.
     bypassed_fake = (
         "\ndef smoke(bundle_path, *, out_dir):\n"
         "    ready = await_engine_ready(marker_path, proc=proc, run_id=run_id)\n"
         "    timing = measure_keypress_to_overlay(pid, marker_path)\n"
-        "\ndef main(argv):\n")
-    fake_body = _smoke_body(bypassed_fake)
-    if fake_body is None:
+        "\ndef _pin_identity(bundle_path, label):\n")
+    fake_smoke_body = _function_body(bypassed_fake, "smoke", "_pin_identity")
+    if fake_smoke_body is None:
         FAILURES.append("the control fixture's own source markers do not isolate")
-    elif required_gate in fake_body:
+    elif "_drive_one_launch(bundle_path, out_dir=out_dir)" in fake_smoke_body:
         FAILURES.append(
             "the caller-contract check does not fail on a bypassed source — "
             "it cannot be trusted to catch a real regression")
@@ -1614,6 +1642,362 @@ def test_a_keypress_figure_must_name_the_launch_it_came_from():
            m.adjudicate_benchmark(pairs(30), BUDGET).verdict, m.BENCHMARK_PASS)
 
 
+# ------------------------------------------------------- run_benchmark (C4)
+
+def _fake_piece(*, run_id, identity, launch_ms=3.0, root_ms=2.0, keypress_ms=5.0):
+    """A `_drive_one_launch` return value for a CLEAN launch — every field
+    `run_benchmark` AND `_launch_receipt_fields` read, nothing they do not."""
+    sample = m.LaunchSample(run=run_id, launch_ms=launch_ms, root_ms=root_ms,
+                            order_front_ms=launch_ms + 1, host_window_id=7)
+    return {
+        "launched": {"run_id": run_id, "pid": 1000, "marker_path": f"/tmp/{run_id}.tsv",
+                    "requested": identity},
+        "resolved": identity, "timebase": (1, 1), "engine_ready_wait_ms": 1.0,
+        "failure": None, "engine_not_ready": False,
+        "screen_locked_before_press": None, "screen_locked_pre_press": False,
+        "result": m.LaunchResult(verdict=m.OK, detail="", sample=sample),
+        "timing": {
+            "verdict": m.OK, "detail": "", "keypress_ms": keypress_ms,
+            "window_id": 7, "host_window_id": 7, "ax_available": True,
+            "match_count_at_stop": 1, "keycode": 61,
+            "poll_resolution_ms_median": 0.25, "poll_resolution_ms_max": 0.5,
+            "polls": 4, "screen_locked_pre_press": False,
+            "screen_locked_post_measurement": False,
+        },
+    }
+
+
+IDENTITY_A = m.Identity(bundle_id=BUNDLE, executable_path=EXE, sha256=SHA)
+IDENTITY_B = m.Identity(bundle_id=BUNDLE, executable_path=EXE.replace("EnviousWispr", "EnviousWisprB"),
+                        sha256="b" * 64)
+
+
+def _identity_for(side):
+    return IDENTITY_A if side == "A" else IDENTITY_B
+
+
+def _patch_benchmark_environment(script):
+    """Runs `script(calls)` with `_drive_one_launch`, `bundle_identity`,
+    `screen_lock_state`, and `running_instances` all patched to synthetic,
+    deterministic behavior — A and B pinned to genuinely DIFFERENT
+    identities, since `run_benchmark` now refuses to compare a build with
+    itself. `calls` accumulates one dict per launch in call order, so a test
+    can assert on ORDER without depending on real timing.
+    """
+    calls = []
+
+    saved = {
+        "_drive_one_launch": m._drive_one_launch,
+        "bundle_identity": m.bundle_identity,
+        "screen_lock_state": m.screen_lock_state,
+        "running_instances": m.running_instances,
+    }
+    m.screen_lock_state = lambda: False
+    m.running_instances = lambda: {}
+    m.bundle_identity = lambda bundle_path: (
+        IDENTITY_A if str(bundle_path) == "A.app" else IDENTITY_B)
+
+    def fake_drive(bundle_path, *, out_dir):
+        run_id = f"RUN-{len(calls)}"
+        side = "A" if str(bundle_path) == "A.app" else "B"
+        calls.append({"bundle": str(bundle_path), "run_id": run_id})
+        return _fake_piece(run_id=run_id, identity=_identity_for(side))
+
+    m._drive_one_launch = fake_drive
+    try:
+        return script(calls)
+    finally:
+        for name, value in saved.items():
+            setattr(m, name, value)
+
+
+def test_run_benchmark_drives_pairs_in_the_declared_ab_ba_order():
+    """The live driver must call the bundle matching `paired_schedule`'s own
+    letters, in order — not merely alternate SOMETHING, which a bug swapping
+    the bundle-for-letter mapping would still satisfy."""
+    def script(calls):
+        return m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    receipt = _patch_benchmark_environment(script)
+
+    expect(f"{m.PAIR_COUNT} pairs drive exactly {m.PAIR_COUNT * 2} launches",
+           receipt["pairs_completed"], m.PAIR_COUNT)
+    expect("a clean run with distinct identities reaches a real benchmark verdict",
+           receipt["verdict"] in (m.BENCHMARK_PASS, m.BENCHMARK_FAIL), True)
+    expect("the schedule alternates AB/BA", receipt["schedule"][:4], ["AB", "BA", "AB", "BA"])
+    # The letter 'A' must always resolve to "A.app" and 'B' to "B.app" in the
+    # per-pair receipt — not merely alternate SOMETHING, which a bug swapping
+    # the bundle-for-letter mapping would still satisfy.
+    expect("every receipt row's side A used A.app",
+           all(row["sides"]["A"]["bundle"] == "A.app" for row in receipt["pair_receipts"]), True)
+    expect("every receipt row's side B used B.app",
+           all(row["sides"]["B"]["bundle"] == "B.app" for row in receipt["pair_receipts"]), True)
+
+
+def test_run_benchmark_blocks_on_identity_drift_mid_run_never_pass_or_fail():
+    """A bundle rebuilt between two launches must BLOCK the whole run, never
+    reach `BENCHMARK_PASS` or `BENCHMARK_FAIL` — the two-way control: the
+    UNCHANGED twin (next test) completes normally."""
+    identity_b_rebuilt = m.Identity(bundle_id=BUNDLE, executable_path=IDENTITY_B.executable_path,
+                                    sha256="f" * 64)
+
+    saved = {"_drive_one_launch": m._drive_one_launch,
+            "bundle_identity": m.bundle_identity,
+            "screen_lock_state": m.screen_lock_state,
+            "running_instances": m.running_instances}
+    m.screen_lock_state = lambda: False
+    m.running_instances = lambda: {}
+    # Pinning (the first two calls, one per bundle) sees the ORIGINAL identity.
+    m.bundle_identity = lambda bundle_path: (
+        IDENTITY_A if str(bundle_path) == "A.app" else IDENTITY_B)
+
+    launch_calls = {"n": 0}
+
+    def fake_drive(bundle_path, *, out_dir):
+        launch_calls["n"] += 1
+        run_id = f"RUN-{launch_calls['n']}"
+        side = "A" if str(bundle_path) == "A.app" else "B"
+        # Second overall launch (side B of pair 0) resolves to the rebuilt
+        # identity, simulating a rebuild that landed between pinning and it.
+        resolved = identity_b_rebuilt if launch_calls["n"] == 2 else _identity_for(side)
+        return _fake_piece(run_id=run_id, identity=resolved)
+
+    m._drive_one_launch = fake_drive
+    try:
+        receipt = m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    finally:
+        for name, value in saved.items():
+            setattr(m, name, value)
+
+    expect("a mid-run identity drift blocks rather than PASS/FAIL",
+           receipt["verdict"], m.BLOCKED_IDENTITY_DRIFT)
+    expect("the run stopped at the drifted pair, none completed",
+           receipt["pairs_completed"], 0)
+    expect("side A of pair 0 launched, then side B drifted — exactly 2 launches",
+           launch_calls["n"], 2)
+
+
+def test_run_benchmark_completes_normally_when_identity_never_drifts():
+    """TWIN of the drift test: the same run with identity held constant
+    throughout must reach a real benchmark verdict, proving the drift
+    test's block is about the DRIFT, not about identity-checking itself
+    always blocking."""
+    def script(calls):
+        return m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    receipt = _patch_benchmark_environment(script)
+    expect("an unchanged identity throughout reaches PASS or FAIL, never BLOCKED",
+           receipt["verdict"] in (m.BENCHMARK_PASS, m.BENCHMARK_FAIL), True)
+    expect(f"all {m.PAIR_COUNT} pairs completed", receipt["pairs_completed"], m.PAIR_COUNT)
+    expect("the final re-hash is recorded", "final_identity" in receipt, True)
+    expect("every pair produced a receipt row",
+           len(receipt["pair_receipts"]), m.PAIR_COUNT)
+    expect("each pair receipt row carries both arms",
+           all(set(row["sides"]) == {"A", "B"} for row in receipt["pair_receipts"]), True)
+
+    expect("the complete schedule is retained",
+           receipt["schedule"], m.paired_schedule(m.PAIR_COUNT))
+    expect("pair indexes and orders match that schedule",
+           [(row["index"], row["order"]) for row in receipt["pair_receipts"]],
+           list(enumerate(receipt["schedule"])))
+    expect("the final identities equal the pinned identities",
+           receipt["final_identity"], receipt["pinned_identity"])
+
+    required_timing = {
+        "keypress_ms", "host_window_id", "ax_available",
+        "match_count_at_stop", "keycode", "poll_resolution_ms_median",
+        "poll_resolution_ms_max", "polls",
+        "screen_locked_pre_press", "screen_locked_post_measurement",
+    }
+    for row in receipt["pair_receipts"]:
+        for side in ("A", "B"):
+            item = row["sides"][side]
+            expect(f"pair {row['index']} side {side} retains its pinned identity",
+                   item["requested_identity"], receipt["pinned_identity"][side])
+            expect(f"pair {row['index']} side {side} retains its resolved identity",
+                   item["resolved_identity"], receipt["pinned_identity"][side])
+            expect(f"pair {row['index']} side {side} retains the full timing receipt",
+                   required_timing <= set(item["keypress"]), True)
+
+    expect("both root p95 diagnostics are retained",
+           {"root_p95_a_ms", "root_p95_b_ms"} <= set(receipt["measured"]), True)
+
+
+def test_run_benchmark_stops_after_the_first_bad_side_no_top_up():
+    """One blocked side must stop the run BEFORE launching that pair's other
+    side, and before any further pair — no top-up (#2377, C4 plan §3 step 1),
+    and no wasted launch on a pair that is already known bad."""
+    launch_calls = {"n": 0}
+
+    saved = {"_drive_one_launch": m._drive_one_launch,
+            "bundle_identity": m.bundle_identity,
+            "screen_lock_state": m.screen_lock_state,
+            "running_instances": m.running_instances}
+    m.screen_lock_state = lambda: False
+    m.running_instances = lambda: {}
+    m.bundle_identity = lambda bundle_path: (
+        IDENTITY_A if str(bundle_path) == "A.app" else IDENTITY_B)
+
+    def fake_drive(bundle_path, *, out_dir):
+        launch_calls["n"] += 1
+        run_id = f"RUN-{launch_calls['n']}"
+        side = "A" if str(bundle_path) == "A.app" else "B"
+        if launch_calls["n"] == 1:
+            # The FIRST launch overall (side A of pair 0) never got
+            # engine-ready — side B of that same pair must never launch.
+            piece = _fake_piece(run_id=run_id, identity=_identity_for(side))
+            piece["engine_not_ready"] = True
+            return piece
+        return _fake_piece(run_id=run_id, identity=_identity_for(side))
+
+    m._drive_one_launch = fake_drive
+    try:
+        receipt = m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    finally:
+        for name, value in saved.items():
+            setattr(m, name, value)
+
+    expect("a bad side blocks with the specific per-side reason",
+           receipt["verdict"], m.BLOCKED_INCOMPLETE_PAIRS)
+    expect("the detail names the underlying side verdict",
+           m.BLOCKED_ENGINE_NOT_READY in receipt["detail"], True)
+    expect("the run never reaches PASS or FAIL",
+           receipt["verdict"] in (m.BENCHMARK_PASS, m.BENCHMARK_FAIL), False)
+    expect("no pair completed", receipt["pairs_completed"], 0)
+    expect("side B of the bad pair never launched — exactly 1 launch total",
+           launch_calls["n"], 1)
+
+
+def test_run_benchmark_rechecks_occupancy_before_every_launch():
+    """A peer app appearing partway through a 30-pair run must block the
+    NEXT launch it precedes, not only pair 0's initial check — a run
+    spanning up to 60 launches is wide enough for a peer to appear well
+    after the start."""
+    launch_calls = {"n": 0}
+    occupancy_calls = {"n": 0}
+
+    saved = {"_drive_one_launch": m._drive_one_launch,
+            "bundle_identity": m.bundle_identity,
+            "screen_lock_state": m.screen_lock_state,
+            "running_instances": m.running_instances}
+    m.screen_lock_state = lambda: False
+    m.bundle_identity = lambda bundle_path: (
+        IDENTITY_A if str(bundle_path) == "A.app" else IDENTITY_B)
+
+    def fake_instances():
+        occupancy_calls["n"] += 1
+        # Call 1 is the initial pre-loop check; call 2 is the per-side
+        # recheck before pair 0 side A launches — both clear. Call 3 is the
+        # recheck before pair 0 side B: a peer has appeared by then.
+        return {} if occupancy_calls["n"] <= 2 else {4242: "/peer/EnviousWispr.app"}
+
+    def fake_drive(bundle_path, *, out_dir):
+        launch_calls["n"] += 1
+        run_id = f"RUN-{launch_calls['n']}"
+        side = "A" if str(bundle_path) == "A.app" else "B"
+        return _fake_piece(run_id=run_id, identity=_identity_for(side))
+
+    m.running_instances = fake_instances
+    m._drive_one_launch = fake_drive
+    try:
+        receipt = m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    finally:
+        for name, value in saved.items():
+            setattr(m, name, value)
+
+    expect("a peer appearing mid-run blocks on occupancy",
+           receipt["verdict"], m.BLOCKED_OCCUPANCY)
+    expect("only side A of pair 0 launched before the peer was seen",
+           launch_calls["n"], 1)
+
+
+def test_run_benchmark_rejects_any_pair_count_other_than_the_binding_thirty():
+    """Fewer than 30 pairs has no statistical claim on a p95; more than 30
+    is not the binding evidence set the plan names. Every count other than
+    exactly `PAIR_COUNT` must block before any launch."""
+    for bad_count in (0, 2, 29, 32):
+        receipt = m.run_benchmark("A.app", "B.app", pairs=bad_count, out_dir="/tmp")
+        expect(f"{bad_count} pairs blocks before any launch",
+               receipt["verdict"], m.BLOCKED_INCOMPLETE_PAIRS)
+
+    def script(calls):
+        return m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    twin = _patch_benchmark_environment(script)
+    expect(f"exactly {m.PAIR_COUNT} pairs reaches a real verdict, proving the "
+           "count check is not vacuously blocking everything",
+           twin["verdict"] in (m.BENCHMARK_PASS, m.BENCHMARK_FAIL), True)
+
+
+def test_run_benchmark_refuses_two_arms_that_resolve_to_the_same_build():
+    """Comparing a build with itself proves nothing about the optimization.
+    Path OR hash matching alone must block."""
+    saved = {"bundle_identity": m.bundle_identity,
+            "screen_lock_state": m.screen_lock_state,
+            "running_instances": m.running_instances}
+    m.screen_lock_state = lambda: False
+    m.running_instances = lambda: {}
+    m.bundle_identity = lambda bundle_path: IDENTITY_A  # both arms identical
+    try:
+        receipt = m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    finally:
+        for name, value in saved.items():
+            setattr(m, name, value)
+    expect("identical arms block before any launch",
+           receipt["verdict"], m.BLOCKED_IDENTICAL_ARMS)
+
+
+def test_cli_rejects_smoke_with_an_explicit_pairs_argument():
+    """`--smoke --pairs 30` must be refused even though 30 equals the
+    benchmark default — the parser cannot tell an explicit benchmark-only
+    argument from an unset one unless the default itself is `None`."""
+    calls = {"n": 0}
+    saved_drive = m._drive_one_launch
+    m._drive_one_launch = lambda bundle_path, *, out_dir: calls.__setitem__("n", calls["n"] + 1)
+    try:
+        exited = None
+        try:
+            m.main(["--smoke", "--bundle", "A.app", "--pairs", "30"])
+        except SystemExit as exc:
+            exited = exc.code
+    finally:
+        m._drive_one_launch = saved_drive
+
+    expect("--smoke --pairs 30 exits with an argparse error", exited, 2)
+    expect("no launch was ever attempted", calls["n"], 0)
+
+
+def test_run_benchmark_pins_identity_before_the_first_pair():
+    """Both bundles' identities must be read BEFORE pair 0 launches, not
+    lazily on first use — else a rebuild during pair 0 itself would have no
+    baseline to be compared against."""
+    order = []
+
+    saved = {"_drive_one_launch": m._drive_one_launch,
+            "bundle_identity": m.bundle_identity,
+            "screen_lock_state": m.screen_lock_state,
+            "running_instances": m.running_instances}
+    m.screen_lock_state = lambda: False
+    m.running_instances = lambda: {}
+
+    def fake_identity(bundle_path):
+        order.append(("pin", str(bundle_path)))
+        return IDENTITY_A if str(bundle_path) == "A.app" else IDENTITY_B
+
+    def fake_drive(bundle_path, *, out_dir):
+        order.append(("launch", str(bundle_path)))
+        side = "A" if str(bundle_path) == "A.app" else "B"
+        return _fake_piece(run_id=f"RUN-{len(order)}", identity=_identity_for(side))
+
+    m.bundle_identity = fake_identity
+    m._drive_one_launch = fake_drive
+    try:
+        m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
+    finally:
+        for name, value in saved.items():
+            setattr(m, name, value)
+
+    expect("both bundles are pinned before the first launch",
+           order[:2], [("pin", "A.app"), ("pin", "B.app")])
+
+
 # ------------------------------------------------------------------- runner
 
 TESTS = [
@@ -1656,6 +2040,15 @@ TESTS = [
     test_a_keypress_figure_must_name_the_launch_it_came_from,
     test_median_uses_statistics_median,
     test_p95_uses_nearest_rank,
+    test_run_benchmark_drives_pairs_in_the_declared_ab_ba_order,
+    test_run_benchmark_blocks_on_identity_drift_mid_run_never_pass_or_fail,
+    test_run_benchmark_completes_normally_when_identity_never_drifts,
+    test_run_benchmark_stops_after_the_first_bad_side_no_top_up,
+    test_run_benchmark_rechecks_occupancy_before_every_launch,
+    test_run_benchmark_rejects_any_pair_count_other_than_the_binding_thirty,
+    test_run_benchmark_refuses_two_arms_that_resolve_to_the_same_build,
+    test_cli_rejects_smoke_with_an_explicit_pairs_argument,
+    test_run_benchmark_pins_identity_before_the_first_pair,
 ]
 
 


### PR DESCRIPTION
## Summary

Phase 6 C4 of the pill-system refactor (#2377) — the idle-prewarm launch optimization, the last piece of finding #6.

- **Chunk 1 (0714624d):** the live 30-pair benchmark runner. `measure_overlay_first_render.py --benchmark` was declared in P6-C1 but never implemented — this adds the alternating AB/BA driver, identity pinning (pinned before pair 0, re-hashed after pair 30, blocks rather than silently mixing evidence on a mid-run rebuild), per-launch occupancy rechecks, and no-top-up (one bad side stops the run before its pair's other side ever launches).
- **Chunk 2 (954e0141):** the Swift idle-prewarm wiring. A one-shot `CFRunLoopObserver` for the main run loop's `.beforeWaiting`, registered at the tail of `applicationDidFinishLaunching()`, lets first-overlay root construction happen at the first genuinely idle moment after launch instead of waiting for the first real keypress. The existing on-demand `DispatchQueue.main.async` scheduler (C3) is untouched and still wins any race if a keypress arrives first.

## Benchmark result

**BENCHMARK_PASS**, 30/30 pairs, all three binding budgets held (prewarmed build measured faster on every axis):

| Budget | Bound | Measured | Verdict |
|---|---|---|---|
| Launch median regression | ≤ 5 ms | -1.03 ms | PASS |
| Root construction p95 | ≤ 8 ms | 0.27 ms | PASS |
| Keypress-to-overlay p95 regression | ≤ 16.7 ms | -3.06 ms | PASS |

Full numbers and the retry history (3 intermittent instrument flakes before a clean run — diagnosed, not a defect in either build) are on issue #2377.

Part of #2377.

## Test plan

- [x] Debug lane: `scripts/xcode-test.sh` — 7116 tests, all accepted, 0 failures.
- [x] Python harness suite: `python3 Tests/RuntimeUAT/measure_overlay_first_render_test.py` — 48 tests, 0 failures, 3 mutation controls verified.
- [x] Real 30-pair benchmark against the actual baseline (main, pre-C4) and prewarmed (this branch) builds — BENCHMARK_PASS.
- [x] Both chunks reached CHUNK-CLEAN with Codex's persistent build-orchestrator session before commit.
