### PR TITLE
C1: EnviousWisprAppLive owns the live implementation choice (#2458)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -262,13 +262,31 @@ let package = Package(
       path: "Sources/EnviousWisprASRService",
       exclude: ["Resources"]
     ),
+    // #2455 C1 (#2458): the production composition root. Chooses the live
+    // desktop-effect implementations and hands them to `WisprBootstrapper`,
+    // whose init requires them.
+    //
+    // NOT yet the wall. EnviousWisprTests still links EnviousWisprServices in C1
+    // and can construct `HotkeyService(telemetry: .live)` itself. What C1 buys is
+    // that no IMPLICIT production assembly path exists, and that AppLive is the
+    // only production-choice site. C2 (#2459) removes the live implementation
+    // from the test link graph and replaces the Services edge below with
+    // EnviousWisprDesktopEffects; unlinkable becomes true then, not now.
+    .target(
+      name: "EnviousWisprAppLive",
+      dependencies: [
+        "EnviousWisprAppKit",
+        "EnviousWisprServices",
+      ],
+      path: "Sources/EnviousWisprAppLive"
+    ),
     // #919: thin launchable shell. Owns @main + the AppDelegate adaptor +
-    // app identity/Resources; delegates ALL construction + lifecycle to
-    // `WisprBootstrapper` in EnviousWisprAppKit. Depends ONLY on the kit.
+    // app identity/Resources; delegates ALL construction + lifecycle downward.
+    // #2455 C1: depends ONLY on EnviousWisprAppLive.
     .executableTarget(
       name: "EnviousWispr",
       dependencies: [
-        "EnviousWisprAppKit"
+        "EnviousWisprAppLive"
       ],
       path: "Sources/EnviousWispr",
       exclude: ["Resources"]

--- a/Project.swift
+++ b/Project.swift
@@ -463,6 +463,38 @@ let project = Project(
       // Open Source Licenses screen, read via Bundle.module at runtime.
       hasResources: true),
 
+    // #2455 C1 (#2458): the PRODUCTION composition root. The app target imports
+    // ONLY this, and the unit-test target does not link it.
+    //
+    // Not a forwarding shim: `WisprBootstrapper` takes a required, non-defaulted
+    // `makeHotkeyService`, so EnviousWisprAppKit contains no IMPLICIT production
+    // assembly path — every caller must state its hotkey-service choice
+    // explicitly — and this module is the only production-choice site.
+    //
+    // It is NOT yet unlinkability. EnviousWisprTests still links
+    // EnviousWisprServices in C1 and can construct the same live HotkeyService
+    // itself. C2 (#2459) removes the live implementation from the test link
+    // graph; that is the chunk that earns the word.
+    //
+    // The direct EnviousWisprServices edge is TEMPORARY — C2 (#2459) replaces the
+    // concrete HotkeyService construction with a live adapter from
+    // EnviousWisprDesktopEffects and drops this edge.
+    firstPartyLibrary(
+      "EnviousWisprAppLive",
+      dependencies: [
+        .target(name: "EnviousWisprAppKit"),
+        .target(name: "EnviousWisprServices"),
+        // Declared directly for the same reason EnviousWisprAppKit declares
+        // them: Xcode does not propagate a static framework's package products
+        // transitively, so a module importing AppKit must resolve AppKit's
+        // vendor modules itself. Without these, AppLive fails to build with
+        // "unable to resolve module dependency: 'FastClusterWrapper'" — a
+        // FluidAudio internal named nowhere in this project's source.
+        .package(product: "WhisperKit"),
+        .package(product: "FluidAudio"),
+        .package(product: "Sparkle"),
+      ]),
+
     // ---- XPC services (audio capture is in-process since #1543; ASR stays isolated) ----
     .target(
       name: "EnviousWisprASRService",
@@ -567,7 +599,9 @@ let project = Project(
       // service stays direct so it bundles into Contents/XPCServices (#1543:
       // the audio capture service was removed — capture is in-process).
       dependencies: [
-        .target(name: "EnviousWisprAppKit"),
+        // #2455 C1: AppLive, not AppKit. The shell reaches the kit only THROUGH
+        // the module that chooses live implementations.
+        .target(name: "EnviousWisprAppLive"),
         .package(product: "Sparkle"),
         .target(name: "EnviousWisprASRService"),
       ],

--- a/Sources/EnviousWispr/AppDelegate.swift
+++ b/Sources/EnviousWispr/AppDelegate.swift
@@ -1,5 +1,5 @@
 import AppKit
-import EnviousWisprAppKit
+import EnviousWisprAppLive
 import Foundation
 
 /// AppDelegate manages the menu bar status item lifecycle via AppKit.
@@ -9,62 +9,45 @@ import Foundation
 ///
 /// #919: `AppDelegate` stays in the thin shell (the `@NSApplicationDelegateAdaptor`
 /// must live in the `@main` `App` struct's module). It is a pure AppKit adapter:
-/// it owns no app state and holds a single `weak` ref to the `WisprBootstrapper`
+/// it owns no app state and holds a single `weak` ref to the `LiveApplication`
 /// (constructed and attached synchronously in `EnviousWisprApp.init()`, before
-/// any delegate callback fires). The forced delegate callbacks forward to the
-/// bootstrapper, which drives Sparkle + the lifecycle coordinator internally —
-/// so the shell imports ONLY `EnviousWisprAppKit`, never the engine modules.
+/// any delegate callback fires). The forced delegate callbacks forward to it, and
+/// it drives Sparkle + the lifecycle coordinator internally — so the shell imports
+/// ONLY `EnviousWisprAppLive` (#2455 C1), never AppKit and never the engine
+/// modules.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-  private weak var bootstrapper: WisprBootstrapper?
+  private weak var application: LiveApplication?
 
   /// Receive the composition root from `EnviousWisprApp.init()` before any
   /// delegate callback fires.
-  func attach(bootstrapper: WisprBootstrapper) {
-    self.bootstrapper = bootstrapper
+  func attach(application: LiveApplication) {
+    self.application = application
   }
 
   /// Issue #739: Sparkle's cross-launch correlation must run at this earliest
   /// callback, before SwiftUI mounts the App's scenes.
   func applicationWillFinishLaunching(_ notification: Notification) {
     assertAttached()
-    bootstrapper?.applicationWillFinishLaunching()
-    // #2377 Phase 6: arm the DEBUG marker sink here — in the callback BEFORE the
-    // measured one, and AFTER this callback's own production work.
-    //
-    // Before `applicationDidFinishLaunching` because that interval is what is
-    // measured, and the sink's one-time setup must not land inside it once
-    // Phase 6 moves root construction earlier. After the forwarding above
-    // because #739 requires Sparkle's cross-launch correlation to run at the
-    // earliest callback, and putting measurement in front of it would make a
-    // DEBUG instrument the first thing a launch does.
-    #if DEBUG
-      OverlayFirstRenderMarkers.prepare()
-    #endif
+    // #2455 C1: the DEBUG marker arming moved into `LiveApplication`, keeping its
+    // position relative to the production call unchanged, so this shell imports
+    // only `EnviousWisprAppLive`.
+    application?.applicationWillFinishLaunching()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     assertAttached()
-    // #2377 Phase 6: DEBUG-only measurement of this forwarding call, which is
-    // where launch work happens. `capture` reads the clock and nothing else; the
-    // environment read, the string and the write all run in `emit`, after the
-    // interval has closed.
-    #if DEBUG
-      let launchEnter = OverlayFirstRenderMarkers.capture(.launchEnter)
-    #endif
-    bootstrapper?.applicationDidFinishLaunching()
-    #if DEBUG
-      OverlayFirstRenderMarkers.emit(
-        launchEnter, OverlayFirstRenderMarkers.capture(.launchExit))
-    #endif
+    // #2455 C1: the DEBUG launch measurement moved into `LiveApplication`,
+    // wrapping the same production call in the same order.
+    application?.applicationDidFinishLaunching()
   }
 
   func applicationDidBecomeActive(_ notification: Notification) {
-    bootstrapper?.applicationDidBecomeActive()
+    application?.applicationDidBecomeActive()
   }
 
   func applicationWillTerminate(_ notification: Notification) {
-    bootstrapper?.applicationWillTerminate()
+    application?.applicationWillTerminate()
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -82,9 +65,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// any wiring regression at development time.
   private func assertAttached() {
     #if DEBUG
-      if bootstrapper == nil {
+      if application == nil {
         assertionFailure(
-          "AppDelegate.bootstrapper was nil during a lifecycle callback — "
+          "AppDelegate.application was nil during a lifecycle callback — "
             + "EnviousWisprApp.init() wiring failure.")
       }
     #endif

--- a/Sources/EnviousWispr/EnviousWisprApp.swift
+++ b/Sources/EnviousWispr/EnviousWisprApp.swift
@@ -1,4 +1,4 @@
-import EnviousWisprAppKit
+import EnviousWisprAppLive
 import SwiftUI
 
 /// #919: the thin launchable shell. This is all that remains in the app target
@@ -7,26 +7,29 @@ import SwiftUI
 ///     struct, per Apple's `NSApplicationDelegateAdaptor` contract),
 ///   - app identity / Info.plist / entitlements / icon (in `Resources/`),
 ///   - the SwiftUI `Scene` declarations (window ids, sizes, resizability),
-///   - constructing ONE `WisprBootstrapper` in `init()` and attaching it to the
+///   - constructing ONE `LiveApplication` in `init()` and attaching it to the
 ///     delegate before any lifecycle callback fires.
 /// Everything else — every home, the construction order, the lifecycle work,
-/// the view content — lives in the kit. The unit-test target links the kit, so
-/// `xcodebuild test` never launches this app.
+/// the view content — lives below. #2455 C1: this shell now imports ONLY
+/// `EnviousWisprAppLive`, the sole production-choice site for live desktop-effect
+/// implementations. The unit-test target links the kit and never AppLive. That
+/// does not yet stop a test constructing a live implementation of its own — it
+/// still links `EnviousWisprServices` — which C2 (#2459) closes.
 @main
 struct EnviousWisprApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-  @State private var bootstrapper: WisprBootstrapper
+  @State private var application: LiveApplication
 
   init() {
     // Construct the composition root synchronously here (NOT lazily in a
     // delegate callback) so home construction keeps its pre-#919 ordering, then
     // hand it to the delegate before `applicationWillFinishLaunching` fires.
-    let bootstrapper = WisprBootstrapper()
+    let application = LiveApplication()
     // Initialize the stored `@State` BEFORE touching `appDelegate` (a property
     // wrapper access counts as using `self`, which Swift forbids until all
     // stored properties are initialized — same ordering the pre-#919 App used).
-    _bootstrapper = State(initialValue: bootstrapper)
-    appDelegate.attach(bootstrapper: bootstrapper)
+    _application = State(initialValue: application)
+    appDelegate.attach(application: application)
   }
 
   var body: some Scene {
@@ -34,15 +37,15 @@ struct EnviousWisprApp: App {
     // have a name for this window; the visible title text is suppressed by the
     // principal toolbar item (the centered wordmark is the visible identity).
     // AppWindowCoordinator identifies this window by this title.
-    Window(bootstrapper.mainWindowTitle, id: "main") {
-      bootstrapper.mainWindowContent()
+    Window(application.mainWindowTitle, id: "main") {
+      application.mainWindowContent()
     }
     .defaultSize(width: 820, height: 600)
     .windowToolbarStyle(.unifiedCompact)
 
     // Onboarding window — non-resizable, centered, auto-opens on first launch.
-    Window(bootstrapper.onboardingWindowTitle, id: "onboarding") {
-      bootstrapper.onboardingWindowContent()
+    Window(application.onboardingWindowTitle, id: "onboarding") {
+      application.onboardingWindowContent()
     }
     .windowResizability(.contentSize)
     .defaultSize(width: 500, height: 550)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// bootstrapper type + its init + 4 lifecycle methods + 2 view factories + 2
 /// window-title accessors cross to the shell.
 @MainActor
-public final class WisprBootstrapper {
+package final class WisprBootstrapper {
   // App-owned homes (epic #763 composition root). Held as `let` on this
   // bootstrapper (which the shell keeps alive via a single `@State`); injected
   // into views via `.environment(...)` inside the view factories below.
@@ -109,7 +109,20 @@ public final class WisprBootstrapper {
   /// EnviousWisprAppCeilingsTests).
   let recordingOverlay: OverlayDirector
 
-  public init() {
+  /// - Parameter makeHotkeyService: supplies the one shared `HotkeyService`.
+  ///
+  /// **Required and non-defaulted, which is the point (#2455 C1).** A default here
+  /// would let this module assemble a production root on its own and would make
+  /// `EnviousWisprAppLive` a passive forwarder — the shape grounded review r2
+  /// rejected in advance. With no default, every caller must state its choice, and
+  /// AppLive is the only production-choice site.
+  ///
+  /// This is not yet unlinkability: `EnviousWisprTests` still links
+  /// `EnviousWisprServices` in C1 and can construct a live `HotkeyService` itself.
+  /// C2 (#2459) replaces what AppLive passes here with a live adapter from
+  /// `EnviousWisprDesktopEffects` and removes the live implementation from the
+  /// test link graph. The seam does not move.
+  package init(makeHotkeyService: () -> HotkeyService) {
     // ===== Subsystem construction (epic #763) =====
     // `EnviousWisprApp` is the composition root: every subsystem is constructed
     // here. Construction order is load-bearing: `pasteCompletionRegistry` before
@@ -460,7 +473,9 @@ public final class WisprBootstrapper {
     // `DictationLifecycleCoordinator`, and `AppDelegate` termination.
     // #1175: the live telemetry sink is constructor-injected so it is in place
     // before `start()` runs any registration (heart-path + bootstrap ordering).
-    let hotkeyService = HotkeyService(telemetry: .live)
+    // #2455 C1: constructed by the caller, at exactly this position, so
+    // construction ORDER is unchanged. Only WHO chooses the implementation moved.
+    let hotkeyService = makeHotkeyService()
 
     // 2c: the Remove drain's engine-unload seam — assignable only now that the
     // driver (and its adapter) exist; the wiring that built the coordinator ran
@@ -1233,7 +1248,7 @@ public final class WisprBootstrapper {
   // `applicationWillFinishLaunching`, before the first SwiftUI scene body
   // evaluates (issue #739 / SparkleUpdateController contract).
 
-  public func applicationWillFinishLaunching() {
+  package func applicationWillFinishLaunching() {
     sparkleUpdateController.startUpdater()
     // #1019: wire the active-dictation guard so the new install affordances
     // (menu item / notification) never relaunch the app mid-capture.
@@ -1254,7 +1269,7 @@ public final class WisprBootstrapper {
     updateTriggerCoordinator.start()
   }
 
-  public func applicationDidFinishLaunching() {
+  package func applicationDidFinishLaunching() {
     appLifecycleCoordinator.runDidFinishLaunching()
     // #2381. AFTER launch, not during: `NSApp.servicesProvider` set before the app has finished
     // launching is registered against an app that cannot yet answer, and the menu item is then
@@ -1277,13 +1292,13 @@ public final class WisprBootstrapper {
     recordingOverlay.prewarmFirstRender()
   }
 
-  public func applicationDidBecomeActive() {
+  package func applicationDidBecomeActive() {
     appLifecycleCoordinator.runDidBecomeActive()
     // #958: proactive foreground check (post-sleep freshness), strict >=3600 gated.
     sparkleUpdateController.updateCoordinator?.checkForUpdatesProactively(trigger: "foreground")
   }
 
-  public func applicationWillTerminate() {
+  package func applicationWillTerminate() {
     // #1271: kill the EG-1 child SYNCHRONOUSLY — `Process` children survive
     // parent exit (Codex r1 proved empirically); crash orphans are reaped by
     // the stale-sweep in EGOneServerManager.start on next launch.
@@ -1303,18 +1318,18 @@ public final class WisprBootstrapper {
 
   // MARK: - Window titles (so the shell needs no EnviousWisprCore dependency)
 
-  public var mainWindowTitle: String { AppConstants.appName }
-  public var onboardingWindowTitle: String { AppConstants.onboardingWindowTitle }
+  package var mainWindowTitle: String { AppConstants.appName }
+  package var onboardingWindowTitle: String { AppConstants.onboardingWindowTitle }
 
   // MARK: - Root content
   // Homes are injected here, INSIDE the kit — the shell injects nothing, so no
   // home type crosses the module boundary (keeps the public surface tiny).
 
-  public func mainWindowContent() -> some View {
+  package func mainWindowContent() -> some View {
     MainWindowRoot(b: self)
   }
 
-  public func onboardingWindowContent() -> some View {
+  package func onboardingWindowContent() -> some View {
     OnboardingWindowRoot(b: self)
   }
 }

--- a/Sources/EnviousWisprAppLive/LiveApplication.swift
+++ b/Sources/EnviousWisprAppLive/LiveApplication.swift
@@ -1,0 +1,101 @@
+import EnviousWisprAppKit
+import EnviousWisprServices
+import SwiftUI
+
+/// The production composition root (#2455 C1, issue #2458).
+///
+/// **What this module owns, and why it is not a forwarder.** `WisprBootstrapper`
+/// now takes a REQUIRED, non-defaulted `makeHotkeyService`, so
+/// `EnviousWisprAppKit` no longer exposes an IMPLICIT production assembly path.
+/// AppKit can still be made to assemble one — it imports Services, so a caller
+/// there could pass a live factory explicitly — but nothing does, and the
+/// production source chooses the live implementation here and nowhere else. That
+/// is the ownership grounded review r2 demanded when it rejected "a passive
+/// forwarding module would preserve the wording while changing nothing".
+///
+/// **Why the choice has to live above AppKit, and what that is not yet.**
+/// `EnviousWisprTests` links `EnviousWisprAppKit` and `EnviousWisprServices`. After
+/// C1 it cannot get a production root by accident — `WisprBootstrapper.init` has no
+/// default — but it CAN still construct `HotkeyService(telemetry: .live)` directly,
+/// because Services is still in its link graph. C2 (#2459) moves the live
+/// implementation into `EnviousWisprDesktopEffects`, which the test target does not
+/// link, and that is the wall. C0's environment tripwire (#2457) is the tripwire in
+/// front of it.
+///
+/// C2 (#2459) replaces the concrete `HotkeyService` construction below with a live
+/// adapter from `EnviousWisprDesktopEffects` and drops this module's direct
+/// `EnviousWisprServices` edge. The seam itself does not move.
+@MainActor
+package final class LiveApplication {
+  /// App-lifetime owner of the bootstrapper. The shell strongly retains this
+  /// `LiveApplication` in `@State`; the delegate's reference is `weak`, exactly as
+  /// it was before this module existed. Mounted SwiftUI roots may also retain the
+  /// bootstrapper, but its lifetime does not depend on them.
+  private let bootstrapper: WisprBootstrapper
+
+  package init() {
+    // Construction stays synchronous and in this order for the same reason it
+    // always has: home construction must keep its pre-#919 ordering, and the
+    // delegate must be attached before `applicationWillFinishLaunching` fires.
+    bootstrapper = WisprBootstrapper(
+      makeHotkeyService: {
+        // #1175: the live telemetry sink is constructor-injected so it is in
+        // place before `start()` runs any registration (heart path + bootstrap
+        // ordering). Moving the construction here did not move that guarantee.
+        HotkeyService(telemetry: .live)
+      })
+  }
+
+  // MARK: - Scene surface
+
+  package var mainWindowTitle: String { bootstrapper.mainWindowTitle }
+  package var onboardingWindowTitle: String { bootstrapper.onboardingWindowTitle }
+
+  package func mainWindowContent() -> some View { bootstrapper.mainWindowContent() }
+  package func onboardingWindowContent() -> some View {
+    bootstrapper.onboardingWindowContent()
+  }
+
+  // MARK: - Lifecycle surface
+
+  package func applicationWillFinishLaunching() {
+    bootstrapper.applicationWillFinishLaunching()
+    // #2377 Phase 6: arm the DEBUG marker sink in the callback BEFORE the
+    // measured one, and AFTER this callback's own production work.
+    //
+    // Before `applicationDidFinishLaunching` because that interval is what is
+    // measured, and the sink's one-time setup must not land inside it. After the
+    // forwarding above because #739 requires Sparkle's cross-launch correlation
+    // to run at the earliest callback, and putting measurement in front of it
+    // would make a DEBUG instrument the first thing a launch does.
+    //
+    // #2455 C1: this moved down from the shell's `AppDelegate` so the executable
+    // imports only this module. It still brackets the same bootstrapper production
+    // call in the same order. The measured interval now EXCLUDES the shell's weak
+    // `application` lookup and the dispatch into this type, which were previously
+    // inside it; production lifecycle ordering is unchanged.
+    #if DEBUG
+      OverlayFirstRenderMarkers.prepare()
+    #endif
+  }
+  package func applicationDidFinishLaunching() {
+    // #2377 Phase 6: DEBUG-only measurement of this forwarding call, which is
+    // where launch work happens. `capture` reads the clock and nothing else; the
+    // environment read, the string and the write all run in `emit`, after the
+    // interval has closed.
+    #if DEBUG
+      let launchEnter = OverlayFirstRenderMarkers.capture(.launchEnter)
+    #endif
+    bootstrapper.applicationDidFinishLaunching()
+    #if DEBUG
+      OverlayFirstRenderMarkers.emit(
+        launchEnter, OverlayFirstRenderMarkers.capture(.launchExit))
+    #endif
+  }
+  package func applicationDidBecomeActive() {
+    bootstrapper.applicationDidBecomeActive()
+  }
+  package func applicationWillTerminate() {
+    bootstrapper.applicationWillTerminate()
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/AppDelegateCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppDelegateCeilingsTests.swift
@@ -19,8 +19,11 @@ import Testing
   private static let sourcePath =
     "Sources/EnviousWispr/AppDelegate.swift"
 
+  /// #2455 C1 (#2458): `bootstrapper` -> `application`. The shell delegate now
+  /// forwards into `LiveApplication`, which owns the bootstrapper, because the
+  /// live desktop-effect choice belongs above `EnviousWisprAppKit`.
   private static let storedPropertyAllowlist: Set<String> = [
-    "bootstrapper"
+    "application"
   ]
 
   @Test func storedPropertyNamesMatchAllowlist() throws {
@@ -59,7 +62,14 @@ import Testing
     let actual = RouterCeilingParser.imports(in: source)
     // #919: Services dropped, EnviousWisprAppKit added — the shell delegate
     // forwards into the bootstrapper instead of holding engine-module homes.
-    let allowed: Set<String> = ["AppKit", "EnviousWisprAppKit", "Foundation"]
+    //
+    // #2455 C1 (#2458): AppKit REPLACED by EnviousWisprAppLive, not joined by it.
+    // The shell must reach the kit only THROUGH the module that chooses live
+    // desktop-effect implementations; letting it import both would restore the
+    // ability to assemble a production root without AppLive, which is the whole
+    // thing this boundary buys. `EnviousWisprAppKit` reappearing here is a
+    // regression, not a widening.
+    let allowed: Set<String> = ["AppKit", "EnviousWisprAppLive", "Foundation"]
     let extras = actual.subtracting(allowed)
     #expect(
       extras.isEmpty,
@@ -115,7 +125,7 @@ import Testing
       // `// assertAttached()` must not satisfy this check.
       let guardRange = RouterCeilingParser.rangeOfStatement("assertAttached()", in: body)
       let forwardRange = RouterCeilingParser.rangeOfStatement(
-        "bootstrapper?.\(functionName)()", in: body)
+        "application?.\(functionName)()", in: body)
       #expect(guardRange != nil, "\(functionName) must call assertAttached()")
       #expect(forwardRange != nil, "\(functionName) must forward into the bootstrapper")
       if let guardRange, let forwardRange {

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -264,7 +264,10 @@ private func envWisprAppURL() -> URL {
 
 private func structBodyOfEnviousWisprApp() throws -> String {
   let source = try String(contentsOf: envWisprAppURL(), encoding: .utf8)
-  guard let openRange = source.range(of: "public final class WisprBootstrapper {") else {
+  // #2455 C1: narrowed `public` -> `package`. The shell no longer names this
+  // type at all — it reaches it through `LiveApplication` in EnviousWisprAppLive —
+  // so nothing outside the package needs to see it.
+  guard let openRange = source.range(of: "package final class WisprBootstrapper {") else {
     Issue.record("WisprBootstrapper declaration not found at expected path/shape")
     throw POSIXError(.ENOENT)
   }

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -5,7 +5,13 @@
 # Authoritative dep graph (verified against Package.swift on 2026-04-30).
 # Edit `permitted_imports_for` below when Package.swift changes (and update the
 # Bible if the new edge represents an architectural decision):
-#   EnviousWispr           -> AppKit (thin launchable shell; #919). Imports ONLY the kit.
+#   EnviousWispr           -> AppLive (thin launchable shell; #919/#2455 C1). Imports ONLY AppLive.
+#   EnviousWisprAppLive    -> AppKit, Services (production composition root; #2455 C1). The unit-test
+#                             target does not link this, and WisprBootstrapper.init has no default, so
+#                             there is no implicit production assembly path. NOT yet unlinkability:
+#                             tests still link Services and can build a live HotkeyService themselves.
+#                             The Services edge is TEMPORARY — C2 (#2459) replaces it with
+#                             EnviousWisprDesktopEffects, which is the chunk that earns the word.
 #   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline, Contacts (app-shell library; #919, top of stack)
 #   EnviousWisprASRService -> Core, ASR, Audio, ObservabilityCore (XPC executable; the audio capture XPC service was removed at #1543)
 #   EnviousWisprPipeline   -> Core, ASR, Audio, LLM, PostProcessing, Services, Storage
@@ -60,7 +66,8 @@ permitted_imports_for() {
     EnviousWisprPipeline)          echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprLLM EnviousWisprModelDelivery EnviousWisprPostProcessing EnviousWisprServices EnviousWisprStorage" ;;
     EnviousWisprASRService)        echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprObservabilityCore" ;;
     EnviousWisprAppKit)            echo "EnviousWisprCore EnviousWisprStorage EnviousWisprPostProcessing EnviousWisprAudio EnviousWisprServices EnviousWisprASR EnviousWisprLLM EnviousWisprModelDelivery EnviousWisprPipeline EnviousWisprContacts EnviousWisprLivePreview EnviousWisprWhisperPreviewAdapter" ;;
-    EnviousWispr)                  echo "EnviousWisprAppKit" ;;
+    EnviousWisprAppLive)           echo "EnviousWisprAppKit EnviousWisprServices" ;;
+    EnviousWispr)                  echo "EnviousWisprAppLive" ;;
     *)                             return 1 ;;
   esac
 }


### PR DESCRIPTION
Closes #2458. Chunk C1 of #2455. Follows #2464 (C0).

**Lane:** Code
**Tier:** REFACTOR (chunk C1 of 6)
**Live UAT:** Y — Dev app built, deployed and launched; see Validation

## Problem

The app target imported `EnviousWisprAppKit` directly, and `WisprBootstrapper()` took no arguments. The module the unit-test target links could therefore assemble a complete production root on its own, live desktop effects included. Nothing above it was required, so nothing above it could gate what it reached.

## What this does

`EnviousWisprAppLive` is that missing layer. `WisprBootstrapper.init` now takes a **required, non-defaulted** `makeHotkeyService`; `LiveApplication` supplies it and is the only production-choice site. A default would have restored the implicit path and made this module the passive forwarder grounded review r2 rejected in advance.

`WisprBootstrapper` and its nine shell-facing members narrow `public` → `package`. Nothing outside the package names the type any more.

## What this chunk does NOT do

It does **not** make a live effect unlinkable from a test. `EnviousWisprTests` still links `EnviousWisprServices` and can construct `HotkeyService(telemetry: .live)` itself.

What C1 removes is the *implicit* path: every caller must now name its choice. C2 (#2459) moves the live implementation into `EnviousWisprDesktopEffects`, which the test target does not link, and that is the chunk that earns the word. Seven comments and one knowledge-base row claimed otherwise in an earlier revision and were corrected — that distinction is what a future reader will act on.

## Decisions worth carrying

- **`AppDelegate.swift` stays in the app target.** Codex proposed deleting it and moving the delegate into AppLive. `AppDelegateCeilingsTests.swift:20` hard-codes its path, and `EnviousWisprApp.swift`'s own comment records that `NSApplicationDelegateAdaptor` must live in the `@main` App struct's module. Relocating it is Apple-contract risk with no boundary gain. It forwards to `LiveApplication` instead; the shell still imports only AppLive.
- **DEBUG launch markers moved down with it**, bracketing the same production call. The measured interval now excludes the shell's weak lookup and dispatch. Production lifecycle ordering is unchanged.
- **AppLive declares WhisperKit, FluidAudio and Sparkle directly.** Xcode does not propagate a static framework's package products transitively; without them the build fails on `FastClusterWrapper`, a FluidAudio internal named nowhere in this project's source. C2's new module will hit this identically.

## Guards updated

Five, each pinning something this chunk deliberately changed:

| Guard | Change |
|---|---|
| `AppDelegateCeilingsTests.allowedImports` | AppKit **replaced by** AppLive, not joined by it — the old name reappearing is a regression, not a widening |
| `AppDelegateCeilingsTests.storedPropertyNamesMatchAllowlist` | `bootstrapper` → `application` |
| `AppDelegateCeilingsTests.assertAttachedGuardsLifecycleEntryPoints` | forwarding target string |
| `EnviousWisprAppCeilingsTests` | `public final class WisprBootstrapper` → `package final class` |
| `check-dependency-direction.sh` | AppLive row + authoritative graph header |

## Validation

| Check | Result |
|---|---|
| Debug lane | PASS — 7,126 test cases, zero failures |
| `check-dependency-direction.sh` | OK, 18 modules |
| Dev app launch | Built, deployed, launched. Log shows launch-triggered update check, recovery scan, wedge guard armed, EG-1 server ready — construction, delegate attachment and lifecycle forwarding all run through `LiveApplication` |
| Codex chunk gate | **CHUNK-CLEAN** on a confirming re-run |

Codex rounds: architecture fork → `OPTION-B` → `CHUNK-REVISIONS (2)` → `CHUNK-REVISIONS (1)` → `CHUNK-REVISIONS (1)` → **`CHUNK-CLEAN`**.

## Note for other active worktrees

`WisprBootstrapper()` no longer compiles. Callers must supply `makeHotkeyService:`. There is exactly one production call site and it is in this diff.
