### PR TITLE
C4: the overlay's test double is no longer a real window (#2461)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -282,6 +282,14 @@ let package = Package(
     // it, and this manifest is what makes `swift build` reject it, but CI runs
     // Tuist and xcodebuild only. `scripts/check-dependency-direction.sh` is what
     // actually catches it on every run.
+    // #2455 C4: a NON-SHIPPING library holding fakes both test targets need.
+    // Not a `.testTarget`: SwiftPM does not let one test target depend on another,
+    // and duplicating the fakes would let two copies drift apart silently.
+    .target(
+      name: "EnviousWisprAppKitTestSupport",
+      dependencies: ["EnviousWisprAppKit", "EnviousWisprCore"],
+      path: "Sources/EnviousWisprAppKitTestSupport"
+    ),
     .target(
       name: "EnviousWisprDesktopEffects",
       dependencies: [
@@ -309,6 +317,23 @@ let package = Package(
       path: "Sources/EnviousWispr",
       exclude: ["Resources"]
     ),
+    // #2455 C4: the only test target the dep-direction gate permits to construct a
+    // live desktop effect. Nothing in the module graph enforces that — the gate does.
+    // Three suites live here, each of which DELIBERATELY drives a real window:
+    // `LiveOverlayPanelDriverTests`, `OverlayRetainedWindowRealPanelTests`, and
+    // `RecordingPollingRealPanelTests`. `OverlayHostingParityTests` is NOT one of
+    // them — with the panel injected it compares two host implementations and
+    // needs no live effect, so it stays in the unit target.
+    .testTarget(
+      name: "EnviousWisprDesktopEffectsTests",
+      dependencies: [
+        "EnviousWisprCore",
+        "EnviousWisprAppKit",
+        "EnviousWisprAppKitTestSupport",
+        "EnviousWisprDesktopEffects",
+      ],
+      path: "Tests/EnviousWisprDesktopEffectsTests"
+    ),
     .testTarget(
       name: "EnviousWisprTests",
       dependencies: [
@@ -328,6 +353,7 @@ let package = Package(
         // #919: link the app-shell code from the library, NOT the app target,
         // so `swift test` / `xcodebuild test` never launch the app.
         "EnviousWisprAppKit",
+        "EnviousWisprAppKitTestSupport",
         "EnviousWisprContacts",
         // #1741 Chunk 10: EngineMutationInventoryFreezeTests's real Swift
         // parser (replaces its hand-rolled comment/string scanner). This is

--- a/Project.swift
+++ b/Project.swift
@@ -492,6 +492,17 @@ let project = Project(
     // `scripts/check-dependency-direction.sh` is the enforcing wall: it rejects the
     // import from the test targets, and rejects the OS calls themselves anywhere
     // outside this module.
+    // #2455 C4: non-shipping fakes shared by both test targets.
+    firstPartyLibrary(
+      "EnviousWisprAppKitTestSupport",
+      dependencies: [
+        .target(name: "EnviousWisprAppKit"),
+        .target(name: "EnviousWisprCore"),
+        .package(product: "WhisperKit"),
+        .package(product: "FluidAudio"),
+        .package(product: "Sparkle"),
+      ]),
+
     firstPartyLibrary(
       "EnviousWisprDesktopEffects",
       dependencies: [
@@ -643,6 +654,33 @@ let project = Project(
     // #919: depends on EnviousWisprAppKit (the app-shell library), NOT the app
     // target — Tuist therefore wires NO test host, so `xcodebuild test` runs
     // hermetically without launching EnviousWispr.app.
+    // #2455 C4: the only test target the dep-direction gate permits to construct a
+    // live desktop effect. Nothing in the module graph enforces that — the gate does.
+    // Three suites: `LiveOverlayPanelDriverTests`,
+    // `OverlayRetainedWindowRealPanelTests`, `RecordingPollingRealPanelTests`.
+    // Each needs REAL AppKit behaviour — panel construction, window retention
+    // across hide/show, and view-hierarchy teardown cancelling a SwiftUI task —
+    // none of which a recorder can reproduce.
+    .target(
+      name: "EnviousWisprDesktopEffectsTests",
+      destinations: .macOS,
+      product: .unitTests,
+      bundleId: "com.enviouswispr.desktopeffects.tests",
+      deploymentTargets: deploymentTargets,
+      infoPlist: .default,
+      sources: ["Tests/EnviousWisprDesktopEffectsTests/**"],
+      dependencies: [
+        .target(name: "EnviousWisprCore"),
+        .target(name: "EnviousWisprAppKit"),
+        .target(name: "EnviousWisprAppKitTestSupport"),
+        .target(name: "EnviousWisprDesktopEffects"),
+        .package(product: "WhisperKit"),
+        .package(product: "FluidAudio"),
+        .package(product: "Sparkle"),
+      ],
+      settings: testTargetSettings
+    ),
+
     .target(
       name: "EnviousWisprTests",
       destinations: .macOS,
@@ -653,6 +691,7 @@ let project = Project(
       sources: ["Tests/EnviousWisprTests/**"],
       dependencies: firstPartyTargetDeps + [
         .target(name: "EnviousWisprAppKit"),
+        .target(name: "EnviousWisprAppKitTestSupport"),
         .target(name: "EnviousWisprContacts"),
         .target(name: "EnviousWisprLivePreview"),
         // #2108: the preview-engine tests import the adapter directly. Xcode
@@ -708,7 +747,7 @@ let project = Project(
         findImplicitDependencies: true
       ),
       testAction: .targets(
-        ["EnviousWisprTests", "EnviousWisprASRTests"],
+        ["EnviousWisprTests", "EnviousWisprDesktopEffectsTests", "EnviousWisprASRTests"],
         arguments: denyDesktopEffects,
         configuration: "Debug"
       )
@@ -726,7 +765,7 @@ let project = Project(
         findImplicitDependencies: true
       ),
       testAction: .targets(
-        ["EnviousWisprTests", "EnviousWisprASRTests"],
+        ["EnviousWisprTests", "EnviousWisprDesktopEffectsTests", "EnviousWisprASRTests"],
         arguments: denyDesktopEffects,
         configuration: "Dev"
       )
@@ -742,7 +781,7 @@ let project = Project(
       // `xcodebuild test -scheme EnviousWispr-Release -configuration Release`,
       // preserving the release-config test coverage the old post-merge job ran.
       testAction: .targets(
-        ["EnviousWisprTests", "EnviousWisprASRTests"],
+        ["EnviousWisprTests", "EnviousWisprDesktopEffectsTests", "EnviousWisprASRTests"],
         arguments: denyDesktopEffects,
         configuration: "Release"
       )

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDesktopEffects.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDesktopEffects.swift
@@ -1,0 +1,84 @@
+import AppKit
+
+/// The overlay's window and workspace effects (#2455 C4, issue #2461).
+///
+/// **The abstraction was one level too low.** `OverlayPanelFactory` vended an
+/// `NSPanel`, so every possible implementation WAS one — including the test
+/// double, `CommandRecordingPanel: NSPanel`, which called `super` on every
+/// override and therefore really displayed. That is the pill the founder sees
+/// flash mid-suite: not an oversight in the fake, but the only fake the seam's
+/// type permitted.
+///
+/// Driving a panel is now a protocol over BEHAVIOUR, so a recorder can satisfy it
+/// without being a window.
+@MainActor
+package protocol OverlayPanelDriving: AnyObject {
+  // Reads.
+  var frame: CGRect { get }
+  var isVisible: Bool { get }
+  var windowNumber: Int { get }
+
+  // Configuration.
+  var backgroundColor: NSColor? { get set }
+  var collectionBehavior: NSWindow.CollectionBehavior { get set }
+  var contentView: NSView? { get set }
+  var hasShadow: Bool { get set }
+  var isMovableByWindowBackground: Bool { get set }
+  var isOpaque: Bool { get set }
+  var isReleasedWhenClosed: Bool { get set }
+  var level: NSWindow.Level { get set }
+
+  /// The move callback, replacing `NSWindowDelegate.windowDidMove`.
+  ///
+  /// `delegate` does NOT cross this boundary. The host used to BE the window's
+  /// delegate, which forced it to inherit `NSObject` and made `windowDidMove`
+  /// `nonisolated`. The live driver owns the delegate relationship now and hands
+  /// the host a plain callback, so the host is an ordinary `@MainActor` type and
+  /// the ordering `programmaticMoveDepth` depends on is preserved by the call
+  /// being synchronous.
+  var onMove: (@MainActor (CGRect) -> Void)? { get set }
+
+  // Commands.
+  func orderFrontRegardless()
+  func orderOut()
+  func setAccessibilityIdentifier(_ identifier: String?)
+  func setFrame(_ frame: CGRect, display: Bool)
+  func setFrame(_ frame: CGRect, display: Bool, animate: Bool)
+}
+
+/// A live workspace subscription, cancellable exactly once.
+package protocol WorkspaceObservation: AnyObject {
+  func cancel()
+}
+
+/// How the overlay learns the user switched Spaces.
+///
+/// Only the OBSERVER pair crosses. `NSWorkspace.shared.frontmostApplication`
+/// (`OverlayWindowHost.swift:548`) stays a direct read: it observes and cannot
+/// alter the desktop, and C3 established that reads stay out — `NSApp.windows` is
+/// the precedent.
+@MainActor
+package protocol WorkspaceObserving: AnyObject {
+  func observeActiveSpaceChanges(
+    _ callback: @escaping @MainActor () -> Void
+  ) -> any WorkspaceObservation
+}
+
+/// The overlay's two effects, carried together.
+///
+/// A composition carrier with no `shared`, no static storage and no default —
+/// the same shape as `DesktopPresentationEffects`, and for the same reason: a
+/// default is what lets a test reach the real desktop by simply not saying
+/// otherwise.
+package struct DesktopOverlayEffects {
+  package let makePanel: @MainActor () -> any OverlayPanelDriving
+  package let workspace: any WorkspaceObserving
+
+  package init(
+    makePanel: @escaping @MainActor () -> any OverlayPanelDriving,
+    workspace: any WorkspaceObserving
+  ) {
+    self.makePanel = makePanel
+    self.workspace = workspace
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayWindowHost.swift
@@ -67,10 +67,14 @@ protocol OverlayWindowHosting: AnyObject {
 }
 
 @MainActor
-final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate {
+final class OverlayWindowHost: OverlayWindowHosting {
 
-  /// `nil` until the first presentation. Never closed, never released.
-  private var panel: NSPanel?
+  /// `nil` until the first presentation. Never released.
+  ///
+  /// #2455 C4: this type is the sole AppKit CONSUMER of the overlay panel driver;
+  /// the live driver owns the `NSPanel` itself. "Never closed" is now structural
+  /// rather than a discipline — `OverlayPanelDriving` declares no `close`.
+  private var panel: (any OverlayPanelDriving)?
   private var placement = OverlayPlacementState()
   private let screens: () -> OverlayScreenResolver
 
@@ -90,7 +94,10 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
   /// not flagged.
   private var programmaticMoveDepth = 0
 
-  private let panelFactory: OverlayPanelFactory
+  /// #2455 C4: required and non-defaulted. The old `OverlayPanelFactory` vended
+  /// an `NSPanel`, so every implementation WAS a window — including the test
+  /// double, which is why the suite flashed a real pill.
+  private let effects: DesktopOverlayEffects
 
   /// Registered here rather than on the panel because **every fact this
   /// callback needs already lives in this object**: the placement anchor, the
@@ -101,27 +108,25 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
   /// used: the notification centre guarantees the main thread, so hopping
   /// through a `Task` only adds a scheduling round trip and delays how fast the
   /// pill reacts to the swipe.
-  private nonisolated(unsafe) var spaceChangeObserver: NSObjectProtocol?
+  private var spaceChangeObservation: (any WorkspaceObservation)?
 
   init(
     screens: @escaping () -> OverlayScreenResolver = { .live },
-    panelFactory: OverlayPanelFactory = .live
+    effects: DesktopOverlayEffects
   ) {
     self.screens = screens
-    self.panelFactory = panelFactory
-    super.init()
-    spaceChangeObserver = NSWorkspace.shared.notificationCenter.addObserver(
-      forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main
-    ) { [weak self] _ in
-      MainActor.assumeIsolated { self?.repositionForActiveSpaceChange() }
+    self.effects = effects
+    spaceChangeObservation = effects.workspace.observeActiveSpaceChanges { [weak self] in
+      self?.repositionForActiveSpaceChange()
     }
   }
 
-  deinit {
-    if let spaceChangeObserver {
-      NSWorkspace.shared.notificationCenter.removeObserver(spaceChangeObserver)
-    }
-  }
+  // No `deinit`. The observation owns its own token and cancels in ITS deinit, so
+  // releasing this host releases the observation and unsubscribes — one owner for
+  // one lifetime. A `deinit` here could not touch the property anyway: `deinit` is
+  // nonisolated and the observation is `@MainActor`-isolated and non-Sendable, and
+  // the compiler says so. That constraint pointed at the better shape rather than
+  // an obstacle to work around.
 
   // MARK: - Presenting
 
@@ -266,7 +271,7 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
   /// window that still swallows clicks — the panel accepts events across its
   /// whole frame because it is drag-to-relocate.
   func hide() {
-    panel?.orderOut(nil)
+    panel?.orderOut()
     // **Release the hosting view, or a hidden pill keeps working.** The shipped
     // panel got this for free by being destroyed. `RecordingOverlayView` runs a
     // `.task` polling the audio level every 50 ms and `OverlayCapsuleBackground`
@@ -289,14 +294,14 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
 
   // MARK: - Window ownership
 
-  private func ensurePanel() -> NSPanel {
+  private func ensurePanel() -> any OverlayPanelDriving {
     if let panel { return panel }
     // Configuration below is copied verbatim from
     // `05411427:Sources/EnviousWisprAppKit/App/RecordingOverlayPanel.swift` so
     // this chunk changes the panel's LIFETIME and nothing about its identity;
     // the panel object itself comes from the injected factory so a test can
     // observe every AppKit command issued against it.
-    let p = panelFactory.makePanel()
+    var p = effects.makePanel()
     p.isReleasedWhenClosed = false
     p.isOpaque = false
     p.backgroundColor = .clear
@@ -304,7 +309,10 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
     p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     p.isMovableByWindowBackground = true
     p.hasShadow = true
-    p.delegate = self
+    // The move callback replaces `NSWindowDelegate.windowDidMove`. The driver
+    // owns the delegate relationship now, so this type no longer inherits
+    // `NSObject` and the callback is plain `@MainActor` rather than `nonisolated`.
+    p.onMove = { [weak self] frame in self?.panelDidMove(to: frame) }
     panel = p
     return p
   }
@@ -406,37 +414,12 @@ final class OverlayWindowHost: NSObject, OverlayWindowHosting, NSWindowDelegate 
   /// against it later, so a wrong one makes a pill the user deliberately placed
   /// stop counting as user-anchored on its own display — and the next Space
   /// change moves it out from under them.
-  nonisolated func windowDidMove(_ notification: Notification) {
-    MainActor.assumeIsolated {
-      guard programmaticMoveDepth == 0, let panel else { return }
-      guard let screen = screens().containing(panel.frame) ?? screens().current() else { return }
-      placement.userDidMove(to: panel.frame.origin, screen: screen)
-    }
+  private func panelDidMove(to frame: CGRect) {
+    guard programmaticMoveDepth == 0 else { return }
+    guard let screen = screens().containing(frame) ?? screens().current() else { return }
+    placement.userDidMove(to: frame.origin, screen: screen)
   }
 
-}
-
-/// How the host builds its `NSPanel`.
-///
-/// A seam rather than a direct construction, mirroring `OverlayScreenResolver`
-/// immediately below: a test injects a recording subclass through this same
-/// point instead of reading private state off the host, so the real AppKit
-/// commands the host issues are what a test observes (#2377, P6-C2).
-@MainActor
-struct OverlayPanelFactory {
-  let makePanel: () -> NSPanel
-
-  init(makePanel: @escaping () -> NSPanel) {
-    self.makePanel = makePanel
-  }
-
-  static let live = OverlayPanelFactory {
-    NSPanel(
-      contentRect: NSRect(x: 0, y: 0, width: 185, height: 44),
-      styleMask: [.borderless, .nonactivatingPanel],
-      backing: .buffered,
-      defer: false)
-  }
 }
 
 /// How the host learns about screens.

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -229,10 +229,15 @@ extension RecordingPillDesign {
 ///
 /// **Available in Release, not `#if DEBUG`.** Phase 5's proofs must execute in
 /// both configurations, and a DEBUG-only seam forecloses that.
-struct RecordingPollCadence: Sendable {
+/// `package` (#2455 C4): the shared test-support library builds a manual cadence
+/// over this, and that library is a non-shipping target rather than a test target,
+/// so `@testable` is not available to it. Widened one level, not to `public`.
+package struct RecordingPollCadence: Sendable {
 
   /// Returns when it is time to read the providers again.
-  let wait: @Sendable () async -> Void
+  package let wait: @Sendable () async -> Void
+
+  package init(_ wait: @escaping @Sendable () async -> Void) { self.wait = wait }
 
   /// 50 ms, which is what shipped and what `RainbowLevelMeter`'s history depth
   /// is scaled to.
@@ -240,7 +245,7 @@ struct RecordingPollCadence: Sendable {
   /// **`try?` here does NOT swallow cancellation into another read.** A cancelled
   /// sleep returns immediately and the loop's own `while !Task.isCancelled` is
   /// what ends it, so a cancelled poll performs no further provider read.
-  static let live = RecordingPollCadence {
+  package static let live = RecordingPollCadence {
     try? await Task.sleep(for: .milliseconds(50))
   }
 
@@ -257,7 +262,7 @@ struct RecordingPollCadence: Sendable {
   /// The continuation is created per call, so two pills parked on this share no
   /// state, and `finish()` is safe before the loop starts: the stream is already
   /// finished and `for await` returns immediately.
-  static let still = RecordingPollCadence {
+  package static let still = RecordingPollCadence {
     let (stream, continuation) = AsyncStream<Void>.makeStream()
     await withTaskCancellationHandler {
       for await _ in stream { break }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -143,7 +143,8 @@ package final class WisprBootstrapper {
   package init(
     makeHotkeyEffects: () -> any DesktopHotkeyEffects,
     presentationEffects: DesktopPresentationEffects,
-    relocationRelauncher: any RelocationRelaunching
+    relocationRelauncher: any RelocationRelaunching,
+    overlayEffects: DesktopOverlayEffects
   ) {
     self.application = presentationEffects.application
     // ===== Subsystem construction (epic #763) =====
@@ -176,7 +177,7 @@ package final class WisprBootstrapper {
     // further down this function. `PipelineSettingsSync` is downstream of both
     // ASR pipelines, so hoisting the installer would mean hoisting those — the
     // move that does work is this one.
-    let overlayHost = OverlayWindowHost()
+    let overlayHost = OverlayWindowHost(effects: overlayEffects)
     let audioDeviceList = AudioDeviceList()
     let inputDevicePreferenceReconciler = InputDevicePreferenceReconciler(settings: settings)
     audioDeviceList.onDevicesChanged = { [weak inputDevicePreferenceReconciler] devices in

--- a/Sources/EnviousWisprAppKitTestSupport/PollingCadenceFakes.swift
+++ b/Sources/EnviousWisprAppKitTestSupport/PollingCadenceFakes.swift
@@ -1,0 +1,109 @@
+import EnviousWisprAppKit
+import Foundation
+
+// #2455 C4 (#2461): moved out of `RecordingPollingLifetimeTests` so the polling
+// test that needs a REAL panel — and therefore lives in
+// `EnviousWisprDesktopEffectsTests` — can share them instead of owning a second
+// copy. Two copies of a cadence fake drift apart and nothing fails.
+
+package enum PostHideOutcome: Equatable {
+  case cancelled
+  case repolled
+}
+
+/// `@unchecked Sendable` because the cadence closure it vends is `@Sendable` and
+/// captures it. Safe in practice and in a way the compiler cannot see: every
+/// caller drives it from the main actor, and the poll loop it feeds is itself
+/// main-actor-bound. It was nested inside a `@MainActor` suite before it moved
+/// here, which is why the capture compiled without this.
+package final class ManualCadence: @unchecked Sendable {
+
+  package init() {}
+  private var gate: CheckedContinuation<Void, Never>?
+  private var parkWaiter: CheckedContinuation<Void, Never>?
+  private(set) var parks = 0
+
+  /// **Which of the two things happened first after `hide()`.**
+  ///
+  /// Awaiting cancellation alone cannot fail FAST: a host that never releases
+  /// its content simply never cancels, so the row hits its hang guard and
+  /// reports a timeout instead of the poll that carried on. Racing the two
+  /// outcomes reports whichever the code actually did, promptly, with no
+  /// elapsed time involved either way.
+  private var observingPostHide = false
+  private var postHideOutcome: PostHideOutcome?
+  private var postHideWaiter: CheckedContinuation<PostHideOutcome, Never>?
+
+  package var cadence: RecordingPollCadence {
+    RecordingPollCadence { [weak self] in
+      guard let self else { return }
+      await self.park()
+    }
+  }
+
+  /// Called by the view's poll loop in place of its 50 ms wait.
+  private func park() async {
+    parks += 1
+    // A park AFTER hide is the pill completing another poll.
+    if observingPostHide { finishPostHide(.repolled) }
+    // A waiter that asked BEFORE this park gets its answer now.
+    parkWaiter?.resume()
+    parkWaiter = nil
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+        gate = c
+      }
+    } onCancel: {
+      Task { @MainActor [weak self] in self?.releaseOnCancel() }
+    }
+  }
+
+  private func releaseOnCancel() {
+    finishPostHide(.cancelled)
+    gate?.resume()
+    gate = nil
+  }
+
+  /// Suspend until the view parks. Resolves immediately if it already has more
+  /// parks than `count`.
+  package func awaitPark(after count: Int) async {
+    if parks > count { return }
+    await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+      parkWaiter = c
+    }
+  }
+
+  private func finishPostHide(_ outcome: PostHideOutcome) {
+    guard postHideOutcome == nil else { return }
+    postHideOutcome = outcome
+    postHideWaiter?.resume(returning: outcome)
+    postHideWaiter = nil
+  }
+
+  /// Start watching for whichever happens first once the host is hidden.
+  package func beginPostHideObservation() {
+    observingPostHide = true
+  }
+
+  package func awaitPostHideOutcome() async -> PostHideOutcome {
+    if let postHideOutcome { return postHideOutcome }
+    return await withCheckedContinuation { postHideWaiter = $0 }
+  }
+
+  /// Let the poll loop run one more iteration.
+  package func advance() {
+    gate?.resume()
+    gate = nil
+  }
+}
+
+
+package final class Counts {
+
+  package init() {}
+  package var audio = 0
+  package var elapsed = 0
+  package var preview = 0
+  package var all: [Int] { [audio, elapsed, preview] }
+}
+

--- a/Sources/EnviousWisprAppKitTestSupport/RecordingOverlayPanelDriver.swift
+++ b/Sources/EnviousWisprAppKitTestSupport/RecordingOverlayPanelDriver.swift
@@ -1,0 +1,145 @@
+import AppKit
+import EnviousWisprAppKit
+import Foundation
+
+/// The overlay double that is NOT a window (#2455 C4).
+///
+/// **This is the pill that used to flash.** Its predecessor,
+/// `CommandRecordingPanel: NSPanel`, called `super` on every override, so a test
+/// asking for a fake pill got a real one that really appeared on the developer's
+/// screen mid-suite. The fake was not sloppy — `OverlayPanelFactory` vended an
+/// `NSPanel`, so a non-displaying implementation was not expressible. C4 moved the
+/// seam up to BEHAVIOUR, and this is what that buys.
+///
+/// It records commands in ORDER, because the assertions that matter here are
+/// sequential: configure before showing, order out before releasing the hosting
+/// view. Separate counters cannot express an interleaving.
+@MainActor
+package final class RecordingOverlayPanelDriver: OverlayPanelDriving {
+
+  package init() {}
+
+  package enum Command: Equatable {
+    case setFrame(CGRect, display: Bool, animated: Bool)
+    case setContentView(ObjectIdentifier?)
+    case orderFrontRegardless
+    case orderOut
+    case accessibilityIdentifier(String?)
+  }
+
+  package private(set) var commands: [Command] = []
+
+  // MARK: - Reads
+
+  /// Starts at the shipped pill's size, so geometry maths sees the real starting
+  /// point rather than `.zero` — a fake that starts at the origin makes every
+  /// centring calculation trivially correct.
+  package private(set) var frame = CGRect(x: 0, y: 0, width: 185, height: 44)
+  package private(set) var isVisible = false
+  package let windowNumber = 0
+
+  // MARK: - Configuration
+
+  package var backgroundColor: NSColor?
+  package var collectionBehavior: NSWindow.CollectionBehavior = []
+  package var contentView: NSView? {
+    didSet { commands.append(.setContentView(contentView.map(ObjectIdentifier.init))) }
+  }
+  package var hasShadow = false
+  package var isMovableByWindowBackground = false
+  package var isOpaque = true
+  package var isReleasedWhenClosed = true
+  package var level: NSWindow.Level = .normal
+  package var onMove: (@MainActor (CGRect) -> Void)?
+
+  // MARK: - Commands
+
+  package func setFrame(_ value: CGRect, display: Bool) {
+    frame = value
+    commands.append(.setFrame(value, display: display, animated: false))
+    onMove?(value)
+  }
+
+  package func setFrame(_ value: CGRect, display: Bool, animate: Bool) {
+    frame = value
+    commands.append(.setFrame(value, display: display, animated: animate))
+    onMove?(value)
+  }
+
+  package func orderFrontRegardless() {
+    isVisible = true
+    commands.append(.orderFrontRegardless)
+  }
+
+  package func orderOut() {
+    isVisible = false
+    commands.append(.orderOut)
+  }
+
+  package func setAccessibilityIdentifier(_ identifier: String?) {
+    commands.append(.accessibilityIdentifier(identifier))
+  }
+
+  // MARK: - Driving the host from the OS side
+
+  /// The user dragged the pill.
+  ///
+  /// **`setFrame` fires `onMove` too, and that is the point.** The live driver's
+  /// `onMove` fires for programmatic moves as well as drags — AppKit reports both
+  /// — and `programmaticMoveDepth` is what tells them apart. An earlier revision of this
+  /// fake suppressed the callback on `setFrame`, reasoning that it would conflate
+  /// the two — which had it backwards: with no programmatic callback, the depth
+  /// counter is never exercised, and every test of it passes without testing it.
+  /// A fake arranged so a guard cannot fire is the guard's coverage removed.
+  ///
+  /// The difference is WHERE the callback lands: `setFrame`'s arrives inside
+  /// `withProgrammaticMove`, this one arrives outside it.
+  package func simulateUserMove(to origin: CGPoint) {
+    frame.origin = origin
+    onMove?(frame)
+  }
+}
+
+/// A workspace observer that never subscribes to anything.
+@MainActor
+package final class RecordingWorkspaceObserver: WorkspaceObserving {
+
+  package init() {}
+
+  package private(set) var observerCount = 0
+  package private(set) var cancelledCount = 0
+  private var callback: (@MainActor () -> Void)?
+
+  package func observeActiveSpaceChanges(
+    _ callback: @escaping @MainActor () -> Void
+  ) -> any WorkspaceObservation {
+    observerCount += 1
+    self.callback = callback
+    return Observation { [weak self] in self?.cancelledCount += 1 }
+  }
+
+  /// The user switched Spaces.
+  package func simulateActiveSpaceChange() { callback?() }
+
+  private final class Observation: WorkspaceObservation {
+    private var onCancel: (() -> Void)?
+    init(onCancel: @escaping () -> Void) { self.onCancel = onCancel }
+    package func cancel() {
+      onCancel?()
+      onCancel = nil
+    }
+    deinit { cancel() }
+  }
+}
+
+extension DesktopOverlayEffects {
+  /// The default for a test that does not care about the panel — it still gets a
+  /// recorder rather than a window, which is the whole point.
+  @MainActor
+  package static func recording(
+    panel: RecordingOverlayPanelDriver = RecordingOverlayPanelDriver(),
+    workspace: RecordingWorkspaceObserver = RecordingWorkspaceObserver()
+  ) -> DesktopOverlayEffects {
+    DesktopOverlayEffects(makePanel: { panel }, workspace: workspace)
+  }
+}

--- a/Sources/EnviousWisprAppKitTestSupport/WindowlessOverlayHost.swift
+++ b/Sources/EnviousWisprAppKitTestSupport/WindowlessOverlayHost.swift
@@ -1,8 +1,19 @@
+// #2455 C4 (#2461): moved out of `EnviousWisprTests` into a shared support target.
+//
+// Sixteen suites use this fake. `OverlayHostingParityTests` stays in
+// `EnviousWisprTests` and compares this against the real host; the suites in
+// `EnviousWisprDesktopEffectsTests` need it too. Duplicating it would defeat the
+// parity check it exists to serve: two copies of a fake drift apart and nothing
+// fails.
+//
+// A NON-SHIPPING library target, not a test target: a SwiftPM `.testTarget`
+// cannot be depended on by another test target.
+
 import AppKit
 import SwiftUI
 import CoreGraphics
+import EnviousWisprAppKit
 import EnviousWisprCore
-import Testing
 
 @testable import EnviousWisprAppKit
 
@@ -14,7 +25,9 @@ import Testing
 /// refused presentation left its state behind, and C7 removed exactly that. A
 /// test asserting what the overlay shows needs a host that shows it.
 ///
-/// It exists only in the test target, so no runtime flag or test-shaped branch
+/// It exists only in the non-shipping `EnviousWisprAppKitTestSupport` target,
+/// which the test targets link and the app does not, so no runtime flag or
+/// test-shaped branch
 /// enters `OverlayWindowHost` and nothing here can ship.
 ///
 /// **It deliberately cannot answer a geometry question.** It records the request
@@ -22,22 +35,24 @@ import Testing
 /// geometry regression goes unnoticed — the real host owns placement, ordering
 /// and the panel count, and its own suite keeps them.
 @MainActor
-final class WindowlessOverlayHost: OverlayWindowHosting {
+package final class WindowlessOverlayHost: OverlayWindowHosting {
+
+  package init() {}
 
   /// Every presentation this host was asked for, in order.
-  private(set) var presented: [(width: OverlayWidth, fixedHeight: CGFloat?, isFresh: Bool)] = []
-  private(set) var resizes: [CGSize] = []
-  private(set) var hideCount = 0
+  package private(set) var presented: [(width: OverlayWidth, fixedHeight: CGFloat?, isFresh: Bool)] = []
+  package private(set) var resizes: [CGSize] = []
+  package private(set) var hideCount = 0
   /// Whether a presentation is currently up, which is the one piece of window
   /// state a caller can legitimately ask a windowless host about.
-  private(set) var isShowing = false
+  package private(set) var isShowing = false
 
   /// The root view the director handed over, captured so a test can enter
   /// through the SAME closure a click does (#2292 C5c).
   private var hostedRoot: OverlayRootView?
 
   @discardableResult
-  func present(
+  package func present(
     _ view: NSView, width: OverlayWidth, fixedHeight: CGFloat?, isFresh: Bool,
     position: OverlayPillPosition
   ) -> Bool {
@@ -56,10 +71,16 @@ final class WindowlessOverlayHost: OverlayWindowHosting {
   /// closure would leave every visible button dead while every test using such a
   /// seam stayed green. Grant, Discard, Undo, the language chip and the Bluetooth
   /// card all travel this closure when a user clicks, so they travel it here too.
-  func sendUserActionThroughRoot(
+  package func sendUserActionThroughRoot(
     _ action: PillAction, for receipt: PillReceipt
   ) throws {
-    let root = try #require(hostedRoot, "nothing was presented, so no root exists to press")
+    // #2455 C4: `#require` -> a thrown error. A non-test target cannot import
+    // `Testing`, and this fake now lives in one so BOTH test targets can share it.
+    // The failure still surfaces as a test failure — Swift Testing reports a
+    // thrown error from a `throws` test — and the message is preserved.
+    guard let root = hostedRoot else {
+      throw WindowlessOverlayHostError("nothing was presented, so no root exists to press")
+    }
     root.sendEvent(.action(receipt.presentationID, action))
   }
 
@@ -69,18 +90,33 @@ final class WindowlessOverlayHost: OverlayWindowHosting {
   /// Unlike a real leaf callback, this reads `model.presentation` at invocation time;
   /// it therefore cannot prove stale, replacement, or queued-click behavior. Those
   /// cases must use `sendUserActionThroughRoot(_:for:)`.
-  func sendCurrentUserActionThroughRoot(_ action: PillAction) throws {
-    let root = try #require(hostedRoot, "nothing was presented, so no root exists")
-    let id = try #require(root.model.state.presentation?.id, "no pill is currently presented")
+  package func sendCurrentUserActionThroughRoot(_ action: PillAction) throws {
+    guard let root = hostedRoot else {
+      throw WindowlessOverlayHostError("nothing was presented, so no root exists")
+    }
+    guard let id = root.model.state.presentation?.id else {
+      throw WindowlessOverlayHostError("no pill is currently presented")
+    }
     root.sendEvent(.action(id, action))
   }
 
-  func resizeCurrentPresentation(to size: CGSize) {
+  package func resizeCurrentPresentation(to size: CGSize) {
     resizes.append(size)
   }
 
-  func hide() {
+  package func hide() {
     hideCount += 1
     isShowing = false
   }
+}
+
+/// What this fake throws when a test asks it for something that is not there.
+///
+/// Replaces `#require`, which needs `Testing` — unavailable to the non-test target
+/// this fake moved into so both test targets could share it. Swift Testing reports
+/// a thrown error from a `throws` test, so the failure is equally visible and the
+/// message is unchanged.
+package struct WindowlessOverlayHostError: Error, CustomStringConvertible {
+  package let description: String
+  package init(_ description: String) { self.description = description }
 }

--- a/Sources/EnviousWisprAppLive/LiveApplication.swift
+++ b/Sources/EnviousWisprAppLive/LiveApplication.swift
@@ -40,7 +40,12 @@ package final class LiveApplication {
       makeHotkeyEffects: { LiveDesktopHotkeyEffects() },
       presentationEffects: DesktopPresentationEffects(
         application: presentation, panels: presentation),
-      relocationRelauncher: LiveRelocationRelauncher())
+      relocationRelauncher: LiveRelocationRelauncher(),
+      // #2455 C4: the pill. `makePanel` is a factory rather than an instance
+      // because the host builds its panel lazily, on first presentation.
+      overlayEffects: DesktopOverlayEffects(
+        makePanel: { LiveOverlayPanelDriver() },
+        workspace: LiveWorkspaceObserver()))
   }
 
   // MARK: - Scene surface

--- a/Sources/EnviousWisprDesktopEffects/LiveOverlayPanelDriver.swift
+++ b/Sources/EnviousWisprDesktopEffects/LiveOverlayPanelDriver.swift
@@ -1,0 +1,139 @@
+import AppKit
+import EnviousWisprAppKit
+
+/// The real overlay window (#2455 C4).
+///
+/// Owns the `NSPanel` AND its delegate relationship. Before C4 the host was the
+/// delegate, which forced `OverlayWindowHost` to inherit `NSObject` and made
+/// `windowDidMove` `nonisolated`. Moving both here lets the host be an ordinary
+/// `@MainActor` type that receives a plain callback.
+@MainActor
+package final class LiveOverlayPanelDriver: NSObject, OverlayPanelDriving, NSWindowDelegate {
+
+  private let panel: NSPanel
+
+  /// The real window, for `EnviousWisprDesktopEffectsTests` ONLY.
+  ///
+  /// A deliberate widening, and narrow: that target exists to assert what a real
+  /// `NSPanel` does in response to the host's commands, which is unobservable
+  /// through the protocol by design. Nothing else may reach it — the unit target
+  /// does not link this module, and `check-dependency-direction.sh` says so.
+  package var underlyingPanel: NSPanel { panel }
+
+  package var onMove: (@MainActor (CGRect) -> Void)?
+
+  package override init() {
+    // Moved verbatim from `OverlayPanelFactory.live`. Borderless and
+    // non-activating is what makes the pill appear without stealing focus; a
+    // plain `NSWindow` here would take the keyboard from whatever the user is
+    // typing in.
+    panel = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 185, height: 44),
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false)
+    super.init()
+    panel.delegate = self
+  }
+
+  // MARK: - Reads
+
+  package var frame: CGRect { panel.frame }
+  package var isVisible: Bool { panel.isVisible }
+  package var windowNumber: Int { panel.windowNumber }
+
+  // MARK: - Configuration
+
+  package var backgroundColor: NSColor? {
+    get { panel.backgroundColor }
+    set { panel.backgroundColor = newValue }
+  }
+  package var collectionBehavior: NSWindow.CollectionBehavior {
+    get { panel.collectionBehavior }
+    set { panel.collectionBehavior = newValue }
+  }
+  package var contentView: NSView? {
+    get { panel.contentView }
+    set { panel.contentView = newValue }
+  }
+  package var hasShadow: Bool {
+    get { panel.hasShadow }
+    set { panel.hasShadow = newValue }
+  }
+  package var isMovableByWindowBackground: Bool {
+    get { panel.isMovableByWindowBackground }
+    set { panel.isMovableByWindowBackground = newValue }
+  }
+  package var isOpaque: Bool {
+    get { panel.isOpaque }
+    set { panel.isOpaque = newValue }
+  }
+  package var isReleasedWhenClosed: Bool {
+    get { panel.isReleasedWhenClosed }
+    set { panel.isReleasedWhenClosed = newValue }
+  }
+  package var level: NSWindow.Level {
+    get { panel.level }
+    set { panel.level = newValue }
+  }
+
+  // MARK: - Commands
+
+  package func orderFrontRegardless() { panel.orderFrontRegardless() }
+  package func orderOut() { panel.orderOut(nil) }
+  package func setAccessibilityIdentifier(_ identifier: String?) {
+    panel.setAccessibilityIdentifier(identifier)
+  }
+  package func setFrame(_ frame: CGRect, display: Bool) {
+    panel.setFrame(frame, display: display)
+  }
+  package func setFrame(_ frame: CGRect, display: Bool, animate: Bool) {
+    panel.setFrame(frame, display: display, animate: animate)
+  }
+
+  // MARK: - NSWindowDelegate
+
+  nonisolated package func windowDidMove(_ notification: Notification) {
+    MainActor.assumeIsolated { [weak self] in
+      guard let self else { return }
+      onMove?(panel.frame)
+    }
+  }
+}
+
+/// The live Space-change subscription.
+@MainActor
+package final class LiveWorkspaceObserver: WorkspaceObserving {
+
+  package init() {}
+
+  package func observeActiveSpaceChanges(
+    _ callback: @escaping @MainActor () -> Void
+  ) -> any WorkspaceObservation {
+    let token = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main
+    ) { _ in
+      MainActor.assumeIsolated { callback() }
+    }
+    return Observation(token: token)
+  }
+
+  /// Owns the opaque token, so nothing outside this module ever holds one.
+  ///
+  /// `cancel()` and `deinit` are both idempotent: removing twice is a no-op, and
+  /// the alternative — cancelling in only one place — is the leak that outlives
+  /// the host.
+  private final class Observation: WorkspaceObservation {
+    private var token: (any NSObjectProtocol)?
+
+    init(token: any NSObjectProtocol) { self.token = token }
+
+    func cancel() {
+      guard let token else { return }
+      self.token = nil
+      NSWorkspace.shared.notificationCenter.removeObserver(token)
+    }
+
+    deinit { cancel() }
+  }
+}

--- a/Tests/EnviousWisprDesktopEffectsTests/Overlay/LiveOverlayPanelDriverTests.swift
+++ b/Tests/EnviousWisprDesktopEffectsTests/Overlay/LiveOverlayPanelDriverTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+@testable import EnviousWisprAppKit
+import EnviousWisprDesktopEffects
+import Testing
+
+/// What the REAL panel is built as (#2455 C4, issue #2461).
+///
+/// These assertions used to live in `OverlayWindowHostTests`, where they read
+/// `panel.styleMask` off the host's panel. That worked only because the "fake"
+/// was a real `NSPanel` — which is the defect this chunk removes. They belong
+/// here: this is the only test target the dep-direction gate permits to construct a live driver, and construction is
+/// the driver's business rather than the host's.
+///
+/// **These deliberately touch a real window**, which is why this target exists
+/// and why it is the only one that may.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct LiveOverlayPanelDriverTests {
+
+  init() { _ = NSApplication.shared }
+
+  @Test("the live driver builds a borderless, non-activating panel")
+  func styleMaskIsBorderlessNonActivating() {
+    let driver = LiveOverlayPanelDriver()
+    defer { driver.orderOut() }
+
+    // The two flags this test is NAMED for. An earlier revision asserted the
+    // frame size instead — a test that moved and lost the thing it was moved to
+    // check, which is worse than not moving it.
+    let panel = driver.underlyingPanel
+    #expect(panel.styleMask.contains(.borderless))
+    #expect(panel.styleMask.contains(.nonactivatingPanel))
+  }
+
+  /// Both flags matter and for different reasons, so they are asserted apart:
+  /// `.borderless` is why the pill has no title bar, and `.nonactivatingPanel` is
+  /// why showing it does not steal the keyboard from whatever the user is typing
+  /// in. Losing the second one is the founder-visible focus bug this epic exists
+  /// to prevent, and it would not change a single pixel.
+  @Test("the live driver does not take focus when ordered front")
+  func orderingFrontDoesNotActivate() {
+    let driver = LiveOverlayPanelDriver()
+    defer { driver.orderOut() }
+
+    driver.contentView = NSView(frame: NSRect(x: 0, y: 0, width: 185, height: 44))
+
+    // Captured BEFORE, and compared against AFTER. The earlier form asserted
+    // `NSApp.isActive == false || NSApp.keyWindow == nil`, which is true of a
+    // headless test process whatever the panel does — it would have passed with
+    // `.nonactivatingPanel` removed.
+    let wasActive = NSApp.isActive
+    let previousKeyWindow = NSApp.keyWindow
+
+    driver.orderFrontRegardless()
+
+    #expect(driver.isVisible)
+    #expect(NSApp.isActive == wasActive, "ordering the pill front changed app activation")
+    #expect(NSApp.keyWindow === previousKeyWindow, "the pill took key from another window")
+    #expect(
+      driver.underlyingPanel.isKeyWindow == false,
+      "a non-activating panel must never become key")
+  }
+
+  @Test("configuration set through the protocol reaches the real panel")
+  func configurationRoundTrips() {
+    let driver = LiveOverlayPanelDriver()
+    defer { driver.orderOut() }
+
+    driver.level = .floating
+    driver.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    driver.hasShadow = true
+    driver.isOpaque = false
+    driver.isReleasedWhenClosed = false
+
+    #expect(driver.level == .floating)
+    #expect(driver.collectionBehavior == [.canJoinAllSpaces, .fullScreenAuxiliary])
+    #expect(driver.hasShadow)
+    #expect(driver.isOpaque == false)
+    #expect(driver.isReleasedWhenClosed == false, "a released panel cannot be retained")
+  }
+}

--- a/Tests/EnviousWisprDesktopEffectsTests/Overlay/OverlayRetainedWindowRealPanelTests.swift
+++ b/Tests/EnviousWisprDesktopEffectsTests/Overlay/OverlayRetainedWindowRealPanelTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+@testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
+import EnviousWisprCore
+import EnviousWisprDesktopEffects
+import Testing
+
+// #2455 C4 (#2461): moved out of `EnviousWisprTests`.
+//
+// This suite DELIBERATELY drives a real `NSPanel` — that is its entire value, and
+// it is exactly why it cannot live in the unit target any more. `EnviousWisprTests`
+// is not permitted by `check-dependency-direction.sh` to import
+// `EnviousWisprDesktopEffects`. Xcode would let it — the gate is what does not.
+//
+// The chunk plan named only `OverlayHostingParityTests` as needing to move. This
+// suite was found by grepping for the live factory after that one was handled.
+
+/// The unit target's pure recorder proves the host issues the right COMMANDS; it says
+/// nothing about what a real `NSPanel` does in response to them, because the
+/// pure recorder is not a window at all. This suite injects
+/// `LiveOverlayPanelDriver` itself — the identical driver production uses —
+/// so the panel under test is exactly what ships.
+///
+/// **Show / hide / show, asserting identity across all three, not just the
+/// last one.** A host that rebuilt on hide would still show correctly the
+/// second time; only comparing the SAME `ObjectIdentifier` across the full
+/// cycle catches that.
+///
+/// **`willCloseNotification`, not just final visibility.** `isVisible == false`
+/// is what BOTH `orderOut` and `close` leave behind on a panel with
+/// `isReleasedWhenClosed = false` — the earlier mutation control found exactly
+/// this (`compensatingMechanismsStayGone`'s sibling test up the file). The
+/// notification is the only observation that tells them apart without reading
+/// private host state.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayRetainedWindowRealPanelTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static let screen = ScreenGeometry(
+    id: ScreenID(rawValue: 1),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
+
+  @Test("a real panel survives show, hide, show with identity intact")
+  func showHideShowRetainsTheRealPanel() throws {
+    // **A CAPTURING factory, not `firstView.window`.** Reading the panel off
+    // the attached view can only see the panel that ended up attached — it is
+    // blind to an extra real panel constructed and then discarded before or
+    // instead of that one. Wrapping `.live` itself, so every panel it
+    // constructs is genuinely production configuration, is what lets
+    // `constructedPanels.count == 1` prove there was only ever ONE.
+    var constructedPanels: [LiveOverlayPanelDriver] = []
+    let capturingEffects = DesktopOverlayEffects(
+      makePanel: {
+        let panel = LiveOverlayPanelDriver()
+        constructedPanels.append(panel)
+        return panel
+      },
+      workspace: LiveWorkspaceObserver())
+    let host = OverlayWindowHost(
+      screens: { OverlayScreenResolver { Self.screen } }, effects: capturingEffects)
+
+    nonisolated(unsafe) var closed = false
+    var closeToken: NSObjectProtocol?
+    defer { closeToken.map(NotificationCenter.default.removeObserver) }
+
+    let firstView = NSView(frame: NSRect(x: 0, y: 0, width: 185, height: 44))
+    #expect(
+      host.present(
+        firstView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
+    )
+    #expect(constructedPanels.count == 1, "the first presentation built more than one panel")
+    let panel = try #require(constructedPanels.first)
+    #expect(
+      firstView.window === panel.underlyingPanel,
+      "the view attached to a DIFFERENT panel than was built")
+    closeToken = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification, object: panel.underlyingPanel, queue: nil
+    ) { _ in closed = true }
+    defer { host.hide() }
+
+    #expect(panel.isVisible, "show did not put the panel on screen")
+    #expect(panel.contentView === firstView, "show did not attach the content view")
+
+    host.hide()
+    #expect(panel.isVisible == false, "hide left the panel on screen")
+    #expect(panel.contentView == nil, "hide left the previous content attached")
+
+    let secondView = NSView(frame: NSRect(x: 0, y: 0, width: 185, height: 44))
+    #expect(
+      host.present(
+        secondView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
+    )
+    #expect(
+      constructedPanels.count == 1,
+      "showing after a hide built a SECOND real panel — the window is not retained")
+    let secondPanel = try #require(secondView.window)
+
+    #expect(
+      ObjectIdentifier(secondPanel) == ObjectIdentifier(panel.underlyingPanel),
+      "show after hide built a NEW panel — the window is not retained")
+    #expect(secondPanel.isVisible, "the second show did not put the panel back on screen")
+    #expect(secondPanel.contentView === secondView, "the second show kept the old content view")
+    #expect(
+      closed == false,
+      "the panel was CLOSED at some point in show/hide/show — orderOut never posts this")
+  }
+}

--- a/Tests/EnviousWisprDesktopEffectsTests/Overlay/RecordingPollingRealPanelTests.swift
+++ b/Tests/EnviousWisprDesktopEffectsTests/Overlay/RecordingPollingRealPanelTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+@testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
+import EnviousWisprCore
+import EnviousWisprDesktopEffects
+import SwiftUI
+import Testing
+
+/// #2455 C4 (#2461): moved out of `EnviousWisprTests`.
+///
+/// **This test depends on REAL AppKit view-hierarchy teardown.** `hide()` sets
+/// `contentView = nil`, and what cancels `RecordingOverlayView`'s polling `.task`
+/// is AppKit removing the view from a real window. A recording driver cannot
+/// reproduce that: nothing was ever in a view hierarchy, so nothing is torn out of
+/// one. The host's own comment said as much — "the shipped panel got this for free
+/// by being destroyed".
+///
+/// It is therefore a real-panel test, and it was only ever passing in the unit
+/// target because the double was a real `NSPanel`. That is this chunk's whole
+/// subject, so it moves rather than being weakened.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct RecordingPollingRealPanelTests {
+
+  private static let screen = ScreenGeometry(
+    id: ScreenID(rawValue: 1),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
+
+ @Test("a hidden recording pill stops reading its providers", .timeLimit(.minutes(1)))
+  func hidingTheHostStopsThePoll() async throws {
+    let counts = Counts()
+    let manual = ManualCadence()
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } }, effects: DesktopOverlayEffects(
+        makePanel: { LiveOverlayPanelDriver() }, workspace: LiveWorkspaceObserver()))
+    defer { host.hide() }
+
+    let view = RecordingOverlayView(
+      audioLevelProvider: {
+        counts.audio += 1
+        return 0.4
+      },
+      recordingElapsedProvider: {
+        counts.elapsed += 1
+        return 12
+      },
+      livePreviewProvider: {
+        counts.preview += 1
+        return .off
+      },
+      onContentHeightChange: { _ in },
+      chrome: RecordingPillDesign.classic.chrome,
+      isLocked: false,
+      noticeText: nil,
+      cadence: manual.cadence)
+
+    let hosted = NSHostingView(rootView: AnyView(view))
+    // Required, not ignored: a refused presentation would otherwise surface as an
+    // unrelated hang-guard timeout rather than as the thing that went wrong.
+    try #require(
+      host.present(
+        hosted, width: .fixed(RecordingPillDesign.classic.width),
+        fixedHeight: RecordingPillDesign.classic.reservedHeight,
+        isFresh: true, position: .top),
+      "the recording pill never reached the host")
+
+    // 1. The first poll runs immediately, then the loop parks.
+    await manual.awaitPark(after: 0)
+    let afterFirstPoll = counts.all
+    #expect(
+      afterFirstPoll == [1, 1, 1],
+      "the first poll read \(afterFirstPoll), not one of each")
+
+    // 2. THE NON-VACUOUS CONTROL. Without this, a row proving the counts stop
+    //    would pass on a view that never polled at all.
+    manual.advance()
+    await manual.awaitPark(after: 1)
+    let afterOneTick = counts.all
+    #expect(
+      afterOneTick == [2, 2, 2],
+      "one advance moved the counts to \(afterOneTick), so the poll is not running")
+
+    // 3. Take the content away — what `hide()` does in production — and push the
+    //    loop at the same time. Whichever happens first is the answer: the wait
+    //    is cancelled, or the pill completes another poll.
+    manual.beginPostHideObservation()
+    host.hide()
+    manual.advance()
+
+    let outcome = await manual.awaitPostHideOutcome()
+    #expect(outcome == .cancelled, "the hidden pill completed another poll")
+
+    // 4. And nothing was read on the way.
+    #expect(
+      counts.all == afterOneTick,
+      "a hidden pill kept polling: \(afterOneTick) became \(counts.all)")
+  }
+
+}

--- a/Tests/EnviousWisprDesktopEffectsTests/TestClassTags.swift
+++ b/Tests/EnviousWisprDesktopEffectsTests/TestClassTags.swift
@@ -1,0 +1,14 @@
+import Testing
+
+/// This target's own tag declarations (#2455 C4).
+///
+/// `EnviousWisprTests` declares the same names in its own `TestClassTags.swift`.
+/// Tags are target-local, so a suite moved across the boundary loses them unless
+/// the new target declares its own — which is why moving a file alone does not
+/// compile.
+extension Tag {
+  @Tag static var productOutcome: Self
+  @Tag static var driftGuard: Self
+  @Tag static var harnessContract: Self
+  @Tag static var realBoundary: Self
+}

--- a/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
@@ -3,6 +3,7 @@ import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 
 /// The language chip's dismissal belongs to the director, and the leaf owns no
 /// clock (#2377 Phase 5, C3).
@@ -61,7 +62,7 @@ struct LanguageChipExpiryOwnershipTests {
   func theDirectorOwnsTheChipsDismissal() throws {
     let counts = Counts()
     let armed = Armed()
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } })
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } }, effects: .recording())
     defer { host.hide() }
     let d = OverlayDirector(
       host: host,

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 
 /// A director for tests that need one only as a DEPENDENCY (#2292, C4c).
 ///

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -13,6 +13,7 @@ import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 
 /// #2292 chunk C4b. The presentation transaction.
 ///
@@ -252,9 +253,10 @@ struct OverlayDirectorTests {
   ) -> (OverlayDirector, Armed, Sink) {
     let armed = Armed()
     let sink = Sink()
-    // Real panels again: the director renders through a real host. Held so the
-    // caller can order the window out when the test ends.
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { screen } })
+    // Real HOST, inert panel driver (#2455 C4): the director renders through the
+    // production host, whose panel is a recorder rather than a window. Held so the
+    // caller can hide the host and release its content when the test ends.
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { screen } }, effects: .recording())
     let d = OverlayDirector(
       host: host,
       position: position,
@@ -938,7 +940,7 @@ struct OverlayDirectorTests {
   @Test("a recording's effect is delivered before its geometry is resolved")
   func recordingEffectsPrecedeGeometry() {
     var recordingStarted = false
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } })
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } }, effects: .recording())
     // **Both halves ride on the SAME bridge now** (#2292 C2), which states the
     // ordering this case is about more directly than the old pair did: the
     // recording signal and the geometry answer arrive together, so "did the
@@ -1407,23 +1409,24 @@ struct OverlayDirectorTests {
     #expect(secondResults == [.notPresented], "the second caller did not hear the shared refusal")
   }
 
-  /// **The real AppKit surface, not the windowless fake's call count.** Every
-  /// other same-id row above counts calls into `RefusingWindowlessHost`; this
-  /// one asks the actual `OverlayWindowHost` what it told a real `NSPanel` to
-  /// do, so a bug that produced one FAKE-host call but two real
-  /// `orderFrontRegardless` commands — a shape none of the windowless rows
-  /// above could ever see — still fails here.
-  @Test("two same-id updates before readiness issue exactly one real orderFrontRegardless")
+  /// **The real HOST's command stream, not the windowless fake's call count.**
+  /// Every other same-id row above counts calls into `RefusingWindowlessHost`;
+  /// this one asks the actual `OverlayWindowHost` what it told its panel driver to
+  /// do, so a bug that produced one FAKE-host call but two `orderFrontRegardless`
+  /// commands — a shape none of the windowless rows above could ever see — still
+  /// fails here. The driver is a recorder, not an `NSPanel` (#2455 C4); what
+  /// distinguishes this row is the HOST being real, which was always the point.
+  @Test("two same-id updates before readiness issue exactly one host orderFrontRegardless")
   func twoSameIDUpdatesIssueExactlyOneRealHostCommand() {
     let recorder = OverlayPanelCommandRecorder()
     let host = OverlayWindowHost(
-      screens: { OverlayScreenResolver { Self.screen } }, panelFactory: recorder.makeFactory())
+      screens: { OverlayScreenResolver { Self.screen } }, effects: recorder.makeEffects())
     let deferral = Deferral()
     let d = OverlayDirector(
       host: host, scheduler: .manual { _ in }, announce: { _ in }, livePreview: .disabled,
       grantAccessibility: {}, selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
-    defer { recorder.panel?.orderOut(nil) }
+    defer { recorder.panel?.orderOut() }
 
     Self.record(d, level: 0.2)
     Self.record(d, level: 0.4)
@@ -1435,7 +1438,7 @@ struct OverlayDirectorTests {
     }
     #expect(
       orderFrontCount == 1,
-      "two same-id updates issued \(orderFrontCount) real orderFrontRegardless commands")
+      "two same-id updates issued \(orderFrontCount) host orderFrontRegardless commands")
   }
 
   /// **Nothing announces or arms before the gate fires, and coalescing an
@@ -1907,7 +1910,8 @@ struct OverlayDirectorTests {
     let sink = Sink()
     let armed = Armed()
     let host = OverlayWindowHost(
-      screens: { OverlayScreenResolver { screenAvailable() ? screen : nil } })
+      screens: { OverlayScreenResolver { screenAvailable() ? screen : nil } },
+      effects: .recording())
     let d = OverlayDirector(
       host: host,
       scheduler: .manual { armed.work = $0 },

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
@@ -4,6 +4,7 @@ import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 
 /// The contract BOTH `OverlayWindowHosting` implementations must satisfy
 /// (#2292, C7).
@@ -61,74 +62,5 @@ struct OverlayHostingContractTests {
 
     #expect(host.hideCount == 1, "the fake was never asked to hide")
     #expect(!host.isShowing, "the fake was hidden and still reports a presentation showing")
-  }
-}
-
-/// The half that COMPARES the two hosts.
-///
-/// **Release-visible since C6.** It needed the director's debug seams to do the
-/// comparison, which confined it to the Debug lane; it now reads `renderModel`,
-/// which is production surface, so both hosts are compared in both lanes.
-@MainActor
-@Suite(.tags(.productOutcome))
-struct OverlayHostingParityTests {
-
-  init() { _ = NSApplication.shared }
-
-  private static var realHosts: [OverlayWindowHost] = []
-
-  private static let screen = ScreenGeometry(
-    id: ScreenID(rawValue: 1),
-    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
-    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
-
-  /// Both hosts, behind the protocol, so a case is written ONCE and runs
-  /// twice. A per-host copy is how the two definitions drift apart without
-  /// anything failing.
-  private static func hosts() -> [(name: String, host: any OverlayWindowHosting)] {
-    let real = OverlayWindowHost(screens: { OverlayScreenResolver { screen } })
-    realHosts.append(real)
-    return [("real", real), ("windowless", WindowlessOverlayHost())]
-  }
-
-  private static func closeRealHosts() {
-    for host in realHosts { host.hide() }
-    realHosts.removeAll()
-  }
-
-  private static func director(on host: any OverlayWindowHosting) -> OverlayDirector {
-    OverlayDirector(
-      host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
-      selections: { .shipped },
-      firstRenderSchedule: { $0() })
-  }
-
-  @Test("both hosts report a presentation they accepted")
-  func presentationSucceedsOnBothHosts() {
-    defer { Self.closeRealHosts() }
-    for (name, host) in Self.hosts() {
-      let d = Self.director(on: host)
-
-      d.present(.warning(reason: .polishFailed))
-
-      #expect(
-        d.renderModel.state.presentation != nil,
-        "the \(name) host refused a presentation the other accepted")
-    }
-  }
-
-  @Test("both hosts release the slot when the overlay is hidden")
-  func hidingClearsOnBothHosts() {
-    defer { Self.closeRealHosts() }
-    for (name, host) in Self.hosts() {
-      let d = Self.director(on: host)
-      d.present(.warning(reason: .polishFailed))
-
-      d.dismissCurrent(.announced)
-
-      #expect(
-        d.renderModel.state.presentation == nil,
-        "the \(name) host left a pill on screen after hiding")
-    }
   }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingParityTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+@testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
+import EnviousWisprCore
+import Testing
+
+// #2455 C4 (#2461): STAYS in the unit target, and the chunk plan expected it to
+// move.
+//
+// The plan's reason was "the unit target cannot both exclude DesktopEffects and
+// compile a suite that uses it". Once the panel is injected, this suite does not
+// use it: what it compares is two HOST implementations — `OverlayWindowHost`
+// against `WindowlessOverlayHost` — and the `NSPanel` underneath was incidental to
+// that comparison. It was also the thing that flashed on screen. With a recording
+// driver the comparison is unchanged and nothing displays, so moving it would
+// carry it across a boundary it no longer crosses.
+//
+// `OverlayRetainedWindowRealPanelTests` DOES construct the live driver, and that
+// suite is why `EnviousWisprDesktopEffectsTests` exists.
+
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayHostingParityTests {
+
+  init() { _ = NSApplication.shared }
+
+  private static var realHosts: [OverlayWindowHost] = []
+
+  private static let screen = ScreenGeometry(
+    id: ScreenID(rawValue: 1),
+    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
+
+  /// Both hosts, behind the protocol, so a case is written ONCE and runs
+  /// twice. A per-host copy is how the two definitions drift apart without
+  /// anything failing.
+  private static func hosts() -> [(name: String, host: any OverlayWindowHosting)] {
+    let real = OverlayWindowHost(screens: { OverlayScreenResolver { screen } }, effects: .recording())
+    realHosts.append(real)
+    return [("real", real), ("windowless", WindowlessOverlayHost())]
+  }
+
+  private static func closeRealHosts() {
+    for host in realHosts { host.hide() }
+    realHosts.removeAll()
+  }
+
+  private static func director(on host: any OverlayWindowHosting) -> OverlayDirector {
+    OverlayDirector(
+      host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      selections: { .shipped },
+      firstRenderSchedule: { $0() })
+  }
+
+  @Test("both hosts report a presentation they accepted")
+  func presentationSucceedsOnBothHosts() {
+    defer { Self.closeRealHosts() }
+    for (name, host) in Self.hosts() {
+      let d = Self.director(on: host)
+
+      d.present(.warning(reason: .polishFailed))
+
+      #expect(
+        d.renderModel.state.presentation != nil,
+        "the \(name) host refused a presentation the other accepted")
+    }
+  }
+
+  @Test("both hosts release the slot when the overlay is hidden")
+  func hidingClearsOnBothHosts() {
+    defer { Self.closeRealHosts() }
+    for (name, host) in Self.hosts() {
+      let d = Self.director(on: host)
+      d.present(.warning(reason: .polishFailed))
+
+      d.dismissCurrent(.announced)
+
+      #expect(
+        d.renderModel.state.presentation == nil,
+        "the \(name) host left a pill on screen after hiding")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayPanelCommandRecorder.swift
@@ -1,127 +1,84 @@
 import AppKit
-import CoreGraphics
+import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
+import Foundation
 
-@testable import EnviousWisprAppKit
-
-/// One AppKit command `OverlayWindowHost` issued against a panel (#2377, P6-C2).
+/// Every command the host issued against a panel, in order.
 ///
-/// **These observe the actual overridden AppKit calls, not the host's INTENT.**
-/// A receipt shaped `.presented(width:height:isFresh:position:)` would restate
-/// what the host meant to do and could stay green after the real command
-/// disappeared from `present()` — exactly the risk the deleted `*ForTesting`
-/// accessors carried, one layer down. `setFrame`/`setContentView`/
-/// `orderFrontRegardless`/`orderOut`/`close` are the actual AppKit surface the
-/// host drives; recording those, and nothing higher-level, is what makes a
-/// missing call visible instead of a missing INTENTION.
+/// **`close` is gone (#2455 C4).** It existed as a negative tripwire — production
+/// must never call it — and `OverlayPanelDriving` simply does not declare it, so
+/// the case it guarded is now unrepresentable rather than merely unasserted. That
+/// is the stronger form of the same check.
 enum OverlayPanelCommand: Equatable {
   case constructed(panel: ObjectIdentifier)
   case setFrame(panel: ObjectIdentifier, frame: CGRect, display: Bool, animated: Bool)
   case setContentView(panel: ObjectIdentifier, view: ObjectIdentifier?)
   case orderFrontRegardless(panel: ObjectIdentifier)
   case orderOut(panel: ObjectIdentifier)
-  case close(panel: ObjectIdentifier)
 }
 
-/// Owns every panel `OverlayPanelFactory` has produced and the commands each
-/// one received.
+/// Owns every panel the host has produced and the commands each one received.
 ///
-/// **One recorder per test, one factory closure per recorder.** `panel`
-/// answers `panelForTesting`'s old question (the current occupant) without
-/// reading private host state; `constructionCount` answers
-/// `panelConstructionCount`'s old question by counting `.constructed` receipts
-/// instead of keeping a second, independently-incrementable counter — one
-/// authority for "how many panels exist" instead of two that could drift.
+/// **The panels are no longer `NSPanel`s (#2455 C4.)** This type's predecessor
+/// vended `CommandRecordingPanel: NSPanel`, which called `super` on every
+/// override — so a suite asking for a fake pill got a real one, and the founder
+/// watched it flash. The seam vended an `NSPanel`, so a non-displaying double was
+/// not expressible; C4 moved the seam to behaviour and this records against that.
+///
+/// **One recorder per test, one factory closure per recorder.** `panel` answers
+/// "the current occupant" without reading private host state; `constructionCount`
+/// counts `.constructed` receipts rather than keeping a second, independently
+/// incrementable counter — one authority for "how many panels exist" instead of
+/// two that could drift.
 @MainActor
 final class OverlayPanelCommandRecorder {
-  fileprivate(set) var commands: [OverlayPanelCommand] = []
-  fileprivate(set) var panels: [NSPanel] = []
 
-  var panel: NSPanel? { panels.last }
+  private(set) var panels: [RecordingOverlayPanelDriver] = []
 
-  var constructionCount: Int {
-    commands.reduce(into: 0) { count, command in
-      if case .constructed = command { count += 1 }
+  var panel: RecordingOverlayPanelDriver? { panels.last }
+
+  /// Flattened from every panel this recorder vended, tagged by panel identity,
+  /// so the assertions that ask "which panel got this" still can.
+  var commands: [OverlayPanelCommand] {
+    var out: [OverlayPanelCommand] = []
+    for p in panels {
+      let id = ObjectIdentifier(p)
+      out.append(.constructed(panel: id))
+      for c in p.commands {
+        switch c {
+        case .setFrame(let f, let display, let animated):
+          out.append(.setFrame(panel: id, frame: f, display: display, animated: animated))
+        case .setContentView(let view):
+          out.append(.setContentView(panel: id, view: view))
+        case .orderFrontRegardless:
+          out.append(.orderFrontRegardless(panel: id))
+        case .orderOut:
+          out.append(.orderOut(panel: id))
+        case .accessibilityIdentifier:
+          // Not in the original vocabulary; the suites that care assert on the
+          // driver directly rather than through this flattening.
+          break
+        }
+      }
     }
+    return out
   }
 
-  func makeFactory() -> OverlayPanelFactory {
-    OverlayPanelFactory { [weak self] in
-      let p = CommandRecordingPanel(recorder: self)
-      self?.panels.append(p)
-      self?.commands.append(.constructed(panel: ObjectIdentifier(p)))
-      return p
-    }
-  }
-}
+  var constructionCount: Int { panels.count }
 
-/// A real `NSPanel` that reports every command this suite cares about to its
-/// recorder — the panel behaves exactly as the production one does; only the
-/// reporting is added.
-///
-/// **`close()` records BEFORE calling `super`; every successful command records
-/// AFTER.** Closing is a negative tripwire on the attempted call itself, so its
-/// receipt must not depend on the superclass operation completing. Production
-/// never calls `close()`.
-///
-/// **`setFrame` is normalized to one receipt per Host call.** `NSWindow`
-/// exposes animated and non-animated overloads. `animatedSetFrameDepth`
-/// normalizes either AppKit implementation: independent overloads or an
-/// animated overload that internally routes through the non-animated one.
-private final class CommandRecordingPanel: NSPanel {
-  private weak var recorder: OverlayPanelCommandRecorder?
-  private var animatedSetFrameDepth = 0
-
-  init(recorder: OverlayPanelCommandRecorder?) {
-    self.recorder = recorder
-    super.init(
-      contentRect: NSRect(x: 0, y: 0, width: 185, height: 44),
-      styleMask: [.borderless, .nonactivatingPanel],
-      backing: .buffered,
-      defer: false)
-  }
-
-  override func setFrame(_ frameRect: NSRect, display displayFlag: Bool) {
-    super.setFrame(frameRect, display: displayFlag)
-    guard animatedSetFrameDepth == 0 else { return }
-    recorder?.commands.append(
-      .setFrame(
-        panel: ObjectIdentifier(self), frame: frameRect, display: displayFlag, animated: false))
-  }
-
-  override func setFrame(_ frameRect: NSRect, display displayFlag: Bool, animate animateFlag: Bool)
-  {
-    animatedSetFrameDepth += 1
-    defer { animatedSetFrameDepth -= 1 }
-    super.setFrame(frameRect, display: displayFlag, animate: animateFlag)
-    recorder?.commands.append(
-      .setFrame(
-        panel: ObjectIdentifier(self), frame: frameRect, display: displayFlag,
-        animated: animateFlag))
-  }
-
-  override var contentView: NSView? {
-    get { super.contentView }
-    set {
-      super.contentView = newValue
-      recorder?.commands.append(
-        .setContentView(
-          panel: ObjectIdentifier(self),
-          view: newValue.map(ObjectIdentifier.init)))
-    }
-  }
-
-  override func orderFrontRegardless() {
-    super.orderFrontRegardless()
-    recorder?.commands.append(.orderFrontRegardless(panel: ObjectIdentifier(self)))
-  }
-
-  override func orderOut(_ sender: Any?) {
-    super.orderOut(sender)
-    recorder?.commands.append(.orderOut(panel: ObjectIdentifier(self)))
-  }
-
-  override func close() {
-    recorder?.commands.append(.close(panel: ObjectIdentifier(self)))
-    super.close()
+  /// The effects a host under test receives.
+  ///
+  /// Replaces `makeFactory()`. Each call vends a NEW driver, matching the old
+  /// factory's contract — the host builds its panel lazily and may rebuild it.
+  func makeEffects(
+    workspace: RecordingWorkspaceObserver = RecordingWorkspaceObserver()
+  ) -> DesktopOverlayEffects {
+    DesktopOverlayEffects(
+      makePanel: { [weak self] in
+        let driver = RecordingOverlayPanelDriver()
+        self?.panels.append(driver)
+        return driver
+      },
+      workspace: workspace)
   }
 }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
@@ -83,19 +83,28 @@ struct OverlayRetainedWindowTests {
     return found
   }
 
-  /// Exactly one `NSPanel(` constructor in the whole module, and it is the host's.
-  @Test("only OverlayWindowHost constructs a panel")
-  func onlyTheHostConstructsAPanel() throws {
+  /// **ZERO `NSPanel(` constructors in this module now (#2455 C4).**
+  ///
+  /// This asserted exactly one, in `OverlayWindowHost.swift`. C4 moved it to
+  /// `LiveOverlayPanelDriver` in `EnviousWisprDesktopEffects`, which this target
+  /// does not DECLARE — so the guard gets STRONGER, not weaker: the original worry
+  /// was a second constructor becoming a second window (#930's flicker by another
+  /// route), and this test plus `check-dependency-direction.sh`'s `NSPanel[[:space:]]*[(]`
+  /// rule are what reject one. Xcode would compile it — the gate is what does not.
+  @Test("no overlay source in this module constructs a panel")
+  func noOverlaySourceConstructsAPanel() throws {
     let sources = try Self.overlayModuleSources()
     #expect(sources.count > 50, "the sweep found almost nothing — it is pointed at the wrong tree")
 
     let constructors = sources.filter { Self.panelCalls(in: $0.text).constructs > 0 }
     #expect(
-      constructors.map(\.name) == ["OverlayWindowHost.swift"],
+      constructors.isEmpty,
       """
-      \(constructors.map(\.name)) construct an NSPanel. Exactly one owner may, or \
-      the retained window is not retained: a second constructor is a second \
-      window, which is the #930 flicker returning by another route.
+      \(constructors.map(\.name)) construct an NSPanel inside EnviousWisprAppKit. \
+      Panel construction belongs to LiveOverlayPanelDriver in \
+      EnviousWisprDesktopEffects; one here is a window this module can build \
+      without going through the seam, which is exactly what made the suite flash \
+      a pill.
       """)
   }
 
@@ -221,12 +230,12 @@ struct OverlayRetainedWindowBehaviourTests {
   @Test("several transitions build one window")
   func transitionsReuseTheRetainedWindow() async {
     let recorder = OverlayPanelCommandRecorder()
-    let host = OverlayWindowHost(panelFactory: recorder.makeFactory())
+    let host = OverlayWindowHost(effects: recorder.makeEffects())
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
       selections: { .shipped },
       firstRenderSchedule: { $0() })
-    defer { recorder.panel?.orderOut(nil) }
+    defer { recorder.panel?.orderOut() }
 
     d.present(.processing(phase: .polishing))
     await drainMainQueue()
@@ -252,12 +261,12 @@ struct OverlayRetainedWindowBehaviourTests {
   @Test("hiding and showing again reuses the same window")
   func hideThenShowReusesTheWindow() async {
     let recorder = OverlayPanelCommandRecorder()
-    let host = OverlayWindowHost(panelFactory: recorder.makeFactory())
+    let host = OverlayWindowHost(effects: recorder.makeEffects())
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
       selections: { .shipped },
       firstRenderSchedule: { $0() })
-    defer { recorder.panel?.orderOut(nil) }
+    defer { recorder.panel?.orderOut() }
 
     for _ in 0..<4 {
       d.present(.processing(phase: .polishing))
@@ -273,95 +282,9 @@ struct OverlayRetainedWindowBehaviourTests {
 }
 
 /// **The real-panel integration Codex ruled C2 needed (#2377): retained
-/// identity proven with a genuine base `NSPanel`, not the recording subclass.**
+/// identity proven with a genuine `NSPanel`, not a recorder.**
 ///
-/// The recorder above proves the host issues the right AppKit COMMANDS; it says
-/// nothing about what a real `NSPanel` does in response to them, because the
-/// recording subclass overrides those same methods. This suite injects
-/// `OverlayPanelFactory.live` itself — the identical factory production uses —
-/// so the panel under test is exactly what ships.
+/// #2455 C4: that proof now lives in `OverlayRetainedWindowRealPanelTests`, in the
+/// one test target `check-dependency-direction.sh` permits to construct a live
+/// driver. Xcode would let this target import it; the gate is what does not.
 ///
-/// **Show / hide / show, asserting identity across all three, not just the
-/// last one.** A host that rebuilt on hide would still show correctly the
-/// second time; only comparing the SAME `ObjectIdentifier` across the full
-/// cycle catches that.
-///
-/// **`willCloseNotification`, not just final visibility.** `isVisible == false`
-/// is what BOTH `orderOut` and `close` leave behind on a panel with
-/// `isReleasedWhenClosed = false` — the earlier mutation control found exactly
-/// this (`compensatingMechanismsStayGone`'s sibling test up the file). The
-/// notification is the only observation that tells them apart without reading
-/// private host state.
-@MainActor
-@Suite(.tags(.productOutcome))
-struct OverlayRetainedWindowRealPanelTests {
-
-  init() { _ = NSApplication.shared }
-
-  private static let screen = ScreenGeometry(
-    id: ScreenID(rawValue: 1),
-    frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
-    visibleFrame: CGRect(x: 0, y: 85, width: 1512, height: 860))
-
-  @Test("a real panel survives show, hide, show with identity intact")
-  func showHideShowRetainsTheRealPanel() throws {
-    // **A CAPTURING factory, not `firstView.window`.** Reading the panel off
-    // the attached view can only see the panel that ended up attached — it is
-    // blind to an extra real panel constructed and then discarded before or
-    // instead of that one. Wrapping `.live` itself, so every panel it
-    // constructs is genuinely production configuration, is what lets
-    // `constructedPanels.count == 1` prove there was only ever ONE.
-    let live = OverlayPanelFactory.live
-    var constructedPanels: [NSPanel] = []
-    let capturingFactory = OverlayPanelFactory {
-      let panel = live.makePanel()
-      constructedPanels.append(panel)
-      return panel
-    }
-    let host = OverlayWindowHost(
-      screens: { OverlayScreenResolver { Self.screen } }, panelFactory: capturingFactory)
-
-    nonisolated(unsafe) var closed = false
-    var closeToken: NSObjectProtocol?
-    defer { closeToken.map(NotificationCenter.default.removeObserver) }
-
-    let firstView = NSView(frame: NSRect(x: 0, y: 0, width: 185, height: 44))
-    #expect(
-      host.present(
-        firstView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
-    )
-    #expect(constructedPanels.count == 1, "the first presentation built more than one panel")
-    let panel = try #require(constructedPanels.first)
-    #expect(firstView.window === panel, "the view attached to a DIFFERENT panel than was built")
-    closeToken = NotificationCenter.default.addObserver(
-      forName: NSWindow.willCloseNotification, object: panel, queue: nil
-    ) { _ in closed = true }
-    defer { host.hide() }
-
-    #expect(panel.isVisible, "show did not put the panel on screen")
-    #expect(panel.contentView === firstView, "show did not attach the content view")
-
-    host.hide()
-    #expect(panel.isVisible == false, "hide left the panel on screen")
-    #expect(panel.contentView == nil, "hide left the previous content attached")
-
-    let secondView = NSView(frame: NSRect(x: 0, y: 0, width: 185, height: 44))
-    #expect(
-      host.present(
-        secondView, width: .fixed(185), fixedHeight: nil, isFresh: true, position: .bottom)
-    )
-    #expect(
-      constructedPanels.count == 1,
-      "showing after a hide built a SECOND real panel — the window is not retained")
-    let secondPanel = try #require(secondView.window)
-
-    #expect(
-      ObjectIdentifier(secondPanel) == ObjectIdentifier(panel),
-      "show after hide built a NEW panel — the window is not retained")
-    #expect(secondPanel.isVisible, "the second show did not put the panel back on screen")
-    #expect(secondPanel.contentView === secondView, "the second show kept the old content view")
-    #expect(
-      closed == false,
-      "the panel was CLOSED at some point in show/hide/show — orderOut never posts this")
-  }
-}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayWindowHostTests.swift
@@ -5,6 +5,7 @@ import SwiftUI
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 
 /// #2292 chunk C3. The retained window.
 ///
@@ -12,8 +13,12 @@ import Testing
 /// destroyed and rebuilt (#930), jump sideways after they dragged it (#2195), or
 /// a hidden window keeps swallowing clicks over an empty patch of screen.
 ///
-/// These touch AppKit, so they build a real `NSPanel` — that is the point. The
-/// probe on 2026-08-21 established what a retained panel costs
+/// **These build NO window (#2455 C4).** They used to: the recorder was an
+/// `NSPanel` subclass, so every case here displayed a real pill for as long as the
+/// suite ran. The host now drives an `OverlayPanelDriving` and the recorder is
+/// inert. What is asserted — which commands, in which order, with which geometry —
+/// is unchanged, because none of it was ever about AppKit's response.
+/// The probe on 2026-08-21 established what a retained panel costs
 /// (`docs/audits/2026-08-21-overlay-probe-results.md`); this suite establishes
 /// that OUR host retains exactly one and places it correctly. Screens are faked
 /// so geometry is deterministic and a full-screen space is reachable, neither of
@@ -22,8 +27,9 @@ import Testing
 /// **Every case observes the panel through an `OverlayPanelCommandRecorder`
 /// rather than a `#if DEBUG` accessor on the host (#2377, P6-C2).** That is what
 /// lets this whole file — and its production counterpart — build and run in
-/// RELEASE: the recorder is a real `NSPanel` subclass injected through the same
-/// `OverlayPanelFactory` seam production code uses, not a compiled-out hatch.
+/// RELEASE: the recorder is a pure `OverlayPanelDriving` implementation injected
+/// through the same `DesktopOverlayEffects` seam production code uses, not a
+/// compiled-out hatch.
 @MainActor
 @Suite(.tags(.productOutcome))
 struct OverlayWindowHostTests {
@@ -46,14 +52,14 @@ struct OverlayWindowHostTests {
 
   private static func makeHost(
     _ geometry: @escaping @autoclosure () -> ScreenGeometry = screen,
-    panelFactory: OverlayPanelFactory = .live
+    effects: DesktopOverlayEffects = .recording()
   ) -> OverlayWindowHost {
     OverlayWindowHost(
-      screens: { OverlayScreenResolver { geometry() } }, panelFactory: panelFactory)
+      screens: { OverlayScreenResolver { geometry() } }, effects: effects)
   }
 
-  private static func host(panelFactory: OverlayPanelFactory = .live) -> OverlayWindowHost {
-    makeHost(panelFactory: panelFactory)
+  private static func host(effects: DesktopOverlayEffects = .recording()) -> OverlayWindowHost {
+    makeHost(effects: effects)
   }
 
   /// A view whose FRAME and FITTING size are independently settable.
@@ -82,8 +88,8 @@ struct OverlayWindowHostTests {
   @Test("one panel is constructed however many presentations arrive")
   func onePanelForEveryPresentation() {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     for i in 0..<12 {
       h.present(
         Self.view(width: 185 + CGFloat(i), height: 44), width: .fixed(185 + CGFloat(i)),
@@ -101,17 +107,19 @@ struct OverlayWindowHostTests {
   @Test("a continuing presentation keeps the pill where the user dragged it")
   func continuingKeepsTheDraggedPosition() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
     let panel = try #require(recorder.panel)
 
-    // The user drags it well left of centre. `windowDidMove` is how the host
+    // The user drags it well left of centre. the driver's synchronous `onMove` callback is how the host
     // learns; there is no rebuild for the fact to survive.
-    panel.setFrameOrigin(NSPoint(x: 120, y: 85))
-    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+    // #2455 C4: one call replaces the setFrameOrigin + delegate-notification pair. The
+    // driver owns the delegate relationship now, so a test says what the USER did
+    // rather than reproducing AppKit\'s notification plumbing.
+    panel.simulateUserMove(to: CGPoint(x: 120, y: 85))
 
     h.present(
       Self.view(width: 320, height: 120), width: .fixed(320), fixedHeight: nil, isFresh: false,
@@ -125,26 +133,28 @@ struct OverlayWindowHostTests {
   @Test("a fresh presentation is centred even after a drag")
   func freshRecentresAfterADrag() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
     let panel = try #require(recorder.panel)
-    panel.setFrameOrigin(NSPoint(x: 120, y: 85))
-    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+    // #2455 C4: one call replaces the setFrameOrigin + delegate-notification pair. The
+    // driver owns the delegate relationship now, so a test says what the USER did
+    // rather than reproducing AppKit\'s notification plumbing.
+    panel.simulateUserMove(to: CGPoint(x: 120, y: 85))
     h.hide()
 
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
 
-    // Within a point, not exact: **AppKit aligns a window frame to whole
-    // points**, so a placement value of 663.5 lands at 663.0. The value type is
-    // right and the window is right; an exact float comparison against the
-    // unrounded computation is what was wrong. Half a point is tight enough that
-    // a pill left at 120 still fails this.
-    #expect(abs(panel.frame.origin.x - (Self.screen.visibleFrame.midX - 92.5)) <= 0.5)
+    // EXACT, not within a point (#2455 C4). The tolerance existed because AppKit
+    // aligns a real window frame to whole points, so a placement value of 663.5
+    // landed at 663.0. The recorder stores the `CGRect` it was handed, so there is
+    // no rounding to absorb — and a tolerance with nothing to absorb is slack that
+    // hides real drift.
+    #expect(panel.frame.origin.x == Self.screen.visibleFrame.midX - 92.5)
   }
 
   /// **A programmatic move is not a drag**, and telling them apart is what makes
@@ -160,14 +170,14 @@ struct OverlayWindowHostTests {
   @Test("the host's own frame changes never count as a user drag")
   func programmaticMovesAreNotDrags() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
     let panel = try #require(recorder.panel)
     // Every present/resize/reposition below moves the panel, and each fires
-    // `windowDidMove` for real.
+    // the driver's `onMove` callback for real.
     h.resizeCurrentPresentation(to: CGSize(width: 240, height: 60))
     h.repositionForActiveSpaceChange()
     h.present(
@@ -188,14 +198,16 @@ struct OverlayWindowHostTests {
     // Paired with the case above: a host that never promotes would recentre
     // here too.
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
     let panel = try #require(recorder.panel)
-    panel.setFrameOrigin(NSPoint(x: 400, y: 300))
-    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+    // #2455 C4: one call replaces the setFrameOrigin + delegate-notification pair. The
+    // driver owns the delegate relationship now, so a test says what the USER did
+    // rather than reproducing AppKit\'s notification plumbing.
+    panel.simulateUserMove(to: CGPoint(x: 400, y: 300))
 
     // The same proof as `continuingKeepsTheDraggedPosition`: a continuation
     // preserves X only when the drag was recorded as user-anchored.
@@ -215,8 +227,8 @@ struct OverlayWindowHostTests {
   @Test("hiding orders the panel out and keeps it alive")
   func hideOrdersOutWithoutClosing() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
@@ -235,17 +247,17 @@ struct OverlayWindowHostTests {
 
   /// **The recorder's own coverage.** Every other test in this file reads
   /// `recorder.panel`/`recorder.constructionCount`, which only exercise
-  /// `.constructed` and (indirectly, via `hideNeverCloses` below) `.close`.
+  /// `.constructed`.
   /// Nothing directly asserted `setFrame`, `setContentView` or
   /// `orderFrontRegardless` ever appear — a recorder that silently stopped
   /// recording any one of those would leave every OTHER test in this file
   /// green, because they all read the PANEL's own state, never the recorder's
   /// command log. Codex found this gap in chunk review.
-  @Test("present, resize and hide issue the real panel commands in order")
+  @Test("present, resize and hide issue the panel commands in order")
   func panelCommandOrderIsObservable() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
 
     let view = Self.view(width: 185, height: 44)
     let presentStart = recorder.commands.count
@@ -257,13 +269,16 @@ struct OverlayWindowHostTests {
     let panelID = ObjectIdentifier(panel)
     let presented = Array(recorder.commands[presentStart...])
 
-    // **`NSPanel`'s OWN designated initializer sets a default `contentView`
-    // internally, before `.constructed` is even appended** — measured live:
-    // `super.init(contentRect:styleMask:backing:defer:)` issues a
-    // `.setContentView` receipt of its own, ahead of construction finishing.
-    // That is a real AppKit fact this test is not about, so it locates
-    // `.constructed` rather than assuming position 0, and asserts only what
-    // HOST code issues after it — the three commands `present` itself drives.
+    // Locate `.constructed` explicitly rather than assuming position 0, then
+    // assert the three commands the HOST issues after it.
+    //
+    // #2455 C4: the original reason was an AppKit fact — `NSPanel`'s own
+    // designated initializer appended a `.setContentView` receipt before
+    // construction finished, because the recorder WAS an `NSPanel`. That cannot
+    // happen now. Locating `.constructed` is kept anyway: it makes the
+    // command-order contract independent of how the recorder flattens each
+    // driver's receipts, which is a property of the assertion rather than of
+    // whichever double is underneath it.
     guard
       let constructedIndex = presented.firstIndex(where: {
         if case .constructed = $0 { return true }
@@ -327,59 +342,29 @@ struct OverlayWindowHostTests {
       ])
   }
 
-  /// **`hide()` must ORDER OUT, and a mutation control is what proved this test
-  /// was needed.** Substituting `close()` for `orderOut` left all eight cases
-  /// green: with `isReleasedWhenClosed = false` a closed panel is still alive,
-  /// still the same instance, still `isVisible == false`, and the construction
-  /// count is unchanged — every assertion the suite had. The distinction that
-  /// matters is not observable through any of them.
+  /// **`hide()` must ORDER OUT, not close — and the check for it moved (#2455 C4).**
   ///
-  /// `close()` posts `willCloseNotification`; `orderOut` does not. Observing the
-  /// notification needs no production seam and no text matching, so it holds
-  /// whatever the method is called. The C5 freeze assertion (zero `.close()`
-  /// calls in the overlay module) is a second, structural protection — but it
-  /// does not exist yet, and deferring to it would have left the central claim
-  /// of this change unguarded for two chunks.
-  @Test("hiding never closes the window")
-  func hideNeverCloses() throws {
-    let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
-    h.present(
-      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-      position: .bottom)
-    let panel = try #require(recorder.panel)
+  /// This suite carried a `hideNeverCloses` case that observed
+  /// `NSWindow.willCloseNotification` on the recorder. That worked only while the
+  /// recorder WAS an `NSPanel`. Against a pure driver the notification can never
+  /// fire, so the test passed by construction and proved nothing — a mutation
+  /// control's worth of coverage, silently reduced to zero by the very change that
+  /// made the fake inert.
+  ///
+  /// Two things replaced it, and both are stronger than the original:
+  /// `OverlayPanelDriving` declares NO `close`, so the call is unrepresentable
+  /// rather than merely unasserted; and `OverlayRetainedWindowRealPanelTests` in
+  /// `EnviousWisprDesktopEffectsTests` still observes `willCloseNotification` on a
+  /// real panel, where it can actually fire.
 
-    nonisolated(unsafe) var closed = false
-    let token = NotificationCenter.default.addObserver(
-      forName: NSWindow.willCloseNotification, object: panel, queue: nil
-    ) { _ in closed = true }
-    defer { NotificationCenter.default.removeObserver(token) }
-
-    h.hide()
-    h.present(
-      Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
-      position: .bottom)
-    h.hide()
-
-    #expect(
-      closed == false,
-      "the panel was CLOSED rather than ordered out — every rebuild this change removes comes from that"
-    )
-    // Command-log corroboration of the same fact, now that the recorder can
-    // observe it directly: `.close` must never appear.
-    #expect(
-      recorder.commands.contains { if case .close = $0 { true } else { false } } == false,
-      "the recorder saw a `.close` command — `hide()` must issue only `orderOut`")
-  }
 
   /// **Three sizing paths, three DIFFERENT numbers**, so each is separable.
   @Test("fixed, fitting and frame-fallback widths are told apart")
   func sizingPathsAreDistinguishable() throws {
     // fixed 300, fitting 211, frame 150 — no two alike.
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     let v = Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58))
 
     h.present(v, width: .fixed(300), fixedHeight: nil, isFresh: true, position: .bottom)
@@ -404,8 +389,8 @@ struct OverlayWindowHostTests {
   @Test("a presentation that cannot be sized is refused, not shown at zero")
   func unsizablePresentationIsRefused() {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     let empty = Self.view(width: 0, height: 0)
     h.present(empty, width: .measured, fixedHeight: nil, isFresh: true, position: .bottom)
 
@@ -424,8 +409,8 @@ struct OverlayWindowHostTests {
   @Test("morphing replaces the panel's content view")
   func morphReplacesContent() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
@@ -444,8 +429,8 @@ struct OverlayWindowHostTests {
   @Test("the panel's shipped configuration is unchanged")
   func panelConfigurationIsPinned() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
@@ -457,8 +442,11 @@ struct OverlayWindowHostTests {
     #expect(panel.hasShadow)
     #expect(panel.isOpaque == false)
     #expect(panel.isReleasedWhenClosed == false, "a released panel cannot be retained")
-    #expect(panel.styleMask.contains(.borderless))
-    #expect(panel.styleMask.contains(.nonactivatingPanel))
+    // #2455 C4: `styleMask` is not on `OverlayPanelDriving`. It is a property of
+    // the REAL panel's construction, not of anything the host does, so asserting
+    // it here was testing the factory through the host. It moved to
+    // `LiveOverlayPanelDriverTests` in `EnviousWisprDesktopEffectsTests`, which is
+    // the target that can see a real `NSPanel`.
   }
 
   /// Top continuity through the HOST, not just the placement value: a
@@ -467,8 +455,8 @@ struct OverlayWindowHostTests {
   @Test("Top continuity re-anchors by top edge when the outgoing pill was content-sized")
   func topContinuityContentSized() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44, fitting: NSSize(width: 185, height: 44)),
       width: .fixed(185), fixedHeight: nil, isFresh: true, position: .top)
@@ -485,8 +473,8 @@ struct OverlayWindowHostTests {
   @Test("Top continuity re-anchors by centre when the outgoing pill had a fixed height")
   func topContinuityFixedHeight() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
       position: .top)
@@ -522,8 +510,8 @@ struct OverlayWindowHostTests {
   @Test("a measured width with a fixed height is not content-sized vertically")
   func measuredWidthWithFixedHeightIsNotContentSized() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 150, height: 40, fitting: NSSize(width: 211, height: 58)),
       width: .measured, fixedHeight: 92, isFresh: true, position: .top)
@@ -553,8 +541,8 @@ struct OverlayWindowHostTests {
   @Test("hiding releases the hosting view so its work stops")
   func hideReleasesTheHostingView() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
@@ -573,33 +561,43 @@ struct OverlayWindowHostTests {
   /// geometry back across the seam; every fact the callback needs — the anchor,
   /// the screen, the window — already lives here.
   ///
-  /// Posting the real `NSWorkspace` notification is the observation: it proves
-  /// the host is REGISTERED, which a direct call to
-  /// `repositionForActiveSpaceChange()` would not.
+  /// **Driving the injected observer is the observation**, and it proves the same
+  /// thing the real notification did: the host REGISTERED. A direct call to
+  /// `repositionForActiveSpaceChange()` would not — it would bypass registration
+  /// entirely, which is the half that can break.
+  ///
+  /// #2455 C4: this posted a real `NSWorkspace` notification, which reached every
+  /// workspace observer in the process, not just this host's. The fake now fires
+  /// exactly one subscription and nothing else in the app hears it.
   @Test("the host re-anchors a Bottom pill when the active Space changes")
   func spaceChangeReachesTheHost() throws {
     var geometry = Self.screen
     let recorder = OverlayPanelCommandRecorder()
+    let workspace = RecordingWorkspaceObserver()
     let h = OverlayWindowHost(
-      screens: { OverlayScreenResolver { geometry } }, panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+      screens: { OverlayScreenResolver { geometry } },
+      effects: recorder.makeEffects(workspace: workspace))
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
     let panel = try #require(recorder.panel)
     #expect(panel.frame.origin.y == 85)
+    #expect(workspace.observerCount == 1, "the host must subscribe exactly once")
 
     // A full-screen space appears: `visibleFrame` does not shrink, so the pill
     // must drop to the true screen edge (#1341).
     let spaceChangeStart = recorder.commands.count
     geometry = Self.fullScreened
-    NSWorkspace.shared.notificationCenter.post(
-      name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
-    RunLoop.main.run(until: Date())  // settle: deliver a posted notification, no polling
+    workspace.simulateActiveSpaceChange()
+    // No run-loop settle: the fake calls back synchronously, so there is no
+    // posted notification to deliver. The real observer used `queue: .main` and
+    // the notification centre guarantees the main thread, so the ordering the
+    // host sees is unchanged.
 
     #expect(
       panel.frame.origin.y == 0,
-      "the Space-change notification never reached the host — it is not registered")
+      "the Space change never reached the host — it is not registered")
 
     // One Host animated move must yield exactly one `setFrame` receipt. Count ALL
     // frame receipts first: filtering to `animated == true` would hide the extra
@@ -625,14 +623,12 @@ struct OverlayWindowHostTests {
 
     // **A SECOND swipe, and this is the assertion that matters.** The first one
     // proves only that the host is listening. The host moves the window itself
-    // to re-anchor, and that move fires `windowDidMove` — so if the programmatic
+    // to re-anchor, and that move fires the driver's `onMove` — so if the programmatic
     // guard did not hold, the host would record its OWN reposition as the user
     // dragging the pill and refuse to follow Spaces ever again. One swipe cannot
     // see that; the pill would look correct and then silently stop.
     geometry = Self.screen
-    NSWorkspace.shared.notificationCenter.post(
-      name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
-    RunLoop.main.run(until: Date())  // settle: deliver a posted notification, no polling
+    workspace.simulateActiveSpaceChange()
 
     #expect(
       panel.frame.origin.y == 85,
@@ -646,8 +642,8 @@ struct OverlayWindowHostTests {
   @Test("a measured width is taken from the view, not from a default")
   func measuredWidthComesFromTheView() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 271, height: 58), width: .measured, fixedHeight: nil, isFresh: true,
       position: .bottom)
@@ -661,8 +657,8 @@ struct OverlayWindowHostTests {
   @Test("a fixed height is honoured and overrides the view's own")
   func fixedHeightIsHonoured() throws {
     let recorder = OverlayPanelCommandRecorder()
-    let h = Self.host(panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+    let h = Self.host(effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
       position: .bottom)
@@ -690,11 +686,11 @@ struct OverlayWindowHostTests {
   private static func splitHost(
     pointer: @escaping () -> ScreenGeometry,
     containing: @escaping (CGRect) -> ScreenGeometry?,
-    panelFactory: OverlayPanelFactory = .live
+    effects: DesktopOverlayEffects = .recording()
   ) -> OverlayWindowHost {
     OverlayWindowHost(
       screens: { OverlayScreenResolver(containing: containing, current: pointer) },
-      panelFactory: panelFactory)
+      effects: effects)
   }
 
   /// **The regression, stated as the user sees it.** Start dictating on the
@@ -712,8 +708,8 @@ struct OverlayWindowHostTests {
     var pointer = Self.screen
     let recorder = OverlayPanelCommandRecorder()
     let h = Self.splitHost(
-      pointer: { pointer }, containing: { _ in Self.screen }, panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+      pointer: { pointer }, containing: { _ in Self.screen }, effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
 
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
@@ -741,8 +737,8 @@ struct OverlayWindowHostTests {
   func continuationFallsBackWhenItsScreenIsGone() throws {
     let recorder = OverlayPanelCommandRecorder()
     let h = Self.splitHost(
-      pointer: { Self.screen }, containing: { _ in nil }, panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+      pointer: { Self.screen }, containing: { _ in nil }, effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
 
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
@@ -771,8 +767,8 @@ struct OverlayWindowHostTests {
     var pointer = Self.screen
     let recorder = OverlayPanelCommandRecorder()
     let h = Self.splitHost(
-      pointer: { pointer }, containing: { _ in Self.screen }, panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+      pointer: { pointer }, containing: { _ in Self.screen }, effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
 
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,
@@ -809,15 +805,17 @@ struct OverlayWindowHostTests {
     let recorder = OverlayPanelCommandRecorder()
     let h = Self.splitHost(
       pointer: { Self.shortSecondary }, containing: { _ in containingScreen },
-      panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+      effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: nil, isFresh: true,
       position: .bottom)
     let panel = try #require(recorder.panel)
 
-    panel.setFrameOrigin(NSPoint(x: 120, y: 85))
-    h.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+    // #2455 C4: one call replaces the setFrameOrigin + delegate-notification pair. The
+    // driver owns the delegate relationship now, so a test says what the USER did
+    // rather than reproducing AppKit\'s notification plumbing.
+    panel.simulateUserMove(to: CGPoint(x: 120, y: 85))
 
     // Continued on the LANDING screen (id 1, where `containing` placed the
     // panel): the drag is user-anchored there, so X is preserved.
@@ -856,8 +854,8 @@ struct OverlayWindowHostTests {
     let recorder = OverlayPanelCommandRecorder()
     let h = Self.splitHost(
       pointer: { Self.shortSecondary }, containing: { _ in Self.screen },
-      panelFactory: recorder.makeFactory())
-    defer { recorder.panel?.orderOut(nil) }
+      effects: recorder.makeEffects())
+    defer { recorder.panel?.orderOut() }
 
     h.present(
       Self.view(width: 185, height: 44), width: .fixed(185), fixedHeight: 92, isFresh: true,

--- a/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
@@ -5,6 +5,7 @@ import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 
 /// What the typed pill boundary DOES, asserted on outputs an observer outside
 /// the director can see (#2292 Phase 1).
@@ -49,6 +50,7 @@ import Testing
 struct PillRequestParityTests {
 
   /// One director, plus every observable output it produces, recorded in order.
+  @MainActor
   private final class Rig {
     let host = WindowlessOverlayHost()
     var effects: [PillEffect] = []

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 @testable import EnviousWisprCore
 @testable import EnviousWisprPipeline
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPollingLifetimeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPollingLifetimeTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 
 /// A hidden recording pill stops polling (#2377 Phase 5, C5).
 ///
@@ -23,100 +24,6 @@ import Testing
 @MainActor
 struct RecordingPollingLifetimeTests {
 
-  private enum PostHideOutcome: Equatable {
-    case cancelled
-    case repolled
-  }
-
-  /// A cadence the test drives, with the receipts the probe needs: it has PARKED,
-  /// it may ADVANCE, it was CANCELLED, and — after `hide()` — which of
-  /// cancellation and another poll came first.
-  @MainActor
-  private final class ManualCadence {
-    private var gate: CheckedContinuation<Void, Never>?
-    private var parkWaiter: CheckedContinuation<Void, Never>?
-    private(set) var parks = 0
-
-    /// **Which of the two things happened first after `hide()`.**
-    ///
-    /// Awaiting cancellation alone cannot fail FAST: a host that never releases
-    /// its content simply never cancels, so the row hits its hang guard and
-    /// reports a timeout instead of the poll that carried on. Racing the two
-    /// outcomes reports whichever the code actually did, promptly, with no
-    /// elapsed time involved either way.
-    private var observingPostHide = false
-    private var postHideOutcome: PostHideOutcome?
-    private var postHideWaiter: CheckedContinuation<PostHideOutcome, Never>?
-
-    var cadence: RecordingPollCadence {
-      RecordingPollCadence { [weak self] in
-        guard let self else { return }
-        await self.park()
-      }
-    }
-
-    /// Called by the view's poll loop in place of its 50 ms wait.
-    private func park() async {
-      parks += 1
-      // A park AFTER hide is the pill completing another poll.
-      if observingPostHide { finishPostHide(.repolled) }
-      // A waiter that asked BEFORE this park gets its answer now.
-      parkWaiter?.resume()
-      parkWaiter = nil
-      await withTaskCancellationHandler {
-        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-          gate = c
-        }
-      } onCancel: {
-        Task { @MainActor [weak self] in self?.releaseOnCancel() }
-      }
-    }
-
-    private func releaseOnCancel() {
-      finishPostHide(.cancelled)
-      gate?.resume()
-      gate = nil
-    }
-
-    /// Suspend until the view parks. Resolves immediately if it already has more
-    /// parks than `count`.
-    func awaitPark(after count: Int) async {
-      if parks > count { return }
-      await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
-        parkWaiter = c
-      }
-    }
-
-    private func finishPostHide(_ outcome: PostHideOutcome) {
-      guard postHideOutcome == nil else { return }
-      postHideOutcome = outcome
-      postHideWaiter?.resume(returning: outcome)
-      postHideWaiter = nil
-    }
-
-    /// Start watching for whichever happens first once the host is hidden.
-    func beginPostHideObservation() {
-      observingPostHide = true
-    }
-
-    func awaitPostHideOutcome() async -> PostHideOutcome {
-      if let postHideOutcome { return postHideOutcome }
-      return await withCheckedContinuation { postHideWaiter = $0 }
-    }
-
-    /// Let the poll loop run one more iteration.
-    func advance() {
-      gate?.resume()
-      gate = nil
-    }
-  }
-
-  private final class Counts {
-    var audio = 0
-    var elapsed = 0
-    var preview = 0
-    var all: [Int] { [audio, elapsed, preview] }
-  }
 
   /// A one-shot latch: the subject announces, the test suspends until it has.
   ///
@@ -148,73 +55,6 @@ struct RecordingPollingLifetimeTests {
   /// The time limit is a final harness guard, not part of the proof. The row
   /// resolves from either cancellation or another completed poll, with no
   /// elapsed-time assertion.
-  @Test("a hidden recording pill stops reading its providers", .timeLimit(.minutes(1)))
-  func hidingTheHostStopsThePoll() async throws {
-    let counts = Counts()
-    let manual = ManualCadence()
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } })
-    defer { host.hide() }
-
-    let view = RecordingOverlayView(
-      audioLevelProvider: {
-        counts.audio += 1
-        return 0.4
-      },
-      recordingElapsedProvider: {
-        counts.elapsed += 1
-        return 12
-      },
-      livePreviewProvider: {
-        counts.preview += 1
-        return .off
-      },
-      onContentHeightChange: { _ in },
-      chrome: RecordingPillDesign.classic.chrome,
-      isLocked: false,
-      noticeText: nil,
-      cadence: manual.cadence)
-
-    let hosted = NSHostingView(rootView: AnyView(view))
-    // Required, not ignored: a refused presentation would otherwise surface as an
-    // unrelated hang-guard timeout rather than as the thing that went wrong.
-    try #require(
-      host.present(
-        hosted, width: .fixed(RecordingPillDesign.classic.width),
-        fixedHeight: RecordingPillDesign.classic.reservedHeight,
-        isFresh: true, position: .top),
-      "the recording pill never reached the host")
-
-    // 1. The first poll runs immediately, then the loop parks.
-    await manual.awaitPark(after: 0)
-    let afterFirstPoll = counts.all
-    #expect(
-      afterFirstPoll == [1, 1, 1],
-      "the first poll read \(afterFirstPoll), not one of each")
-
-    // 2. THE NON-VACUOUS CONTROL. Without this, a row proving the counts stop
-    //    would pass on a view that never polled at all.
-    manual.advance()
-    await manual.awaitPark(after: 1)
-    let afterOneTick = counts.all
-    #expect(
-      afterOneTick == [2, 2, 2],
-      "one advance moved the counts to \(afterOneTick), so the poll is not running")
-
-    // 3. Take the content away — what `hide()` does in production — and push the
-    //    loop at the same time. Whichever happens first is the answer: the wait
-    //    is cancelled, or the pill completes another poll.
-    manual.beginPostHideObservation()
-    host.hide()
-    manual.advance()
-
-    let outcome = await manual.awaitPostHideOutcome()
-    #expect(outcome == .cancelled, "the hidden pill completed another poll")
-
-    // 4. And nothing was read on the way.
-    #expect(
-      counts.all == afterOneTick,
-      "a hidden pill kept polling: \(afterOneTick) became \(counts.all)")
-  }
 
   // MARK: - The still cadence (#2435)
 
@@ -234,7 +74,7 @@ struct RecordingPollingLifetimeTests {
   func aStillPillReadsOnceThenParks() async throws {
     let counts = Counts()
     let parked = Latch()
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } })
+    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } }, effects: .recording())
     defer { host.hide() }
 
     let view = RecordingOverlayView(

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 @testable import EnviousWisprCore
 @testable import EnviousWisprPipeline
 

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -8,6 +8,7 @@ import Testing
 
 @testable import EnviousWisprASR
 @testable import EnviousWisprAppKit
+import EnviousWisprAppKitTestSupport
 @testable import EnviousWisprAudio
 @testable import EnviousWisprPipeline
 @testable import EnviousWisprStorage

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -8,11 +8,12 @@
 #   EnviousWispr           -> AppLive (thin launchable shell; #919/#2455 C1). Imports ONLY AppLive.
 #   EnviousWisprAppLive    -> AppKit, DesktopEffects (production composition root; #2455 C1/C2).
 #   EnviousWisprDesktopEffects -> AppKit, Services (#2455 C2). The ONLY module holding Carbon and
-#                             NSEvent calls. Neither test target declares it — but that alone does
-#                             NOT stop a test importing it (see the Tests/ loop below for why), so
-#                             this script is the enforcement. Adding either test target to that
-#                             loop's allowlist would silently reopen the hole this epic exists to
-#                             close.
+#                             NSEvent calls. The UNIT and ASR targets do not declare it; the
+#                             dedicated EnviousWisprDesktopEffectsTests target DOES, deliberately —
+#                             three suites there need real AppKit behaviour. Absence alone does not
+#                             stop an import (see the Tests/ loop below), so this script is the
+#                             enforcement. Adding the unit or ASR target to that loop's allowlist
+#                             would silently reopen the hole this epic exists to close.
 #   EnviousWisprAppKit     -> Core, Storage, PostProcessing, Audio, Services, ASR, LLM, Pipeline, Contacts (app-shell library; #919, top of stack)
 #   EnviousWisprASRService -> Core, ASR, Audio, ObservabilityCore (XPC executable; the audio capture XPC service was removed at #1543)
 #   EnviousWisprPipeline   -> Core, ASR, Audio, LLM, PostProcessing, Services, Storage
@@ -67,6 +68,7 @@ permitted_imports_for() {
     EnviousWisprPipeline)          echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprLLM EnviousWisprModelDelivery EnviousWisprPostProcessing EnviousWisprServices EnviousWisprStorage" ;;
     EnviousWisprASRService)        echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprObservabilityCore" ;;
     EnviousWisprAppKit)            echo "EnviousWisprCore EnviousWisprStorage EnviousWisprPostProcessing EnviousWisprAudio EnviousWisprServices EnviousWisprASR EnviousWisprLLM EnviousWisprModelDelivery EnviousWisprPipeline EnviousWisprContacts EnviousWisprLivePreview EnviousWisprWhisperPreviewAdapter" ;;
+    EnviousWisprAppKitTestSupport) echo "EnviousWisprAppKit EnviousWisprCore" ;;
     EnviousWisprDesktopEffects)    echo "EnviousWisprAppKit EnviousWisprServices" ;;
     EnviousWisprAppLive)           echo "EnviousWisprAppKit EnviousWisprDesktopEffects" ;;
     EnviousWispr)                  echo "EnviousWisprAppLive" ;;
@@ -160,6 +162,16 @@ done
 # required rather than optional. That closes the hole at the call site instead of
 # at the pattern.
 #
+# `NSWorkspace.shared.notificationCenter` is NOT in this pattern — it matches every
+# workspace subscription in the app (`UpdateTriggerCoordinator`,
+# `AccessibilityWarmupObserver`, `MenuBarIconAnimator`), which are different families
+# with their own lifecycles. `activeSpaceDidChangeNotification` IS, because it names
+# the exact event C4 moved rather than the mechanism that carries it. That is the
+# difference between matching an effect and matching an API.
+#
+# `NSPanel(` is here too: a test can build its own overlay window without touching
+# the seam at all, which import discipline alone would never see.
+#
 # KNOWN GAP, tracked rather than silently excluded: `PasteCascadeExecutor.swift`
 # `:573`, `:852`, `:862` call `app.activate()` on an `NSRunningApplication` in
 # `EnviousWisprPipeline`, bringing the paste target forward. Real activations, in
@@ -172,13 +184,14 @@ done
 # removes a `//` or `/*` and its tail on ONE line, not the continuation lines of a
 # block comment. A false positive is a sentence to rewrite; a false negative is a
 # suite back on the developer's real desktop.
-live_effect_pattern='RegisterEventHotKey|InstallEventHandler|NSEvent[.]add(Global|Local)MonitorForEvents|(NSApp|NSApplication[.]shared)[.](activate|setActivationPolicy)|panel[.]makeKeyAndOrderFront|NSWorkspace[.]shared[.]openApplication'
+live_effect_pattern='RegisterEventHotKey|InstallEventHandler|NSEvent[.]add(Global|Local)MonitorForEvents|(NSApp|NSApplication[.]shared)[.](activate|setActivationPolicy)|panel[.]makeKeyAndOrderFront|NSWorkspace[.]shared[.]openApplication|NSPanel[[:space:]]*[(]|NSPanel[.]init|activeSpaceDidChangeNotification'
 
 test_targets_and_permitted() {
   case "$1" in
     # Everything the unit suite legitimately links. EnviousWisprDesktopEffects and
     # EnviousWisprAppLive are ABSENT on purpose — that absence is the point.
-    EnviousWisprTests) echo "EnviousWisprCore EnviousWisprObservabilityCore EnviousWisprModelDelivery EnviousWisprPostProcessing EnviousWisprLLM EnviousWisprPipeline EnviousWisprStorage EnviousWisprAudio EnviousWisprLivePreview EnviousWisprWhisperPreviewAdapter EnviousWisprFluidAudioBridge EnviousWisprAppKit EnviousWisprContacts EnviousWisprServices EnviousWisprASR" ;;
+    EnviousWisprDesktopEffectsTests) echo "EnviousWisprCore EnviousWisprAppKit EnviousWisprAppKitTestSupport EnviousWisprDesktopEffects" ;;
+    EnviousWisprTests) echo "EnviousWisprCore EnviousWisprObservabilityCore EnviousWisprModelDelivery EnviousWisprPostProcessing EnviousWisprLLM EnviousWisprPipeline EnviousWisprStorage EnviousWisprAudio EnviousWisprLivePreview EnviousWisprWhisperPreviewAdapter EnviousWisprFluidAudioBridge EnviousWisprAppKit EnviousWisprAppKitTestSupport EnviousWisprContacts EnviousWisprServices EnviousWisprASR" ;;
     EnviousWisprASRTests) echo "EnviousWisprCore EnviousWisprASR EnviousWisprAudio EnviousWisprFluidAudioBridge EnviousWisprServices" ;;
     *) return 1 ;;
   esac


### PR DESCRIPTION
Closes #2461. Chunk C4 of #2455. Follows #2464 (C0), #2468 (C1), #2470 (C2), #2471 (C3).

**Lane:** Code · **Tier:** REFACTOR (chunk C4 of 6) · **Live UAT:** deferred to C5's executable scenario

## Problem — this is the pill the founder watched flash

`OverlayPanelFactory` vended an `NSPanel`, so **every implementation was one** — including the test double, `CommandRecordingPanel: NSPanel`, which called `super` on every override. A suite asking for a fake pill got a real one that really appeared on screen.

The fake was not sloppy. A non-displaying one **was not expressible**: the seam's type made every double a window.

## What this does

`OverlayPanelDriving` (**16 members, not the issue's 15** — `orderOut` included) and `WorkspaceObserving` live in AppKit beside their consumers, behind a non-defaulted `DesktopOverlayEffects` carrier. `LiveOverlayPanelDriver` in DesktopEffects owns the `NSPanel` *and* its delegate — so the host stops being an `NSObject` `NSWindowDelegate` and `windowDidMove` becomes a plain `onMove` callback.

`OverlayWindowHost` has **no `deinit`**: the workspace observation owns its token and cancels in its own. The compiler forced this (a nonisolated `deinit` cannot touch a `@MainActor` non-Sendable property) and one owner for one lifetime beats the two the first draft had.

## Three suites needed a real panel, not the one the plan named

| Suite | Why it needs a real window |
|---|---|
| `OverlayRetainedWindowRealPanelTests` | window retention across hide/show |
| `RecordingPollingRealPanelTests` | **the finding** — see below |
| `LiveOverlayPanelDriverTests` (new) | what the driver actually builds |

**The polling one is the interesting one.** It asserts a hidden pill stops polling, and what cancels the `.task` is AppKit removing the view from a real window. It had only ever passed *because* the double was a real `NSPanel` — a test whose setup depended on the subject, which is this chunk's entire subject.

`LiveOverlayPanelDriverTests` adds coverage that never existed: **ordering the pill front must not take key focus.** Losing `.nonactivatingPanel` would be the founder's focus symptom and would not change a single pixel.

## Against the plan: the parity suite STAYS in the unit target

The plan's reason was "the unit target cannot both exclude DesktopEffects and compile a suite that uses it." With the panel injected, it doesn't use it — that suite compares two *host* implementations, and the `NSPanel` underneath was incidental to the comparison and was the thing that flashed.

## Two defects review found in my own work, both the shape of the bug being fixed

1. **The recorder suppressed `onMove` on `setFrame`.** My reasoning was backwards: with no programmatic callback, `programmaticMoveDepth` — the drag-versus-programmatic discriminator — was exercised by nothing, so every test of it passed without testing it.

2. **`hideNeverCloses` went vacuous.** A previous author *mutation-proved* it was needed: substituting `close()` for `orderOut` left all eight sibling cases green. It worked by watching `willCloseNotification`, which can never fire against a non-window. My change silently reduced a mutation-proven check to a tautology. Deleted, with two stronger replacements — the protocol declares no `close`, and the real-panel suite still watches that notification where it *can* fire.

`freshRecentresAfterADrag` also drops its half-point tolerance: that existed for AppKit's whole-point frame alignment, and tolerance with nothing to absorb is slack that hides drift.

## New targets

`EnviousWisprAppKitTestSupport` — non-shipping library holding `WindowlessOverlayHost` (sixteen suites use it), the overlay recorders, the polling cadence fakes. Shared rather than copied: two copies of a fake drift apart and nothing fails.

`EnviousWisprDesktopEffectsTests` — the only test target the gate permits to construct a live effect. Both are in all three schemes; a declared-but-never-run test target looks like coverage and executes nothing.

## Guards

`onlyTheHostConstructsAPanel` asserted exactly **one** `NSPanel(` constructor in AppKit's overlay module; it now asserts **zero**. Gate gains `NSPanel[[:space:]]*[(]` and `activeSpaceDidChangeNotification`, both mutation-checked. `NSWorkspace.shared.notificationCenter` was tried and **reverted** — it matches every workspace subscription in the app; the *event* is what C4 moved, not the mechanism.

## Validation

| Check | Result |
|---|---|
| Debug lane | PASS — 7,123 test cases, zero failures |
| `check-dependency-direction.sh` | OK, 23 modules; both new rules mutation-checked |
| Codex chunk gate | **CHUNK-CLEAN** on a confirming re-run |

Codex rounds: design → `PROCEED` → `CHUNK-REVISIONS (4)` → `(1)` → `(2)` → `(2)` → `(1)` → `(1)` → **`CHUNK-CLEAN`**.

Rounds 3–7 all returned instances of one class: prose claiming the compiler prevents something when the gate is the enforcer. I eventually swept the class myself rather than taking it one round at a time.

## Note for other worktrees

`OverlayWindowHost(screens:)` now requires `effects:`. `WindowlessOverlayHost` comes from `import EnviousWisprAppKitTestSupport`. Tests use `DesktopOverlayEffects.recording()`.
