### PR TITLE
C3: move activation and panel presentation out of AppKit (#2460)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -77,7 +77,12 @@ final class AppLifecycleCoordinator {
   /// dependency.
   private let batchDecodeFaultController: BatchDecodeFaultController?
 
+  /// #2455 C3: required and non-defaulted. The one call this type makes moves the
+  /// app to accessory at launch, which a unit test must never do to the real app.
+  private let application: any ApplicationActivating
+
   init(
+    application: any ApplicationActivating,
     settings: SettingsManager,
     permissions: PermissionsService,
     keychainManager: KeychainManager,
@@ -102,6 +107,7 @@ final class AppLifecycleCoordinator {
     onboardingProgress: OnboardingProgress,
     batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
+    self.application = application
     self.settings = settings
     self.permissions = permissions
     self.keychainManager = keychainManager
@@ -146,7 +152,7 @@ final class AppLifecycleCoordinator {
     // hierarchy and ActionWirer can wire callbacks before opening the
     // onboarding window.
     if settings.onboardingState == .completed {
-      NSApp.setActivationPolicy(.accessory)
+      application.setPolicy(.accessory)
     }
 
     // #1451: recover from App Translocation. Runs on EVERY launch (NOT gated by

--- a/Sources/EnviousWisprAppKit/App/AppWindowCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppWindowCoordinator.swift
@@ -48,10 +48,18 @@ final class AppWindowCoordinator {
   /// `openOnboardingAction` is wired; drained by `consumePendingOpenOnboarding()`.
   private var pendingOpenOnboarding: Bool = false
 
+  /// #2455 C3: required and non-defaulted. Every activation and Dock-policy call
+  /// this type makes goes through it, so a default would let a unit test move the
+  /// real app between accessory and regular — the pill-flash half of the symptom
+  /// this epic exists to remove.
+  private let application: any ApplicationActivating
+
   init(
+    application: any ApplicationActivating,
     canOpenOnboarding: @escaping @MainActor () -> Bool,
     isOnboardingComplete: @escaping @MainActor () -> Bool
   ) {
+    self.application = application
     self.canOpenOnboarding = canOpenOnboarding
     self.isOnboardingComplete = isOnboardingComplete
   }
@@ -82,7 +90,7 @@ final class AppWindowCoordinator {
         }
         // Match by identity so status-bar/panel windows never trigger the reset.
         guard window === self.mainWindow else { return }
-        NSApp.setActivationPolicy(.accessory)
+        self.application.setPolicy(.accessory)
       }
     }
   }
@@ -169,8 +177,8 @@ final class AppWindowCoordinator {
         break
       }
     }
-    NSApp.setActivationPolicy(.regular)
-    NSApp.activate(ignoringOtherApps: true)
+    application.setPolicy(.regular)
+    application.activate(.ignoringOtherApps)
   }
 
   /// Open the onboarding window and begin monitoring for early close (abort flow).
@@ -185,8 +193,8 @@ final class AppWindowCoordinator {
       return
     }
     openOnboardingAction?()
-    NSApp.setActivationPolicy(.regular)
-    NSApp.activate(ignoringOtherApps: true)
+    application.setPolicy(.regular)
+    application.activate(.ignoringOtherApps)
     // Hide the main window so only the onboarding window is visible during setup.
     if let mainWin = self.mainWindow {
       mainWin.orderOut(nil)
@@ -242,7 +250,7 @@ final class AppWindowCoordinator {
   /// dismisses the window.
   func closeOnboardingWindow() {
     dismissOnboardingAction?()
-    NSApp.setActivationPolicy(.accessory)
+    application.setPolicy(.accessory)
     onOnboardingDismissed?()
   }
 

--- a/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
+++ b/Sources/EnviousWisprAppKit/App/ApplicationRelocationCoordinator+Live.swift
@@ -90,12 +90,26 @@ private struct RelocationCard<Actions: View>: View {
 public final class CenteredRelocationPresenter: RelocationPresenting {
   private var progressPanel: NSPanel?
 
+  /// #2455 C3. An extension cannot store state, so the seams are carried by this
+  /// type — the one that actually makes the calls — and threaded through the
+  /// `live()` factory below.
+  ///
+  /// `panels` covers three `makeKeyAndOrderFront` calls the chunk plan's population
+  /// did not list; they were found by grepping AppKit after the listed sites were
+  /// done. Routing them too is what lets the ownership rule stay a flat "not in
+  /// AppKit" with no carve-out — and a carve-out is a hole that widens.
+  private let application: any ApplicationActivating
+  private let panels: any PanelPresenting
+
+  package init(application: any ApplicationActivating, panels: any PanelPresenting) {
+    self.application = application
+    self.panels = panels
+  }
+
   /// Brand accent (#7c3aed) — the primary action's fill.
   private static let accent = Color(red: 124.0 / 255, green: 58.0 / 255, blue: 237.0 / 255)
   private static let moveResponse = NSApplication.ModalResponse(rawValue: 1001)
   private static let notNowResponse = NSApplication.ModalResponse(rawValue: 1002)
-
-  public init() {}
 
   /// Builds a chromeless, self-sizing, centered card panel around a SwiftUI view.
   private func makeCardPanel<Content: View>(_ content: Content) -> NSPanel {
@@ -144,8 +158,8 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
       }
     }
     let panel = makeCardPanel(card)
-    NSApp.activate(ignoringOtherApps: true)
-    panel.makeKeyAndOrderFront(nil)
+    application.activate(.ignoringOtherApps)
+    panels.makeKeyAndOrderFront(panel)
     let response = NSApp.runModal(for: panel)
     panel.orderOut(nil)
     return response == Self.moveResponse ? .move : .notNow
@@ -158,7 +172,7 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
       showsSpinner: true
     ) { EmptyView() }
     let panel = makeCardPanel(card)
-    panel.makeKeyAndOrderFront(nil)
+    panels.makeKeyAndOrderFront(panel)
     progressPanel = panel
   }
 
@@ -210,8 +224,8 @@ public final class CenteredRelocationPresenter: RelocationPresenting {
       }
     }
     let panel = makeCardPanel(card)
-    NSApp.activate(ignoringOtherApps: true)
-    panel.makeKeyAndOrderFront(nil)
+    application.activate(.ignoringOtherApps)
+    panels.makeKeyAndOrderFront(panel)
     NSApp.runModal(for: panel)
     panel.orderOut(nil)
   }
