### PR TITLE
feat(ci): notice when the Sentry alerter goes quiet

### DIFF
--- a/.github/workflows/alerting-heartbeat.yml
+++ b/.github/workflows/alerting-heartbeat.yml
@@ -1,0 +1,111 @@
+name: Alerting Heartbeat
+
+# Asks one question daily: is anything still reaching the Sentry -> Discord
+# notifier? On 2026-08-16 Sentry stopped firing it and nobody noticed for 12 days,
+# because the only symptom was an absence and no alert is not a signal (#2486).
+#
+# HERE RATHER THAN IN A WORKER, for two reasons. A watchdog that lives inside the
+# system it watches dies with it. And the Cloudflare account is at its 5-cron
+# free-plan limit (#1092), which is why daily-report-ping.yml already schedules from
+# here too.
+#
+# Reuses secrets this repo already holds. No new credential is introduced by this
+# workflow: CLOUDFLARE_* drive the analytics query, and DISCORD_RELEASE_WEBHOOK is
+# the same channel release.yml already uses for proactive "something needs you"
+# posts, which is exactly this message's shape.
+
+on:
+  schedule:
+    # ~10:41am EDT / ~9:41am EST. Offset minute, not top-of-hour: GitHub flags
+    # :00 as a high-load window where scheduled runs are delayed or dropped
+    # (#1131), and a watchdog that silently does not run is the failure it exists
+    # to prevent.
+    - cron: "41 14 * * *"
+  workflow_dispatch:
+    inputs:
+      threshold_days:
+        description: "Days of silence before this alerts (default 7)"
+        required: false
+        type: string
+      notify:
+        description: "Post to Discord when stale (off for a dry run)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: alerting-heartbeat
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      # Runs first and takes no credentials. If the decision layer is broken, that
+      # is a fact about this checkout, and finding it out here is cheaper than
+      # finding it out from a verdict nobody can trust.
+      - name: Self-test the decision layer
+        run: python3 scripts/ci/check-alerting-heartbeat.py --self-test
+
+      - name: Check the notifier heartbeat
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          THRESHOLD: ${{ inputs.threshold_days }}
+          # A scheduled run always notifies. A manual run notifies only when asked,
+          # so this can be exercised without posting to the founder's channel.
+          NOTIFY: ${{ github.event_name == 'schedule' || inputs.notify }}
+        run: |
+          set -uo pipefail
+
+          ARGS=""
+          if [ -n "${THRESHOLD:-}" ]; then ARGS="$ARGS --threshold-days $THRESHOLD"; fi
+          if [ "${NOTIFY}" = "true" ]; then ARGS="$ARGS --notify"; fi
+
+          # Deliberately capturing the status rather than letting `set -e` abort:
+          # the three outcomes need three different reports, and an aborted shell
+          # would render "could not measure" identically to "the notifier is dead".
+          # Claiming an outage we did not observe is its own kind of wrong.
+          RC=0
+          python3 scripts/ci/check-alerting-heartbeat.py $ARGS | tee /tmp/heartbeat.txt || RC=$?
+          OUT="$(cat /tmp/heartbeat.txt)"
+
+          case "$RC" in
+            0)
+              echo "### Alerting heartbeat: healthy" >> "$GITHUB_STEP_SUMMARY"
+              echo "$OUT" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            1)
+              echo "::error::Sentry error alerts appear to have stopped reaching Discord."
+              {
+                echo "### Alerting heartbeat: STALE"
+                echo ""
+                echo "$OUT"
+                echo ""
+                echo "Runbook: \`.claude/knowledge/sentry-triage-pipeline.md\`"
+                echo "FACT: the-notifier-can-go-silent-and-silence-is-indistinguishable-from-quiet"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+              ;;
+            *)
+              # UNKNOWN. Red, because a watchdog that cannot see must not look green,
+              # but explicitly NOT an outage claim.
+              echo "::error::The alerting heartbeat could not be measured. This is not a claim that alerting is broken."
+              {
+                echo "### Alerting heartbeat: COULD NOT MEASURE"
+                echo ""
+                echo "The check failed to read Cloudflare. Nothing is asserted about"
+                echo "whether alerts are flowing; only that this could not tell."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/alerting-heartbeat.yml
+++ b/.github/workflows/alerting-heartbeat.yml
@@ -67,16 +67,32 @@ jobs:
         run: |
           set -uo pipefail
 
-          ARGS=""
-          if [ -n "${THRESHOLD:-}" ]; then ARGS="$ARGS --threshold-days $THRESHOLD"; fi
-          if [ "${NOTIFY}" = "true" ]; then ARGS="$ARGS --notify"; fi
+          # An ARRAY, not a string. `threshold_days` is free-text from
+          # workflow_dispatch, and appending it to a string then expanding `$ARGS`
+          # unquoted lets a value with spaces or shell metacharacters change the
+          # command's structure. Cloud review, PR for #2486.
+          #
+          # Validated here as well as quoted: argparse would reject a non-integer,
+          # but failing at the door with a readable message beats a stack trace,
+          # and it keeps the injection surface at zero rather than merely inert.
+          ARGS=()
+          if [ -n "${THRESHOLD:-}" ]; then
+            case "$THRESHOLD" in
+              ''|*[!0-9]*)
+                echo "::error::threshold_days must be a whole number, got '$THRESHOLD'"
+                exit 1
+                ;;
+            esac
+            ARGS+=(--threshold-days "$THRESHOLD")
+          fi
+          if [ "${NOTIFY}" = "true" ]; then ARGS+=(--notify); fi
 
           # Deliberately capturing the status rather than letting `set -e` abort:
           # the three outcomes need three different reports, and an aborted shell
           # would render "could not measure" identically to "the notifier is dead".
           # Claiming an outage we did not observe is its own kind of wrong.
           RC=0
