### PR TITLE
fix(quickadd): the panel takes the keyboard without bringing the app forward

### DIFF
--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddPanelHost.swift
@@ -7,12 +7,22 @@ import SwiftUI
 /// coordinator after the fact; this starts where that ended up. The coordinator below it decides
 /// WHAT to show and never touches a window.
 ///
-/// **This panel is key-capable, and that is the one way it must differ from the dictation overlay.**
-/// `OverlayWindowHost` builds `[.borderless, .nonactivatingPanel]`, and a non-activating panel can
-/// never become key — so it could never receive the Return keypress this whole feature is built
-/// around. The shape here follows `RelocationCardPanel` instead, which is the app's existing
-/// key-capable card: `.titled` + `.fullSizeContentView` with the title bar hidden, which also buys
-/// native rounding and shadow rather than hand-drawn ones.
+/// **This panel is key-capable AND non-activating, and the second half is what keeps our other
+/// windows out of the user's way (#2479).** It follows `RelocationCardPanel`'s shape — `.titled` +
+/// `.fullSizeContentView` with the title bar hidden, which buys native rounding and shadow rather
+/// than hand-drawn ones — plus `.nonactivatingPanel`.
+///
+/// **Corrected 2026-08-27: the text here used to say a non-activating panel "can never become key".**
+/// That attributed to `.nonactivatingPanel` what `.borderless` actually does. The dictation overlay
+/// carries BOTH flags, and it is borderless that defaults `canBecomeKey` to false; `KeyCapablePanel`
+/// overrides it. The two are independent, so this panel takes the keyboard without our application
+/// becoming frontmost.
+///
+/// **Verified by a human keypress, because nothing else can verify it on this OS.** A synthetic
+/// Escape never reaches this app (`code-tooling.md` FACT: synthetic-escape-does-not-reach-a-carbon-hotkey),
+/// so an automated run reports "the key did not arrive" for a working panel and a broken one alike.
+/// Three automated verdicts were produced against that unusable oracle before the founder confirmed
+/// on 2026-08-27 that the panel opens without the app taking over and that Escape dismisses it.
 ///
 /// Nonmodal on purpose. A modal panel would trap the user in a limb: Quick Add is something you
 /// abandon by pressing Escape or clicking away, and a run loop that refuses to let you is worse than