@@ -572,50 +586,13 @@ public struct FileManagerApplicationMover: ApplicationMoving {
 
 // MARK: - Relauncher
 
-/// Launches the installed copy as a NEW instance carrying the relaunch marker +
-/// attempt ID. Both instances run briefly; the original terminates only after
-/// the handshake confirms (A1).
-public struct NSWorkspaceRelocationRelauncher: RelocationRelaunching {
-  public init() {}
-
-  public func relaunch(
-    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String,
-    expectedBundleVersion: String
-  ) async -> Bool {
-    let config = NSWorkspace.OpenConfiguration()
-    config.createsNewApplicationInstance = true
-    config.activates = true
-    // Reason + scope let the CHILD emit its own `completed` event. A child that
-    // receives neither (old parent) still writes its health ack and simply
-    // emits nothing (#2006 §9).
-    config.environment = [
-      "EW_RELOCATION_RELAUNCH": "1",
-      "EW_RELOCATION_ATTEMPT_ID": attemptID,
-      "EW_RELOCATION_REASON": reason,
-      "EW_RELOCATION_DESTINATION_SCOPE": destinationScope,
-      // The child validates these before claiming completion, so a different
-      // registered copy cannot report success for our attempt (review P2).
-      "EW_RELOCATION_EXPECTED_PATH": installedURL.standardizedFileURL.path,
-      "EW_RELOCATION_EXPECTED_VERSION": expectedBundleVersion,
-    ]
-    return await withCheckedContinuation { continuation in
-      NSWorkspace.shared.openApplication(at: installedURL, configuration: config) { app, error in
-        continuation.resume(returning: error == nil && app != nil)
-      }
-    }
-  }
-
-  public func activateRunning(_ url: URL) async -> Bool {
-    // Bring the already-running instance at this exact URL to the front; never
-    // spawn a new one (cloud Codex review #1490).
-    let target = url.standardizedFileURL
-    let running = NSWorkspace.shared.runningApplications.first {
-      $0.bundleURL?.standardizedFileURL == target
-    }
-    guard let app = running else { return false }
-    return app.activate()
-  }
-}
+// `NSWorkspaceRelocationRelauncher` moved to
+// `Sources/EnviousWisprDesktopEffects/LiveRelocationRelauncher.swift` (#2455 C3).
+// It calls `NSWorkspace.shared.openApplication` with `configuration.activates =
+// true` and `NSRunningApplication.activate()` — both bring an app to the front,
+// so leaving them here would have left AppKit able to activate the desktop
+// through a door the activation seam does not cover. Found by Codex chunk review,
+// not by the chunk plan's population.
 
 // MARK: - Handshake (ack file)
 
@@ -762,14 +739,21 @@ extension ApplicationRelocationCoordinator {
   /// Production wiring. `AppLifecycleCoordinator` constructs this once via
   /// `WisprBootstrapper` and calls `evaluateAndOfferIfNeeded()` on launch.
   @MainActor
-  public static func live() -> ApplicationRelocationCoordinator {
+  /// #2455 C3: `application` is required and non-defaulted, and is threaded
+  /// straight to the presenter, which is the only collaborator here that touches
+  /// the desktop.
+  package static func live(
+    presentation: DesktopPresentationEffects,
+    relauncher: any RelocationRelaunching
+  ) -> ApplicationRelocationCoordinator {
     ApplicationRelocationCoordinator(
       env: .live(),
       detector: ApplicationLocationDetector(),
       suppression: UserDefaultsRelocationSuppressionStore(),
-      presenter: CenteredRelocationPresenter(),
+      presenter: CenteredRelocationPresenter(
+        application: presentation.application, panels: presentation.panels),
       mover: FileManagerApplicationMover(),
-      relauncher: NSWorkspaceRelocationRelauncher(),
+      relauncher: relauncher,
       handshake: FileRelocationHandshake(),
       telemetry: TelemetryServiceRelocationSink(),
       terminate: { NSApp.terminate(nil) },

--- a/Sources/EnviousWisprAppKit/App/DesktopPresentationEffects.swift
+++ b/Sources/EnviousWisprAppKit/App/DesktopPresentationEffects.swift
@@ -1,0 +1,110 @@
+import AppKit
+import ApplicationServices
+
+/// The activation and panel-presentation calls that reach the desktop (#2455 C3,
+/// issue #2460).
+///
+/// **Why these live in AppKit and the hotkey contract lives in Services.** An
+/// interface belongs with its CONSUMER. `DesktopHotkeyEffects` sits in Services
+/// because `HotkeyService` — its only consumer — is there. Every consumer of these
+/// two is in AppKit: `AppWindowCoordinator`, `SparkleUpdateController`,
+/// `AppLifecycleCoordinator`, `CenteredRelocationPresenter`, `QuickAddPanelHost`,
+/// `WisprBootstrapper` and `ActionWirer`. Putting them in Services would move them
+/// everything that uses them and make that module a place interfaces go when
+/// nobody decided where they belong.
+///
+/// **AppKit still never imports `EnviousWisprDesktopEffects`.** The conformances
+/// live in that module and are injected downward from `EnviousWisprAppLive`, so
+/// this direction of the graph is unchanged and there is no temporary edge to
+/// remove later.
+///
+/// **`PanelPresenting` takes an `NSPanel`, unlike the hotkey contract, which is
+/// framework-pure.** That is deliberate and bounded: the panel is created and
+/// owned by AppKit, which already has `NSPanel` in every signature around it, so
+/// hiding the type here would buy nothing and cost a wrapper. What crosses is a
+/// COMMAND — "give this panel the keyboard" — not an opaque handle a caller could
+/// misuse. C4 (#2461) takes the overlay's own panel driving, where the calculus is
+/// different because the tests there must be able to observe the commands.
+
+package enum ApplicationActivationMode: Sendable {
+  /// `NSApp.activate()`.
+  case standard
+  /// `NSApp.activate(ignoringOtherApps: true)`.
+  ///
+  /// A SEPARATE case rather than a Bool, and separate from `.standard` rather than
+  /// mapped onto `activate(ignoringOtherApps: false)`: the parameterless overload
+  /// is its own AppKit entry point, used at
+  /// `SparkleUpdateController.swift:134`, and routing it through the other one
+  /// would change which API that site calls on every macOS version.
+  case ignoringOtherApps
+}
+
+package enum ApplicationPolicy: Sendable {
+  case accessory
+  case regular
+}
+
+/// Bring the app forward, and set whether it appears in the Dock.
+///
+/// Both operations, not one. An earlier revision of the plan listed a single
+/// parameterless `activate()`; `setPolicy` is what moves the app between accessory
+/// and regular, and a dictation app that cannot do that is a menu-bar app whose
+/// windows never take focus properly.
+@MainActor
+package protocol ApplicationActivating: AnyObject {
+  func activate(_ mode: ApplicationActivationMode)
+  func setPolicy(_ policy: ApplicationPolicy)
+
+  /// Bring ANOTHER running application to the front.
+  ///
+  /// Same family as the two above, and it took a review round to see why: the
+  /// distinction that felt load-bearing — our app versus the user's — is about
+  /// WHOSE focus moves, while the symptom is identical either way. A unit test
+  /// that calls this steals focus on the developer's machine exactly as
+  /// `NSApp.activate` does. Escape Recovery uses it to hand the caret back after a
+  /// cancel.
+  @discardableResult
+  func activate(_ application: NSRunningApplication) -> Bool
+
+  /// Bring another application forward through the Accessibility API.
+  ///
+  /// The route macOS 14+ needs: a background process is refused the foreground by
+  /// `NSRunningApplication.activate()`, so the AX path is the one that works.
+  /// Separate from `activate(_:)` above because Escape Recovery tries THIS first
+  /// and falls back to that — two calls, and a test must be able to see which one
+  /// the code chose.
+  func forceActivate(processIdentifier: pid_t) -> Bool
+
+  /// Put the caret in a specific field.
+  ///
+  /// The THIRD route in this family, and the one that made the point: I closed
+  /// `activateFallback`, then `forceActivate`, and reported the hole shut both
+  /// times while this one still defaulted live. Restoring the app alone hands the
+  /// caret back to wherever that app last left it, which after a cancel is
+  /// frequently a different field — so this is not decoration.
+  func focus(_ element: AXUIElement) -> Bool
+}
+
+/// Give a panel the keyboard and bring it to the front.
+@MainActor
+package protocol PanelPresenting: AnyObject {
+  func makeKeyAndOrderFront(_ panel: NSPanel)
+}
+
+/// The two presentation seams, carried together.
+///
+/// A non-defaulted composition CARRIER, not a service locator: no `shared`, no
+/// static storage, no environment key, no default. AppLive fills both fields from
+/// one stateless live instance; `WisprBootstrapper` retains only `application` and
+/// passes `panels` straight to the collaborators that consume it. Leaf types
+/// receive the narrow protocol they actually use — holding one of these
+/// existentials never implies holding the other.
+package struct DesktopPresentationEffects {
+  package let application: any ApplicationActivating
+  package let panels: any PanelPresenting
+
+  package init(application: any ApplicationActivating, panels: any PanelPresenting) {
+    self.application = application
+    self.panels = panels
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -139,7 +139,13 @@ final class DictationLifecycleCoordinator {
   private lazy var whisperKitStateHandler: PipelineStateChangeHandler =
     makeStateChangeHandler(backendLabel: "whisperKit")
 
+  /// #2455 C3: the activation seam, required and non-defaulted. Escape Recovery's
+  /// pill hands the caret back to the user's app after a cancel, which is a focus
+  /// change a unit test must not be able to make.
+  private let application: any ApplicationActivating
+
   init(
+    application: any ApplicationActivating,
     kernelDriver: KernelDictationDriver,
     whisperKitKernelDriver: KernelDictationDriver,
     recordingOverlay: OverlayDirector,
@@ -152,6 +158,7 @@ final class DictationLifecycleCoordinator {
     languageSuggestionPresenter: LanguageSuggestionPresenter?,
     recordingLockedAccess: RecordingLockedAccess
   ) {
+    self.application = application
     self.kernelDriver = kernelDriver
     self.whisperKitKernelDriver = whisperKitKernelDriver
     self.recordingOverlay = recordingOverlay
@@ -544,6 +551,7 @@ final class DictationLifecycleCoordinator {
               payload: payload,
               onPaste: EscapeRecoveryWiring.pasteAction(
                 coordinator: self.transcriptCoordinator,
+                application: self.application,
                 report: EscapeRecoveryWiring.restoreReporter(source: .pill))))
         },
         // The SAME `append` an ordinary completion uses. A held row differs by

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPasteAction.swift
@@ -33,18 +33,23 @@ enum EscapeRecoveryPasteAction {
   ///     Injected because `NSRunningApplication.isTerminated` cannot be staged
   ///     in a unit test, and the branch it guards is the one that decides
   ///     whether the user's words land somewhere they never asked for.
-  ///   - retarget: activate the app and refocus the field, injected for the same
-  ///     reason `report` is. It defaults to the real AX calls, so production
-  ///     reads exactly as it did; a test cannot otherwise observe that the
-  ///     FIELD was restored, only that the app was, and those are the two
-  ///     halves a cancel most often separates.
+  ///   - retarget: required activation-and-focus seam. Production supplies
+  ///     `liveRetarget(application:)`; a test must supply an explicit fake.
+  ///     #2455 C3 removed its default, which WAS the real AX calls — so a test
+  ///     that omitted it activated a real app and moved a real caret. A test
+  ///     cannot otherwise observe that the FIELD was restored, only that the app
+  ///     was, and those are the two halves a cancel most often separates.
   static func paste(
     payload: CancelUndoPayload,
     restorable: (UUID) -> (text: String, stampedAt: Date, takeID: String?)?,
     copyToClipboard: @MainActor (String) -> Void,
     dispatchPaste: @escaping @MainActor () -> Void,
     report: (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void,
-    retarget: @MainActor (CancelUndoPayload) -> Bool = Self.defaultRetarget,
+    // #2455 C3: no default. `Self.defaultRetarget` reached a live activation, so
+    // the same hole existed one level up from `activateFallback`. Every caller —
+    // production and all six test sites — already passed this explicitly, so
+    // removing the default cost nothing and closed both.
+    retarget: @MainActor (CancelUndoPayload) -> Bool,
     targetHasQuit: (CancelUndoPayload) -> Bool = { $0.targetApp?.isTerminated == true },
     recordLog: @MainActor (_ outcome: String, _ ageMs: Int?, _ takeID: String?) -> Void = Self.log
   ) {
@@ -213,16 +218,41 @@ enum EscapeRecoveryPasteAction {
   /// was right about History and wrong about the pill: History activates
   /// nothing, so it promises nothing, while returning to the target app is the
   /// entire reason this pill exists.
-  private static func defaultRetarget(_ payload: CancelUndoPayload) -> Bool {
-    retargetWithAccessibility(payload)
+  /// The production retarget, built from the activation seam.
+  ///
+  /// A factory rather than a static function used as a default argument: a default
+  /// cannot be handed a dependency, which is exactly how the live activation stayed
+  /// reachable from a test that simply did not override it.
+  @MainActor
+  static func liveRetarget(
+    application: any ApplicationActivating
+  ) -> @MainActor (CancelUndoPayload) -> Bool {
+    { payload in
+      retargetWithAccessibility(
+        payload,
+        forceActivate: { application.forceActivate(processIdentifier: $0) },
+        activateFallback: { application.activate($0) },
+        focusElement: { application.focus($0) })
+    }
   }
 
   @MainActor
   static func retargetWithAccessibility(
     _ payload: CancelUndoPayload,
-    forceActivate: (pid_t) -> Bool = PasteService.forceActivateApp,
-    activateFallback: (NSRunningApplication) -> Bool = { $0.activate() },
-    focusElement: (AXUIElement) -> Bool = PasteService.focusElement
+    // #2455 C3: no default, for the same reason `activateFallback` below has
+    // none. This one is worse than that one was: it runs FIRST, so a test that
+    // omitted it reached the live AX activation before its own fake fallback was
+    // ever consulted. Removing only the second default left this path open, which
+    // is what the Codex round after that fix found.
+    forceActivate: (pid_t) -> Bool,
+    // #2455 C3: no default. It was `{ $0.activate() }` — a live focus change any
+    // test could reach by simply not overriding it. The seam existed; the default
+    // is what made it optional.
+    activateFallback: (NSRunningApplication) -> Bool,
+    // #2455 C3: the THIRD live default in this signature. Two rounds each closed
+    // one and reported the path shut. Counting the routes before claiming closure
+    // is now RULE: fix-the-path-that-runs-first-not-the-one-you-were-reading.
+    focusElement: (AXUIElement) -> Bool
   ) -> Bool {
     guard let app = payload.targetApp else { return true }
     // Both routes report. `forceActivateApp` is the AX path macOS 14+ needs for

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryWiring.swift
@@ -55,6 +55,7 @@ enum EscapeRecoveryWiring {
   @MainActor
   static func pasteAction(
     coordinator: TranscriptCoordinator,
+    application: any ApplicationActivating,
     report: @escaping (_ ageMs: Int, _ result: EscapeRecoveryPasteResult, _ takeID: String) -> Void
   ) -> (CancelUndoPayload) -> Void {
     { [weak coordinator] payload in
@@ -64,7 +65,8 @@ enum EscapeRecoveryWiring {
         restorable: { coordinator.restorableHeldRow(id: $0) },
         copyToClipboard: { PasteService.copyToClipboard($0) },
         dispatchPaste: { PasteService.simulatePaste() },
-        report: report)
+        report: report,
+        retarget: EscapeRecoveryPasteAction.liveRetarget(application: application))
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -20,6 +20,18 @@ import SwiftUI
 @MainActor
 final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
+  /// #2455 C3: both required and non-defaulted. `takeFocus` is the single
+  /// chokepoint for activating and keying the Quick Add panel, so these two are
+  /// exactly the calls a unit test must not be able to make.
+  private let application: any ApplicationActivating
+  private let presenter: any PanelPresenting
+
+  init(application: any ApplicationActivating, presenter: any PanelPresenting) {
+    self.application = application
+    self.presenter = presenter
+    super.init()
+  }
+
   /// Fired when the panel goes away for any reason the host can see — Escape, clicking away, or the
   /// window closing under it. The coordinator treats all three as "the user is done".
   var onDismiss: (() -> Void)?
@@ -116,8 +128,8 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// **One owner for both takers.** `present` and `raise` both activate and both call
   /// `makeKeyAndOrderFront`, so a third taker cannot be added without coming through here.
   private func takeFocus(_ panel: NSPanel) {
-    NSApp.activate(ignoringOtherApps: true)
-    panel.makeKeyAndOrderFront(nil)
+    application.activate(.ignoringOtherApps)
+    presenter.makeKeyAndOrderFront(panel)
   }
 
   /// Whether taking focus should record who held it first.

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -18,7 +18,12 @@ import SwiftUI
 final class QuickAddWiring {
 
   private let coordinator: QuickAddCoordinator
-  private let panelHost = QuickAddPanelHost()
+  /// #2455 C3: was `= QuickAddPanelHost()`, a stored-property initializer. The
+  /// host now requires its presentation seams, which only the composition root
+  /// has, so it is constructed in `init` from what is passed down. That is the
+  /// point rather than an inconvenience: a default-constructible host is one a
+  /// test can build with the real desktop attached.
+  private let panelHost: QuickAddPanelHost
   /// Built in `install()`, not here: its whole job is to call back into this object, and `self` does
   /// not exist yet during init. Constructing it early with a placeholder closure is how a door ships
   /// registered, enabled, and wired to nothing.
@@ -49,8 +54,15 @@ final class QuickAddWiring {
   init(
     hotkeyService: HotkeyService,
     customWords: CustomWordsCoordinator,
-    packManager: VocabularyPackManager
+    packManager: VocabularyPackManager,
+    presentationEffects: DesktopPresentationEffects
   ) {
+    // FIRST, before anything else in this initializer: the host was previously a
+    // stored-property initializer, which ran before every line here. Constructing
+    // it first keeps that ordering.
+    self.panelHost = QuickAddPanelHost(
+      application: presentationEffects.application,
+      presenter: presentationEffects.panels)
     self.hotkeyService = hotkeyService
     self.customWords = customWords
     self.coordinator = QuickAddCoordinator(

--- a/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
+++ b/Sources/EnviousWisprAppKit/App/SparkleUpdateController.swift
@@ -51,12 +51,20 @@ final class SparkleUpdateController: NSObject {
     assertionFailure(message)
   }
 
+  /// #2455 C3: required and non-defaulted, unlike the two parameters below it.
+  /// Those have defaults because a test that does not exercise updates still needs
+  /// the type; this one has none because the calls it carries are exactly what a
+  /// unit test must never make.
+  private let application: any ApplicationActivating
+
   init(
     holder: UpdateCoordinatorHolder,
+    application: any ApplicationActivating,
     bundleVersionProvider: @escaping () -> String = { AppConstants.appVersion },
     updaterFactory: SparkleUpdaterFactory = SparkleUpdateController.defaultUpdaterFactory
   ) {
     self.holder = holder
+    self.application = application
     self.bundleVersionProvider = bundleVersionProvider
     self.updaterFactory = updaterFactory
     super.init()
@@ -130,8 +138,8 @@ extension SparkleUpdateController: @preconcurrency SPUStandardUserDriverDelegate
 
   /// Bring app to front when Sparkle shows an update dialog (LSUIElement fix).
   func standardUserDriverWillShowModalAlert() {
-    NSApp.setActivationPolicy(.regular)
-    NSApp.activate()
+    application.setPolicy(.regular)
+    application.activate(.standard)
   }
 
   /// Return to accessory mode when the entire update session ends — but only
@@ -141,7 +149,7 @@ extension SparkleUpdateController: @preconcurrency SPUStandardUserDriverDelegate
   /// with it whenever the user checked for updates from inside it.
   func standardUserDriverWillFinishUpdateSession() {
     guard !AppWindowCoordinator.isMainWindowPresented() else { return }
-    NSApp.setActivationPolicy(.accessory)
+    application.setPolicy(.accessory)
   }
 
   /// Issue #343: pure yes/no decision per Sparkle's documented gentle-reminder

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -122,7 +122,30 @@ package final class WisprBootstrapper {
   /// `EnviousWisprDesktopEffects`, which `EnviousWisprTests` may not import —
   /// enforced by `scripts/check-dependency-direction.sh`, not by the module graph,
   /// which does not enforce itself under Xcode. The seam does not move.
-  package init(makeHotkeyEffects: () -> any DesktopHotkeyEffects) {
+  /// #2455 C3: this type's own activation seam, for the onboarding-dismissal
+  /// policy change in the scene body below.
+  ///
+  /// One stored property, not two: `EnviousWisprAppCeilingsTests` caps what this
+  /// type may hold, and the panel seam is consumed by collaborators rather than by
+  /// this type, so only the activator is retained.
+  ///
+  /// `fileprivate`, not `private`: `ActionWirer` below is a separate type in this
+  /// file and is handed this seam at construction. Swift's `private` does not reach
+  /// across type boundaries even within one file. Still unreachable from anywhere
+  /// else, which is what the C3 seam is for.
+  fileprivate let application: any ApplicationActivating
+
+  /// - Parameter presentationEffects: the activation and panel-presentation seams
+  ///   (#2455 C3). Required and non-defaulted for the same reason
+  ///   `makeHotkeyEffects` is: a default would let this module assemble a
+  ///   production root that reaches the real desktop, which is precisely what
+  ///   `EnviousWisprTests` links.
+  package init(
+    makeHotkeyEffects: () -> any DesktopHotkeyEffects,
+    presentationEffects: DesktopPresentationEffects,
+    relocationRelauncher: any RelocationRelaunching
+  ) {
+    self.application = presentationEffects.application
     // ===== Subsystem construction (epic #763) =====
     // `EnviousWisprApp` is the composition root: every subsystem is constructed
     // here. Construction order is load-bearing: `pasteCompletionRegistry` before
@@ -772,7 +795,8 @@ package final class WisprBootstrapper {
     }
 
     let updateCoordinatorHolder = UpdateCoordinatorHolder()
-    let sparkleUpdateController = SparkleUpdateController(holder: updateCoordinatorHolder)
+    let sparkleUpdateController = SparkleUpdateController(
+      holder: updateCoordinatorHolder, application: presentationEffects.application)
 
     // #1019: event-driven update-discovery triggers (wake / network). Data-free
     // — it reads `updateCoordinator` lazily (nil until `startUpdater()`), so it
@@ -963,6 +987,7 @@ package final class WisprBootstrapper {
       set: { locked in liveRecordingState.isRecordingLocked = locked }
     )
     let dictationLifecycleCoordinator = DictationLifecycleCoordinator(
+      application: presentationEffects.application,
       kernelDriver: kernelDriver,
       whisperKitKernelDriver: whisperKitKernelDriver,
       recordingOverlay: recordingOverlay,
@@ -1034,6 +1059,7 @@ package final class WisprBootstrapper {
 
     // PR-B.2 of #763: window-lifecycle home.
     let appWindowCoordinator = AppWindowCoordinator(
+      application: presentationEffects.application,
       canOpenOnboarding: { [weak settings] in
         guard let settings else { return false }
         return settings.onboardingState != .completed
@@ -1060,7 +1086,8 @@ package final class WisprBootstrapper {
     let quickAdd = QuickAddWiring(
       hotkeyService: hotkeyService,
       customWords: customWordsCoordinator,
-      packManager: vocabularyPackManager)
+      packManager: vocabularyPackManager,
+      presentationEffects: presentationEffects)
 
     let menuBarController = MenuBarController(
       liveRecordingState: liveRecordingState,
@@ -1085,7 +1112,8 @@ package final class WisprBootstrapper {
     )
 
     // #1451: App Translocation recovery limb, driven from the launch sequence.
-    let applicationRelocationCoordinator = ApplicationRelocationCoordinator.live()
+    let applicationRelocationCoordinator = ApplicationRelocationCoordinator.live(
+      presentation: presentationEffects, relauncher: relocationRelauncher)
 
     // #1480: Bluetooth cold-start card. Single decision owner; ingress facts come
     // from AppLifecycleCoordinator + settings.onChange. Wiring lives in `.live(...)`;
@@ -1102,6 +1130,7 @@ package final class WisprBootstrapper {
     // PR-B.4 of #763: process-lifecycle home. Constructed last. It receives the
     // 10 specific homes it reads.
     let appLifecycleCoordinator = AppLifecycleCoordinator(
+      application: presentationEffects.application,
       settings: settings,
       permissions: permissions,
       keychainManager: keychainManager,
@@ -1385,6 +1414,7 @@ private struct MainWindowRoot: View {
       .environment(\.keychainManager, b.keychainManager)
       .background(
         ActionWirer(
+          application: b.application,
           settings: b.settings,
           appWindowCoordinator: b.appWindowCoordinator,
           menuBarController: b.menuBarController,
@@ -1439,6 +1469,10 @@ private struct OnboardingWindowRoot: View {
 /// Hidden view that wires SwiftUI environment actions into App-owned homes.
 /// Must live inside a SwiftUI view hierarchy to access @Environment.
 private struct ActionWirer: View {
+  /// #2455 C3. This view makes the onboarding-dismissal policy call, so it holds
+  /// the seam directly rather than reaching through the bootstrapper — it already
+  /// takes each collaborator it uses by value for the same reason.
+  let application: any ApplicationActivating
   /// The onboarding-auto-open gate reads `onboardingState` off the settings
   /// store directly (epic #763).
   let settings: SettingsManager
@@ -1486,7 +1520,7 @@ private struct ActionWirer: View {
         if !newValue {
           // State-driven dismissal: binding flipped to false → close window.
           dismissWindow(id: "onboarding")
-          NSApp.setActivationPolicy(.accessory)
+          application.setPolicy(.accessory)
           menuBarController.updateIcon()
         }
       }

--- a/Sources/EnviousWisprAppLive/LiveApplication.swift
+++ b/Sources/EnviousWisprAppLive/LiveApplication.swift
@@ -33,8 +33,14 @@ package final class LiveApplication {
     // Construction stays synchronous and in this order for the same reason it
     // always has: home construction must keep its pre-#919 ordering, and the
     // delegate must be attached before `applicationWillFinishLaunching` fires.
+    // One stateless live type conforms to both protocols, and the same instance
+    // fills both fields of `DesktopPresentationEffects`.
+    let presentation = LiveDesktopPresentationEffects()
     bootstrapper = WisprBootstrapper(
-      makeHotkeyEffects: { LiveDesktopHotkeyEffects() })
+      makeHotkeyEffects: { LiveDesktopHotkeyEffects() },
+      presentationEffects: DesktopPresentationEffects(
+        application: presentation, panels: presentation),
+      relocationRelauncher: LiveRelocationRelauncher())
   }
 
   // MARK: - Scene surface

--- a/Sources/EnviousWisprDesktopEffects/LiveDesktopPresentationEffects.swift
+++ b/Sources/EnviousWisprDesktopEffects/LiveDesktopPresentationEffects.swift
@@ -1,0 +1,61 @@
+import AppKit
+import EnviousWisprAppKit
+import EnviousWisprServices
+
+/// The real activation and panel-presentation calls (#2455 C3).
+///
+/// One stateless type conforms to both protocols because both are `NSApp`-adjacent;
+/// splitting them would be two objects wrapping the same singleton. Consumers still
+/// receive only the narrow protocol they use.
+///
+/// **Translation only, no decisions.** Which mode, which policy, and when are
+/// AppKit's calls to make; this converts an enum case into the AppKit entry point
+/// that case names, and nothing else. A `guard` or a policy check added here would
+/// put half the activation rule in a module no test can read.
+@MainActor
+package final class LiveDesktopPresentationEffects: ApplicationActivating, PanelPresenting {
+
+  package init() {}
+
+  package func activate(_ mode: ApplicationActivationMode) {
+    switch mode {
+    case .standard:
+      // The parameterless overload, preserved exactly. NOT
+      // `activate(ignoringOtherApps: false)` — that is a different AppKit entry
+      // point, and the one site using this form (#739's Sparkle flow) has always
+      // called this one.
+      NSApp.activate()
+    case .ignoringOtherApps:
+      NSApp.activate(ignoringOtherApps: true)
+    }
+  }
+
+  package func setPolicy(_ policy: ApplicationPolicy) {
+    switch policy {
+    case .accessory:
+      // `@discardableResult` is not on AppKit's declaration, and every existing
+      // call site ignored the Bool. Discarding it explicitly preserves that
+      // rather than introducing a warning the next reader silences differently.
+      _ = NSApp.setActivationPolicy(.accessory)
+    case .regular:
+      _ = NSApp.setActivationPolicy(.regular)
+    }
+  }
+
+  @discardableResult
+  package func activate(_ application: NSRunningApplication) -> Bool {
+    application.activate()
+  }
+
+  package func forceActivate(processIdentifier: pid_t) -> Bool {
+    PasteService.forceActivateApp(pid: processIdentifier)
+  }
+
+  package func focus(_ element: AXUIElement) -> Bool {
+    PasteService.focusElement(element)
+  }
+
+  package func makeKeyAndOrderFront(_ panel: NSPanel) {
+    panel.makeKeyAndOrderFront(nil)
+  }
+}

--- a/Sources/EnviousWisprDesktopEffects/LiveRelocationRelauncher.swift
+++ b/Sources/EnviousWisprDesktopEffects/LiveRelocationRelauncher.swift
@@ -1,0 +1,48 @@
+import AppKit
+import EnviousWisprAppKit
+import Foundation
+
+/// Launches the installed copy as a NEW instance carrying the relaunch marker +
+/// attempt ID. Both instances run briefly; the original terminates only after
+/// the handshake confirms (A1).
+package struct LiveRelocationRelauncher: RelocationRelaunching {
+  package init() {}
+
+  package func relaunch(
+    _ installedURL: URL, attemptID: String, reason: String, destinationScope: String,
+    expectedBundleVersion: String
+  ) async -> Bool {
+    let config = NSWorkspace.OpenConfiguration()
+    config.createsNewApplicationInstance = true
+    config.activates = true
+    // Reason + scope let the CHILD emit its own `completed` event. A child that
+    // receives neither (old parent) still writes its health ack and simply
+    // emits nothing (#2006 §9).
+    config.environment = [
+      "EW_RELOCATION_RELAUNCH": "1",
+      "EW_RELOCATION_ATTEMPT_ID": attemptID,
+      "EW_RELOCATION_REASON": reason,
+      "EW_RELOCATION_DESTINATION_SCOPE": destinationScope,
+      // The child validates these before claiming completion, so a different
+      // registered copy cannot report success for our attempt (review P2).
+      "EW_RELOCATION_EXPECTED_PATH": installedURL.standardizedFileURL.path,
+      "EW_RELOCATION_EXPECTED_VERSION": expectedBundleVersion,
+    ]
+    return await withCheckedContinuation { continuation in
+      NSWorkspace.shared.openApplication(at: installedURL, configuration: config) { app, error in
+        continuation.resume(returning: error == nil && app != nil)
+      }
+    }
+  }
+
+  package func activateRunning(_ url: URL) async -> Bool {
+    // Bring the already-running instance at this exact URL to the front; never
+    // spawn a new one (cloud Codex review #1490).
+    let target = url.standardizedFileURL
+    let running = NSWorkspace.shared.runningApplications.first {
+      $0.bundleURL?.standardizedFileURL == target
+    }
+    guard let app = running else { return false }
+    return app.activate()
+  }
+}

--- a/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/AppWindowCoordinatorTests.swift
@@ -34,6 +34,7 @@ struct AppWindowCoordinatorTests {
   func pendingOpenOnboardingQueuesAndReplays() {
     var openCount = 0
     let coordinator = AppWindowCoordinator(
+      application: RecordingDesktopPresentationEffects(),
       canOpenOnboarding: { true },
       isOnboardingComplete: { false }
     )
@@ -60,6 +61,7 @@ struct AppWindowCoordinatorTests {
   func consumePendingOpenOnboardingNoOpsWhenFlagClear() {
     var openCount = 0
     let coordinator = AppWindowCoordinator(
+      application: RecordingDesktopPresentationEffects(),
       canOpenOnboarding: { true },
       isOnboardingComplete: { false }
     )
@@ -77,6 +79,7 @@ struct AppWindowCoordinatorTests {
   func completedOnboardingDoesNotQueue() {
     var openCount = 0
     let coordinator = AppWindowCoordinator(
+      application: RecordingDesktopPresentationEffects(),
       canOpenOnboarding: { false },  // onboarding complete → ineligible
       isOnboardingComplete: { true }
     )
@@ -97,6 +100,7 @@ struct AppWindowCoordinatorTests {
   func openOnboardingWindowRespectsEligibilityGuard() {
     var openCount = 0
     let coordinator = AppWindowCoordinator(
+      application: RecordingDesktopPresentationEffects(),
       canOpenOnboarding: { false },
       isOnboardingComplete: { true }
     )
@@ -112,6 +116,7 @@ struct AppWindowCoordinatorTests {
   func closeOnboardingWindowFiresOnboardingDismissedSeam() {
     var dismissedCount = 0
     let coordinator = AppWindowCoordinator(
+      application: RecordingDesktopPresentationEffects(),
       canOpenOnboarding: { true },
       isOnboardingComplete: { false }
     )

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -56,6 +56,7 @@ import Testing
     let lastRecordingResult = LastRecordingResult()
     let lockBox = TestRecordingLockedBox()
     let coordinator = DictationLifecycleCoordinator(
+      application: RecordingDesktopPresentationEffects(),
       kernelDriver: pipeline,
       whisperKitKernelDriver: whisperKitKernelDriver,
       recordingOverlay: overlay,

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryRestoreTests.swift
@@ -205,6 +205,7 @@ struct EscapeRecoveryRestoreTests {
       transcriptID: UUID(), targetApp: app, targetElement: nil)
     var forcedPIDs: [pid_t] = []
     var fallbackCalls = 0
+    var focusCalls = 0
 
     let retargeted = EscapeRecoveryPasteAction.retargetWithAccessibility(
       payload,
@@ -215,9 +216,17 @@ struct EscapeRecoveryRestoreTests {
       activateFallback: { _ in
         fallbackCalls += 1
         return false
+      },
+      // #2455 C3: was the live `PasteService.focusElement` default, so this case
+      // moved a real caret on the developer's machine. Unreached here — both
+      // activation routes fail above — and asserted as unreached below.
+      focusElement: { _ in
+        focusCalls += 1
+        return true
       })
 
     #expect(forcedPIDs == [app.processIdentifier], "the Accessibility route is tried first")
+    #expect(focusCalls == 0, "focus is not attempted when the app could not be reached")
     #expect(fallbackCalls == 1, "the AppKit fallback is tried when Accessibility is unavailable")
     #expect(
       retargeted == false,
@@ -232,6 +241,7 @@ struct EscapeRecoveryRestoreTests {
     let payload = CancelUndoPayload(
       transcriptID: UUID(), targetApp: nil, targetElement: nil)
     var activationAttempted = false
+    var focusAttempted = false
 
     let retargeted = EscapeRecoveryPasteAction.retargetWithAccessibility(
       payload,
@@ -242,9 +252,14 @@ struct EscapeRecoveryRestoreTests {
       activateFallback: { _ in
         activationAttempted = true
         return false
+      },
+      focusElement: { _ in
+        focusAttempted = true
+        return true
       })
 
     #expect(activationAttempted == false, "there is no app to activate")
+    #expect(focusAttempted == false, "and no field to focus")
     #expect(retargeted == true, "the existing no-target behavior is intentional and preserved")
   }
 

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -609,6 +609,7 @@ struct MenuBarControllerTests {
     // Nil-fake updater factory — no real Sparkle boot in the test process.
     let sparkle = SparkleUpdateController(
       holder: UpdateCoordinatorHolder(),
+      application: RecordingDesktopPresentationEffects(),
       bundleVersionProvider: { "v-test" },
       updaterFactory: SparkleUpdaterFactory { _, _ in nil })
     let controller = MenuBarController(

--- a/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/SparkleUpdateControllerTests.swift
@@ -24,6 +24,7 @@ struct SparkleUpdateControllerTests {
     let holder = UpdateCoordinatorHolder()
     let controller = SparkleUpdateController(
       holder: holder,
+      application: RecordingDesktopPresentationEffects(),
       bundleVersionProvider: { "v-test-1.0" },
       updaterFactory: SparkleUpdaterFactory { _, _ in nil }
     )
@@ -61,6 +62,7 @@ struct SparkleUpdateControllerTests {
     let holder = UpdateCoordinatorHolder()
     let controller = SparkleUpdateController(
       holder: holder,
+      application: RecordingDesktopPresentationEffects(),
       bundleVersionProvider: { "v-test-1.0" },
       updaterFactory: SparkleUpdaterFactory { _, _ in nil }
     )
@@ -132,6 +134,7 @@ struct SparkleUpdateControllerTests {
       let holder = UpdateCoordinatorHolder()
       let controller = SparkleUpdateController(
         holder: holder,
+        application: RecordingDesktopPresentationEffects(),
         // Provider returns the SAME version as the persisted attempt.
         // `evaluateLastInstallAttempt` should resolve to `.completed` and
         // fire `update.install_completed`.

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -57,6 +57,9 @@ import Testing
     "Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift"
 
   private static let storedPropertyAllowlist: Set<String> = [
+    // #2455 C3 (#2460): the activation seam. Required and non-defaulted, so this
+    // type can no longer reach the real app's Dock policy or foreground state.
+    "application",
     "audioEnvironmentSnapshotter",
     "audioSystemEventReporter",
     "debugFaultEndpoint",

--- a/Tests/EnviousWisprTests/Architecture/AppWindowCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppWindowCoordinatorCeilingsTests.swift
@@ -26,6 +26,9 @@ import Testing
     "Sources/EnviousWisprAppKit/App/AppWindowCoordinator.swift"
 
   private static let storedPropertyAllowlist: Set<String> = [
+    // #2455 C3 (#2460): the activation seam. Required and non-defaulted, so this
+    // type can no longer reach the real app's Dock policy or foreground state.
+    "application",
     "canOpenOnboarding",
     "isOnboardingComplete",
     "mainWindow",

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -56,9 +56,12 @@ import Testing
       named: "DictationLifecycleCoordinator", at: Self.sourcePath)
     let count = RouterCeilingParser.collaboratorCount(in: body)
     #expect(
-      count <= 11,
+      // #2455 C3 (#2460): 11 -> 12. `application`, the activation seam. Escape
+      // Recovery's pill hands the caret back to the user's app after a cancel,
+      // and that call had a live DEFAULT until this chunk made it required.
+      count <= 12,
       """
-      DictationLifecycleCoordinator collaborator ceiling exceeded: \(count) > 11. \
+      DictationLifecycleCoordinator collaborator ceiling exceeded: \(count) > 12. \
       Allowed (PR9 baseline): pipeline, whisperKitKernelDriver, recordingOverlay, \
       hotkeyService, settingsSync, audioCapture, transcriptCoordinator, settings, \
       lastRecordingResult, languageSuggestionPresenter, recordingLockedAccess. \

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -182,9 +182,13 @@ import Testing
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
     #expect(
-      count <= 40,
+      // #2455 C3 (#2460): 40 -> 41. `application`, the activation seam this type
+      // needs for the onboarding-dismissal policy change. ONE property, not two:
+      // the panel seam is consumed by collaborators and is passed through rather
+      // than retained here.
+      count <= 41,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 40. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 41. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.

--- a/Tests/EnviousWisprTests/Architecture/SparkleUpdateControllerCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SparkleUpdateControllerCeilingsTests.swift
@@ -33,10 +33,13 @@ import Testing
       named: "SparkleUpdateController", at: Self.sourcePath)
     let count = RouterCeilingParser.collaboratorCount(in: body)
     #expect(
-      count <= 2,
+      // #2455 C3 (#2460): 2 -> 3. The activation seam, required and non-defaulted,
+      // so this controller can no longer move the real app between accessory and
+      // regular or bring it to the front — the #739 update flow's three calls.
+      count <= 3,
       """
-      SparkleUpdateController collaborator ceiling exceeded: \(count) > 2 \
-      (parser-visible). Allowed (PR-B.1 baseline): holder, updaterFactory. \
+      SparkleUpdateController collaborator ceiling exceeded: \(count) > 3 \
+      (parser-visible). Allowed (C3 baseline): holder, updaterFactory, application. \
       The Sparkle-owned `updaterController` and `updateCoordinator` are \
       `private(set)` and intentionally invisible to the shared parser. \
       Raising requires a Bible §30 entry.
@@ -64,9 +67,11 @@ import Testing
       RouterCeilingParser.collaboratorCount(in: body)
       + RouterCeilingParser.closureInjectedCount(in: body)
     #expect(
-      total <= 3,
+      // #2455 C3 (#2460): 3 -> 4, the activation seam. Same one property as the
+      // collaborator count above.
+      total <= 4,
       """
-      SparkleUpdateController total stored-property ceiling exceeded: \(total) > 3 \
+      SparkleUpdateController total stored-property ceiling exceeded: \(total) > 4 \
       (parser-visible). The home publishes the coordinator into the env-carrier \
       and routes Sparkle delegate callbacks. Additional state is a sign of \
       scope creep.

--- a/Tests/EnviousWisprTests/Support/RecordingDesktopPresentationEffects.swift
+++ b/Tests/EnviousWisprTests/Support/RecordingDesktopPresentationEffects.swift
@@ -1,0 +1,97 @@
+import AppKit
+import EnviousWisprAppKit
+import Foundation
+
+/// The unit suite's stand-in for activation and panel presentation (#2455 C3).
+///
+/// **This is the founder-visible half of the epic.** C2 stopped the suite stealing
+/// the Escape key; these are the calls behind the other two symptoms — a pill
+/// flashing on screen and focus being taken while the developer was typing
+/// somewhere else. `NSApp.activate` and `setActivationPolicy` reach the real
+/// running app, so a unit test making them pulls the developer's machine into the
+/// foreground mid-suite.
+///
+/// It RECORDS rather than absorbing, for the same reason
+/// `RecordingDesktopHotkeyEffects` does: activation ordering is load-bearing —
+/// `QuickAddPanelHost.takeFocus` activates BEFORE keying the panel, because the
+/// selection was read while another app was frontmost — and nothing could assert
+/// that ordering while the calls went straight to AppKit.
+@MainActor
+final class RecordingDesktopPresentationEffects: ApplicationActivating, PanelPresenting {
+
+  /// Every call, in order, across BOTH protocols.
+  ///
+  /// One list rather than three, because the assertions that matter are about
+  /// SEQUENCE — activate then key, or policy-regular then activate — and separate
+  /// lists cannot express an interleaving.
+  enum Call: Equatable {
+    case activate(ApplicationActivationMode)
+    case setPolicy(ApplicationPolicy)
+    case makeKeyAndOrderFront(panel: ObjectIdentifier)
+    /// Bringing ANOTHER app forward — Escape Recovery handing the caret back.
+    /// Recorded by bundle id rather than by object, because what a test asserts
+    /// is WHICH app was returned to, and `NSRunningApplication` identity is not
+    /// stable to construct in a test.
+    case activateOther(bundleID: String?)
+    /// The Accessibility route, tried BEFORE `activateOther`. Recorded separately
+    /// so a test can assert which route the code chose, not merely that focus moved.
+    case forceActivate(pid: pid_t)
+    /// Putting the caret in a field, after the app is frontmost.
+    case focus
+  }
+
+  private(set) var calls: [Call] = []
+
+  func activate(_ mode: ApplicationActivationMode) {
+    calls.append(.activate(mode))
+  }
+
+  func setPolicy(_ policy: ApplicationPolicy) {
+    calls.append(.setPolicy(policy))
+  }
+
+  /// Always reports success. A test that needs the refusal path — macOS 14+ can
+  /// refuse a background process the foreground — sets `activateOtherSucceeds`.
+  var activateOtherSucceeds = true
+
+  @discardableResult
+  func activate(_ application: NSRunningApplication) -> Bool {
+    calls.append(.activateOther(bundleID: application.bundleIdentifier))
+    return activateOtherSucceeds
+  }
+
+  /// Defaults to FAILING, unlike `activateOtherSucceeds`. That asymmetry is the
+  /// production reality: macOS 14+ refuses a background process the foreground
+  /// unless Accessibility is granted, so the fallback path is the common one and a
+  /// test that assumes otherwise is testing a machine we do not ship to.
+  var forceActivateSucceeds = false
+
+  func forceActivate(processIdentifier: pid_t) -> Bool {
+    calls.append(.forceActivate(pid: processIdentifier))
+    return forceActivateSucceeds
+  }
+
+  var focusSucceeds = true
+
+  func focus(_ element: AXUIElement) -> Bool {
+    calls.append(.focus)
+    return focusSucceeds
+  }
+
+  func makeKeyAndOrderFront(_ panel: NSPanel) {
+    calls.append(.makeKeyAndOrderFront(panel: ObjectIdentifier(panel)))
+  }
+
+  // MARK: - Assertion helpers
+
+  var policies: [ApplicationPolicy] {
+    calls.compactMap { if case .setPolicy(let p) = $0 { p } else { nil } }
+  }
+
+  var activations: [ApplicationActivationMode] {
+    calls.compactMap { if case .activate(let m) = $0 { m } else { nil } }
+  }
+}
+
+extension ApplicationActivationMode: @retroactive Equatable {}
+extension ApplicationPolicy: @retroactive Equatable {}

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -142,7 +142,28 @@ done
 #
 # Keep the lists exhaustive: a test target absent from here is unchecked, which
 # looks exactly like a test target that passes.
-# The hotkey OS calls, wherever they appear.
+# The desktop calls C2 and C3 moved, wherever they appear.
+#
+# C3 (#2460) added activation, Dock policy, Quick Add's panel presentation, and
+# `NSWorkspace.shared.openApplication` — the calls behind the pill flashing and
+# focus being taken mid-suite. `NSApp.windows` and other READS are deliberately
+# absent: they observe, they do not act.
+#
+# `NSRunningApplication.activate()` is NOT in this pattern, and the reason matters
+# because the obvious fix does not work. A bare `[.]activate[(][)]` was tried and
+# reverted: it matches `DispatchSource.activate()` in
+# `EGOneServerManager.swift:328`, which is not a desktop effect at all. Receiver
+# TYPE is what distinguishes them, and a grep cannot see types.
+#
+# What replaced it for the case C3 owns: `EscapeRecoveryPasteAction`'s
+# `activateFallback` and `retarget` both lost their live DEFAULTS, so the seam is
+# required rather than optional. That closes the hole at the call site instead of
+# at the pattern.
+#
+# KNOWN GAP, tracked rather than silently excluded: `PasteCascadeExecutor.swift`
+# `:573`, `:852`, `:862` call `app.activate()` on an `NSRunningApplication` in
+# `EnviousWisprPipeline`, bringing the paste target forward. Real activations, in
+# the core dictation path, listed by no chunk plan. Filed on #2455.
 #
 # No trailing `(` on the Carbon names ON PURPOSE: `let register = RegisterEventHotKey`
 # takes a function reference and calls it later, which a call-shaped pattern would
@@ -151,7 +172,7 @@ done
 # removes a `//` or `/*` and its tail on ONE line, not the continuation lines of a
 # block comment. A false positive is a sentence to rewrite; a false negative is a
 # suite back on the developer's real desktop.
-live_effect_pattern='RegisterEventHotKey|InstallEventHandler|NSEvent[.]add(Global|Local)MonitorForEvents'
+live_effect_pattern='RegisterEventHotKey|InstallEventHandler|NSEvent[.]add(Global|Local)MonitorForEvents|(NSApp|NSApplication[.]shared)[.](activate|setActivationPolicy)|panel[.]makeKeyAndOrderFront|NSWorkspace[.]shared[.]openApplication'
 
 test_targets_and_permitted() {
   case "$1" in
@@ -194,7 +215,7 @@ for test_dir in Tests/*/; do
   done < <(grep -rEn "$import_grep_pattern" "$test_dir" || true)
 done
 
-# OWNERSHIP: the hotkey OS calls may appear in EnviousWisprDesktopEffects and
+# OWNERSHIP: the live desktop calls may appear in EnviousWisprDesktopEffects and
 # nowhere else, in Sources OR Tests.
 #
 # Import discipline is necessary and NOT sufficient. `RegisterEventHotKey` comes
@@ -215,7 +236,7 @@ while IFS= read -r line; do
   esac
   code=$(echo "$line" | cut -d: -f3- | sed -E 's|//.*$||; s|/\*.*$||')
   if echo "$code" | grep -Eq "$live_effect_pattern"; then
-    echo "DEP-DIRECTION: $file: hotkey OS call outside Sources/EnviousWisprDesktopEffects/"
+    echo "DEP-DIRECTION: $file: live desktop call outside Sources/EnviousWisprDesktopEffects/"
     violations=$((violations + 1))
   fi
 done < <(grep -rEn --include='*.swift' "$live_effect_pattern" Sources Tests || true)


### PR DESCRIPTION
Closes #2460. Chunk C3 of #2455. Follows #2464 (C0), #2468 (C1), #2470 (C2).

**Lane:** Code · **Tier:** REFACTOR (chunk C3 of 6) · **Live UAT:** deferred to C5's executable scenario

## Problem

The two founder-visible symptoms this epic exists to remove — a pill flashing on screen, and focus taken while typing elsewhere — came from `NSApp.activate`, `setActivationPolicy` and panel presentation reaching the real running app from `EnviousWisprAppKit`, which `EnviousWisprTests` links.

## What this does

`ApplicationActivating` and `PanelPresenting` live in **AppKit**, beside their consumers — unlike C2's hotkey contract, whose only consumer was in Services. `LiveDesktopPresentationEffects` in DesktopEffects implements both; AppLive injects them. AppKit still never imports DesktopEffects.

**17 sites moved, not the 14 the issue listed.** Three `panel.makeKeyAndOrderFront` calls in `CenteredRelocationPresenter` turned up by grepping after the listed ones were done. Routed through the same seam rather than exempted — an exemption would have forced an AppKit carve-out in the ownership rule.

`NSApp.activate()` and `NSApp.activate(ignoringOtherApps:)` stay **distinct enum cases**. Separate AppKit entry points; folding one onto the other changes which API the #739 update flow calls on every macOS version.

`NSWorkspaceRelocationRelauncher` → `LiveRelocationRelauncher` in DesktopEffects. It brings apps forward via `NSWorkspace.shared.openApplication` and `NSRunningApplication.activate()`, neither caught by the pattern. Found by review, not by the plan.

## Escape Recovery had three live defaults in one signature

`forceActivate` (tried **first**), `activateFallback`, and `focusElement` all defaulted to real AX calls. A test omitting any reached the real system.

Closing them took three rounds, because each closure was reported as shutting the path while another stayed open. Two tests failed to compile once `focusElement` became required — **proof the hole was live: they were moving a real caret.** Both now supply a fake *and assert it was not called*, which is coverage they lacked.

Fed back into `workflow-process.md` RULE: fix-the-path-that-runs-first-not-the-one-you-were-reading, because this instance breaks that rule's own heuristic — it says the missed path is usually not in the diff; this one was one line above the line changed.

`CenteredRelocationPresenter.init()` deleted: a public do-nothing initializer was exactly the default-constructible path this chunk closes.

## Two gaps filed, not silently excluded

Both on #2455, with what closing them would take:

| Gap | Why not here |
|---|---|
| `PasteCascadeExecutor.swift:573,852,862` activate the paste target | `EnviousWisprPipeline`. The epic's Architecture DoD says verbatim *"Heart untouched — no pipeline, audio, ASR or LLM code moves."* Verified in the plan file, not paraphrased |
| `PasteService.forceActivateApp` / `focusElement` stay in Services | Pipeline calls the former, so moving it means editing Pipeline. Moving only the latter splits a pair and closes nothing |

**A `[.]activate[(][)]` pattern was tried and reverted** — it matches `DispatchSource.activate()` at `EGOneServerManager.swift:328`. The discriminator is the receiver **type**, which a grep cannot see. A name-keyed variant (`app.activate()`) was declined for a sharper reason: rename the variable and the rule goes silent, still reporting clean. That converts "does not cover X" into "covers X unless someone renames a variable". Both the attempt and the reason are recorded beside `live_effect_pattern`.

## Guards

Six ceilings updated, each because exactly one stored property was added to the type it caps, with the reason beside the number — not just the number.

## Validation

| Check | Result |
|---|---|
| Debug lane | PASS — 7,121 test cases, zero failures |
| `check-dependency-direction.sh` | OK, 21 modules; activation + panel rules mutation-checked |
| Codex chunk gate | **CHUNK-CLEAN** on a confirming re-run |

Codex rounds: design → `PROCEED` → `CHUNK-REVISIONS (3)` → `(2)` → `(2)` → `(2)` → **`CHUNK-CLEAN`**.

## Note for other worktrees

`AppWindowCoordinator`, `SparkleUpdateController`, `AppLifecycleCoordinator`, `DictationLifecycleCoordinator`, `QuickAddWiring` and `QuickAddPanelHost` all take a required presentation seam. `EscapeRecoveryPasteAction.paste`'s `retarget:` and `retargetWithAccessibility`'s three callbacks are required. Tests use `RecordingDesktopPresentationEffects()`.