-          python3 scripts/ci/check-alerting-heartbeat.py $ARGS | tee /tmp/heartbeat.txt || RC=$?
+          python3 scripts/ci/check-alerting-heartbeat.py "${ARGS[@]}" | tee /tmp/heartbeat.txt || RC=$?
           OUT="$(cat /tmp/heartbeat.txt)"
 
           case "$RC" in

--- a/scripts/ci/check-alerting-heartbeat.py
+++ b/scripts/ci/check-alerting-heartbeat.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Is the Sentry -> Discord notifier still being fed?
+
+WHY THIS EXISTS. On 2026-08-16 Sentry stopped firing the integration webhook that
+drives `workers/sentry-triage`, and nobody noticed for 12 days (#2486). At least 13
+new problem groups were created in that window. Nothing was broken in a way anyone
+could see: the Worker was healthy, Discord was healthy, and the only symptom was an
+absence. **A dead notifier and a quiet week produce the identical observation**, so
+no dashboard anyone was already reading could have caught it.
+
+WHAT IT WATCHES, AND WHY FROM OUT HERE. GitHub Actions, not a Cloudflare cron: a
+watchdog living inside the system it watches dies with it, and the CF account is at
+its 5-cron free-plan limit anyway (#1092). The signal is Cloudflare's own count of
+invocations of the notifier Worker, which is the last thing in the chain we can see
+from outside Sentry.
+
+WHAT IT CANNOT WATCH, stated so nobody reads more into a green run than it carries:
+Sentry's own delivery log is UI-only for us (`/sentry-apps/<slug>/requests/` 404s
+even with `sentry-master-key`, measured 2026-08-28), so this cannot distinguish
+"Sentry sent nothing" from "Sentry sent something that never arrived". It answers
+one question — has ANYTHING reached the notifier lately — and that is the question
+whose "no" went unnoticed for 12 days.
+
+**AND "ANYTHING" IS LITERAL: ANY HTTP REQUEST REFRESHES THIS, INCLUDING A REFUSED
+ONE.** `workersInvocationsAdaptive` counts invocations, not authenticated webhooks,
+and the Worker's URL is public. Demonstrated rather than theorised: on the very day
+this was written the check reported "last ran 0 days ago" against an alerting path
+that had been dead for twelve, because the diagnosis of #2486 had itself curled the
+endpoint that afternoon. So a green run means "something reached it", never "Sentry
+delivered". The outage window is unaffected — Cloudflare recorded a true zero across
+Aug 17-28 because nobody was poking it — but a future outage accompanied by any
+traffic at all would hide behind this.
+
+The sharp version needs the Worker to record a heartbeat only after a VERIFIED
+signature, in the KV namespace it already binds, and this check to read that key
+instead. That is a Worker change plus a deploy; it is deliberately NOT bundled here,
+so the coarse net can land while the deploy is blocked. Follow-up on #2486.
+
+THRESHOLD, and why it is not tighter. Healthy traffic is bursty, not steady: the
+real invocation dates before the outage were Aug 6, 8, 14, 16, a natural gap of six
+days. A threshold under that cries wolf, and a guard that cries wolf gets ignored,
+which is the failure mode this is supposed to prevent. Seven days is a coarse net
+whose only job is to catch a SUSTAINED silence. It would have caught #2486 on Aug 23
+rather than Aug 28.
+
+FAIL CLOSED, THREE WAYS. A measurement authority that cannot measure must never
+render as a number (validation-discipline.md RULE:
+measure-with-the-real-tool-never-a-simulation). Cloudflare has three distinct ways to
+answer badly and #1589 was caused by conflating them: a non-2xx, a GraphQL `errors`
+array on a 200, and a well-formed response for a script that does not exist. Each
+exits UNKNOWN here, which is loud and is NOT reported as "your alerting is broken" —
+claiming an outage we did not observe is its own kind of wrong.
+
+ZERO ROWS IS THE ALARM, NOT THE QUIET CASE. An empty result means the Worker has not
+run in the whole window, or has been renamed out from under this check. Both are
+states somebody must look at, and both are exactly what "no news" looks like if the
+empty case is allowed to pass.
+"""
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+CF_GRAPHQL = "https://api.cloudflare.com/client/v4/graphql"
+DEFAULT_SCRIPT = "enviouswispr-sentry-triage"
+DEFAULT_THRESHOLD_DAYS = 7
+LOOKBACK_DAYS = 30
+
+# Exit codes. Distinct on purpose: the caller must be able to tell "the notifier is
+# stale" from "this check could not run", because only the first is a claim about
+# production.
+EXIT_FRESH = 0
+EXIT_STALE = 1
+EXIT_UNKNOWN = 2
+
+QUERY = """
+query($acct:String!,$since:Time!,$until:Time!){
+  viewer { accounts(filter:{accountTag:$acct}) {
+    workersInvocationsAdaptive(limit:1000, filter:{datetime_geq:$since, datetime_leq:$until}) {
+      sum { requests }
+      dimensions { scriptName date }
+    }
+  } }
+}
+"""
+
+
+class Unknown(Exception):
+    """The check could not be performed. Never conflate with a stale verdict."""
+
+
+def _utc_now():
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def fetch_rows(account_id, api_key, email, *, now=None, opener=None):
+    """Return the raw workersInvocationsAdaptive rows, or raise Unknown."""
+    now = now or _utc_now()
+    since = (now - dt.timedelta(days=LOOKBACK_DAYS)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    until = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    payload = json.dumps(
+        {"query": QUERY, "variables": {"acct": account_id, "since": since, "until": until}}
+    ).encode()
+    req = urllib.request.Request(
+        CF_GRAPHQL,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "X-Auth-Email": email,
+            "X-Auth-Key": api_key,
+        },
+    )
+    try:
+        raw = (opener or urllib.request.urlopen)(req).read()
+    except urllib.error.HTTPError as exc:  # producer 1: non-2xx
+        raise Unknown(f"Cloudflare returned HTTP {exc.code}") from exc
+    except Exception as exc:  # network, DNS, TLS
+        raise Unknown(f"Cloudflare request failed: {exc}") from exc
+
+    try:
+        body = json.loads(raw)
+    except ValueError as exc:
+        raise Unknown("Cloudflare response was not JSON") from exc
+
+    # Producer 2: a 200 carrying a GraphQL errors array. Silently rendering this as
+    # zero rows is exactly how a broken query became "0" in #1589.
+    if body.get("errors"):
+        raise Unknown(f"Cloudflare GraphQL errors: {json.dumps(body['errors'])[:300]}")
+
+    try:
+        accounts = body["data"]["viewer"]["accounts"]
+    except (KeyError, TypeError) as exc:
+        raise Unknown("Cloudflare response missing data.viewer.accounts") from exc
+    if not accounts:  # producer 3: the account filter matched nothing
+        raise Unknown("Cloudflare returned no account for the given account id")
+
+    rows = accounts[0].get("workersInvocationsAdaptive")
+    if rows is None:
+        raise Unknown("Cloudflare response missing workersInvocationsAdaptive")
+    return rows
+
+
+def last_invocation_date(rows, script_name):
+    """Latest YYYY-MM-DD on which `script_name` ran, or None if it never did.
+
+    None is a REAL answer here and the caller must treat it as the alarm, not as a
+    missing value to skip over.
+    """
+    dates = [
+        r["dimensions"]["date"]
+        for r in rows
+        if r.get("dimensions", {}).get("scriptName") == script_name
+        and (r.get("sum", {}) or {}).get("requests", 0) > 0
+    ]
+    return max(dates) if dates else None
+
+
+def days_since(date_str, now=None):
+    now = now or _utc_now()
+    seen = dt.datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=dt.timezone.utc)
+    return (now.date() - seen.date()).days
+
+
+def verdict(rows, script_name, threshold_days, now=None):
+    """(exit_code, message). The only place staleness is decided."""
+    last = last_invocation_date(rows, script_name)
+    if last is None:
+        return (
+            EXIT_STALE,
+            f"The Sentry alerter has not run once in the last {LOOKBACK_DAYS} days. "
+            f"Either nothing has reached it at all, or the worker named "
+            f"'{script_name}' no longer exists under that name. Someone has to look.",
+        )
+    age = days_since(last, now=now)
+    if age > threshold_days:
+        return (
+            EXIT_STALE,
+            f"The Sentry alerter last ran {age} days ago, on {last}. Anything longer "
+            f"than {threshold_days} days means error alerts have probably stopped "
+            f"reaching Discord, which is silent by nature and will not announce "
+            f"itself. This is what happened for 12 days in August 2026.",
+        )
+    return (EXIT_FRESH, f"The Sentry alerter last ran {age} day(s) ago, on {last}.")
+
+
+def post_discord(webhook_url, message, *, opener=None):
+    payload = json.dumps({"content": message}).encode()
+    req = urllib.request.Request(
+        webhook_url, data=payload, headers={"Content-Type": "application/json"}
+    )
+    resp = (opener or urllib.request.urlopen)(req)
+    return getattr(resp, "status", None) or resp.getcode()
+
+
+def _self_test():
+    """Pure checks over the decision layer. No network."""
+    now = dt.datetime(2026, 8, 28, tzinfo=dt.timezone.utc)
+
+    def row(name, date, requests=1):
+        return {"sum": {"requests": requests}, "dimensions": {"scriptName": name, "date": date}}
+
+    # The real #2486 data: last run Aug 16, checked on Aug 28.
+    rows = [row("enviouswispr-sentry-triage", d) for d in ("2026-08-08", "2026-08-14", "2026-08-16")]
+    code, msg = verdict(rows, "enviouswispr-sentry-triage", 7, now=now)
+    assert code == EXIT_STALE, "the real outage must trip this guard"
+    assert "12 days ago" in msg, msg
+
+    # Two-way control: a healthy path leaves it disarmed.
+    code, _ = verdict(rows + [row("enviouswispr-sentry-triage", "2026-08-27")], "x", 7, now=now)
+    assert code == EXIT_STALE, "an unknown script name must be loud, not quiet"
+    code, msg = verdict(
+        [row("enviouswispr-sentry-triage", "2026-08-27")],
+        "enviouswispr-sentry-triage", 7, now=now,
+    )
+    assert code == EXIT_FRESH, msg
+
+    # A six-day gap is NORMAL traffic and must not fire, or the guard cries wolf.
+    code, _ = verdict(
+        [row("enviouswispr-sentry-triage", "2026-08-22")],
+        "enviouswispr-sentry-triage", 7, now=now,
+    )
+    assert code == EXIT_FRESH, "a 6-day gap is real healthy traffic; firing here would train dismissal"
+
+    # No rows at all is the alarm, never the quiet case.
+    code, _ = verdict([], "enviouswispr-sentry-triage", 7, now=now)
+    assert code == EXIT_STALE
+
+    # A row with zero requests is not an invocation.
+    code, _ = verdict(
+        [row("enviouswispr-sentry-triage", "2026-08-27", requests=0)],
+        "enviouswispr-sentry-triage", 7, now=now,
+    )
+    assert code == EXIT_STALE
+
+    # Each Cloudflare failure producer is UNKNOWN, never a number.
+    for body in (
+        b'{"errors":[{"message":"bad query"}]}',
+        b'{"data":{"viewer":{"accounts":[]}}}',
+        b"not json",
+        b'{"data":{"viewer":{"accounts":[{}]}}}',
+    ):
+        class _R:
+            def __init__(self, b):
+                self._b = b
+
+            def read(self):
+                return self._b
+
+        try:
+            fetch_rows("a", "k", "e", now=now, opener=lambda req, b=body: _R(b))
+        except Unknown:
+            pass
+        else:
+            raise AssertionError(f"expected Unknown for {body!r}")
+
+    print("self-test OK")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--script-name", default=DEFAULT_SCRIPT)
+    ap.add_argument("--threshold-days", type=int, default=DEFAULT_THRESHOLD_DAYS)
+    ap.add_argument("--notify", action="store_true", help="post to Discord when stale")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test()
+
+    missing = [
+        n
+        for n in ("CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_KEY", "CLOUDFLARE_EMAIL")
+        if not os.environ.get(n)
+    ]
+    if missing:
+        print(f"UNKNOWN: missing {', '.join(missing)}", file=sys.stderr)
+        return EXIT_UNKNOWN
+
+    try:
+        rows = fetch_rows(
+            os.environ["CLOUDFLARE_ACCOUNT_ID"],
+            os.environ["CLOUDFLARE_API_KEY"],
+            os.environ["CLOUDFLARE_EMAIL"],
+        )
+    except Unknown as exc:
+        # Loud, and deliberately NOT a Discord post: we did not observe an outage,
+        # we failed to look. Saying otherwise would be a claim we cannot support.
+        print(f"UNKNOWN: {exc}", file=sys.stderr)
+        return EXIT_UNKNOWN
+
+    code, message = verdict(rows, args.script_name, args.threshold_days)
+    print(message)
+
+    if code == EXIT_STALE and args.notify:
+        webhook = os.environ.get("DISCORD_WEBHOOK_URL")
+        if not webhook:
+            print("UNKNOWN: stale, but DISCORD_WEBHOOK_URL is unset", file=sys.stderr)
+            return EXIT_UNKNOWN
+        status = post_discord(webhook, f"Error alerts may have stopped. {message}")
+        print(f"Discord responded {status}")
+        if status not in (200, 204):
+            return EXIT_UNKNOWN
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-alerting-heartbeat.py
+++ b/scripts/ci/check-alerting-heartbeat.py
@@ -164,6 +164,31 @@ def days_since(date_str, now=None):
     return (now.date() - seen.date()).days
 
 
+def threshold_is_answerable(threshold_days):
+    """None if this threshold can be decided, else why it cannot.
+
+    **The query window is a FIXED 30 days, so a threshold at or beyond it cannot
+    produce a true verdict — only a confident false one.** With a threshold of 60 and
+    a last invocation 31 days ago, that invocation falls outside the window,
+    `last_invocation_date` returns None, and the run reports the alarm "has not run
+    once in 30 days" about a notifier that is healthy by the threshold it was given.
+
+    Refusing at the door rather than widening the window: Cloudflare's retention for
+    this dataset is not a number we have measured, so a longer window would trade a
+    known false alarm for an unknown one. UNKNOWN is the honest answer to a question
+    this instrument cannot reach. Cloud review, PR for #2486.
+    """
+    if threshold_days < 1:
+        return f"threshold must be at least 1 day, got {threshold_days}"
+    if threshold_days >= LOOKBACK_DAYS:
+        return (
+            f"threshold of {threshold_days} days cannot be judged from a "
+            f"{LOOKBACK_DAYS}-day query window; anything older simply is not in the "
+            f"data, so a verdict here would be invented rather than measured"
+        )
+    return None
+
+
 def verdict(rows, script_name, threshold_days, now=None):
     """(exit_code, message). The only place staleness is decided."""
     last = last_invocation_date(rows, script_name)
@@ -321,6 +346,16 @@ def _self_test():
     assert notify_if_stale(EXIT_FRESH, "m", "https://hook", lambda *a: posted.append(a) or 204) == EXIT_FRESH
     assert posted == [], "a healthy heartbeat must never post"
 
+    # A threshold the 30-day window cannot decide must be refused, not answered.
+    # The worked example from review: threshold 60, last run 31 days ago — outside
+    # the window, so the data alone would say "never ran" about a healthy notifier.
+    assert threshold_is_answerable(7) is None
+    assert threshold_is_answerable(29) is None
+    assert threshold_is_answerable(LOOKBACK_DAYS) is not None, "at the window it is already unanswerable"
+    assert threshold_is_answerable(60) is not None
+    assert threshold_is_answerable(0) is not None
+    assert threshold_is_answerable(-1) is not None
+
     print("self-test OK")
     return 0
 
@@ -335,6 +370,13 @@ def main():
 
     if args.self_test:
         return _self_test()
+
+    # Before spending a credential or a request: a threshold this window cannot
+    # answer must be refused, not answered wrongly.
+    unanswerable = threshold_is_answerable(args.threshold_days)
+    if unanswerable:
+        print(f"UNKNOWN: {unanswerable}", file=sys.stderr)
+        return EXIT_UNKNOWN
 
     missing = [
         n

--- a/scripts/ci/check-alerting-heartbeat.py
+++ b/scripts/ci/check-alerting-heartbeat.py
@@ -125,20 +125,35 @@ def fetch_rows(account_id, api_key, email, *, now=None, opener=None):
     except ValueError as exc:
         raise Unknown("Cloudflare response was not JSON") from exc
 
-    # Producer 2: a 200 carrying a GraphQL errors array. Silently rendering this as
+    # **EVERY shape below is read defensively, and that is a CLASS decision rather
+    # than a list of shapes.** Review found this file mis-classifying an
+    # unmeasurable state as a measured verdict four separate times, each a different
+    # member: a GraphQL error array, a missing account, a threshold past the window,
+    # and finally valid JSON of an unexpected shape (`null`, a list, `accounts:
+    # [null]`) raising an uncaught `AttributeError`. Enumerating shapes only ever
+    # produces the next member, so the question asked here is the closed one — is
+    # this thing the type I need — and `main` additionally maps ANY escaping
+    # exception to UNKNOWN so the exit code cannot be wrong even if this misses one.
+    if not isinstance(body, dict):
+        raise Unknown(f"Cloudflare response was {type(body).__name__}, not an object")
+
+    # Producer: a 200 carrying a GraphQL errors array. Silently rendering this as
     # zero rows is exactly how a broken query became "0" in #1589.
     if body.get("errors"):
         raise Unknown(f"Cloudflare GraphQL errors: {json.dumps(body['errors'])[:300]}")
 
-    try:
-        accounts = body["data"]["viewer"]["accounts"]
-    except (KeyError, TypeError) as exc:
-        raise Unknown("Cloudflare response missing data.viewer.accounts") from exc
-    if not accounts:  # producer 3: the account filter matched nothing
+    data = body.get("data")
+    viewer = data.get("viewer") if isinstance(data, dict) else None
+    accounts = viewer.get("accounts") if isinstance(viewer, dict) else None
+    if not isinstance(accounts, list):
+        raise Unknown("Cloudflare response missing data.viewer.accounts")
+    if not accounts:  # the account filter matched nothing
         raise Unknown("Cloudflare returned no account for the given account id")
+    if not isinstance(accounts[0], dict):
+        raise Unknown("Cloudflare returned a malformed account entry")
 
     rows = accounts[0].get("workersInvocationsAdaptive")
-    if rows is None:
+    if not isinstance(rows, list):
         raise Unknown("Cloudflare response missing workersInvocationsAdaptive")
     return rows
 
@@ -312,12 +327,20 @@ def _self_test():
     )
     assert code == EXIT_STALE
 
-    # Each Cloudflare failure producer is UNKNOWN, never a number.
+    # EVERY malformed shape is UNKNOWN, never a number and never a crash. The last
+    # five are the ones review found by inspection rather than by imagination:
+    # valid JSON that simply is not the shape this code assumed.
     for body in (
         b'{"errors":[{"message":"bad query"}]}',
         b'{"data":{"viewer":{"accounts":[]}}}',
         b"not json",
         b'{"data":{"viewer":{"accounts":[{}]}}}',
+        b"null",
+        b"[]",
+        b'{"data":null}',
+        b'{"data":{"viewer":{"accounts":[null]}}}',
+        b'{"data":{"viewer":{"accounts":{}}}}',
+        b'{"data":{"viewer":{"accounts":[{"workersInvocationsAdaptive":"nope"}]}}}',
     ):
         class _R:
             def __init__(self, b):
@@ -387,19 +410,30 @@ def main():
         print(f"UNKNOWN: missing {', '.join(missing)}", file=sys.stderr)
         return EXIT_UNKNOWN
 
+    # **THE MEASUREMENT AND THE DECISION SIT INSIDE ONE BLANKET GUARD, and the
+    # bare `except Exception` is the point rather than a lapse.** An escaping
+    # exception exits Python with status 1, and 1 is this script's STALE code — so
+    # any unforeseen crash would be read by the workflow as "your alerting is dead",
+    # a confident outage claim produced by a bug. Mapping every unhandled failure to
+    # UNKNOWN makes that structurally impossible instead of dependent on having
+    # enumerated the failure shapes correctly, which four review rounds showed was
+    # not a thing to rely on.
     try:
         rows = fetch_rows(
             os.environ["CLOUDFLARE_ACCOUNT_ID"],
             os.environ["CLOUDFLARE_API_KEY"],
             os.environ["CLOUDFLARE_EMAIL"],
         )
+        code, message = verdict(rows, args.script_name, args.threshold_days)
     except Unknown as exc:
         # Loud, and deliberately NOT a Discord post: we did not observe an outage,
         # we failed to look. Saying otherwise would be a claim we cannot support.
         print(f"UNKNOWN: {exc}", file=sys.stderr)
         return EXIT_UNKNOWN
+    except Exception as exc:
+        print(f"UNKNOWN: unexpected {type(exc).__name__}: {exc}", file=sys.stderr)
+        return EXIT_UNKNOWN
 
-    code, message = verdict(rows, args.script_name, args.threshold_days)
     print(message)
 
     if args.notify:

--- a/scripts/ci/check-alerting-heartbeat.py
+++ b/scripts/ci/check-alerting-heartbeat.py
@@ -175,7 +175,13 @@ def verdict(rows, script_name, threshold_days, now=None):
             f"'{script_name}' no longer exists under that name. Someone has to look.",
         )
     age = days_since(last, now=now)
-    if age > threshold_days:
+    # **`>=`, NOT `>`.** The input is described as "days of silence before this
+    # alerts", so at exactly the threshold it must alert. With `>` a 7-day setting
+    # first fired on day 8, which quietly made this file's own claim — that it would
+    # have caught #2486 on Aug 23 — false by a day. Cloud review, PR for #2486.
+    # The boundary is pinned in the self-test at both 6 and 7 days so the off-by-one
+    # cannot come back silently.
+    if age >= threshold_days:
         return (
             EXIT_STALE,
             f"The Sentry alerter last ran {age} days ago, on {last}. Anything longer "
@@ -245,12 +251,30 @@ def _self_test():
     )
     assert code == EXIT_FRESH, msg
 
-    # A six-day gap is NORMAL traffic and must not fire, or the guard cries wolf.
+    # THE BOUNDARY, pinned on both sides. A six-day gap is NORMAL traffic (Aug 8 to
+    # Aug 14 really happened) and must stay quiet, or the guard cries wolf. Exactly
+    # seven days IS the threshold and must fire — "days of silence before this
+    # alerts" means at seven it alerts, and a `>` here silently pushed that to eight.
     code, _ = verdict(
         [row("enviouswispr-sentry-triage", "2026-08-22")],
         "enviouswispr-sentry-triage", 7, now=now,
     )
     assert code == EXIT_FRESH, "a 6-day gap is real healthy traffic; firing here would train dismissal"
+    code, msg = verdict(
+        [row("enviouswispr-sentry-triage", "2026-08-21")],
+        "enviouswispr-sentry-triage", 7, now=now,
+    )
+    assert code == EXIT_STALE, "at exactly the threshold it must alert, not on the day after"
+    assert "7 days ago" in msg, msg
+
+    # The dated promise this file makes about #2486, asserted rather than claimed:
+    # last run Aug 16, so a check on Aug 23 fires.
+    code, _ = verdict(
+        [row("enviouswispr-sentry-triage", "2026-08-16")],
+        "enviouswispr-sentry-triage", 7,
+        now=dt.datetime(2026, 8, 23, tzinfo=dt.timezone.utc),
+    )
+    assert code == EXIT_STALE, "the prose says Aug 23; the code must agree"
 
     # No rows at all is the alarm, never the quiet case.
     code, _ = verdict([], "enviouswispr-sentry-triage", 7, now=now)

--- a/scripts/ci/check-alerting-heartbeat.py
+++ b/scripts/ci/check-alerting-heartbeat.py
@@ -195,6 +195,34 @@ def post_discord(webhook_url, message, *, opener=None):
     return getattr(resp, "status", None) or resp.getcode()
 
 
+def notify_if_stale(code, message, webhook, poster):
+    """Post when stale, and return the exit code the caller should use.
+
+    **A FAILED DELIVERY DOES NOT UNMAKE THE VERDICT.** The measurement already
+    succeeded and said stale; only the notification failed. Returning UNKNOWN here
+    would make the workflow report "could not measure", which is false, and would
+    hide a real outage behind a Discord problem.
+
+    `urlopen` RAISES on a non-2xx rather than returning one, so an unguarded call
+    exits with a traceback and status 1 — indistinguishable from a clean stale
+    verdict, with the message lost. Cloud review, PR for #2486.
+    """
+    if code != EXIT_STALE:
+        return code
+    if not webhook:
+        print("DISCORD DELIVERY FAILED: DISCORD_WEBHOOK_URL is unset", file=sys.stderr)
+        return EXIT_STALE
+    try:
+        status = poster(webhook, f"Error alerts may have stopped. {message}")
+    except Exception as exc:  # transport, DNS, TLS, or a non-2xx raised as HTTPError
+        print(f"DISCORD DELIVERY FAILED: {exc}", file=sys.stderr)
+        return EXIT_STALE
+    print(f"Discord responded {status}")
+    if status not in (200, 204):
+        print(f"DISCORD DELIVERY FAILED: status {status}", file=sys.stderr)
+    return EXIT_STALE
+
+
 def _self_test():
     """Pure checks over the decision layer. No network."""
     now = dt.datetime(2026, 8, 28, tzinfo=dt.timezone.utc)
@@ -256,6 +284,19 @@ def _self_test():
         else:
             raise AssertionError(f"expected Unknown for {body!r}")
 
+    # A Discord problem must never be able to downgrade a real STALE verdict, and
+    # must never be able to upgrade a FRESH one.
+    def raiser(*_a, **_k):
+        raise urllib.error.HTTPError("u", 500, "boom", None, None)
+
+    assert notify_if_stale(EXIT_STALE, "m", "https://hook", raiser) == EXIT_STALE
+    assert notify_if_stale(EXIT_STALE, "m", None, raiser) == EXIT_STALE
+    assert notify_if_stale(EXIT_STALE, "m", "https://hook", lambda *_a: 500) == EXIT_STALE
+    assert notify_if_stale(EXIT_STALE, "m", "https://hook", lambda *_a: 204) == EXIT_STALE
+    posted = []
+    assert notify_if_stale(EXIT_FRESH, "m", "https://hook", lambda *a: posted.append(a) or 204) == EXIT_FRESH
+    assert posted == [], "a healthy heartbeat must never post"
+
     print("self-test OK")
     return 0
 
@@ -295,15 +336,10 @@ def main():
     code, message = verdict(rows, args.script_name, args.threshold_days)
     print(message)
 
-    if code == EXIT_STALE and args.notify:
-        webhook = os.environ.get("DISCORD_WEBHOOK_URL")
-        if not webhook:
-            print("UNKNOWN: stale, but DISCORD_WEBHOOK_URL is unset", file=sys.stderr)
-            return EXIT_UNKNOWN
-        status = post_discord(webhook, f"Error alerts may have stopped. {message}")
-        print(f"Discord responded {status}")
-        if status not in (200, 204):
-            return EXIT_UNKNOWN
+    if args.notify:
+        code = notify_if_stale(
+            code, message, os.environ.get("DISCORD_WEBHOOK_URL"), post_discord
+        )
     return code
 
 


### PR DESCRIPTION
Part of #2486. The prevention half; PR #2487 was the repair.

## Why

Sentry stopped firing the notifier webhook on **2026-08-16** and it went unnoticed for **12 days**, with
at least 13 new problem groups created in the window. Nothing was visibly broken — the Worker was
healthy, Discord was healthy — and the only symptom was an absence. **A dead notifier and a quiet week
produce the identical observation**, so nothing anyone was already reading could have caught it. The
founder asking "why have I had no errors" is what surfaced it.

## Where it lives, and why not in a Worker

GitHub Actions. A watchdog inside the system it watches dies with it, and the Cloudflare account is at
its 5-cron free-plan limit (#1092) — already the reason `daily-report-ping.yml` schedules from here.

**No new credential.** `CLOUDFLARE_*` drive the analytics query; `DISCORD_RELEASE_WEBHOOK` is the same
channel `release.yml` already uses for proactive "something needs you" posts.

## Proven to fire before it was believed

`code-validation.md` RULE: prove-the-regression-before-building-the-guard. The regression is not
hypothetical — it is the outage being fixed — and the self-test runs the decision layer over the **real**
invocation dates (Aug 8, 14, 16, evaluated as of Aug 28) and asserts it trips. The kill criterion is
declared in the same test: if it does not fire on that data, it is broken.

Two-way controls, so a healthy path leaves it disarmed:

| case | expected | why it matters |
|---|---|---|
| ran yesterday | quiet | ordinary healthy day |
| **six-day gap** | **quiet** | Aug 8 → Aug 14 was real healthy traffic; firing here trains dismissal |
| last ran 12 days ago | **fires** | the actual outage |
| zero rows in 30 days | **fires** | never ran, or renamed out from under the check |
| row with 0 requests | **fires** | not an invocation |
| FRESH verdict + notify | **posts nothing** | a guard that posts on a healthy path gets muted |

Seven days is a coarse net for *sustained* silence, chosen above the six-day healthy gap rather than as
tight as possible. It would have caught #2486 on Aug 23 instead of Aug 28.

## Honest limit, demonstrated rather than reasoned about

`workersInvocationsAdaptive` counts invocations, not authenticated webhooks, and the Worker URL is
public. Run live while writing this, the check reported **"last ran 0 days ago" about an alerting path
that had been dead for twelve** — because diagnosing #2486 had curled that endpoint the same afternoon.

So green means "something reached it", never "Sentry delivered". The outage window is unaffected
(Cloudflare recorded a true zero across Aug 17-28 because nobody was poking it), but a future outage
accompanied by any incidental traffic would hide behind this. The sharp version needs the Worker to
record a heartbeat only after a **verified** signature and this check to read that KV key — a Worker
change plus a deploy, deliberately not bundled so the coarse net can land while the deploy is blocked.
That limit is written at the top of the script, not buried in a PR body.

## Fails closed, three ways

Cloudflare has three distinct ways to answer badly and #1589 was caused by conflating them: a non-2xx, a
GraphQL `errors` array on a 200, and a well-formed response for an account or script that does not
exist. Each exits UNKNOWN, turns the job red, and deliberately posts **nothing** to Discord — we did not
observe an outage, we failed to look, and claiming otherwise is its own kind of wrong. Each producer has
a self-test case.

Zero rows is the **alarm**, not the quiet case.

## Review

Round 1 returned two real findings, both adopted:

- **P2** — `post_discord` was unguarded, and `urlopen` *raises* on a non-2xx. A Discord outage exited
  with a traceback and status 1, which the workflow reads as a clean STALE verdict with the message
  gone; the existing non-2xx branch returned UNKNOWN, reported as "could not measure". Both false in the
  same way: the measurement succeeded, only delivery failed. Now `notify_if_stale`, which encodes that a
  delivery problem never rewrites a verdict — extracted as a function specifically so it could be tested
  rather than asserted. **Hiding a real outage behind a Discord problem is the exact failure this issue
  exists to prevent**, so it was worth restructuring for.
- **P3** — `threshold_days` is free text from `workflow_dispatch` and was appended into a string then
  expanded unquoted. Now a bash array with each value quoted, plus a whole-number check at the door.
  Validating as well as quoting is deliberate: quoting makes injection inert, the check makes it
  impossible and replaces an argparse stack trace with a readable `::error::`.

Confirming round clean: *"logically consistent... no high-confidence bug with a meaningful impact was
identified."*

## Test plan

- [x] `--self-test` passes (decision layer, no network); runs first in CI **without credentials**, so a
      broken decision layer is caught before any verdict is trusted
- [x] Executed against live Cloudflare data before and after the review refactor
- [x] Workflow YAML parses; `actions/checkout` pinned to the sha already used in `pr-check.yml`
- [ ] First scheduled run observed green

Lane: CI/workflow.