@@ -20,14 +30,15 @@ import SwiftUI
 @MainActor
 final class QuickAddPanelHost: NSObject, NSWindowDelegate {
 
-  /// #2455 C3: both required and non-defaulted. `takeFocus` is the single
-  /// chokepoint for activating and keying the Quick Add panel, so these two are
-  /// exactly the calls a unit test must not be able to make.
-  private let application: any ApplicationActivating
+  /// #2455 C3: required and non-defaulted. `takeFocus` is the single chokepoint for keying the
+  /// Quick Add panel, so this is exactly the call a unit test must not be able to make.
+  ///
+  /// **`ApplicationActivating` was here too and is gone (#2479).** Nothing in this class activates
+  /// any more, and an injected seam nothing uses is worse than no seam: it is a live route back to
+  /// the behaviour just removed, sitting in the initializer where the next edit will find it.
   private let presenter: any PanelPresenting
 
-  init(application: any ApplicationActivating, presenter: any PanelPresenting) {
-    self.application = application
+  init(presenter: any PanelPresenting) {
     self.presenter = presenter
     super.init()
   }
@@ -112,8 +123,8 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     panel.setContentSize(size)
     panel.center()
 
-    // Activate BEFORE making key, and only now — the selection was read while the other app was
-    // still frontmost, which is the whole reason this happens here rather than at capture time.
+    // Keyed only now, not at capture time — the selection was read while the other app was still
+    // frontmost, and that ordering still matters even though nothing activates any more (#2479).
     takeFocus(panel)
     return true
   }
@@ -125,10 +136,23 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
   /// word the user is already reaching for the place they want to type, so putting the caret
   /// somewhere on their behalf competes with the click they were going to make.
   ///
-  /// **One owner for both takers.** `present` and `raise` both activate and both call
-  /// `makeKeyAndOrderFront`, so a third taker cannot be added without coming through here.
+  /// **One owner for both takers.** `present` and `raise` both call `makeKeyAndOrderFront`, so a
+  /// third taker cannot be added without coming through here.
+  ///
+  /// **No application activation (#2479), and that IS the fix.** `NSApp.activate` activates the
+  /// APPLICATION, which raises every window it owns — so opening Quick Add while the Settings window
+  /// was open dragged Settings in front of whatever the user was working in. Measured through the
+  /// window server: our main window climbed from index 2 to index 0.
+  ///
+  /// **Two lighter repairs were tried and both measurably failed**, which is why the panel's style
+  /// mask is carrying this rather than the call site. `NSApp.activate()` — the parameterless overload
+  /// — still raised the main window to index 0. So did activating and then calling `orderBack(nil)`
+  /// on every other visible window we own. Activation and window-raising are not separable from here.
+  ///
+  /// It also settles the focus-return question by removing it: seven review rounds went into giving
+  /// focus back after a Quick Add and the founder retired the requirement (2026-08-25). With no
+  /// activation there is nothing to give back, because the user's app never stopped being frontmost.
   private func takeFocus(_ panel: NSPanel) {
-    application.activate(.ignoringOtherApps)
     presenter.makeKeyAndOrderFront(panel)
   }
 
@@ -221,7 +245,7 @@ final class QuickAddPanelHost: NSObject, NSWindowDelegate {
     #endif
     let p = KeyCapablePanel(
       contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
-      styleMask: [.titled, .fullSizeContentView],
+      styleMask: [.titled, .fullSizeContentView, .nonactivatingPanel],
       backing: .buffered,
       defer: false)
     p.titleVisibility = .hidden

--- a/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/QuickAdd/QuickAddWiring.swift
@@ -75,9 +75,7 @@ final class QuickAddWiring {
     // FIRST, before anything else in this initializer: the host was previously a
     // stored-property initializer, which ran before every line here. Constructing
     // it first keeps that ordering.
-    self.panelHost = QuickAddPanelHost(
-      application: presentationEffects.application,
-      presenter: presentationEffects.panels)
+    self.panelHost = QuickAddPanelHost(presenter: presentationEffects.panels)
     self.hotkeyService = hotkeyService
     self.customWords = customWords
     self.settings = settings

--- a/Tests/EnviousWisprTests/Support/RecordingDesktopPresentationEffects.swift
+++ b/Tests/EnviousWisprTests/Support/RecordingDesktopPresentationEffects.swift
@@ -12,10 +12,16 @@ import Foundation
 /// foreground mid-suite.
 ///
 /// It RECORDS rather than absorbing, for the same reason
-/// `RecordingDesktopHotkeyEffects` does: activation ordering is load-bearing —
-/// `QuickAddPanelHost.takeFocus` activates BEFORE keying the panel, because the
-/// selection was read while another app was frontmost — and nothing could assert
-/// that ordering while the calls went straight to AppKit.
+/// `RecordingDesktopHotkeyEffects` does: nothing could assert what was called
+/// while the calls went straight to AppKit.
+///
+/// **The Quick Add example this used to cite is gone (#2479).** It read:
+/// "activation ordering is load-bearing — `QuickAddPanelHost.takeFocus`
+/// activates BEFORE keying the panel". That host no longer activates at all; its
+/// panel is `.nonactivatingPanel` and takes the keyboard without bringing our
+/// application forward, which is what stopped it dragging the Settings window in
+/// front of whatever the user was working in. Other consumers still make these
+/// calls, so this double stays.
 @MainActor
 final class RecordingDesktopPresentationEffects: ApplicationActivating, PanelPresenting {
 


### PR DESCRIPTION
Founder report: opening Quick Add from the menu bar pulled the Settings window in front of whatever he was working in — but only while that window was open, which is why it looked intermittent. With no window open the app is `.accessory` and there is nothing to raise.

## Cause

`takeFocus` called `NSApp.activate(ignoringOtherApps:)`. Activating an APPLICATION raises every window it owns. Measured through the window server, not inferred:

```
BEFORE:   front window owner='TextEdit'      our main window index=2
PANEL UP: front window owner='EnviousWispr'  our main window index=0
```

The panel is now `.nonactivatingPanel` and nothing activates. It takes key status on its own, so the user's app never stops being frontmost.

## Two lighter repairs were tried and both measurably failed

| attempt | main window index |
|---|---|
| `NSApp.activate()` (the `.standard` overload the effects layer already exposes) | still climbed to 0 |
| activate, then `orderBack(nil)` on every other visible window we own | still climbed to 0 |

Activation and window-raising are not separable from this call site, which is why the fix lives in the style mask rather than in the activation call.

## The premise this overturns, and why it survived

The header said `[.borderless, .nonactivatingPanel]` "can never become key", so the panel could never receive the Return this feature turns on. That attributed to `.nonactivatingPanel` what `.borderless` actually does — borderless defaults `canBecomeKey` to false, and `KeyCapablePanel` already overrides it. One window carried both flags and the two were conflated.

## Verified by a human keypress, because nothing else can verify it here

`code-tooling.md` FACT: synthetic-escape-does-not-reach-a-carbon-hotkey — a synthetic Escape never reaches this app. **Three automated runs reported "the key did not arrive" against that oracle**, which reads identically for a working panel and a broken one, and one of those readings briefly retired this approach. The knowledge file already said a verdict from that instrument is about the HARNESS, not the app.

Founder confirmed on the running app, 2026-08-27, in his words: *"just the pop-up appeared, the full application didn't take over, that worked nicely. And I confirmed the escape key works."*

## Also in this change

- **The `ApplicationActivating` dependency is removed from this class.** Nothing here activates any more, and an injected seam nothing calls is a live route back to the behaviour just removed, sitting in the initializer where the next edit will find it. `QuickAddWiring` updated; the recording double stays, because other consumers still make those calls.
- **Three comments across two files** explained that this host activates before keying the panel. All three were true before this change and false after it. All three corrected rather than left to stop the next reader checking.

## Validation

- `scripts/xcode-test.sh`: **7162 tests, all accepted**, exit 0 read directly rather than through a pipe.
- Dev-configuration build clean.
- Live UAT by the founder, which is the only valid instrument for the keyboard half.

## Follow-ups, filed not folded in

- **#2480** — Dock icon always on, menu bar item becomes a toggle. This fix is its prerequisite: once the Dock icon is permanent, the raise this removes would have become the every-time case rather than an occasional one.
- **#2481** — the fallback gives up after 250 ms waiting for the shortcut keys to be released, which is shorter than a deliberate three-key press. Found by the founder in ordinary use while testing this.

Closes #2479
