### PR TITLE
fix(worker): answer Sentry's alert-action probe so alerts can reach Discord again

### DIFF
--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -62,11 +62,47 @@ export default {
 
     const body = await request.text();
 
+    // **Sentry's alert-rule-action SETTINGS probe, answered before the HMAC gate and
+    // deliberately doing nothing (#2486).** The integration's schema declares
+    // `"settings": { "type": "alert-rule-settings", "uri": "/" }`, so when a workflow
+    // action is saved Sentry POSTs the submitted fields to this same root path. That
+    // probe carries NO `sentry-hook-signature`, so the gate below answered it 401 and
+    // Sentry surfaced `{"actionFilters":{"nonfielderrors":["Claude Triage Webhook:
+    // Something went wrong!"]}}` on every save — measured on
+    // `PUT /organizations/envious-labs-llc/workflows/3202076/`, which is why the
+    // integration could not be wired as an explicit workflow action at all.
+    //
+    // **The discriminator is the PRESENCE of the signature header, not the body.** A
+    // real webhook always carries it, so requiring it for the triage path is unchanged
+    // and a forged probe cannot reach `handleTriage`: this branch returns before any
+    // Sentry, GitHub, KV or Discord work is scheduled. The endpoint becomes
+    // unauthenticated only for a request that performs no action and reads no state.
+    //
+    // Sentry uses the STATUS to decide whether the action saved; the body is not read
+    // for `alert-rule-settings` (a `select` field's options come from its own `uri`,
+    // and this schema declares none). So `{}` is the honest answer.
+    if (!request.headers.has("sentry-hook-signature")) {
+      console.log(
+        `[sentry-triage] settings probe answered 200; headers=${headerNames(request)}`
+      );
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
     // Verify HMAC-SHA256 signature — must happen before 202 so we can 401 on bad sig
     const sigHeader = request.headers.get("sentry-hook-signature") ?? "";
     const verified = await verifyHmac(body, sigHeader, env.SENTRY_WEBHOOK_SECRET);
     if (!verified) {
-      console.error("[sentry-triage] HMAC verification failed");
+      // **Header NAMES, never values.** A signature value is a credential and a
+      // body can carry user content; the names alone answer the only question a
+      // refusal leaves open — whether this was a forged webhook or a Sentry
+      // request shape we do not yet handle — which is precisely what could not be
+      // answered while #2486 was open.
+      console.error(
+        `[sentry-triage] HMAC verification failed; headers=${headerNames(request)}`
+      );
       return new Response("Unauthorized", { status: 401 });
     }
 
@@ -76,6 +112,11 @@ export default {
     return new Response("Accepted", { status: 202 });
   },
 };
+
+/** Sorted header NAMES, comma-joined. Never values: one of them is a credential. */
+export function headerNames(request) {
+  return [...request.headers.keys()].sort().join(",");
+}
 
 // ── HMAC verification ─────────────────────────────────────────────────────────
 

--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -82,8 +82,26 @@ export default {
     // for `alert-rule-settings` (a `select` field's options come from its own `uri`,
     // and this schema declares none). So `{}` is the honest answer.
     if (!request.headers.has("sentry-hook-signature")) {
+      // **A UI-component request is signed under a DIFFERENT header name.** Sentry's
+      // webhooks carry `Sentry-Hook-Signature`; its integration-platform component
+      // requests carry `Sentry-App-Signature`, over the same client secret. So the
+      // probe is authenticated whenever that header is present, and a signature that
+      // is present and WRONG is a forgery rather than a probe — refuse it.
+      //
+      // The `appSig` absent case still answers 200, deliberately: the header name is
+      // Sentry's to change, and refusing an unrecognised shape is exactly the failure
+      // this commit exists to end. That path returns a constant with no work behind
+      // it, so the cost of being wrong here is an endpoint that says `{}`.
+      const appSig = request.headers.get("sentry-app-signature");
+      if (appSig && !(await verifyHmac(body, appSig, env.SENTRY_WEBHOOK_SECRET))) {
+        console.error(
+          `[sentry-triage] component request signature invalid; headers=${headerNames(request)}`
+        );
+        return new Response("Unauthorized", { status: 401 });
+      }
       console.log(
-        `[sentry-triage] settings probe answered 200; headers=${headerNames(request)}`
+        `[sentry-triage] settings probe answered 200; signed=${appSig ? "yes" : "no"}; ` +
+          `headers=${headerNames(request)}`
       );
       return new Response("{}", {
         status: 200,

--- a/workers/sentry-triage/test/index.test.js
+++ b/workers/sentry-triage/test/index.test.js
@@ -733,3 +733,100 @@ test("buildFailOpenEmbed: Unknown build source + details-unavailable note", () =
   const details = embed.fields.find((f) => f.name === "Details");
   assert.match(details.value, /unavailable/i);
 });
+
+// ── Entry point: the request gate (#2486) ────────────────────────────────────
+//
+// The gate had NO tests before this, which is why an unsigned request being
+// refused was invisible: Sentry's alert-rule-action settings probe carries no
+// `sentry-hook-signature`, so it was answered 401 and the integration could
+// never be attached as a workflow action.
+//
+// The load-bearing property is NOT the status code, it is that the unsigned
+// path performs NO WORK. `ctx.waitUntil` is the only route to `handleTriage`,
+// so asserting it was never called asserts the subject rather than something
+// beside it: a future edit that answers 200 and also schedules triage fails
+// here.
+
+import worker, { headerNames } from "../src/index.js";
+import { createHmac } from "node:crypto";
+
+function ctxSpy() {
+  const scheduled = [];
+  return { scheduled, ctx: { waitUntil: (p) => scheduled.push(p) } };
+}
+
+const GATE_SECRET = "test-secret";
+
+function signed(body, secret = GATE_SECRET) {
+  return createHmac("sha256", secret).update(body, "utf8").digest("hex");
+}
+
+test("gate: a non-POST is refused before anything reads the body", async () => {
+  const { scheduled, ctx } = ctxSpy();
+  const res = await worker.fetch(new Request("https://w/", { method: "GET" }), {}, ctx);
+  assert.equal(res.status, 405);
+  assert.equal(scheduled.length, 0);
+});
+
+test("gate: an UNSIGNED post is answered 200 and schedules no work", async () => {
+  const { scheduled, ctx } = ctxSpy();
+  const body = JSON.stringify({ fields: { note: "New issue detected" } });
+  const res = await worker.fetch(
+    new Request("https://w/", { method: "POST", body }),
+    { SENTRY_WEBHOOK_SECRET: GATE_SECRET },
+    ctx
+  );
+  assert.equal(res.status, 200, "Sentry reads the STATUS to decide the action saved");
+  assert.equal(await res.text(), "{}");
+  assert.equal(
+    res.headers.get("content-type"),
+    "application/json",
+    "Sentry's client expects JSON, not the default text/plain"
+  );
+  assert.equal(scheduled.length, 0, "the probe must never reach handleTriage");
+});
+
+test("gate: a post with a WRONG signature is still 401 and schedules no work", async () => {
+  const { scheduled, ctx } = ctxSpy();
+  const body = JSON.stringify({ action: "created", data: { issue: { id: "1" } } });
+  const res = await worker.fetch(
+    new Request("https://w/", {
+      method: "POST",
+      body,
+      headers: { "sentry-hook-signature": signed(body, "wrong-secret") },
+    }),
+    { SENTRY_WEBHOOK_SECRET: GATE_SECRET },
+    ctx
+  );
+  assert.equal(res.status, 401);
+  assert.equal(scheduled.length, 0, "a forged webhook must not reach handleTriage");
+});
+
+test("gate: a CORRECTLY signed webhook still reaches triage with 202", async () => {
+  const { scheduled, ctx } = ctxSpy();
+  const body = JSON.stringify({ action: "created", data: { issue: { id: "1" } } });
+  const res = await worker.fetch(
+    new Request("https://w/", {
+      method: "POST",
+      body,
+      headers: { "sentry-hook-signature": signed(body) },
+    }),
+    { SENTRY_WEBHOOK_SECRET: GATE_SECRET },
+    ctx
+  );
+  assert.equal(res.status, 202);
+  assert.equal(scheduled.length, 1, "the real path is unchanged by the probe branch");
+  await Promise.allSettled(scheduled);
+});
+
+test("headerNames: names only, sorted, never values", () => {
+  const req = new Request("https://w/", {
+    method: "POST",
+    body: "{}",
+    headers: { "sentry-hook-signature": "deadbeef", "z-last": "1", "a-first": "2" },
+  });
+  const names = headerNames(req);
+  assert.match(names, /sentry-hook-signature/);
+  assert.ok(!names.includes("deadbeef"), "a signature value must never reach a log line");
+  assert.deepEqual(names.split(","), [...names.split(",")].sort(), "sorted, so two runs compare");
+});

--- a/workers/sentry-triage/test/index.test.js
+++ b/workers/sentry-triage/test/index.test.js
@@ -830,3 +830,35 @@ test("headerNames: names only, sorted, never values", () => {
   assert.ok(!names.includes("deadbeef"), "a signature value must never reach a log line");
   assert.deepEqual(names.split(","), [...names.split(",")].sort(), "sorted, so two runs compare");
 });
+
+test("gate: a probe signed with sentry-app-signature is accepted, no work", async () => {
+  const { scheduled, ctx } = ctxSpy();
+  const body = JSON.stringify({ fields: { note: "New issue detected" } });
+  const res = await worker.fetch(
+    new Request("https://w/", {
+      method: "POST",
+      body,
+      headers: { "sentry-app-signature": signed(body) },
+    }),
+    { SENTRY_WEBHOOK_SECRET: GATE_SECRET },
+    ctx
+  );
+  assert.equal(res.status, 200);
+  assert.equal(scheduled.length, 0);
+});
+
+test("gate: a probe whose sentry-app-signature is WRONG is a forgery, not a probe", async () => {
+  const { scheduled, ctx } = ctxSpy();
+  const body = JSON.stringify({ fields: { note: "New issue detected" } });
+  const res = await worker.fetch(
+    new Request("https://w/", {
+      method: "POST",
+      body,
+      headers: { "sentry-app-signature": signed(body, "wrong-secret") },
+    }),
+    { SENTRY_WEBHOOK_SECRET: GATE_SECRET },
+    ctx
+  );
+  assert.equal(res.status, 401, "present-but-invalid must never be treated as unsigned");
+  assert.equal(scheduled.length, 0);
+});


### PR DESCRIPTION
Closes #2486.

## The outage

Sentry error alerts stopped reaching Discord on **2026-08-16** and nobody noticed for 12 days. At
least 13 new problem groups appeared in that window; two were still firing while this was written
(`polish_provider_failed` ENVIOUSWISPR-4M, 23 events; `model_load_wedged` ENVIOUSWISPR-30).

Silence is also what a healthy quiet week looks like, which is the whole reason it ran that long.

## Where the break is, measured three ways

Sentry is not failing to deliver. It **stopped firing**.

- **Sentry's own Request Log** (Custom Integrations → Claude Triage Webhook → Dashboard): every past
  delivery `202`, then no rows at all after Aug 16 11:51 EDT.
- **Cloudflare `workersInvocationsAdaptive`** agrees exactly: Aug 8 (3), Aug 14 (1), Aug 16 (3), then
  zero.
- **Audit log, all time**: no change on or near Aug 16. Nobody switched it off, and the integration is
  still correctly configured (right URL, `issue.created` subscribed, Alert Action enabled).

The one relevant change is **Aug 10**: `workflow.add` "Notify Suggested Assignees" and
`detector_workflow.add` connecting detector "Issue Stream" — this org was migrated to Sentry's
Workflow Engine. Stated as a **hypothesis, not a fact**: Sentry's internals are not observable from
here, and the two deliveries after Aug 10 are equally consistent with a staged rollout.

## Why the supported repair could not be applied, and what this PR fixes

Under the Workflow Engine the correct wiring is explicit: attach the integration as an action on the
workflow. It offers exactly that and appears in the picker. Saving it failed:

    PUT /api/0/organizations/envious-labs-llc/workflows/3202076/  ->  400
    {"actionFilters":{"nonfielderrors":["Claude Triage Webhook: Something went wrong!"]}}

The integration's schema declares `"settings": {"type": "alert-rule-settings", "uri": "/"}`, so on
save Sentry POSTs to this Worker's ROOT path — the same path the triage webhook uses. The Worker had
one entry shape: non-POST 405, then HMAC or 401. The probe was refused, so Sentry called the
integration broken.

**Measured, not inferred.** `wrangler tail` against the live Worker while re-driving the save:

    POST https://enviouswispr-sentry-triage.saurabhav.workers.dev/ - Ok
      (error) [sentry-triage] HMAC verification failed

## The change

Sentry signs integration-platform **component** requests under a different header from its webhooks:
`Sentry-App-Signature` rather than `Sentry-Hook-Signature`, over the same client secret this Worker
already holds. So the probe is now authenticated with the HMAC routine already in this file:

- `sentry-hook-signature` present → the triage path, **byte-for-byte unchanged**.
- No hook signature, valid `sentry-app-signature` → `200 {}`, no work.
- No hook signature, **wrong** `sentry-app-signature` → `401`. Present-but-invalid is a forgery, not a
  probe; collapsing those two is how the original 401 came to swallow a legitimate request.
- Neither header → `200 {}`, deliberately. The header name is Sentry's to change, and refusing an
  unrecognised shape is exactly the failure this issue exists to end. That branch returns before
  `ctx.waitUntil`, the only route to `handleTriage`, so the cost of being wrong is an endpoint that
  says `{}` and does nothing.

Both branches log header **names**, never values: one of them is a credential. That makes the first
real save state which case it is rather than leaving it to be re-derived.

## Tests

The entry gate had **no tests at all**, which is why a legitimate request being refused was invisible.
Seven added. They assert the SUBJECT, not a marker beside it: `ctx.waitUntil` is spied on, so
"schedules no work" is a real assertion and a future edit that answers 200 *and* triages fails here.

Red-test controls run at both increments, not claimed:

| control | result |
|---|---|
| new tests vs the worker before any fix | 91 tests, **1 fail** — `gate: an UNSIGNED post is answered 200 and schedules no work` |
| new tests vs the first commit | 94 tests, **1 fail** — `gate: a probe whose sentry-app-signature is WRONG is a forgery` |
| final | **94 pass, 0 fail** |

## Review

`codex review --base origin/main`, explicit all-clear: *"I don't see a regression, data-path break, or
security-relevant logic bug introduced in this diff."*

Two earlier attempts died on their own tooling (a GitHub rate limit; a models-manager cache error) and
produced **no verdict**. Recording that because a review that dies silently looks exactly like a clean
one, and neither was treated as approval.

## Not done in this PR, stated rather than implied

- **The Worker still has to be deployed** — `wrangler deploy` is blocked for this session. Merging this
  does not restore alerting on its own.
- **Verification is deploy-gated**: the save returning 200, then a real new issue producing a Discord
  card. A green save button is not the proof.
- **No watcher yet.** Nothing observes the notifier, which is why 12 days passed. Follow-up in #2486.

Lane: Worker.

## Test plan

- [x] `node --test` in `workers/sentry-triage` — 94 pass, 0 fail
- [x] Red-test control at both increments
- [x] Codex review clean
- [ ] Worker deployed
- [ ] Sentry workflow action saves (`PUT` returns 200)
- [ ] A real new issue produces a Discord card
