### PR TITLE
C2: move hotkey OS calls into EnviousWisprDesktopEffects (#2459)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -270,13 +270,31 @@ let package = Package(
     // and can construct `HotkeyService(telemetry: .live)` itself. What C1 buys is
     // that no IMPLICIT production assembly path exists, and that AppLive is the
     // only production-choice site. C2 (#2459) removes the live implementation
-    // from the test link graph and replaces the Services edge below with
-    // EnviousWisprDesktopEffects; unlinkable becomes true then, not now.
+    // from what the test target may import, and replaces the Services edge with
+    // EnviousWisprDesktopEffects, which the dep-direction gate then forbids the
+    // test targets from importing.
+    // #2455 C2 (#2459): the ONLY module holding Carbon and NSEvent calls. Absent
+    // from EnviousWisprTests' dependency list on purpose.
+    //
+    // That absence is NOT self-enforcing under Xcode — an undeclared import of
+    // this module from the test target compiles and links, because Xcode shares
+    // one build-products search path (measured 2026-08-26). SwiftPM does enforce
+    // it, and this manifest is what makes `swift build` reject it, but CI runs
+    // Tuist and xcodebuild only. `scripts/check-dependency-direction.sh` is what
+    // actually catches it on every run.
+    .target(
+      name: "EnviousWisprDesktopEffects",
+      dependencies: [
+        "EnviousWisprAppKit",
+        "EnviousWisprServices",
+      ],
+      path: "Sources/EnviousWisprDesktopEffects"
+    ),
     .target(
       name: "EnviousWisprAppLive",
       dependencies: [
         "EnviousWisprAppKit",
-        "EnviousWisprServices",
+        "EnviousWisprDesktopEffects",
       ],
       path: "Sources/EnviousWisprAppLive"
     ),

--- a/Project.swift
+++ b/Project.swift
@@ -18,12 +18,13 @@ let packageAccessIdentifier = "enviouswispr"
 /// must change both; `DesktopEffectPolicyTests` fails if they drift.
 let DesktopEffectsPolicyKey = "EW_DESKTOP_EFFECTS_POLICY"
 
-/// Mirrors `DesktopEffectDenial.trapEnvironmentKey`. Separate from the policy key
-/// so a shipped app that somehow sees ONLY the policy variable loses its hotkeys
-/// rather than crashing, while every TEST configuration — Debug, Dev and Release
-/// alike — aborts on an unhandled refusal. Selecting that severity with
-/// `#if DEBUG` instead would let the Release suite pass having reached a
-/// prohibited effect (Codex chunk review, 2026-08-26).
+/// Mirrors `DesktopEffectDenial.trapEnvironmentKey`.
+///
+/// **No production path consumes this after C2 (#2459).** It disables nothing and
+/// aborts nothing; the hotkey machinery it once governed was deleted when the OS
+/// calls moved to `EnviousWisprDesktopEffects`. `DesktopEffectPolicyTests` keeps
+/// its scheme wiring visible until C5 (#2462) removes the variable and those cases
+/// together.
 let DesktopEffectsTrapKey = "EW_DESKTOP_EFFECTS_TRAP_DENIALS"
 
 let commonSettings: SettingsDictionary = [
@@ -278,8 +279,14 @@ let firstPartyTargetDeps: [TargetDependency] = [
 /// both select these shared schemes, so neither needs its own copy of the
 /// variable — one owner, per `GR-WRITE-FOR-RETRIEVAL`.
 ///
-/// Removed or demoted in C5 (#2462), once the module boundary makes a live effect
-/// unlinkable from the unit target and this tripwire is redundant.
+/// **After C2 (#2459) these guard NOTHING.** C0's tripwire was only ever
+/// implemented in `HotkeyService`, and C2 deleted that machinery when the Carbon
+/// and `NSEvent` calls moved out. No production path reads either variable now.
+/// They are not protecting overlay or activation — those never had a gate; they
+/// are C3 (#2460) and C4 (#2461), and the dep-direction script is what will cover
+/// them. These two lines are explicit disclosed debt until C5 (#2462) removes
+/// them, kept only so the removal is a single deliberate change rather than a
+/// silent drift.
 let denyDesktopEffects: Arguments = .arguments(
   environmentVariables: [
     DesktopEffectsPolicyKey: .environmentVariable(value: "deny", isEnabled: true),
@@ -467,7 +474,7 @@ let project = Project(
     // ONLY this, and the unit-test target does not link it.
     //
     // Not a forwarding shim: `WisprBootstrapper` takes a required, non-defaulted
-    // `makeHotkeyService`, so EnviousWisprAppKit contains no IMPLICIT production
+    // `makeHotkeyEffects`, so EnviousWisprAppKit contains no IMPLICIT production
     // assembly path — every caller must state its hotkey-service choice
     // explicitly — and this module is the only production-choice site.
     //
@@ -479,11 +486,28 @@ let project = Project(
     // The direct EnviousWisprServices edge is TEMPORARY — C2 (#2459) replaces the
     // concrete HotkeyService construction with a live adapter from
     // EnviousWisprDesktopEffects and drops this edge.
+    // #2455 C2 (#2459): the ONLY module holding Carbon and NSEvent calls. Neither
+    // test target declares it — but Xcode still exposes a built module to every
+    // target in the project, so that absence enforces nothing on its own.
+    // `scripts/check-dependency-direction.sh` is the enforcing wall: it rejects the
+    // import from the test targets, and rejects the OS calls themselves anywhere
+    // outside this module.
+    firstPartyLibrary(
+      "EnviousWisprDesktopEffects",
+      dependencies: [
+        .target(name: "EnviousWisprAppKit"),
+        .target(name: "EnviousWisprServices"),
+        // Same transitive-propagation reason as AppLive below.
+        .package(product: "WhisperKit"),
+        .package(product: "FluidAudio"),
+        .package(product: "Sparkle"),
+      ]),
+
     firstPartyLibrary(
       "EnviousWisprAppLive",
       dependencies: [
         .target(name: "EnviousWisprAppKit"),
-        .target(name: "EnviousWisprServices"),
+        .target(name: "EnviousWisprDesktopEffects"),
         // Declared directly for the same reason EnviousWisprAppKit declares
         // them: Xcode does not propagate a static framework's package products
         // transitively, so a module importing AppKit must resolve AppKit's

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -109,7 +109,8 @@ package final class WisprBootstrapper {
   /// EnviousWisprAppCeilingsTests).
   let recordingOverlay: OverlayDirector
 
-  /// - Parameter makeHotkeyService: supplies the one shared `HotkeyService`.
+  /// - Parameter makeHotkeyEffects: supplies the live desktop-effect adapter the
+  ///   one shared `HotkeyService` will use.
   ///
   /// **Required and non-defaulted, which is the point (#2455 C1).** A default here
   /// would let this module assemble a production root on its own and would make
@@ -117,12 +118,11 @@ package final class WisprBootstrapper {
   /// rejected in advance. With no default, every caller must state its choice, and
   /// AppLive is the only production-choice site.
   ///
-  /// This is not yet unlinkability: `EnviousWisprTests` still links
-  /// `EnviousWisprServices` in C1 and can construct a live `HotkeyService` itself.
-  /// C2 (#2459) replaces what AppLive passes here with a live adapter from
-  /// `EnviousWisprDesktopEffects` and removes the live implementation from the
-  /// test link graph. The seam does not move.
-  package init(makeHotkeyService: () -> HotkeyService) {
+  /// C2 (#2459) made what AppLive passes here a live adapter from
+  /// `EnviousWisprDesktopEffects`, which `EnviousWisprTests` may not import —
+  /// enforced by `scripts/check-dependency-direction.sh`, not by the module graph,
+  /// which does not enforce itself under Xcode. The seam does not move.
+  package init(makeHotkeyEffects: () -> any DesktopHotkeyEffects) {
     // ===== Subsystem construction (epic #763) =====
     // `EnviousWisprApp` is the composition root: every subsystem is constructed
     // here. Construction order is load-bearing: `pasteCompletionRegistry` before
@@ -473,9 +473,12 @@ package final class WisprBootstrapper {
     // `DictationLifecycleCoordinator`, and `AppDelegate` termination.
     // #1175: the live telemetry sink is constructor-injected so it is in place
     // before `start()` runs any registration (heart-path + bootstrap ordering).
-    // #2455 C1: constructed by the caller, at exactly this position, so
-    // construction ORDER is unchanged. Only WHO chooses the implementation moved.
-    let hotkeyService = makeHotkeyService()
+    // #2455 C1/C2: the SERVICE is still constructed here, at exactly this
+    // position, so construction ORDER is unchanged. What the caller supplies is
+    // the desktop-effect adapter it will use — the only part that touches the OS.
+    // #1175: the live telemetry sink is constructor-injected so it is in place
+    // before `start()` runs any registration (heart path + bootstrap ordering).
+    let hotkeyService = HotkeyService(effects: makeHotkeyEffects(), telemetry: .live)
 
     // 2c: the Remove drain's engine-unload seam — assignable only now that the
     // driver (and its adapter) exist; the wiring that built the coordinator ran

--- a/Sources/EnviousWisprAppLive/LiveApplication.swift
+++ b/Sources/EnviousWisprAppLive/LiveApplication.swift
@@ -1,30 +1,26 @@
 import EnviousWisprAppKit
-import EnviousWisprServices
+import EnviousWisprDesktopEffects
 import SwiftUI
 
 /// The production composition root (#2455 C1, issue #2458).
 ///
-/// **What this module owns, and why it is not a forwarder.** `WisprBootstrapper`
-/// now takes a REQUIRED, non-defaulted `makeHotkeyService`, so
-/// `EnviousWisprAppKit` no longer exposes an IMPLICIT production assembly path.
-/// AppKit can still be made to assemble one — it imports Services, so a caller
-/// there could pass a live factory explicitly — but nothing does, and the
-/// production source chooses the live implementation here and nowhere else. That
+/// **What this module owns.** `WisprBootstrapper` takes a REQUIRED, non-defaulted
+/// `makeHotkeyEffects`, so `EnviousWisprAppKit` exposes no implicit production
+/// assembly path, and this is the only place a live implementation is named. That
 /// is the ownership grounded review r2 demanded when it rejected "a passive
 /// forwarding module would preserve the wording while changing nothing".
 ///
-/// **Why the choice has to live above AppKit, and what that is not yet.**
-/// `EnviousWisprTests` links `EnviousWisprAppKit` and `EnviousWisprServices`. After
-/// C1 it cannot get a production root by accident — `WisprBootstrapper.init` has no
-/// default — but it CAN still construct `HotkeyService(telemetry: .live)` directly,
-/// because Services is still in its link graph. C2 (#2459) moves the live
-/// implementation into `EnviousWisprDesktopEffects`, which the test target does not
-/// link, and that is the wall. C0's environment tripwire (#2457) is the tripwire in
-/// front of it.
+/// **Why the choice has to live here.** `EnviousWisprTests` declares
+/// `EnviousWisprAppKit` and `EnviousWisprServices`, and NOT
+/// `EnviousWisprDesktopEffects`. After C2 the Carbon and `NSEvent` calls live only
+/// in that module.
 ///
-/// C2 (#2459) replaces the concrete `HotkeyService` construction below with a live
-/// adapter from `EnviousWisprDesktopEffects` and drops this module's direct
-/// `EnviousWisprServices` edge. The seam itself does not move.
+/// What stops a unit test reaching them is `scripts/check-dependency-direction.sh`,
+/// which scans the test targets and rejects that module by name — NOT the module
+/// graph. Under Xcode the graph does not enforce itself: an undeclared import of
+/// that module from the test target compiles and links (measured 2026-08-26).
+/// C0's environment tripwire (#2457) stood in front of that gap; C5 (#2462) can
+/// retire it for hotkeys now that the gate covers them.
 @MainActor
 package final class LiveApplication {
   /// App-lifetime owner of the bootstrapper. The shell strongly retains this
@@ -38,12 +34,7 @@ package final class LiveApplication {
     // always has: home construction must keep its pre-#919 ordering, and the
     // delegate must be attached before `applicationWillFinishLaunching` fires.
     bootstrapper = WisprBootstrapper(
-      makeHotkeyService: {
-        // #1175: the live telemetry sink is constructor-injected so it is in
-        // place before `start()` runs any registration (heart path + bootstrap
-        // ordering). Moving the construction here did not move that guarantee.
-        HotkeyService(telemetry: .live)
-      })
+      makeHotkeyEffects: { LiveDesktopHotkeyEffects() })
   }
 
   // MARK: - Scene surface

--- a/Sources/EnviousWisprDesktopEffects/LiveDesktopHotkeyEffects.swift
+++ b/Sources/EnviousWisprDesktopEffects/LiveDesktopHotkeyEffects.swift
@@ -1,0 +1,252 @@
+import AppKit
+import Carbon
+import EnviousWisprServices
+import Foundation
+
+/// The Carbon and `NSEvent` calls that actually reach the desktop (#2455 C2).
+///
+/// **This module exists to be out of the unit suite's reach — enforced by a
+/// CHECK, not by the compiler.** `EnviousWisprTests` declares no dependency on
+/// this target, and only `EnviousWisprAppLive` builds one of these.
+///
+/// Be precise about what enforces that, because the obvious belief is wrong.
+/// Measured 2026-08-26: a file in `Tests/EnviousWisprTests/` that imports this
+/// module and constructs this type COMPILES AND LINKS under Xcode, with no
+/// dependency edge declared anywhere. Xcode puts every built product in one
+/// search path, so a declared edge orders the LINK and does not gate imports.
+/// SwiftPM would reject it; CI runs Tuist and xcodebuild only, so SwiftPM never
+/// gets the chance.
+///
+/// `scripts/check-dependency-direction.sh` is therefore the wall: it scans the
+/// test targets and rejects this module by name. Delete that loop and the
+/// boundary silently becomes a convention.
+///
+/// Every causal comment here moved with the behavior it explains, per the C2
+/// contract. Where the reason was recorded against the old call site in
+/// `HotkeyService`, it is recorded against the new one.
+@MainActor
+package final class LiveDesktopHotkeyEffects: DesktopHotkeyEffects {
+
+  /// What a token actually identifies.
+  ///
+  /// Kept in a private table rather than handed out, because every payload here
+  /// is an opaque handle whose only legal consumer is the framework that issued
+  /// it. `remove(_:)` is the single release path, which is what makes double
+  /// teardown a no-op instead of a double free.
+  private enum Resource {
+    case hotkey(EventHotKeyRef)
+    case handler(EventHandlerRef, Unmanaged<CarbonHandlerBox>)
+    case monitor(Any)
+  }
+
+  private var resources: [DesktopEffectToken: Resource] = [:]
+
+  package init() {}
+
+  // MARK: - Carbon handler
+
+  package func installCarbonHandler(
+    _ callback: @escaping @MainActor (DesktopHotkeyEvent) -> Void
+  ) -> DesktopEffectToken? {
+    var eventTypes = [
+      EventTypeSpec(
+        eventClass: OSType(kEventClassKeyboard),
+        eventKind: UInt32(kEventHotKeyPressed)),
+      EventTypeSpec(
+        eventClass: OSType(kEventClassKeyboard),
+        eventKind: UInt32(kEventHotKeyReleased)),
+    ]
+
+    // The user-data pointer addresses a box this adapter owns, NOT the policy
+    // object. Before C2 it was an unretained `HotkeyService`, resolved on every
+    // OS callback — correct only for as long as the service outlives the
+    // handler, which nothing enforced. A retained box has a lifetime this class
+    // controls, released in `remove(_:)` and only after `RemoveEventHandler`.
+    let box = Unmanaged.passRetained(CarbonHandlerBox(callback))
+
+    // Resolved HERE, not at construction: the application event target is a
+    // process resource, and taking it in `init` would make merely building this
+    // adapter touch the OS.
+    var ref: EventHandlerRef?
+    let status = InstallEventHandler(
+      GetApplicationEventTarget(),
+      liveCarbonHotkeyHandler,
+      eventTypes.count,
+      &eventTypes,
+      box.toOpaque(),
+      &ref
+    )
+
+    guard status == noErr, let ref else {
+      if let ref {
+        // Keep the retained box ALIVE if Carbon will not confirm detachment: it
+        // may still hold the pointer, and releasing here would leave it reading
+        // freed memory on the next hotkey. Leaking one closure is the strictly
+        // safer failure.
+        guard RemoveEventHandler(ref) == noErr else { return nil }
+      }
+      // No handler was installed, or it was cleanly detached — the box is
+      // unreachable now, so release it or the closure leaks for the process life.
+      box.release()
+      return nil
+    }
+
+    let token = DesktopEffectToken()
+    resources[token] = .handler(ref, box)
+    return token
+  }
+
+  // MARK: - Registration
+
+  package func registerHotkey(
+    id: UInt32, keyCode: UInt16, rawModifiers: UInt64
+  ) -> HotkeyRegistration {
+    let hotkeyID = EventHotKeyID(signature: Self.hotkeySignature, id: id)
+    var ref: EventHotKeyRef?
+    let status = RegisterEventHotKey(
+      UInt32(keyCode),
+      UInt32(truncatingIfNeeded: rawModifiers),
+      hotkeyID,
+      GetApplicationEventTarget(),
+      0,
+      &ref
+    )
+
+    guard status == noErr else { return .refused(status: Int32(status)) }
+    // #1175: the noErr-but-silent trap. Carbon can accept the registration and
+    // still leave the ref nil, which is a shortcut that is registered, displayed,
+    // and delivers nothing. It is NOT a failure — reporting one here would put a
+    // false alarm in the signal that tells us a real user's shortcut died — and
+    // it is not a success either, so it gets its own case.
+    guard let ref else { return .acceptedWithoutToken }
+
+    let token = DesktopEffectToken()
+    resources[token] = .hotkey(ref)
+    return .registered(token)
+  }
+
+  /// Four-char-code signature for EnviousWispr hotkeys.
+  ///
+  /// Moved verbatim from `HotkeyService`; it is meaningless apart from
+  /// `registerHotkey`. The case is load-bearing — these are raw bytes packed into
+  /// an `OSType`, so "EWSP" and "ewsp" are different signatures and a stale
+  /// registration carrying the other one would not be recognised.
+  private static let hotkeySignature: OSType = {
+    var result: OSType = 0
+    for char in "EWSP".utf8.prefix(4) {
+      result = (result << 8) | OSType(char)
+    }
+    return result
+  }()
+
+  // MARK: - Modifier monitors
+
+  package func installGlobalModifierMonitor(
+    _ callback: @escaping @MainActor (DesktopModifierEvent) -> Void
+  ) -> DesktopEffectToken? {
+    // Global monitor callbacks may arrive off the main thread, and `NSEvent` is
+    // not Sendable — so the event is decoded to plain values HERE and only those
+    // cross the hop.
+    let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { event in
+      let value = DesktopModifierEvent(
+        keyCode: event.keyCode, rawFlags: UInt64(event.modifierFlags.rawValue))
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated { callback(value) }
+      }
+    }
+    return store(monitor)
+  }
+
+  package func installLocalModifierMonitor(
+    _ callback: @escaping @MainActor (DesktopModifierEvent) -> Void
+  ) -> DesktopEffectToken? {
+    let monitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+      MainActor.assumeIsolated {
+        callback(
+          DesktopModifierEvent(
+            keyCode: event.keyCode, rawFlags: UInt64(event.modifierFlags.rawValue)))
+      }
+      // Pass the event through. Returning nil here would swallow the keystroke
+      // for the rest of the app while the callback still fired, so nothing in a
+      // test would notice.
+      return event
+    }
+    return store(monitor)
+  }
+
+  private func store(_ monitor: Any?) -> DesktopEffectToken? {
+    guard let monitor else { return nil }
+    let token = DesktopEffectToken()
+    resources[token] = .monitor(monitor)
+    return token
+  }
+
+  // MARK: - Teardown
+
+  @discardableResult
+  package func remove(_ token: DesktopEffectToken) -> Bool {
+    // Removing first makes an unknown or already-released token a no-op rather
+    // than a second framework call on a dead handle.
+    guard let resource = resources.removeValue(forKey: token) else { return true }
+    switch resource {
+    case .hotkey(let ref):
+      UnregisterEventHotKey(ref)
+    case .handler(let ref, let box):
+      // Order matters: the handler must be detached before the box it points at
+      // is released, or an in-flight callback resolves freed memory. If Carbon
+      // refuses, put the mapping BACK and report failure — the caller keeps its
+      // token and can retry. Dropping it here would strand the handler with
+      // nothing left able to name it.
+      guard RemoveEventHandler(ref) == noErr else {
+        resources[token] = .handler(ref, box)
+        return false
+      }
+      box.release()
+    case .monitor(let monitor):
+      NSEvent.removeMonitor(monitor)
+    }
+    return true
+  }
+}
+
+/// What the Carbon user-data pointer actually addresses.
+@MainActor
+private final class CarbonHandlerBox {
+  let callback: @MainActor (DesktopHotkeyEvent) -> Void
+  init(_ callback: @escaping @MainActor (DesktopHotkeyEvent) -> Void) {
+    self.callback = callback
+  }
+}
+
+/// The C trampoline. Decodes the event and hands plain values to the box.
+///
+/// `GetEventKind` and `GetEventParameter` are Carbon calls but install nothing —
+/// they read an event already delivered — so they are not desktop effects and
+/// have no gate.
+private func liveCarbonHotkeyHandler(
+  _: EventHandlerCallRef?,
+  _ event: EventRef?,
+  _ userData: UnsafeMutableRawPointer?
+) -> OSStatus {
+  guard let event, let userData else { return OSStatus(eventNotHandledErr) }
+
+  var hotkeyID = EventHotKeyID()
+  let status = GetEventParameter(
+    event,
+    UInt32(kEventParamDirectObject),
+    UInt32(typeEventHotKeyID),
+    nil,
+    MemoryLayout<EventHotKeyID>.size,
+    nil,
+    &hotkeyID
+  )
+  guard status == noErr else { return OSStatus(eventNotHandledErr) }
+
+  let value = DesktopHotkeyEvent(
+    id: hotkeyID.id,
+    isRelease: GetEventKind(event) == UInt32(kEventHotKeyReleased))
+
+  let box = Unmanaged<CarbonHandlerBox>.fromOpaque(userData).takeUnretainedValue()
+  MainActor.assumeIsolated { box.callback(value) }
+  return noErr
+}

--- a/Sources/EnviousWisprServices/DesktopHotkeyEffects.swift
+++ b/Sources/EnviousWisprServices/DesktopHotkeyEffects.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// The framework-pure boundary between hotkey POLICY and the OS calls that
+/// enact it (#2455 C2, issue #2459).
+///
+/// **Why a boundary at all.** `EnviousWisprTests` links this module. Before C2
+/// the Carbon and `NSEvent` calls lived here too, so a unit test could reach the
+/// real desktop just by driving `HotkeyService` — which is how a running suite
+/// took the developer's Escape key system-wide. The live implementation now lives
+/// in `EnviousWisprDesktopEffects`, which neither test target declares.
+///
+/// **What enforces that is a script, not the compiler.** Xcode makes a built
+/// module importable from any target in the project regardless of declared edges
+/// (measured 2026-08-26), so `scripts/check-dependency-direction.sh` is the wall:
+/// it rejects that import from the test targets, and separately rejects a test
+/// that writes `RegisterEventHotKey` or `NSEvent.add*MonitorForEvents` itself —
+/// which import discipline alone would miss, since those come from Apple
+/// frameworks any test may import.
+///
+/// **Framework-pure on purpose.** No `EventHotKeyRef`, `EventHandlerRef`,
+/// `OSStatus` or `NSEvent` appears below. Those are opaque handles whose only safe
+/// consumer is the framework that issued them; letting one cross would put a value
+/// in this module that a test can hold and cannot legally use. Callers get a
+/// `DesktopEffectToken` — an opaque identity the adapter maps back to whatever it
+/// actually owns.
+///
+/// **The adapter reports, this module decides.** Implementations return raw
+/// results and emit no telemetry. `HotkeyService` alone interprets them, so
+/// exactly one `registrationFailed` follows a `.refused` and none follows an
+/// `.acceptedWithoutToken`. Splitting that would give two owners for one wire
+/// signal, which is the #2381 defect class.
+
+/// An opaque handle to something the adapter installed.
+///
+/// Identity only. The adapter keeps the real framework object in a private table
+/// and looks it up on `remove(_:)`, so nothing outside can hold — or misuse — a
+/// framework handle.
+package struct DesktopEffectToken: Hashable, Sendable {
+  package let id: UUID
+  package init(id: UUID = UUID()) { self.id = id }
+}
+
+/// A Carbon hotkey press or release, already decoded.
+package struct DesktopHotkeyEvent: Sendable {
+  package let id: UInt32
+  package let isRelease: Bool
+  package init(id: UInt32, isRelease: Bool) {
+    self.id = id
+    self.isRelease = isRelease
+  }
+}
+
+/// A modifier-flags change, already decoded from `NSEvent`.
+///
+/// `rawFlags` rather than `NSEvent.ModifierFlags` so this file needs no AppKit
+/// import; `HotkeyService` rebuilds the option set at the edge.
+package struct DesktopModifierEvent: Sendable {
+  package let keyCode: UInt16
+  package let rawFlags: UInt64
+  package init(keyCode: UInt16, rawFlags: UInt64) {
+    self.keyCode = keyCode
+    self.rawFlags = rawFlags
+  }
+}
+
+/// What asking the OS to register a hotkey produced.
+///
+/// Three cases, not two, because the third is REACHABLE and was the trap the
+/// original code documented in prose: Carbon can return `noErr` and still leave
+/// the ref nil, which is a registration that succeeded and delivers nothing. A
+/// two-case result would have to call that either success or failure, and both
+/// are wrong — one emits a false failure, the other reports a working shortcut
+/// that is inert.
+package enum HotkeyRegistration: Sendable {
+  case registered(DesktopEffectToken)
+  /// `Int32`, not `OSStatus`: identical layout, no Carbon import for consumers.
+  case refused(status: Int32)
+  /// `noErr` with no ref. Emits no telemetry — nothing failed — and yields no
+  /// token, so the caller's occupancy guards see an unregistered slot.
+  case acceptedWithoutToken
+}
+
+/// The OS calls hotkey policy needs, and nothing else.
+@MainActor
+package protocol DesktopHotkeyEffects: AnyObject {
+  /// Install the process-wide Carbon hotkey handler.
+  ///
+  /// Contractual: the adapter owns the callback box the C trampoline receives.
+  /// It must NOT be the policy object — a raw pointer to a live Swift object,
+  /// resolved on every OS callback, is a use-after-free waiting for the first
+  /// teardown ordering change.
+  func installCarbonHandler(
+    _ callback: @escaping @MainActor (DesktopHotkeyEvent) -> Void
+  ) -> DesktopEffectToken?
+
+  func registerHotkey(id: UInt32, keyCode: UInt16, rawModifiers: UInt64) -> HotkeyRegistration
+
+  func installGlobalModifierMonitor(
+    _ callback: @escaping @MainActor (DesktopModifierEvent) -> Void
+  ) -> DesktopEffectToken?
+
+  /// Contractual: the local monitor must return the `NSEvent` it received after
+  /// scheduling the callback. Swallowing it would eat the keystroke for the rest
+  /// of the app — a bug with no test-visible symptom, since the callback still
+  /// fires.
+  func installLocalModifierMonitor(
+    _ callback: @escaping @MainActor (DesktopModifierEvent) -> Void
+  ) -> DesktopEffectToken?
+
+  /// Release whatever this token identifies.
+  ///
+  /// Returns `false` when the framework REFUSED to release it, in which case the
+  /// adapter still owns the resource and the caller must keep its token so a later
+  /// teardown can retry. Dropping the token on a failed release would strand the
+  /// resource permanently — nothing left would name it.
+  ///
+  /// Unknown or already-released tokens return `true`: there is nothing to do and
+  /// nothing owned, so double teardown stays safe.
+  @discardableResult
+  func remove(_ token: DesktopEffectToken) -> Bool
+}

--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -78,39 +78,22 @@ public final class HotkeyService {
 
   // MARK: - Carbon State
 
-  /// A registration that either holds a real framework object or records that
-  /// the effect was refused (#2455 C0).
+  /// What this service currently has installed, as opaque tokens (#2455 C2).
   ///
-  /// A `.denied` case rather than a forged `EventHotKeyRef`: these are opaque
-  /// pointers, and handing a synthetic one to `UnregisterEventHotKey` would be a
-  /// wild-pointer call. Occupancy is what the surrounding state machine actually
-  /// asks about — `guard cancelHotkeyRef == nil`, `guard quickAddHotkeyRef == nil`
-  /// — so a non-nil `.denied` keeps every one of those guards behaving exactly as
-  /// it does against a real registration, while the teardown helpers below refuse
-  /// to pass anything but a `.live` payload back to the framework.
-  private enum HotkeyRegistration {
-    case live(EventHotKeyRef)
-    case denied
-  }
-
-  private enum HandlerRegistration {
-    case live(EventHandlerRef)
-    case denied
-  }
-
-  private enum MonitorRegistration {
-    case live(Any)
-    case denied
-  }
-
-  private var eventHandlerRef: HandlerRegistration?
-  private var toggleHotkeyRef: HotkeyRegistration?
-  private var cancelHotkeyRef: HotkeyRegistration?
-  private var quickAddHotkeyRef: HotkeyRegistration?
+  /// C0 held typed framework values here with a `.denied` case, because the OS
+  /// call happened in this file and a refusal had to be representable without
+  /// forging an `EventHotKeyRef`. C2 removes both problems at once: the framework
+  /// values now live inside `EnviousWisprDesktopEffects`, and a test's fake hands
+  /// back real tokens. Occupancy — all these guards ever ask, e.g.
+  /// `guard cancelHotkeyToken == nil` — is preserved by a token being non-nil.
+  private var eventHandlerToken: DesktopEffectToken?
+  private var toggleHotkeyToken: DesktopEffectToken?
+  private var cancelHotkeyToken: DesktopEffectToken?
+  private var quickAddHotkeyToken: DesktopEffectToken?
 
   /// Whether the cancel role is currently armed.
   ///
-  /// Not derivable from `cancelHotkeyRef`: a bare-modifier cancel key has no
+  /// Not derivable from `cancelHotkeyToken`: a bare-modifier cancel key has no
   /// Carbon registration to hold a ref, so a nil ref means "unarmed" for a chord
   /// and says nothing at all for a modifier. Tracking arming explicitly is what
   /// lets the modifier dispatch path know whether a recording is in flight.
@@ -125,8 +108,8 @@ public final class HotkeyService {
 
   // MARK: - NSEvent Modifier Monitors
 
-  private var globalModifierMonitor: MonitorRegistration?
-  private var localModifierMonitor: MonitorRegistration?
+  private var globalModifierMonitorToken: DesktopEffectToken?
+  private var localModifierMonitorToken: DesktopEffectToken?
 
   public private(set) var isEnabled = false
   public private(set) var isModifierHeld = false
@@ -310,58 +293,45 @@ public final class HotkeyService {
   /// running this suite alongside its siblings while it passed alone.
   private let now: @MainActor () -> Date
 
-  /// #2455 C0. Read once at construction rather than per call, so a service
-  /// cannot change policy mid-life and produce a half-registered state machine.
-  private let desktopEffectPolicy: DesktopEffectPolicy
-  private let onDeniedDesktopEffect: DesktopEffectDenialHandler
-
-  /// Every effect this instance refused, oldest first, in the same wording the
-  /// handler receives.
+  /// The OS calls this service is allowed to make (#2455 C2).
   ///
-  /// `package private(set)` for the same reason `isCancelArmed` is: it lets a
-  /// test assert on what the service DID rather than on a spy for a call the
-  /// production code might simply not make.
-  package private(set) var deniedDesktopEffects: [String] = []
+  /// Required and non-defaulted. Before C2 the Carbon and `NSEvent` calls were
+  /// inline in this file, so constructing a `HotkeyService` in a unit test was
+  /// enough to reach the developer's real desktop — which is how a running suite
+  /// took the Escape key system-wide. This module now declares no implementation
+  /// of this protocol at all: the live one lives in `EnviousWisprDesktopEffects`,
+  /// which `EnviousWisprTests` may not import — enforced by
+  /// `scripts/check-dependency-direction.sh`, since the module graph does not
+  /// enforce itself under Xcode — and tests supply a recording fake. A default
+  /// here would put the choice back inside the module the test target links,
+  /// which is what C2 exists to remove.
+  private let effects: any DesktopHotkeyEffects
 
-  /// - Parameter onDeniedDesktopEffect: what to do when the policy refuses a
-  ///   live effect. `nil` selects `DesktopEffectDenial.defaultHandler()`, which
-  ///   reads the trap variable: a test action sets it, so a test run aborts with
-  ///   a named reason, while a shipped app that somehow sees only the POLICY
-  ///   variable logs and continues rather than crashing. A test that legitimately
-  ///   drives registration injects `DesktopEffectDenial.recordOnly` here and
-  ///   asserts on `deniedDesktopEffects`; passing a handler that does nothing
-  ///   would restore the silent skip this exists to prevent.
-  public init(
+  /// `package`, not `public`: `DesktopHotkeyEffects` is `package`, and Swift will
+  /// not let a public initializer take a package type. That is the right
+  /// constraint rather than an obstacle — widening the protocol to `public` would
+  /// publish the desktop-effect seam outside this package for no caller, and every
+  /// construction site (AppKit's bootstrapper, the unit-test factory) is in-package
+  /// already.
+  package init(
+    effects: any DesktopHotkeyEffects,
     telemetry: HotkeyTelemetrySink = .noop,
-    now: @escaping @MainActor () -> Date = { Date() },
-    onDeniedDesktopEffect: (@MainActor (String) -> Void)? = nil
+    now: @escaping @MainActor () -> Date = { Date() }
   ) {
+    self.effects = effects
     self.telemetry = telemetry
     self.now = now
-    self.desktopEffectPolicy = DesktopEffectPolicy.fromEnvironment()
-    self.onDeniedDesktopEffect = onDeniedDesktopEffect ?? DesktopEffectDenial.defaultHandler()
   }
 
-  /// The single gate in front of every live INSTALLATION call C0 guards here.
+  /// The single release path for anything this service installed.
   ///
-  /// Exactly four: `RegisterEventHotKey`, `InstallEventHandler`, and both
-  /// `NSEvent.add*MonitorForEvents`. Each sits immediately behind a
-  /// `denyDesktopEffect` check, and their three release calls accept only a `.live`
-  /// payload.
-  ///
-  /// Deliberately OUTSIDE the gate: Carbon event DECODING — `GetEventKind` and
-  /// `GetEventParameter` in the handler below — which reads an event already
-  /// delivered and installs nothing. Also outside: desktop effects elsewhere in the
-  /// app; overlay is C4 and activation is C3.
-  ///
-  /// Returns `true` when the caller must NOT touch the framework. Recording
-  /// happens before the handler runs, so a trapping handler still leaves the
-  /// ledger populated for a crash report to carry.
-  private func denyDesktopEffect(_ operation: String) -> Bool {
-    guard desktopEffectPolicy == .deny else { return false }
-    deniedDesktopEffects.append(operation)
-    onDeniedDesktopEffect(operation)
-    return true
+  /// Keeps the token when the adapter reports a REFUSED release, so a later
+  /// teardown can retry. Clearing it regardless would strand the OS resource with
+  /// nothing left able to name it — the one outcome worse than releasing twice,
+  /// which the adapter already makes a no-op.
+  private func release(_ slot: inout DesktopEffectToken?) {
+    guard let token = slot, effects.remove(token) else { return }
+    slot = nil
   }
 
   /// Emit `hotkey.pressed` for an accepted keydown. Synchronous + cheap (computes
@@ -470,8 +440,8 @@ public final class HotkeyService {
     // cancel key opens the Quick Add panel while the recording keeps running.
     reconcileQuickAddRegistration()
     guard cancelBinding.isCarbonRegistrable else { return }
-    guard cancelHotkeyRef == nil else { return }
-    cancelHotkeyRef = registerHotkey(
+    guard cancelHotkeyToken == nil else { return }
+    cancelHotkeyToken = registerHotkey(
       id: HotkeyID.cancel.rawValue,
       keyCode: cancelKeyCode,
       modifiers: carbonModifiers(from: cancelModifiers)
@@ -489,7 +459,7 @@ public final class HotkeyService {
   public func unregisterCancelHotkey() {
     isCancelArmed = false
     cancelArmedBeforeSuspend = false
-    releaseHotkey(&cancelHotkeyRef)
+    release(&cancelHotkeyToken)
     // Cancel has released the chord, so Quick Add may have it back. Unconditional rather than
     // guarded on a collision: the reconciler decides, and asking the question here as well would be
     // the same rule written twice.
@@ -841,34 +811,22 @@ public final class HotkeyService {
   // MARK: - Carbon Event Handler
 
   private func installCarbonEventHandler() {
-    // #2455 C0. `.denied` rather than leaving the slot nil, so
-    // `removeCarbonEventHandler()` still clears an occupied slot and `stop()`
-    // remains symmetric with `start()`.
-    if denyDesktopEffect("InstallEventHandler(GetApplicationEventTarget())") {
-      eventHandlerRef = .denied
-      return
+    // The event-type list, the application target and the C trampoline moved into
+    // the adapter with the call that used them (#2455 C2). What stays here is the
+    // only part that was ever policy: WHEN to install.
+    //
+    // Occupancy guard, matching every other slot: installing over a live handler
+    // would orphan the first one, since the token naming it is about to be
+    // overwritten. NOT reachable by calling `start()` twice — that returns early on
+    // `isEnabled`. It is reachable when `stop()` KEEPS the token because the adapter
+    // refused to remove the handler, and a later `start()` runs; the guard preserves
+    // that retryable token instead of losing it.
+    guard eventHandlerToken == nil else { return }
+    // `[weak self]` because the adapter retains this callback for the life of the
+    // handler; a strong capture would be service -> adapter -> callback -> service.
+    eventHandlerToken = effects.installCarbonHandler { [weak self] event in
+      self?.handleCarbonHotkey(id: event.id, isRelease: event.isRelease)
     }
-    var eventTypes = [
-      EventTypeSpec(
-        eventClass: OSType(kEventClassKeyboard),
-        eventKind: UInt32(kEventHotKeyPressed)),
-      EventTypeSpec(
-        eventClass: OSType(kEventClassKeyboard),
-        eventKind: UInt32(kEventHotKeyReleased)),
-    ]
-
-    let selfPtr = Unmanaged.passUnretained(self).toOpaque()
-
-    var ref: EventHandlerRef?
-    InstallEventHandler(
-      GetApplicationEventTarget(),
-      carbonHotkeyHandler,
-      eventTypes.count,
-      &eventTypes,
-      selfPtr,
-      &ref
-    )
-    eventHandlerRef = ref.map(HandlerRegistration.live)
   }
 
   // MARK: - NSEvent Modifier Monitors
@@ -963,51 +921,31 @@ public final class HotkeyService {
 
     guard shouldInstallModifierMonitors else { return }
 
-    // #2455 C0. Both slots are marked together because one install decision
-    // creates both: a half-denied pair would be a state the production code can
-    // never produce. `recordMonitorInstall` is deliberately NOT consulted here —
-    // its `nil` branch reports a modifier-only shortcut that died on a real
-    // machine, and a policy refusal is not that.
-    if denyDesktopEffect("NSEvent.addGlobalMonitorForEvents(.flagsChanged) + addLocalMonitorForEvents")
-    {
-      globalModifierMonitor = .denied
-      localModifierMonitor = .denied
-      return
-    }
-
     // Read AFTER the teardown above, so both closures carry the identity of the
     // installation being created here rather than the one it replaced. Both
     // monitors are stamped with the same value on purpose: the generation
     // identifies the INSTALLATION, and these two closures are that installation.
     let generation = monitorGeneration
 
-    globalModifierMonitor = recordMonitorInstall(
-      NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) {
-        [weak self] event in
-        // Global monitor callbacks may arrive off the main thread.
-        // Extract event data here (NSEvent is not Sendable).
-        let keyCode = event.keyCode
-        let flags = event.modifierFlags
-        DispatchQueue.main.async {
-          guard let self else { return }
-          MainActor.assumeIsolated {
-            self.handleInstalledMonitorFlagsChangedValues(
-              keyCode: keyCode, flags: flags, generation: generation)
-          }
-        }
-      }, scope: "global"
-    ).map(MonitorRegistration.live)
+    // The off-main-thread hop, the `NSEvent` decoding and the local monitor's
+    // pass-through return all moved into the adapter with the calls that owned
+    // them (#2455 C2). What stays is policy: which installation a callback
+    // belongs to, and what a nil install means.
+    globalModifierMonitorToken = recordMonitorInstall(
+      effects.installGlobalModifierMonitor { [weak self] event in
+        self?.handleInstalledMonitorFlagsChangedValues(
+          keyCode: event.keyCode,
+          flags: NSEvent.ModifierFlags(rawValue: UInt(event.rawFlags)),
+          generation: generation)
+      }, scope: "global")
 
-    localModifierMonitor = recordMonitorInstall(
-      NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
-        [weak self] event in
-        MainActor.assumeIsolated {
-          self?.handleInstalledMonitorFlagsChangedValues(
-            keyCode: event.keyCode, flags: event.modifierFlags, generation: generation)
-        }
-        return event  // pass the event through
-      }, scope: "local"
-    ).map(MonitorRegistration.live)
+    localModifierMonitorToken = recordMonitorInstall(
+      effects.installLocalModifierMonitor { [weak self] event in
+        self?.handleInstalledMonitorFlagsChangedValues(
+          keyCode: event.keyCode,
+          flags: NSEvent.ModifierFlags(rawValue: UInt(event.rawFlags)),
+          generation: generation)
+      }, scope: "local")
   }
 
   /// #1175 (C2): the single chokepoint for an `NSEvent` modifier-monitor install.
@@ -1015,7 +953,10 @@ public final class HotkeyService {
   /// Returns the monitor unchanged so the call site assigns it as before.
   /// `internal` (not `private`) so the nil path is unit-testable without
   /// abstracting the whole `NSEvent` stack.
-  func recordMonitorInstall(_ monitor: Any?, scope: String) -> Any? {
+  /// #2455 C2: takes and returns a `DesktopEffectToken?` rather than a raw `Any?`
+  /// monitor. The telemetry contract is unchanged — a nil install still reports
+  /// the role at risk — but no `NSEvent` value reaches this module any more.
+  func recordMonitorInstall(_ monitor: DesktopEffectToken?, scope: String) -> DesktopEffectToken? {
     if monitor == nil {
       // Which ROLE dies if this monitor is missing. It used to hard-code
       // "toggle", which was true while the monitors only ever existed for a
@@ -1038,17 +979,9 @@ public final class HotkeyService {
     return monitor
   }
 
-  /// The single release path for an `NSEvent` monitor slot — the monitor twin of
-  /// `releaseHotkey`, and for the same reason: `NSEvent.removeMonitor` must never
-  /// be handed a token that no framework ever issued.
-  private func releaseMonitor(_ slot: inout MonitorRegistration?) {
-    if case .live(let token) = slot { NSEvent.removeMonitor(token) }
-    slot = nil
-  }
-
   private func removeModifierMonitors() {
-    releaseMonitor(&globalModifierMonitor)
-    releaseMonitor(&localModifierMonitor)
+    release(&globalModifierMonitorToken)
+    release(&localModifierMonitorToken)
     // Bump on EVERY teardown, including one that removed nothing. This is the
     // single writer of `monitorGeneration`, and it is the only NSEvent-monitor
     // teardown path: `stop()` and `suspend()` call it directly, and
@@ -1059,8 +992,7 @@ public final class HotkeyService {
   }
 
   private func removeCarbonEventHandler() {
-    if case .live(let ref) = eventHandlerRef { RemoveEventHandler(ref) }
-    eventHandlerRef = nil
+    release(&eventHandlerToken)
   }
 
   // MARK: - Registration Helpers
@@ -1073,7 +1005,7 @@ public final class HotkeyService {
     // of one question is how the record and cancel paths drifted apart in the
     // first place.
     guard recordBinding.isCarbonRegistrable else { return }
-    toggleHotkeyRef = registerHotkey(
+    toggleHotkeyToken = registerHotkey(
       id: HotkeyID.toggle.rawValue,
       keyCode: toggleKeyCode,
       modifiers: carbonModifiers(from: toggleModifiers)
@@ -1081,7 +1013,7 @@ public final class HotkeyService {
   }
 
   private func unregisterToggleHotkey() {
-    releaseHotkey(&toggleHotkeyRef)
+    release(&toggleHotkeyToken)
   }
 
   /// Register the Quick Add hotkey (#2381).
@@ -1130,8 +1062,8 @@ public final class HotkeyService {
   /// Pure mechanism, no policy: `reconcileQuickAddRegistration` above decides whether to call it.
   private func registerQuickAddHotkey() {
     guard quickAddBinding.isCarbonRegistrable else { return }
-    guard quickAddHotkeyRef == nil else { return }
-    quickAddHotkeyRef = registerHotkey(
+    guard quickAddHotkeyToken == nil else { return }
+    quickAddHotkeyToken = registerHotkey(
       id: HotkeyID.quickAdd.rawValue,
       keyCode: quickAddKeyCode,
       modifiers: carbonModifiers(from: quickAddModifiers)
@@ -1139,7 +1071,7 @@ public final class HotkeyService {
   }
 
   private func unregisterQuickAddHotkey() {
-    releaseHotkey(&quickAddHotkeyRef)
+    release(&quickAddHotkeyToken)
   }
 
   /// Re-apply the Quick Add binding after the user changes it.
@@ -1159,30 +1091,19 @@ public final class HotkeyService {
   }
 
   private func registerHotkey(id: UInt32, keyCode: UInt16, modifiers: UInt32)
-    -> HotkeyRegistration?
+    -> DesktopEffectToken?
   {
-    // #2455 C0. Placed ahead of the telemetry branch below on purpose: a refusal
-    // by policy is not a Carbon failure, so it must not emit
-    // `registrationFailed`. Emitting it would report a policy refusal as a Carbon
-    // registration failure, corrupting the one signal that tells us a real user's
-    // shortcut died.
-    if denyDesktopEffect("RegisterEventHotKey(id: \(id), keyCode: \(keyCode))") {
-      return .denied
-    }
-    let hotkeyID = EventHotKeyID(signature: hotkeySignature, id: id)
-    var ref: EventHotKeyRef?
-    let status = RegisterEventHotKey(
-      UInt32(keyCode),
-      modifiers,
-      hotkeyID,
-      GetApplicationEventTarget(),
-      0,
-      &ref
-    )
-    guard status == noErr else {
-      // #1175: the noErr-but-silent trap means success can't confirm delivery, so
-      // we only report FAILURE. This is the single Carbon chokepoint — every registration routes
-      // through here.
+    // The adapter reports; this module decides (#2455 C2). That split is
+    // deliberate: with both sides emitting, one Carbon refusal could produce two
+    // `registrationFailed` events or none, depending on which side thought the
+    // other had it — the #2381 defect class, one wire signal with two owners.
+    switch effects.registerHotkey(
+      id: id, keyCode: keyCode, rawModifiers: UInt64(modifiers))
+    {
+    case .registered(let token):
+      return token
+
+    case .refused(let status):
       // #2381: this was `id == cancel ? "cancel" : "toggle"`, which reported a quick-add
       // registration failure as a TOGGLE failure. It now resolves the id to a ROLE and asks the role
       // for its wire name, so the Carbon path and the monitor path below cannot disagree about what
@@ -1191,21 +1112,15 @@ public final class HotkeyService {
       let keyShape = ModifierKeyCodes.isModifierOnly(keyCode) ? "modifier_only" : "chord"
       telemetry.registrationFailed("carbon", kind, status, keyShape)
       return nil
-    }
-    // `noErr` with a nil ref is reachable — see the trap named above — and stays
-    // nil here exactly as it did before, so the caller's occupancy guards see an
-    // unregistered slot rather than a registration it cannot release.
-    return ref.map(HotkeyRegistration.live)
-  }
 
-  /// The single release path for a Carbon hotkey slot.
-  ///
-  /// A `.denied` slot is cleared without a framework call. Every unregister site
-  /// routes through here so no future one can reintroduce a raw
-  /// `UnregisterEventHotKey` on a slot that never held a real registration.
-  private func releaseHotkey(_ slot: inout HotkeyRegistration?) {
-    if case .live(let ref) = slot { UnregisterEventHotKey(ref) }
-    slot = nil
+    case .acceptedWithoutToken:
+      // #1175: the noErr-but-silent trap. Carbon accepted the registration and
+      // still produced no ref, so the shortcut is registered and delivers
+      // nothing. It is NOT a failure — emitting one would put a false alarm into
+      // the signal that says a real user's shortcut died — and the caller's
+      // occupancy guard sees nil and behaves exactly as it did before C2.
+      return nil
+    }
   }
 
   // MARK: - Event Dispatch
@@ -1413,57 +1328,4 @@ public final class HotkeyService {
     return recordingMode == .pushToTalk ? "Hold \(formatted)" : formatted
   }
 
-}
-
-// MARK: - Carbon Helpers
-
-/// Four-char-code signature for EnviousWispr hotkeys.
-private let hotkeySignature: OSType = {
-  var result: OSType = 0
-  for char in "EWSP".utf8.prefix(4) {
-    result = (result << 8) | OSType(char)
-  }
-  return result
-}()
-
-/// C-function callback for Carbon event handler.
-///
-/// Handles kEventHotKeyPressed/Released for key+modifier combos registered
-/// via RegisterEventHotKey. Modifier-only hotkeys are handled separately via
-/// NSEvent flagsChanged monitors, which work globally regardless of app focus.
-private func carbonHotkeyHandler(
-  _: EventHandlerCallRef?,
-  _ event: EventRef?,
-  _ userData: UnsafeMutableRawPointer?
-) -> OSStatus {
-  guard let event = event, let userData = userData else {
-    return OSStatus(eventNotHandledErr)
-  }
-
-  let service = Unmanaged<HotkeyService>.fromOpaque(userData).takeUnretainedValue()
-  let eventKind = GetEventKind(event)
-
-  // --- kEventHotKeyPressed / kEventHotKeyReleased ---
-  var hotkeyID = EventHotKeyID()
-  let status = GetEventParameter(
-    event,
-    UInt32(kEventParamDirectObject),
-    UInt32(typeEventHotKeyID),
-    nil,
-    MemoryLayout<EventHotKeyID>.size,
-    nil,
-    &hotkeyID
-  )
-  guard status == noErr else {
-    return OSStatus(eventNotHandledErr)
-  }
-
-  let isRelease = eventKind == UInt32(kEventHotKeyReleased)
-  let hotkeyIDValue = hotkeyID.id
-
-  MainActor.assumeIsolated {
-    service.handleCarbonHotkey(id: hotkeyIDValue, isRelease: isRelease)
-  }
-
-  return noErr
 }

--- a/Tests/EnviousWisprTests/App/AppLoggerLaunchSyncTests.swift
+++ b/Tests/EnviousWisprTests/App/AppLoggerLaunchSyncTests.swift
@@ -66,7 +66,7 @@ struct AppLoggerLaunchSyncTests {
       audioCapture: audioCapture, asrManager: asrManager, store: transcriptStore)
     let whisperKitKernelDriver = DictationRuntimeFixtures.makeWhisperKitPipeline(
       audioCapture: audioCapture, store: transcriptStore)
-    let hotkeyService = HotkeyService()
+    let hotkeyService = HotkeyService(effects: RecordingDesktopHotkeyEffects())
 
     let sync = PipelineSettingsSync(
       kernelDriver: pipeline,

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -40,7 +40,7 @@ import Testing
       audioCapture: audio, store: store)
     let settings = SettingsManager()
     let overlay = OverlayTestDouble.headlessDirector()
-    let hotkey = HotkeyService()
+    let hotkey = HotkeyService(effects: RecordingDesktopHotkeyEffects())
     let settingsSync = PipelineSettingsSync(
       kernelDriver: pipeline,
       whisperKitKernelDriver: whisperKitKernelDriver,

--- a/Tests/EnviousWisprTests/App/HotkeyControllerAbandonmentDisarmTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerAbandonmentDisarmTests.swift
@@ -104,7 +104,7 @@ struct HotkeyControllerAbandonmentDisarmTests {
       let settings = SettingsManager()
       let overlay = OverlayTestDouble.headlessDirector()
       let permissions = PermissionsService()
-      let hotkey = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+      let hotkey = HotkeyService(effects: RecordingDesktopHotkeyEffects())
       let lockBox = TestRecordingLockedBox()
       let lockAccess = DictationLifecycleCoordinator.RecordingLockedAccess(
         get: { lockBox.isLocked }, set: { lockBox.isLocked = $0 })

--- a/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
@@ -41,7 +41,7 @@ import Testing
     let settings = SettingsManager()
     let overlay = OverlayTestDouble.headlessDirector()
     let permissions = PermissionsService()
-    let hotkey = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    let hotkey = HotkeyService(effects: RecordingDesktopHotkeyEffects())
     let settingsSync = PipelineSettingsSync(
       kernelDriver: pipeline,
       whisperKitKernelDriver: whisperKitKernelDriver,

--- a/Tests/EnviousWisprTests/App/PipelineSettingsSyncOllamaEvictionTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineSettingsSyncOllamaEvictionTests.swift
@@ -67,7 +67,7 @@ struct PipelineSettingsSyncOllamaEvictionTests {
       whisperKitKernelDriver: whisperKit,
       audioCapture: audio,
       asrManager: asr,
-      hotkeyService: HotkeyService(),
+      hotkeyService: HotkeyService(effects: RecordingDesktopHotkeyEffects()),
       ollamaRemotenessLookup: { model in
         lookupCounter?()
         return PipelineSettingsSync.ollamaRemoteness(of: model, in: catalog)

--- a/Tests/EnviousWisprTests/Services/DesktopEffectPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Services/DesktopEffectPolicyTests.swift
@@ -2,24 +2,26 @@ import EnviousWisprServices
 import Foundation
 import Testing
 
-/// #2455 C0 (#2457) — the tripwire that stops the unit suite registering real
-/// hotkeys.
+/// #2455 C0 (#2457) — the environment tripwire, now reduced to its own contract.
 ///
-/// Scope is Carbon hotkey registration, the Carbon event handler, and the `NSEvent`
-/// modifier monitors. Overlay windows and app activation share the root cause and
-/// are NOT covered here; they are C3 (#2460) and C4 (#2461).
+/// **What is left here after C2, and what it does NOT cover.** C2 (#2459) moved
+/// every Carbon and `NSEvent` call into `EnviousWisprDesktopEffects` and deleted
+/// C0's denial machinery from `HotkeyService`. So these variables now guard
+/// nothing: no production path reads either one.
 ///
-/// The suite runs inside Apple's `xctest` agent with no `TEST_HOST`, and
-/// `AppWindowCoordinatorTests.swift:26` promotes that agent to a live GUI app, so
-/// WITHOUT this tripwire a `RegisterEventHotKey` call from a unit test takes the key
-/// SYSTEM-WIDE for as long as the run lasts. Escape is the shipped cancel binding,
-/// so the developer loses Escape in every other application while the tests run.
+/// They never guarded overlay or activation either — C0's tripwire only ever
+/// existed in `HotkeyService`. Those families are C3 (#2460) and C4 (#2461), and
+/// they are still live in this target with nothing in front of them.
 ///
-/// These cases assert the refusal itself. They are also the first coverage in
-/// this repo of whether a registration was ATTEMPTED at all: `registerCancelHotkey`
-/// sets `isCancelArmed` before it asks Carbon, so every existing test proves the
-/// intent to arm and none proves the chord was taken. That gap is what shipped
-/// #2381.
+/// Two cases here assert the switch's own PARSING contract; two assert that the
+/// residual scheme WIRING is still in place. No production path consumes either
+/// variable after C2 — the second pair exists so the wiring stays visible until
+/// C5 (#2462) removes the variables and these cases together. The enforcement that
+/// replaced them is `scripts/check-dependency-direction.sh`.
+///
+/// Registration-attempt coverage moved to the fake: `RecordingDesktopHotkeyEffects`
+/// captures every request, so "cancel took the chord and Quick Add yielded" is
+/// assertable there rather than inferred from a refusal here.
 @MainActor
 @Suite(.tags(.harnessContract)) struct DesktopEffectPolicyTests {
 
@@ -49,143 +51,32 @@ import Testing
     #expect(DesktopEffectPolicy.fromEnvironment([:]) == .allow)
   }
 
-  /// The negative control for the refusal cases below. If the test action ever
-  /// loses this variable those cases FAIL rather than pass — an empty ledger fails
-  /// a `contains` — but they fail three at a time with no shared cause on their
-  /// face, while the suite is once again stealing the developer's Escape key. This
-  /// case names that cause in one line, so the environment is asserted rather than
-  /// diagnosed. Its twin below covers severity, which CAN fail open.
-  @Test("this test run is itself denied — the scheme carries the variable")
+  /// No production path consumes this variable after C2. This assertion keeps the
+  /// disclosed C0 wiring VISIBLE until C5 (#2462) removes it — so the removal is
+  /// one deliberate change that also deletes this case, rather than a variable
+  /// quietly outliving its purpose in three schemes.
+  @Test("the residual C0 policy variable remains wired until C5")
   func thisRunIsDenied() {
     #expect(
       DesktopEffectPolicy.fromEnvironment() == .deny,
       """
-      \(DesktopEffectPolicy.environmentKey) is not set to "deny" for this run. \
-      The test action in Project.swift owns it; regenerate the project.
+      \(DesktopEffectPolicy.environmentKey) is no longer set for this run. Nothing \
+      consumes it after C2, so this is not a safety failure — it means the C0 debt \
+      was removed without removing this case. Delete both together (C5, #2462).
       """)
   }
 
-  /// The second half of the negative control. Denial and SEVERITY are separate
-  /// switches, so the suite can be denied and still fail open: without this
-  /// variable an unmigrated construction site logs and its test passes having
-  /// reached a prohibited effect. That is the Release-lane hole Codex found on
-  /// 2026-08-26, and it is why severity is not selected with `#if DEBUG`.
-  @Test("this test run traps on an unhandled refusal, in every configuration")
+  /// Same, for the severity half. No production path consumes this variable after
+  /// C2 either; the assertion keeps the disclosed C0 wiring visible until C5
+  /// (#2462) removes both together.
+  @Test("the residual C0 trap variable remains wired until C5")
   func thisRunTrapsUnhandledRefusals() {
     #expect(
       ProcessInfo.processInfo.environment[DesktopEffectDenial.trapEnvironmentKey] == "1",
       """
-      \(DesktopEffectDenial.trapEnvironmentKey) is not set for this run, so a test that \
-      reaches one of C0's guarded installation calls would pass instead of failing. The \
-      Project.swift owns it; regenerate the project.
+      \(DesktopEffectDenial.trapEnvironmentKey) is no longer set for this run. Nothing \
+      consumes it after C2, so this is not a safety failure — it means the C0 debt \
+      was removed without removing this case. Delete both together (C5, #2462).
       """)
   }
-
-  // MARK: - What the service does under denial
-
-  /// New coverage, not a restatement: this is the first assertion in the repo
-  /// that `start()` actually ASKS for the record chord. Nothing observable today
-  /// distinguishes "registered the chord" from "set a flag and skipped it".
-  @Test("start() asks for the record chord and the Carbon handler, and is refused")
-  func startAsksForItsEffectsAndIsRefused() {
-    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
-    service.toggleKeyCode = chordKeyCode
-
-    service.start()
-
-    #expect(service.deniedDesktopEffects.contains { $0.hasPrefix("InstallEventHandler") })
-    #expect(
-      service.deniedDesktopEffects.contains {
-        $0.hasPrefix("RegisterEventHotKey(id: 1")
-      },
-      "the record chord must be requested; refused is fine, unasked is the bug")
-
-    service.stop()
-  }
-
-  /// A chord takes the Carbon path and installs no monitors, so the case above
-  /// cannot reach the `NSEvent` refusal at all. A bare-modifier record key is the
-  /// shape that does — `shouldInstallModifierMonitors` is true only when some
-  /// role is bound to a bare modifier.
-  @Test("a bare-modifier record key asks for the flags-changed monitors, and is refused")
-  func bareModifierRecordKeyAsksForMonitorsAndIsRefused() {
-    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
-    service.toggleKeyCode = ModifierKeyCodes.rightOption
-
-    service.start()
-
-    #expect(service.shouldInstallModifierMonitors, "precondition: this shape needs monitors")
-    #expect(
-      service.deniedDesktopEffects.contains { $0.hasPrefix("NSEvent.addGlobalMonitor") })
-    // A bare modifier cannot be a Carbon registration, so the record role must
-    // NOT have asked for one — the #1991 shape, asserted from the refusal ledger.
-    #expect(
-      service.deniedDesktopEffects.contains { $0.hasPrefix("RegisterEventHotKey(id: 1") } == false)
-
-    service.stop()
-  }
-
-  /// The teardown half. A refused registration still occupies its slot, so
-  /// `stop()` must clear it — and must not hand the framework a token no
-  /// framework ever issued. A forged `EventHotKeyRef` here would be a wild-pointer
-  /// call, which is why the refusal is a typed case rather than a synthetic
-  /// pointer.
-  @Test("stop() releases refused registrations without calling the framework")
-  func stopReleasesRefusedRegistrations() {
-    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
-    service.toggleKeyCode = chordKeyCode
-    service.start()
-    service.registerCancelHotkey()
-
-    service.stop()
-
-    #expect(service.isEnabled == false)
-    // Reaching here at all is the assertion: releasing a refused slot must not
-    // reach `UnregisterEventHotKey` or `RemoveEventHandler`.
-    #expect(service.deniedDesktopEffects.isEmpty == false)
-  }
-
-  /// `suspend()`/`resume()` re-registers, so it must be refused each time rather
-  /// than slipping through on the second pass.
-  @Test("a resumed service is refused again rather than registering")
-  func resumeIsRefusedAgain() {
-    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
-    service.toggleKeyCode = chordKeyCode
-    service.start()
-    let afterStart = service.deniedDesktopEffects.count
-
-    service.suspend()
-    service.resume()
-
-    #expect(service.deniedDesktopEffects.count > afterStart)
-    service.stop()
-  }
-
-  /// A policy refusal is not a Carbon failure. Emitting `registrationFailed` for
-  /// it would report a policy refusal as a Carbon registration failure, corrupting
-  /// the one signal that tells us a real user's shortcut died.
-  @Test("a refusal emits no registration-failure telemetry")
-  func refusalEmitsNoRegistrationFailure() {
-    final class Spy: @unchecked Sendable {
-      var failures: [(String, String)] = []
-    }
-    let spy = Spy()
-    let sink = HotkeyTelemetrySink(
-      registrationFailed: { mechanism, kind, _, _ in
-        spy.failures.append((mechanism, kind))
-      },
-      pressed: { _, _, _, _, _ in })
-
-    let service = HotkeyService(
-      telemetry: sink, onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
-    service.toggleKeyCode = chordKeyCode
-    service.start()
-
-    #expect(spy.failures.isEmpty)
-    service.stop()
-  }
-
-  /// `kVK_ANSI_D` — a plain chord, so the record key takes the Carbon path rather
-  /// than the modifier-monitor path.
-  private let chordKeyCode: UInt16 = 2
 }

--- a/Tests/EnviousWisprTests/Services/HotkeyCancelShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyCancelShortcutTests.swift
@@ -97,7 +97,7 @@ import Testing
     let sink = Sink()
     let cancelWaiter = Waiter()
     let toggleWaiter = Waiter()
-    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    let service = HotkeyService(effects: RecordingDesktopHotkeyEffects())
     service.recordingMode = mode
     service.toggleKeyCode = recordKey
     service.toggleModifiers = []
@@ -413,7 +413,7 @@ import Testing
   @Test("a cancel modifier required by the record chord does not cancel")
   func cancelModifierShadowedByRecordChordIsRefused() async {
     let sink = Sink()
-    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    let service = HotkeyService(effects: RecordingDesktopHotkeyEffects())
     service.recordingMode = .toggle
     service.toggleKeyCode = chordKeyCode  // D
     service.toggleModifiers = [.command]  // record is ⌘D
@@ -435,7 +435,7 @@ import Testing
   func cancelModifierUnrelatedToRecordChordStillWorks() async {
     let sink = Sink()
     let waiter = Waiter()
-    let service = HotkeyService(onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+    let service = HotkeyService(effects: RecordingDesktopHotkeyEffects())
     service.recordingMode = .toggle
     service.toggleKeyCode = chordKeyCode
     service.toggleModifiers = [.command]  // record is ⌘D

--- a/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyGlobeKeyTests.swift
@@ -114,8 +114,7 @@ import Testing
     _ spy: Spy, clock: ManualClock, mode: RecordingMode = .pushToTalk
   ) -> HotkeyService {
     let service = HotkeyService(
-      telemetry: spy.sink, now: { clock.now },
-      onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+      effects: RecordingDesktopHotkeyEffects(), telemetry: spy.sink, now: { clock.now })
     service.recordingMode = mode
     service.toggleKeyCode = ModifierKeyCodes.globe
     service.onStartRecording = { [weak spy] in

--- a/Tests/EnviousWisprTests/Services/HotkeyHandsFreeLockGateTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyHandsFreeLockGateTests.swift
@@ -136,7 +136,8 @@ import EnviousWisprServices
   private func makeService(
     _ spy: Spy, driver: StartDriver? = nil, clock: ManualClock
   ) -> HotkeyService {
-    let service = HotkeyService(telemetry: spy.sink, now: { clock.now })
+    let service = HotkeyService(
+      effects: RecordingDesktopHotkeyEffects(), telemetry: spy.sink, now: { clock.now })
     service.onStartResolvedForTesting = { driver?.noteServiceResolved() }
     service.recordingMode = .pushToTalk
     // keyCode 0 ('A') is a chord key, so no NSEvent monitor is involved.

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -87,12 +87,12 @@ struct HotkeyQuickAddShortcutTests {
     let cancelWaiter = Waiter()
     let toggleWaiter = Waiter()
     let service = HotkeyService(
+      effects: RecordingDesktopHotkeyEffects(),
       telemetry: HotkeyTelemetrySink(
         registrationFailed: { _, _, _, _ in },
         pressed: { trigger, _, keyShape, _, action in
           sink.presses.append((trigger, keyShape, action))
-        }),
-      onDeniedDesktopEffect: DesktopEffectDenial.recordOnly)
+        }))
     service.recordingMode = .toggle
     service.toggleKeyCode = recordKey
     service.toggleModifiers = recordModifiers

--- a/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyTelemetryTests.swift
@@ -61,7 +61,7 @@ import Testing
   private func makeService(
     _ spy: Spy, mode: RecordingMode, modifierOnly: Bool = false
   ) -> HotkeyService {
-    let service = HotkeyService(telemetry: spy.sink)
+    let service = HotkeyService(effects: RecordingDesktopHotkeyEffects(), telemetry: spy.sink)
     service.recordingMode = mode
     // keyCode 0 ('A') is a chord key; right Option (61) is modifier-only.
     service.toggleKeyCode = modifierOnly ? ModifierKeyCodes.rightOption : 0
@@ -189,10 +189,14 @@ import Testing
   func monitorOkReportsNothing() {
     let spy = Spy()
     let service = makeService(spy, mode: .toggle, modifierOnly: true)
-    let token = NSObject()
+    // #2455 C2: an opaque `DesktopEffectToken` rather than a raw `NSObject`
+    // monitor. The chokepoint's contract is unchanged — report a nil install,
+    // pass anything else through untouched — but no `NSEvent` value reaches this
+    // module any more.
+    let token = DesktopEffectToken()
     let returned = service.recordMonitorInstall(token, scope: "local")
     #expect(spy.registrations.isEmpty)
-    #expect((returned as? NSObject) === token)
+    #expect(returned == token)
   }
 
   @Test("default .noop sink stays inert — press still processed, nothing emitted")
@@ -201,7 +205,7 @@ import Testing
     // so the existing `HotkeyService()` construction sites are behaviorally
     // unchanged. The press still flows through the state machine (isModifierHeld
     // flips) but the no-op closures swallow every emit.
-    let service = HotkeyService()  // `.noop` default
+    let service = HotkeyService(effects: RecordingDesktopHotkeyEffects())  // `.noop` default
     service.recordingMode = .pushToTalk
     service.toggleKeyCode = 0
     service.handleCarbonHotkey(id: toggleID, isRelease: false)

--- a/Tests/EnviousWisprTests/Support/RecordingDesktopHotkeyEffects.swift
+++ b/Tests/EnviousWisprTests/Support/RecordingDesktopHotkeyEffects.swift
@@ -1,0 +1,120 @@
+import EnviousWisprServices
+import Foundation
+
+/// The unit suite's stand-in for the OS (#2455 C2, issue #2459).
+///
+/// **Why this lives in the test target and not beside the live adapter.**
+/// `EnviousWisprTests` declares no dependency on `EnviousWisprDesktopEffects`, and
+/// `scripts/check-dependency-direction.sh` rejects importing it. A fake shipped
+/// from that module would require adding it to the allowlist, which would hand
+/// every test the live type back through the same door.
+///
+/// **It records rather than merely absorbing.** Before C2 nothing could prove a
+/// registration was ATTEMPTED: `registerCancelHotkey` sets `isCancelArmed` before
+/// it asks Carbon, so a test could only see the intent to arm. That gap is what
+/// shipped #2381, where cancel and Quick Add fought over one chord and the
+/// telemetry named the wrong role. Every call is captured here, so "cancel took
+/// the chord and Quick Add yielded" is finally assertable.
+@MainActor
+final class RecordingDesktopHotkeyEffects: DesktopHotkeyEffects {
+
+  /// A registration request, in the order it was made.
+  struct Request: Equatable {
+    let id: UInt32
+    let keyCode: UInt16
+    let rawModifiers: UInt64
+  }
+
+  private(set) var registrations: [Request] = []
+  private(set) var removed: [DesktopEffectToken] = []
+  private(set) var carbonHandlerInstalls = 0
+  private(set) var globalMonitorInstalls = 0
+  private(set) var localMonitorInstalls = 0
+
+  /// Callbacks the service handed over, so a test can drive an event as the OS
+  /// would rather than calling the service's internals.
+  private(set) var carbonCallback: (@MainActor (DesktopHotkeyEvent) -> Void)?
+  private(set) var globalMonitorCallback: (@MainActor (DesktopModifierEvent) -> Void)?
+  private(set) var localMonitorCallback: (@MainActor (DesktopModifierEvent) -> Void)?
+
+  /// Queued results for the next registrations, oldest first. Empty means
+  /// "accept everything", which is what almost every existing suite wants.
+  ///
+  /// Programmable because Carbon's real duplicate-chord refusal cannot be
+  /// reproduced here — and must not be faked as authority. A test that wants the
+  /// refused path queues `.refused(status:)` and asserts the SERVICE's reaction;
+  /// whether Carbon would actually refuse that chord is proven only by live UAT.
+  var nextResults: [HotkeyRegistration] = []
+
+  /// Make an install return nil, for the paths where the real frameworks can:
+  /// `InstallEventHandler` failing, and a monitor install returning nothing.
+  var failMonitorInstalls = false
+  var failCarbonHandlerInstall = false
+
+  // MARK: - DesktopHotkeyEffects
+
+  func installCarbonHandler(
+    _ callback: @escaping @MainActor (DesktopHotkeyEvent) -> Void
+  ) -> DesktopEffectToken? {
+    carbonHandlerInstalls += 1
+    carbonCallback = callback
+    return failCarbonHandlerInstall ? nil : DesktopEffectToken()
+  }
+
+  func registerHotkey(id: UInt32, keyCode: UInt16, rawModifiers: UInt64) -> HotkeyRegistration {
+    registrations.append(Request(id: id, keyCode: keyCode, rawModifiers: rawModifiers))
+    if nextResults.isEmpty { return .registered(DesktopEffectToken()) }
+    return nextResults.removeFirst()
+  }
+
+  func installGlobalModifierMonitor(
+    _ callback: @escaping @MainActor (DesktopModifierEvent) -> Void
+  ) -> DesktopEffectToken? {
+    globalMonitorInstalls += 1
+    globalMonitorCallback = callback
+    return failMonitorInstalls ? nil : DesktopEffectToken()
+  }
+
+  func installLocalModifierMonitor(
+    _ callback: @escaping @MainActor (DesktopModifierEvent) -> Void
+  ) -> DesktopEffectToken? {
+    localMonitorInstalls += 1
+    localMonitorCallback = callback
+    return failMonitorInstalls ? nil : DesktopEffectToken()
+  }
+
+  @discardableResult
+  func remove(_ token: DesktopEffectToken) -> Bool {
+    removed.append(token)
+    // Always succeeds. A fake that refused would exercise the retry path, which
+    // no current test asks for; add a programmable flag when one does, rather
+    // than making every suite reason about a failure the OS rarely produces.
+    return true
+  }
+
+  // MARK: - Assertions helpers
+
+  /// Whether a registration was requested for this role's id.
+  func didRegister(id: UInt32) -> Bool {
+    registrations.contains { $0.id == id }
+  }
+}
+
+/// Optional convenience for callers that need BOTH the service and its fake.
+///
+/// Most suites construct `HotkeyService(effects: RecordingDesktopHotkeyEffects())`
+/// directly and never touch this. It exists for the cases that assert on what the
+/// fake recorded.
+///
+/// #2146's three-layer pattern: the product initializer's `effects` parameter is
+/// required and non-defaulted, and any DEFAULT lives here, in the test target. A
+/// default on the product initializer would have put the choice back inside the
+/// module the test target links.
+@MainActor
+func makeHotkeyService(
+  effects: RecordingDesktopHotkeyEffects = RecordingDesktopHotkeyEffects(),
+  telemetry: HotkeyTelemetrySink = .noop,
+  now: @escaping @MainActor () -> Date = { Date() }
+) -> (service: HotkeyService, effects: RecordingDesktopHotkeyEffects) {
+  (HotkeyService(effects: effects, telemetry: telemetry, now: now), effects)
+}

--- a/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
@@ -90,7 +90,7 @@ struct KeybindRowDefaultsTests {
     // failure anywhere, because no case built a service. A hard-coded fallback is invisible in every
     // other assertion here — it shows up only as a fresh service holding a stale binding until
     // `HotkeyController` pushes settings over it.
-    let service = HotkeyService()
+    let service = HotkeyService(effects: RecordingDesktopHotkeyEffects())
 
     #expect(service.recordBinding == ShortcutRole.record.defaultBinding)
     #expect(service.cancelBinding == ShortcutRole.cancel.defaultBinding)

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -6,12 +6,13 @@
 # Edit `permitted_imports_for` below when Package.swift changes (and update the
 # Bible if the new edge represents an architectural decision):
 #   EnviousWispr           -> AppLive (thin launchable shell; #919/#2455 C1). Imports ONLY AppLive.
-#   EnviousWisprAppLive    -> AppKit, Services (production composition root; #2455 C1). The unit-test
-#                             target does not link this, and WisprBootstrapper.init has no default, so
-#                             there is no implicit production assembly path. NOT yet unlinkability:
-#                             tests still link Services and can build a live HotkeyService themselves.
-#                             The Services edge is TEMPORARY — C2 (#2459) replaces it with
-#                             EnviousWisprDesktopEffects, which is the chunk that earns the word.
+#   EnviousWisprAppLive    -> AppKit, DesktopEffects (production composition root; #2455 C1/C2).
+#   EnviousWisprDesktopEffects -> AppKit, Services (#2455 C2). The ONLY module holding Carbon and
+#                             NSEvent calls. Neither test target declares it — but that alone does
+#                             NOT stop a test importing it (see the Tests/ loop below for why), so
+#                             this script is the enforcement. Adding either test target to that
+#                             loop's allowlist would silently reopen the hole this epic exists to
+#                             close.
 #   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline, Contacts (app-shell library; #919, top of stack)
 #   EnviousWisprASRService -> Core, ASR, Audio, ObservabilityCore (XPC executable; the audio capture XPC service was removed at #1543)
 #   EnviousWisprPipeline   -> Core, ASR, Audio, LLM, PostProcessing, Services, Storage
@@ -66,7 +67,8 @@ permitted_imports_for() {
     EnviousWisprPipeline)          echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprLLM EnviousWisprModelDelivery EnviousWisprPostProcessing EnviousWisprServices EnviousWisprStorage" ;;
     EnviousWisprASRService)        echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprObservabilityCore" ;;
     EnviousWisprAppKit)            echo "EnviousWisprCore EnviousWisprStorage EnviousWisprPostProcessing EnviousWisprAudio EnviousWisprServices EnviousWisprASR EnviousWisprLLM EnviousWisprModelDelivery EnviousWisprPipeline EnviousWisprContacts EnviousWisprLivePreview EnviousWisprWhisperPreviewAdapter" ;;
-    EnviousWisprAppLive)           echo "EnviousWisprAppKit EnviousWisprServices" ;;
+    EnviousWisprDesktopEffects)    echo "EnviousWisprAppKit EnviousWisprServices" ;;
+    EnviousWisprAppLive)           echo "EnviousWisprAppKit EnviousWisprDesktopEffects" ;;
     EnviousWispr)                  echo "EnviousWisprAppLive" ;;
     *)                             return 1 ;;
   esac
@@ -124,6 +126,99 @@ for module_dir in Sources/*/; do
     esac
   done < <(grep -rEn "$import_grep_pattern" "$module_dir" || true)
 done
+
+# #2455 C2: the TEST targets, scanned for the same reason but by name rather than
+# by directory.
+#
+# **This exists because the module graph does NOT enforce itself under Xcode.**
+# Measured 2026-08-26 on this repo: a file in `Tests/EnviousWisprTests/` that
+# `import EnviousWisprDesktopEffects` and constructed `LiveDesktopHotkeyEffects()`
+# COMPILED AND LINKED, with no dependency edge declared anywhere. Xcode puts every
+# built product in one search path, so a declared edge orders the link — it does
+# not gate module visibility. SwiftPM would reject it, but CI runs Tuist and
+# xcodebuild only (`pr-check.yml`, `main-post-merge.yml`); no `swift build` ever
+# runs. So "the missing dependency IS the wall" was false, and this loop is the
+# wall instead.
+#
+# Keep the lists exhaustive: a test target absent from here is unchecked, which
+# looks exactly like a test target that passes.
+# The hotkey OS calls, wherever they appear.
+#
+# No trailing `(` on the Carbon names ON PURPOSE: `let register = RegisterEventHotKey`
+# takes a function reference and calls it later, which a call-shaped pattern would
+# miss entirely. Matching the bare name deliberately permits conservative false
+# positives from multiline block comments and string literals — the stripper below
+# removes a `//` or `/*` and its tail on ONE line, not the continuation lines of a
+# block comment. A false positive is a sentence to rewrite; a false negative is a
+# suite back on the developer's real desktop.
+live_effect_pattern='RegisterEventHotKey|InstallEventHandler|NSEvent[.]add(Global|Local)MonitorForEvents'
+
+test_targets_and_permitted() {
+  case "$1" in
+    # Everything the unit suite legitimately links. EnviousWisprDesktopEffects and
+    # EnviousWisprAppLive are ABSENT on purpose — that absence is the point.
+    EnviousWisprTests) echo "EnviousWisprCore EnviousWisprObservabilityCore EnviousWisprModelDelivery EnviousWisprPostProcessing EnviousWisprLLM EnviousWisprPipeline EnviousWisprStorage EnviousWisprAudio EnviousWisprLivePreview EnviousWisprWhisperPreviewAdapter EnviousWisprFluidAudioBridge EnviousWisprAppKit EnviousWisprContacts EnviousWisprServices EnviousWisprASR" ;;
+    EnviousWisprASRTests) echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprFluidAudioBridge EnviousWisprServices" ;;
+    *) return 1 ;;
+  esac
+}
+
+for test_dir in Tests/*/; do
+  target=$(basename "$test_dir")
+  # Non-target directories under Tests/ (RuntimeUAT scripts, fixtures) are not
+  # Swift targets and carry no import contract.
+  if ! permitted=$(test_targets_and_permitted "$target"); then
+    # A directory with no Swift in it (RuntimeUAT scripts, fixtures) carries no
+    # import contract. A directory WITH Swift that nobody listed is an unchecked
+    # test target, which looks exactly like a passing one — so it fails loudly.
+    first_swift=$(find "$test_dir" -type f -name '*.swift' -print -quit)
+    if [ -n "$first_swift" ]; then
+      echo "DEP-DIRECTION: unknown Swift test target '$target' — add it to test_targets_and_permitted() or remove it" >&2
+      violations=$((violations + 1))
+    fi
+    continue
+  fi
+  modules_scanned=$((modules_scanned + 1))
+  while IFS= read -r line; do
+    file=$(echo "$line" | cut -d: -f1)
+    code=$(echo "$line" | cut -d: -f3- | sed -E 's|//.*$||; s|/\*.*$||')
+    imp=$(echo "$code" | sed -E "s/^.*import[[:space:]]+(${import_kinds}[[:space:]]+)?(EnviousWispr[A-Za-z_]*).*/\\3/")
+    case "$imp" in
+      EnviousWispr*)
+        if ! echo " $permitted " | grep -q " $imp "; then
+          echo "DEP-DIRECTION: $file: test target '$target' imports '$imp' (not in allowed: $permitted)"
+          violations=$((violations + 1))
+        fi
+        ;;
+    esac
+  done < <(grep -rEn "$import_grep_pattern" "$test_dir" || true)
+done
+
+# OWNERSHIP: the hotkey OS calls may appear in EnviousWisprDesktopEffects and
+# nowhere else, in Sources OR Tests.
+#
+# Import discipline is necessary and NOT sufficient. `RegisterEventHotKey` comes
+# from Carbon and `NSEvent` from AppKit — Apple frameworks any file may import, and
+# 36 test files already do. So a test can reach the real desktop by writing the
+# call itself, never naming EnviousWisprDesktopEffects. Scanning Sources too catches
+# the other direction: a convenience wrapper added to Services would put the call
+# back inside the module the test target links, reopening the hole through a door
+# marked "helper". Found by Codex chunk review 2026-08-26.
+#
+# `--include='*.swift'` because `Tests/RuntimeUAT/*.py` DRIVES the real desktop on
+# purpose — that is what Live UAT is. Those scripts are the sanctioned way to reach
+# the OS; this rule governs compiled code, which is not.
+while IFS= read -r line; do
+  file=$(echo "$line" | cut -d: -f1)
+  case "$file" in
+    Sources/EnviousWisprDesktopEffects/*) continue ;;
+  esac
+  code=$(echo "$line" | cut -d: -f3- | sed -E 's|//.*$||; s|/\*.*$||')
+  if echo "$code" | grep -Eq "$live_effect_pattern"; then
+    echo "DEP-DIRECTION: $file: hotkey OS call outside Sources/EnviousWisprDesktopEffects/"
+    violations=$((violations + 1))
+  fi
+done < <(grep -rEn --include='*.swift' "$live_effect_pattern" Sources Tests || true)
 
 if [ "$violations" -gt 0 ]; then
   echo "FAIL: $violations dep-direction violation(s)" >&2


### PR DESCRIPTION
Closes #2459. Chunk C2 of #2455. Follows #2464 (C0) and #2468 (C1).

**Lane:** Code · **Tier:** REFACTOR (chunk C2 of 6) · **Live UAT:** deferred to C5's executable scenario — see Validation

## Problem

Every Carbon and `NSEvent` call the app makes lived in `EnviousWisprServices`, which `EnviousWisprTests` links. Constructing a `HotkeyService` in a unit test was enough to reach the real desktop — which is how a running suite took the developer's Escape key system-wide.

## What this does

`DesktopHotkeyEffects` is the framework-pure contract — no `EventHotKeyRef`, `EventHandlerRef`, `OSStatus` or `NSEvent` crosses it. `LiveDesktopHotkeyEffects`, in the new `EnviousWisprDesktopEffects`, owns every call. `HotkeyService.init` takes the effects dependency, **required and non-defaulted**; AppLive supplies the live one, tests supply a recording fake.

**The Carbon callback box.** The user-data pointer now addresses an adapter-owned box, retained on install and released only after `RemoveEventHandler` succeeds. Before C2 it was an unretained `HotkeyService` resolved on every OS callback — correct only while the service outlived the handler, which nothing enforced.

**Failed releases are retryable.** `remove(_:)` returns whether the framework accepted the release. A refusal keeps both the adapter's mapping and the service's token, so a later teardown retries rather than stranding a resource nothing can name.

**The adapter reports, the service decides.** Exactly one `registrationFailed` per refusal, none for the reachable `noErr`-with-nil-ref case. Splitting that would give one wire signal two owners — the #2381 defect class.

## ⚠️ A premise of the approved plan is false

Plan §2.5.2 held that the missing dependency **is** the wall, failing with "no such module", and §13's ship criterion depended on it.

**Measured on this branch:** a file in `Tests/EnviousWisprTests/` importing the new module and constructing the live type **compiles and links**, with no dependency edge declared anywhere. Xcode shares one build-products search path, so a declared edge orders the *link* and does not gate imports. SwiftPM enforces it — CI runs Tuist and xcodebuild only.

Full evidence: #2455 comment `5433642128`. C5's criterion corrected on #2462.

## What actually enforces it

`check-dependency-direction.sh` now enforces **ownership**, not imports: the hotkey OS calls may appear in `Sources/EnviousWisprDesktopEffects/` and nowhere else, in Sources *or* Tests.

Import discipline alone was insufficient — `RegisterEventHotKey` is Carbon's and `NSEvent` is AppKit's, and 36 test files already import those, so a test could write the call itself and pass. The ownership rule also catches the alias form (`let register = RegisterEventHotKey`) and a wrapper added to a module tests *do* link.

Three rules, each mutation-checked — violation introduced, gate observed to reject it by name and exit 1, violation removed, gate observed to pass:

| Rule | Proven by |
|---|---|
| Test target may not import the module | `WallProbe.swift` |
| No hotkey OS call outside the owning module | `AliasProbe.swift` (test) + `WrapperProbe.swift` (Services) |
| Unlisted Swift test target fails loudly | `EnviousWisprUnlistedTests/` |

Scoped to `*.swift`: `Tests/RuntimeUAT/*.py` drives the real desktop on purpose.

## C0 debt

C0's denial machinery is deleted from `HotkeyService`; its four ledger tests went with the ledger. **The two environment variables now guard nothing** — C0's tripwire only ever existed in `HotkeyService` and never covered overlay or activation. The two surviving cases are renamed to say they hold residual C0 wiring visible until C5 removes it.

## Validation

| Check | Result |
|---|---|
| Debug lane | PASS — 7,121 test cases, zero failures |
| `check-dependency-direction.sh` | OK, 21 modules; all three rules mutation-checked |
| Codex chunk gate | **CHUNK-CLEAN** on a confirming re-run |

Codex rounds: design → `PROCEED` → `CHUNK-REVISIONS (5)` → `(4)` → `(3)` → `(1)` → **`CHUNK-CLEAN`**.

One round caught me reporting a fix as applied when it was not — the memory-lifetime guard. It surfaced only because the reviewer re-read the source instead of trusting the summary. Every subsequent fix was verified by grep before being claimed.

## Note for other worktrees

`HotkeyService(...)` now requires `effects:`. Tests use `RecordingDesktopHotkeyEffects()`. `WisprBootstrapper` takes `makeHotkeyEffects:` rather than `makeHotkeyService:`.
