### PR TITLE
fix(worker): read the alert-action payload, so alerts actually reach Discord

### DIFF
--- a/workers/sentry-triage/src/index.js
+++ b/workers/sentry-triage/src/index.js
@@ -210,13 +210,51 @@ export async function handleTriage(body, env) {
   // payloads DO carry `data.issue`, so this guard never once fired for them and
   // every rate alert fell straight through to the ordinary error path, where it
   // rendered as `What: unknown / Version: unknown / Impact: 0 user(s)` (#1965).
-  const issue = payload?.data?.issue;
+  // **TWO PAYLOAD SHAPES REACH HERE, and only one of them carries an issue.**
+  // A lifecycle webhook sends `data.issue`. An alert-rule ACTION — which is how
+  // alerting was rewired after Sentry stopped firing the implicit `issue.created`
+  // webhook on 2026-08-16 (#2486) — sends `data.event` instead, an EVENT carrying
+  // `issue_id` and none of `count`, `userCount`, `shortId` or `permalink`.
+  //
+  // So the action payload is not an issue wearing a different name, and reading it
+  // as one would score severity off blanks. The issue is FETCHED by id instead, and
+  // everything downstream is unchanged.
+  let issue = payload?.data?.issue;
+  let action = payload.action ?? "";
+
+  if (!issue) {
+    const eventIssueId = payload?.data?.event?.issue_id;
+    if (eventIssueId) {
+      issue = await fetchIssueById(String(eventIssueId), env, lookupDeadlineAt);
+      if (!issue) {
+        // Loud: Sentry delivered a real alert and we could not resolve it. Silence
+        // here is the exact failure #2486 is about, so it must not be silent.
+        console.error(
+          `[sentry-triage] event_alert for issue ${eventIssueId} but the issue lookup failed — alert DROPPED`
+        );
+        return;
+      }
+      // **`triggered` is normalised to `created`, and the coupling is stated
+      // rather than assumed.** `decideNotification` supports only `created` and
+      // `unresolved`; an alert action always arrives as `triggered`, which would be
+      // ineligible and silently post nothing. This workflow's trigger is literally
+      // "A new issue is created" (Sentry workflow 3202076), so for THIS rule the two
+      // mean the same thing. If that trigger is ever widened, this mapping is the
+      // line to revisit — `data.triggered_rule` is logged so the record says which
+      // rule fired.
+      console.log(
+        `[sentry-triage] event_alert.triggered rule=${payload?.data?.triggered_rule ?? "?"} ` +
+          `issue=${issue.id} — resolved via issue lookup`
+      );
+      action = "created";
+    }
+  }
+
   if (!issue) {
     console.log("[sentry-triage] No data.issue — skipping malformed or unknown payload");
     return;
   }
 
-  const action = payload.action ?? "";
   const issueId = issue.id ?? "";
   if (!issueId) {
     console.error("[sentry-triage] Missing issue ID, skipping");
@@ -818,6 +856,44 @@ async function handleSpike({ action, issue, issueId, env, lookupDeadlineAt, oper
  * failed page, malformed body, deadline expiry, or page-cap-with-more-pending
  * returns an incomplete/malformed status so severity fails open (rule 4).
  */
+/** The issue behind an `event_alert.triggered` payload, or null.
+ *
+ * **WHY THIS EXISTS.** An issue-lifecycle webhook carries `data.issue`, a whole
+ * issue object. An alert-rule ACTION carries `data.event` instead — an EVENT, with
+ * `issue_id` and no `count`, `userCount`, `shortId` or `permalink`. Those four are
+ * exactly what severity scoring, exact-ticket suppression and the embed need, so the
+ * two shapes are not interchangeable and the action payload cannot be read as an
+ * issue.
+ *
+ * Measured 2026-08-28, which is why this exists rather than as a precaution: with
+ * the action freshly wired, Sentry sent `event_alert.triggered`, the Worker answered
+ * 202 and dropped it with "No data.issue". Sentry's request log said delivered, the
+ * save button said saved, and no card reached Discord (#2486).
+ *
+ * One extra subrequest, inside the existing lookup deadline, against an endpoint
+ * this token already reaches (verified 2026-08-28: returns id, shortId, title,
+ * permalink, count, userCount, level, substatus). Returns null on ANY failure so the
+ * caller logs and skips rather than posting a card built from blanks.
+ */
+async function fetchIssueById(issueId, env, deadlineAt) {
+  const url = `https://us.sentry.io/api/0/organizations/${SENTRY_ORG}/issues/${issueId}/`;
+  try {
+    const res = await fetchBefore(
+      url,
+      { headers: { Authorization: `Bearer ${env.SENTRY_AUTH_TOKEN}` } },
+      deadlineAt,
+      SENTRY_FETCH_TIMEOUT_MS,
+      "sentry-issue"
+    );
+    if (!res.ok) return null;
+    const body = await res.json();
+    // The id must come back, or downstream has nothing to key a throttle on.
+    return body && typeof body === "object" && body.id ? body : null;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchEventPartition(issueId, env, deadlineAt) {
   const base =
     `https://us.sentry.io/api/0/organizations/${SENTRY_ORG}/issues/${issueId}/events/` +

--- a/workers/sentry-triage/test/event-alert.test.js
+++ b/workers/sentry-triage/test/event-alert.test.js
@@ -1,0 +1,109 @@
+// The alert-rule ACTION payload (#2486). Sentry stopped firing the implicit
+// `issue.created` webhook on 2026-08-16; alerting was rewired onto a workflow
+// action, and an action sends a DIFFERENT payload — `data.event` with `issue_id`,
+// not `data.issue`.
+//
+// Measured before these tests existed: the Worker answered 202 and dropped it with
+// "No data.issue". Sentry's request log said delivered, the save button said saved,
+// and no card reached Discord. Every assertion here is about that gap.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { handleTriage } from "../src/index.js";
+
+function fakeKV(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    async get(key) { return store.get(key) ?? null; },
+    async put(key, value) { store.set(key, value); },
+    async delete(key) { store.delete(key); },
+  };
+}
+
+const ISSUE = {
+  id: "7647106942",
+  shortId: "ENVIOUSWISPR-4M",
+  title: "polish_provider_failed: EnviousWisprLLM.LLMError#11",
+  permalink: "https://envious-labs-llc.sentry.io/issues/7647106942/",
+  count: "27",
+  userCount: 2,
+  level: "error",
+  substatus: "ongoing",
+};
+
+// The real shape, trimmed to the fields this path reads. `issue_id`, no `id`.
+function eventAlertBody() {
+  return JSON.stringify({
+    action: "triggered",
+    data: {
+      event: { event_id: "abc", issue_id: "7647106942", title: ISSUE.title },
+      triggered_rule: "New Issue Detected",
+    },
+  });
+}
+
+function harness({ issueLookup = () => ok(ISSUE), discordStatus = 204 } = {}) {
+  const realFetch = globalThis.fetch;
+  const requests = [];
+  const embeds = [];
+  globalThis.fetch = async (url, init) => {
+    const target = String(url);
+    requests.push(target);
+    if (/\/issues\/\d+\/$/.test(target)) return issueLookup(target);
+    if (target.includes("/events/")) return ok([]); // degraded partition: fail-open path
+    if (target.startsWith("https://api.github.com")) return ok([]);
+    if (target.startsWith("https://discord.test")) {
+      embeds.push(JSON.parse(init.body).embeds[0]);
+      return { ok: discordStatus >= 200 && discordStatus < 300, status: discordStatus };
+    }
+    throw new Error(`unexpected fetch to ${target}`);
+  };
+  const env = {
+    SENTRY_DEDUP: fakeKV(),
+    SENTRY_AUTH_TOKEN: "token",
+    GITHUB_ISSUES_READ_TOKEN: "gh",
+    GITHUB_REPO: "saurabhav88/EnviousWispr",
+    DISCORD_WEBHOOK_URL: "https://discord.test/hook",
+  };
+  return { env, requests, embeds, restore: () => (globalThis.fetch = realFetch) };
+}
+
+function ok(json) {
+  return { ok: true, status: 200, async json() { return json; }, headers: { get: () => null } };
+}
+
+test("event_alert.triggered resolves the issue by id and POSTS a card", async () => {
+  const h = harness();
+  try {
+    await handleTriage(eventAlertBody(), h.env);
+  } finally {
+    h.restore();
+  }
+  assert.ok(
+    h.requests.some((u) => u.includes("/issues/7647106942/")),
+    "the issue must be fetched by id; the action payload does not carry one"
+  );
+  assert.equal(h.embeds.length, 1, "this is the whole point: a card reaches Discord");
+  assert.match(h.embeds[0].title, /ENVIOUSWISPR-4M|polish_provider_failed/);
+});
+
+test("event_alert.triggered is DROPPED loudly when the issue cannot be resolved", async () => {
+  const h = harness({ issueLookup: () => ({ ok: false, status: 404 }) });
+  try {
+    await handleTriage(eventAlertBody(), h.env);
+  } finally {
+    h.restore();
+  }
+  assert.equal(h.embeds.length, 0, "never post a card built from blanks");
+});
+
+test("a payload with neither data.issue nor an event issue_id still skips", async () => {
+  const h = harness();
+  try {
+    await handleTriage(JSON.stringify({ action: "triggered", data: {} }), h.env);
+  } finally {
+    h.restore();
+  }
+  assert.equal(h.embeds.length, 0);
+  assert.equal(h.requests.length, 0, "nothing to look up means no subrequest spent");
+});


### PR DESCRIPTION
Closes #2486. **Alerts are flowing again — verified by a real Discord card, not by a green save button.**

## What #2487 left behind

That PR got Sentry talking to us again: `alert_rule_action.requested` went 401 → 200, the workflow action
saved, and Sentry's request log showed it delivering. Then a test alert arrived as
`event_alert.triggered`, the Worker answered **202**, and dropped it with `No data.issue`.

Request log said delivered. Save button said saved. **No card reached Discord.** Every intermediate
signal was green while the user-visible outcome was still nothing — which is precisely why the ship
criterion for this issue was a real card.

## The two payload shapes are not interchangeable

| | lifecycle webhook | alert-rule action |
|---|---|---|
| carries | `data.issue` — a whole issue | `data.event` — an EVENT |
| identity | `issue.id` | `event.issue_id` |
| `count` / `userCount` | present | **absent** |
| `shortId` / `permalink` | present | **absent** |
| `action` | `created` / `unresolved` | `triggered` |

Those four absent fields are exactly what severity scoring, exact-open-ticket suppression and the embed
consume. Reading the action payload as an issue would score severity off blanks.

## The change

`fetchIssueById` resolves `data.event.issue_id` against `/organizations/<org>/issues/<id>/` — one extra
subrequest, inside the existing lookup deadline, on an endpoint this token already reaches (verified
live before the code was written: returns `id`, `shortId`, `title`, `permalink`, `count`, `userCount`,
`level`, `substatus`). Everything downstream is untouched.

`triggered` is normalised to `created`, and **the coupling is stated rather than assumed**:
`decideNotification` supports only `created`/`unresolved`, so `triggered` would be ineligible and post
nothing, silently. This workflow's trigger is literally "A new issue is created" (workflow 3202076), so
for this rule they mean the same thing; if that trigger is widened, that line is the one to revisit, and
`data.triggered_rule` is logged so the record says which rule fired.

A failed lookup **drops the alert loudly** rather than posting a card built from blanks.

## Proof it works, end to end

Deployed, then fired Sentry's own test notification. Worker log:

```
POST / - Ok @ 8/28/2026, 8:19:03 PM
  [sentry-triage] event_alert.triggered rule=Issue Stream issue=7698715597 — resolved via issue lookup
  [sentry-triage] Issue 7698715597 posted (P3, webhook-fallback, no-throttle)
```

And the card landed in `#enviouswispr-updates` at 8:19 PM — confirmed by reading the channel, not by
trusting the "posted" log line. **First Sentry alert to reach Discord since 2026-08-16.**

## One honest caveat

That card rendered degraded: `Unknown build (Sentry fetch failed)` / `Details unavailable`. That is the
existing fail-open path behaving as designed, not a new fault, and the alert still delivered with its
issue link.

Cause **not established**, stated rather than guessed. Ruled out: both `sentry-triage-worker-token` and
`sentry-workers-readonly-token` return 200 on the issue-detail AND per-issue-events endpoints, so it is
not permissions. Most likely a synthetic test issue queried ~1 second after creation, before its event
was indexed — it had 1 event when queried minutes later.

Evidence it is test-specific rather than general: the last real alert before the outage, the Aug 16 P0,
rendered `[Sentry P0 · Release] SIGABRT`, and that `· Release` label is derived from event data, so the
events fetch was working on a real issue. The next genuine alert settles it; a synthetic signed request
to check sooner is blocked by Cloudflare's edge (403), which is the edge doing its job.

## Tests

New file, three cases, asserting the OUTCOME (a Discord embed) rather than that a function was reached:
resolves by id and **posts a card**; lookup fails → **no card**, never blanks; neither shape → skips and
spends no subrequest.

Red-test control: against the code that dropped the alert, exactly one fails — `event_alert.triggered
resolves the issue by id and POSTS a card`. 96/97 then, **97/97** with the fix.

Local review clean: *"no definite functional regression was identified in this diff."*

Lane: Worker.
