### PR TITLE
fix(quickadd): the no-close-match header names the word it read

### DIFF
--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -188,38 +188,18 @@ final class MenuBarController: NSObject {
   }
 
   /// The title for a readable selection.
+  ///
+  /// **Display only.** `representedObject` still carries the ORIGINAL selection, so what gets added
+  /// is what the user selected rather than what fitted in a menu — the same separation this cluster
+  /// has had to relearn three times, where a sentence was composed from a neighbouring value
+  /// instead of from what the write path was given.
+  ///
+  /// Trimming, whitespace collapsing and truncation moved to `HeardWordDisplay` (#2476), which the
+  /// panel header now shares. Two renderers of one value had two answers, and only this one bounded
+  /// it; the algorithm is unchanged, so this row's existing assertions still pin it.
   private static func readyTitle(_ selection: String) -> String {
-    let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
-    // **Collapse INTERNAL whitespace, not just the ends.** A selection spanning two document lines
-    // carries a newline, and a newline in an `NSMenuItem` title renders as a malformed, multi-line
-    // row. Tabs and runs of spaces are the same problem, one character over.
-    //
-    // **Display only.** `representedObject` still carries the ORIGINAL selection, so what gets added
-    // is what the user selected rather than what fitted in a menu — the same separation this cluster
-    // has had to relearn three times, where a sentence was composed from a neighbouring value
-    // instead of from what the write path was given.
-    //
-    // Collapsed BEFORE truncating, so the limit counts characters the user can actually see.
-    let collapsed = trimmed.split(whereSeparator: { $0.isWhitespace || $0.isNewline })
-      .joined(separator: " ")
-    // **Truncate on CHARACTERS, not scalars.** A family emoji, a flag, or a letter written as a
-    // base plus a combining mark is several scalars and one character; cutting between them renders
-    // a broken glyph. The scalar ceiling still bounds the worst case, because a character can carry
-    // many scalars — both limits, and the tighter one wins.
-    let shown: String = {
-      guard
-        collapsed.count > Self.quickAddTitleCharacters
-          || collapsed.unicodeScalars.count > Self.quickAddTitleScalars
-      else { return collapsed }
-      var out = ""
-      for character in collapsed {
-        guard out.count < Self.quickAddTitleCharacters,
-          out.unicodeScalars.count + character.unicodeScalars.count <= Self.quickAddTitleScalars
-        else { break }
-        out.append(character)
-      }
-      return out + "\u{2026}"
-    }()
+    let shown = HeardWordDisplay.bounded(
+      selection, characters: Self.quickAddTitleCharacters, scalars: Self.quickAddTitleScalars)
     return "Add \u{201C}\(shown)\u{201D}"
   }
 
@@ -310,8 +290,12 @@ final class MenuBarController: NSObject {
   /// Longer than any healthy Accessibility read, shorter than a user tolerates a menu not opening.
   static let quickAddReadTimeout: Float = 0.25
 
-  static let quickAddTitleCharacters = 24
-  static let quickAddTitleScalars = 96
+  /// **One answer, aliased rather than repeated.** The panel header bounds the same heard word for
+  /// the same reason, and two constants carrying 24 in two files is the shape that agrees today and
+  /// drifts silently later. A site that genuinely wants a different bound passes one — `bounded`
+  /// takes both limits — rather than declaring a second copy of this one.
+  static let quickAddTitleCharacters = HeardWordDisplay.characters
+  static let quickAddTitleScalars = HeardWordDisplay.scalars
 
   /// Pure menu builder. Fills `menu` from `state`. Logic byte-identical to the
   /// pre-PR-B.3 `AppDelegate.populateMenu(_:)`. Internal (not private) so

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/HeardWordDisplay.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/HeardWordDisplay.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Bounds a heard selection for DISPLAY in fixed chrome.
+///
+/// **One algorithm, because there are two places that render the heard word and they had drifted.**
+/// The menu row solved this first (PR #2427): a selection spanning two document lines carries a
+/// newline, and a newline in an `NSMenuItem` title renders as a malformed multi-line row. The Quick
+/// Add panel header interpolated the same value into a `Text` with no bound at all, so the same
+/// selection produced a header as tall as the selection was long — up to
+/// `SelectionReader.maximumSelectionScalars`, which permits a paragraph and strips only SURROUNDING
+/// whitespace.
+///
+/// **Display only, and the distinction is load-bearing.** What gets written to the library is always
+/// the ORIGINAL selection; this value exists to fit inside a row or a header. Every caller must keep
+/// the unbounded value for the write path — the same separation this cluster has had to relearn more
+/// than once, where a sentence was composed from a neighbouring value instead of from what the write
+/// path was given.
+enum HeardWordDisplay {
+  /// The character ceiling. A count of CHARACTERS, so a family emoji or a base-plus-combining-mark
+  /// letter counts once, however many scalars it carries.
+  static let characters = 24
+
+  /// The scalar ceiling, which bounds the worst case a character count cannot: one character can
+  /// carry many scalars. Both limits apply and the tighter one wins.
+  static let scalars = 96
+
+  /// Trim, collapse internal whitespace, then truncate — in that order.
+  ///
+  /// **Collapsed BEFORE truncating**, so the limit counts characters the user can actually see
+  /// rather than the newlines and tab runs that will not render.
+  static func bounded(
+    _ selection: String,
+    characters characterLimit: Int = HeardWordDisplay.characters,
+    scalars scalarLimit: Int = HeardWordDisplay.scalars
+  ) -> String {
+    let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
+    // **Collapse INTERNAL whitespace, not just the ends.** Tabs and runs of spaces are the same
+    // problem as a newline, one character over.
+    let collapsed = trimmed.split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+      .joined(separator: " ")
+    guard
+      collapsed.count > characterLimit || collapsed.unicodeScalars.count > scalarLimit
+    else { return collapsed }
+    // **Truncate on CHARACTERS, not scalars.** Cutting between the scalars of one character renders
+    // a broken glyph.
+    var out = ""
+    for character in collapsed {
+      guard out.count < characterLimit,
+        out.unicodeScalars.count + character.unicodeScalars.count <= scalarLimit
+      else { break }
+      out.append(character)
+    }
+    return out + "\u{2026}"
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -120,10 +120,18 @@ enum QuickAddPanelCopy {
   /// It is also the panel's confidence signal in words rather than in styling. Below the bar nothing
   /// is preselected, and a list that looks identical either way leaves the user to infer the
   /// difference from a missing tint.
+  ///
+  /// **EVERY state names the heard word, and `lowConfidence` needs it most.** It was the one state
+  /// that dropped it, which inverted the need: the other three show a word the user can check
+  /// against a match we found, while this one shows a list of things that are NOT it. With the word
+  /// withheld there is no way to tell a correct read of an unknown word from a misread of a known
+  /// one. It matters more since #2465, because a selection acquired by borrowing the clipboard has
+  /// no other on-screen confirmation that the right text was picked up at all.
+  /// The verb still stays off this state: naming what was read is not offering to add it.
   static func groupHeader(_ state: GroupHeaderState, heard: String) -> String {
     switch state {
     case .confident: "Add \"\(heard)\" to"
-    case .lowConfidence: "No close match · pick one or keep typing"
+    case .lowConfidence: "No close match for \"\(heard)\" · pick one or keep typing"
     case .alreadySaved: "Already knows \"\(heard)\" · nothing to add"
     case .searching: "Add \"\(heard)\" to"
     }

--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -129,11 +129,17 @@ enum QuickAddPanelCopy {
   /// no other on-screen confirmation that the right text was picked up at all.
   /// The verb still stays off this state: naming what was read is not offering to add it.
   static func groupHeader(_ state: GroupHeaderState, heard: String) -> String {
-    switch state {
-    case .confident: "Add \"\(heard)\" to"
-    case .lowConfidence: "No close match for \"\(heard)\" · pick one or keep typing"
-    case .alreadySaved: "Already knows \"\(heard)\" · nothing to add"
-    case .searching: "Add \"\(heard)\" to"
+    // **Bounded ONCE, above the switch, so no state can render the raw value.** Three of the
+    // four interpolate the word, and bounding only the one a review names would leave the other
+    // two — the pair-shaped fix that reads as complete and is not. `SelectionReader.classify`
+    // strips only SURROUNDING whitespace and permits a paragraph, so an unbounded header is as
+    // tall as the selection is long. Shared with the menu row, which solved this first (#2476).
+    let word = HeardWordDisplay.bounded(heard)
+    return switch state {
+    case .confident: "Add \"\(word)\" to"
+    case .lowConfidence: "No close match for \"\(word)\" · pick one or keep typing"
+    case .alreadySaved: "Already knows \"\(word)\" · nothing to add"
+    case .searching: "Add \"\(word)\" to"
     }
   }
 

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -43,6 +43,22 @@ struct QuickAddPanelCopyTests {
     let low = QuickAddPanelCopy.groupHeader(.lowConfidence, heard: "kubernets")
     #expect(!low.contains("Add"), "there is nothing to add yet, so do not use the verb")
     #expect(low.lowercased().contains("no close match"))
+    // **The word, in the one state that used to drop it.** Every other state shows a word the user
+    // can check against a match we found; this one shows a list of things that are NOT it, so
+    // without the word there is nothing distinguishing a correct read of an unknown word from a
+    // misread of a known one (#2476).
+    #expect(low.contains("kubernets"), "name what was read, especially when nothing matched it")
+  }
+
+  @Test("EVERY header state names the word that was read")
+  func everyHeaderStateNamesTheHeardWord() {
+    // Enumerated from the type rather than listed by hand, so a fifth state cannot be added with
+    // the word left out and still pass. This is the property #2476 is about; asserting it per-state
+    // would have gone stale the moment someone added a state.
+    for state in QuickAddPanelCopy.GroupHeaderState.allCases {
+      let header = QuickAddPanelCopy.groupHeader(state, heard: "keybinds")
+      #expect(header.contains("keybinds"), "\(state) dropped the heard word")
+    }
   }
 
   @Test("The already-saved header states the outcome and offers no verb")

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -115,13 +115,21 @@ struct QuickAddPanelCopyTests {
     return String(source[start.lowerBound..<end.upperBound])
   }
 
+  /// **Found by walking up to a marker, not by counting parents.** A hand-counted chain of
+  /// `deletingLastPathComponent()` is correct only for the depth the file sits at today, is silently
+  /// wrong the moment the file moves, and cannot be checked by reading — the first deletion removes
+  /// the FILENAME rather than a directory, which is exactly the off-by-one a reviewer raised against
+  /// the counted version. This asks the filesystem instead, so there is no number to get wrong.
   private static var repoRoot: URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()  // QuickAdd
-      .deletingLastPathComponent()  // Views
-      .deletingLastPathComponent()  // EnviousWisprTests
-      .deletingLastPathComponent()  // Tests
-      .deletingLastPathComponent()  // repo root
+    var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    // Bounded: `deletingLastPathComponent` on "/" returns "/", so stop at the volume root rather
+    // than looping forever if the marker is somehow absent.
+    while directory.path != "/" {
+      let manifest = directory.appendingPathComponent("Package.swift")
+      if FileManager.default.fileExists(atPath: manifest.path) { return directory }
+      directory = directory.deletingLastPathComponent()
+    }
+    return directory
   }
 
   @Test("EVERY header state names the word that was read")

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -50,6 +50,80 @@ struct QuickAddPanelCopyTests {
     #expect(low.contains("kubernets"), "name what was read, especially when nothing matched it")
   }
 
+  /// **A paragraph selection made the header as tall as the selection.** `SelectionReader.classify`
+  /// trims only SURROUNDING whitespace and permits up to `maximumSelectionScalars`, so a two-line
+  /// selection carried its newline straight into a `Text` with no bound. The menu row solved this
+  /// first and the header never did — two renderers of one value with two answers (#2476).
+  @Test("The header collapses internal whitespace instead of growing lines")
+  func headerCollapsesInternalWhitespace() {
+    for state in QuickAddPanelCopy.GroupHeaderState.allCases {
+      let header = QuickAddPanelCopy.groupHeader(state, heard: "clawwed\nmachine")
+      #expect(!header.contains("\n"), "\(state) rendered a newline into fixed chrome")
+      #expect(header.contains("clawwed machine"), "\(state) lost the word to the collapse")
+    }
+    #expect(
+      QuickAddPanelCopy.groupHeader(.lowConfidence, heard: "one\ttwo   three")
+        .contains("one two three"))
+  }
+
+  /// The bound applies to EVERY state, not the one a review happened to name. Three of the four
+  /// interpolate the word; bounding one and leaving the others is the pair-shaped fix that reads
+  /// as complete and is not.
+  @Test("The header truncates a selection no chrome could hold, in every state")
+  func headerTruncatesInEveryState() {
+    let paragraph = String(repeating: "beads ", count: 120)
+    for state in QuickAddPanelCopy.GroupHeaderState.allCases {
+      let header = QuickAddPanelCopy.groupHeader(state, heard: paragraph)
+      #expect(
+        header.count < 120,
+        "\(state) rendered an unbounded selection: \(header.count) characters")
+      #expect(header.contains("\u{2026}"), "\(state) truncated without saying so")
+    }
+  }
+
+  /// **The structural half, because no behavioural test can see a state that forgot to ask.** A
+  /// fifth state added below the `let word` line inherits the bound; one that interpolates `heard`
+  /// directly does not, and would pass every assertion above that does not happen to name it.
+  /// Same defence as the ladder's twice-only policy check, for the same reason.
+  @Test("No header state can interpolate the unbounded selection")
+  func headerStatesCannotReachTheRawSelection() throws {
+    let source = try String(
+      contentsOf: Self.repoRoot.appendingPathComponent(
+        "Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift"), encoding: .utf8)
+    let body = try #require(Self.groupHeaderBody(in: source), "could not locate groupHeader")
+    #expect(
+      body.contains("HeardWordDisplay.bounded(heard)"),
+      "the bound is what every state below it inherits")
+    // **Two-way control, because the negative alone passes vacuously if the escaping is wrong.**
+    // A source-string check that never matches anything is indistinguishable from one that matches
+    // nothing bad. This proves the same escaping mechanism DOES resolve against this body.
+    #expect(
+      body.contains("\\(word)"),
+      "the interpolation check cannot see the source, so its negative proves nothing")
+    #expect(
+      !body.contains("\\(heard)"),
+      "a state interpolated the unbounded selection directly")
+  }
+
+  /// The function body of `groupHeader`, from its signature to its closing brace.
+  private static func groupHeaderBody(in source: String) -> String? {
+    guard
+      let start = source.range(
+        of: "static func groupHeader(_ state: GroupHeaderState, heard: String) -> String {"),
+      let end = source.range(of: "\n  }\n", range: start.upperBound..<source.endIndex)
+    else { return nil }
+    return String(source[start.lowerBound..<end.upperBound])
+  }
+
+  private static var repoRoot: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // QuickAdd
+      .deletingLastPathComponent()  // Views
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+      .deletingLastPathComponent()  // repo root
+  }
+
   @Test("EVERY header state names the word that was read")
   func everyHeaderStateNamesTheHeardWord() {
     // Enumerated from the type rather than listed by hand, so a fifth state cannot be added with


### PR DESCRIPTION
Founder report on the shipped #2465 build: highlighting `keybinds`, a word with no close match in the library, gave a header reading **"No close match · pick one or keep typing"** with the word never named. There was no way to tell a correct read of an unknown word from a misread of a known one.

Now reads **`No close match for "keybinds" · pick one or keep typing`**.

## Why this state and not the others

Four header states, and this was the only one that dropped the word. The need runs the other way round: the other three show a word the user can check against a match we found, while this one shows a list of things that are NOT it.

It matters more since #2465, because a selection acquired by borrowing the clipboard has no other on-screen confirmation anywhere that the right text was picked up. This header is the only witness.

The verb stays off the state. Naming what was read is not offering to add it, and the existing assertion that the string carries no `Add` still holds.

`groupHeader` already takes `heard`, so nothing needed plumbing — the value was in scope at the line that omitted it.

## Test

The per-state assertion gains the word, and is joined by one that enumerates `GroupHeaderState.allCases` and requires EVERY state to name it. A fifth state cannot be added with the word left out and still pass.

Enumerated from the type rather than listed by hand, because a hand-listed version goes stale exactly when someone adds the state it would have caught.

**Red on the base revision by construction:** the baseline string is a literal with no interpolation of `heard`, so `contains("keybinds")` cannot hold there.

## Validation

- `scripts/xcode-test.sh`: **7159 tests, all accepted.** Both changed tests confirmed PRESENT AND PASSED in the result bundle, not inferred from the suite total.
- Dev-configuration build succeeded.
- Local `codex review`: clean.
- Copy swept across `Sources Tests website docs scripts` plus gitignored roots, with a positive control on a neighbouring phrase so the silence is real. One live site, changed.

## Filed, not folded in

The sweep surfaced a sibling the review did not: the header renders only when the candidate list is non-empty (`QuickAddPanelView.swift:352`), so with an empty list the word appears **nowhere on screen**. Reachable by typing in the search field until nothing matches, and by having a near-empty library. That is this issue in its most complete form, but it needs an empty-state layout decision this change does not — **#2477**.

Closes #2476
