### PR TITLE
feat(settings): rebuild Your Words page as the Dictionary shell

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BulkImportEnrichmentCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/BulkImportEnrichmentCoordinator.swift
@@ -35,7 +35,7 @@ final class BulkImportEnrichmentCoordinator {
 
   private static let checkpointChunkSize = 25
   private static let startMessage =
-    "Importing your words now. Check progress in the Your Words menu."
+    "Importing your words now. Check progress on the Dictionary page."
   private static let finishMessage = "Finished importing your words."
   /// Same shipped 1/2/4s schedule as `ManifestFetchTask`, not a new timing invention.
   private static let busyRetryDelays: [Duration] = [.seconds(1), .seconds(2), .seconds(4)]

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -49,7 +49,11 @@ struct CustomTermsSection: View {
   }
 
   var body: some View {
-    BrandedSection(header: "Custom terms · \(filteredWords.count)") {
+    // #2492: no "Your Words" repeated here — the left sub-menu's selected
+    // tab already says it. Keep the count, which is the useful part.
+    BrandedSection(
+      header: "\(filteredWords.count) \(filteredWords.count == 1 ? "word" : "words")"
+    ) {
       // Search + selection controls
       BrandedRow(showDivider: true) {
         HStack(spacing: 6) {
@@ -105,7 +109,7 @@ struct CustomTermsSection: View {
         BrandedRow(showDivider: false) {
           Text(
             searchQuery.isEmpty
-              ? "No custom terms yet. Add one with the button above."
+              ? "No words yet. Add one with the button above."
               : "No matches for \"\(searchQuery)\"."
           )
           .font(.stHelper)

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordsExportPanel.swift
@@ -68,7 +68,7 @@ enum CustomWordsExportPanel {
     // points it, including a synced folder, and it can contain real names.
     panel.message =
       exportSummary(exportableCount: exportableCount) + "\n\n"
-      + "Exported files may contain personal names and other private terms. "
+      + "Exported files may contain personal names and other private words. "
       + "Usage history is not included."
 
     return panel.runModal() == .OK ? panel.url : nil

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -2,9 +2,10 @@ import AppKit
 import EnviousWisprServices
 import SwiftUI
 
-/// Phase 4 (#634) — Learning section of the Your Words settings tab. Two rows:
-/// auto-learn (Phase 7 #629, still "Coming soon") and contacts import (Phase 6
-/// #636, live). Bible §10.2.
+/// Learn from... tab of the Dictionary page. Two rows: auto-learn (Phase 7
+/// #629, still "Coming soon") and contacts import (Phase 6 #636, live).
+/// Bible §10.2. #2492: no section header here — the left sub-menu's selected
+/// tab already says "Learn from...".
 struct LearningSection: View {
   @Environment(ContactsImportCoordinator.self) private var contactsImport
   @Environment(SettingsManager.self) private var settings
@@ -12,7 +13,7 @@ struct LearningSection: View {
   var body: some View {
     @Bindable var settings = settings
 
-    BrandedSection(header: "Learning") {
+    BrandedSection {
       // Row 1: Auto-learn from transcripts (Phase 7 #629)
       BrandedRow(showDivider: true) {
         VStack(alignment: .leading, spacing: 4) {
@@ -21,7 +22,7 @@ struct LearningSection: View {
               Text("Learn from my transcripts")
                 .settingsRowLabel()
               Text(
-                "EnviousWispr will watch for edits to text it just pasted, to suggest custom words. Edits stay on this Mac."
+                "EnviousWispr will watch for edits to text it just pasted, to suggest new words. Edits stay on this Mac."
               )
               .settingsReadingCopy()
             }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -42,17 +42,20 @@ struct LearningSection: View {
       // Row 2: Import from Contacts (Phase 6 #636)
       BrandedRow(showDivider: false) {
         VStack(alignment: .leading, spacing: 8) {
-          HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 2) {
-              Text("Import from Contacts")
-                .settingsRowLabel()
-              Text(
-                "Add the names of people you know to your word list, so dictation spells them right."
-              )
-              .settingsReadingCopy()
+          // ViewThatFits: the Dictionary rail (#2492) narrows this row to
+          // roughly 228pt at the app's 750pt minimum window, where the
+          // imported-count pill + button can't share a line with the copy
+          // (cloud review, PR #2499).
+          ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top) {
+              contactsRowLabel
+              Spacer()
+              importControl
             }
-            Spacer()
-            importControl
+            VStack(alignment: .leading, spacing: 8) {
+              contactsRowLabel
+              importControl
+            }
           }
 
           if case .imported(let count) = contactsImport.phase {
@@ -96,6 +99,17 @@ struct LearningSection: View {
           onConfirm: { contactsImport.confirmImport() },
           onCancel: { contactsImport.cancelImport() })
       }
+    }
+  }
+
+  private var contactsRowLabel: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text("Import from Contacts")
+        .settingsRowLabel()
+      Text(
+        "Add the names of people you know to your word list, so dictation spells them right."
+      )
+      .settingsReadingCopy()
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -69,7 +69,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .recordingSounds: return "Sounds"
     case .keybinds: return "Keybinds"
     case .aiPolish: return "AI Polish"
-    case .wordCorrection: return "Your Words"
+    case .wordCorrection: return "Dictionary"
     case .clipboard: return "Clipboard"
     case .permissions: return "Permissions"
     case .checkForUpdates: return "Check for Updates"
@@ -117,7 +117,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .keybinds: return "Set the keybinds that start, stop, and cancel dictation."
     case .aiPolish: return "Clean up and rewrite your dictation with AI."
     case .wordCorrection:
-      return "Custom terms and vocabulary the app uses to recognize what you say."
+      return "Improve recognition with your words and vocabulary."
     case .clipboard: return "How your transcript reaches the clipboard and the app you're in."
     case .permissions: return "The microphone and accessibility access EnviousWispr needs."
     case .checkForUpdates: return ""

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
@@ -25,36 +25,20 @@ struct VocabPacksSection: View {
       } else {
         ForEach(Array(ids.enumerated()), id: \.element) { index, id in
           BrandedRow(showDivider: index < ids.count - 1) {
-            HStack(alignment: .center) {
-              VStack(alignment: .leading, spacing: 2) {
-                Text(id.displayName)
-                  .font(.body)
-                Text(id.blurb)
-                  .font(.stHelper)
-                  .foregroundStyle(.stTextSecondary)
-                Text(rowDetail(for: id))
-                  .font(.stHelper)
-                  .foregroundStyle(.stTextSecondary)
-                  .padding(.top, 2)
+            // ViewThatFits: the Dictionary rail (#2492) leaves this row roughly
+            // 228pt at the app's 750pt minimum window — enough for the old
+            // full-width page, not for text + a button + a toggle on one line
+            // (cloud review, PR #2499). The horizontal row is tried first.
+            ViewThatFits(in: .horizontal) {
+              HStack(alignment: .center) {
+                packInfo(id)
+                Spacer()
+                packControls(id)
               }
-              Spacer()
-              // No `.controlSize` here: this control owns its own metrics, so the
-              // modifier the previous system `Button` needed became a dead line
-              // that reads as if it still sizes something.
-              SettingsActionButton(title: "See all", isEnabled: true) { selectedPack = id }
-                .accessibilityLabel("See all words in the \(id.displayName) pack")
-
-              Toggle(
-                "",
-                isOn: Binding(
-                  get: { packManager.isEnabled(id) },
-                  set: { packManager.setEnabled(id, $0) }
-                )
-              )
-              .toggleStyle(BrandedToggleStyle())
-              .labelsHidden()
-              .accessibilityLabel("Enable \(id.displayName) pack")
-              .padding(.leading, 6)
+              VStack(alignment: .leading, spacing: 8) {
+                packInfo(id)
+                packControls(id)
+              }
             }
           }
         }
@@ -62,6 +46,44 @@ struct VocabPacksSection: View {
     }
     .sheet(item: $selectedPack) { id in
       VocabularyPackDetailSheet(id: id, terms: packManager.packTerms(id))
+    }
+  }
+
+  @ViewBuilder
+  private func packInfo(_ id: VocabularyPackID) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(id.displayName)
+        .font(.body)
+      Text(id.blurb)
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+      Text(rowDetail(for: id))
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+        .padding(.top, 2)
+    }
+  }
+
+  @ViewBuilder
+  private func packControls(_ id: VocabularyPackID) -> some View {
+    HStack {
+      // No `.controlSize` here: this control owns its own metrics, so the
+      // modifier the previous system `Button` needed became a dead line
+      // that reads as if it still sizes something.
+      SettingsActionButton(title: "See all", isEnabled: true) { selectedPack = id }
+        .accessibilityLabel("See all words in the \(id.displayName) pack")
+
+      Toggle(
+        "",
+        isOn: Binding(
+          get: { packManager.isEnabled(id) },
+          set: { packManager.setEnabled(id, $0) }
+        )
+      )
+      .toggleStyle(BrandedToggleStyle())
+      .labelsHidden()
+      .accessibilityLabel("Enable \(id.displayName) pack")
+      .padding(.leading, 6)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
@@ -1,17 +1,20 @@
 import EnviousWisprPostProcessing
 import SwiftUI
 
-/// Vocabulary Packs section of the Your Words settings tab (#633 Phase 9).
-/// One row per installed ASR-mined pack: a toggle to enable it and a "See all"
-/// button that opens the pack's full word list with the spoken variants each
-/// word catches (#992). Default OFF. Enabling a pack feeds its known mis-hearing
+/// Vocabulary Packs tab of the Dictionary page (#633 Phase 9). One row per
+/// installed ASR-mined pack: a toggle to enable it and a "See all" button
+/// that opens the pack's full word list with the spoken variants each word
+/// catches (#992). Default OFF. Enabling a pack feeds its known mis-hearing
 /// fixes into the corrector; raw dictation is unaffected when off. Bible §10.2.
+/// #2492: no section header here — the left sub-menu's selected tab already
+/// says "Vocabulary Packs"; repeating it inside the content would be the same
+/// title rendered twice.
 struct VocabPacksSection: View {
   @Environment(VocabularyPackManager.self) private var packManager
   @State private var selectedPack: VocabularyPackID?
 
   var body: some View {
-    BrandedSection(header: "Vocabulary packs") {
+    BrandedSection {
       let ids = packManager.availablePackIDs
       if ids.isEmpty {
         BrandedRow(showDivider: false) {

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -12,17 +12,47 @@ private enum YourWordsSheetRoute: String, Identifiable {
   var id: Self { self }
 }
 
-/// Phase 4 (#634) — Your Words settings tab. Replaces the monolithic
-/// `WordFixSettingsView` with a 3-section hub matching the founder-approved
-/// 2026-05-04 mockup. Bible §10.
-///
-/// - Header: title + description + "+ Add term" CTA top-right.
-/// - LearningSection: rows for Phase 6 + Phase 7 (disabled until those land).
-/// - VocabPacksSection: empty state until Phase 5.
-/// - CustomTermsSection: search + pagination + Edit per term.
+/// #2492: the Dictionary page's fixed left sub-menu, one case per tab. Owned
+/// here (not a nested type) so a later phase (#2497, the Quick Add tab) adds
+/// exactly one case rather than inventing a second tab mechanism — the
+/// shared-plumbing seam the Gate 2 plan on #2491 calls out explicitly.
+enum DictionaryTab: String, CaseIterable, Identifiable {
+  case yourWords
+  case vocabularyPacks
+  case learnFrom
+
+  var id: Self { self }
+
+  var label: String {
+    switch self {
+    case .yourWords: return "Your Words"
+    case .vocabularyPacks: return "Vocabulary Packs"
+    case .learnFrom: return "Learn from..."
+    }
+  }
+
+  var icon: String {
+    switch self {
+    case .yourWords: return "textformat.abc"
+    case .vocabularyPacks: return "shippingbox"
+    case .learnFrom: return "sparkle.magnifyingglass"
+    }
+  }
+}
+
+/// #2492 — the Dictionary page (was "Your Words"). Rebuilt onto a fixed
+/// banner + fixed left sub-menu + independently-scrolling right pane,
+/// mirroring AI Polish's rail/detail visual language without reusing its
+/// container: `SettingsContentView` puts its whole page (header included)
+/// inside ONE `ScrollView`, and the founder's ask here is the opposite — the
+/// banner and the tab list never move, only the selected tab's content does.
+/// Internal type name is unchanged from the pre-redesign `YourWordsView`
+/// (#2493 explicitly scopes the terminology pass to user-facing copy, not
+/// Swift symbols).
 struct YourWordsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
+  @State private var selectedTab: DictionaryTab = .yourWords
   @State private var sheetRoute: YourWordsSheetRoute?
   // Outcome-to-message mapping is shared with `BulkDeleteConfirmSheet` so both
   // export entry points present the identical copy (#1703).
@@ -31,91 +61,32 @@ struct YourWordsView: View {
   var body: some View {
     @Bindable var settings = settings
 
-    SettingsContentView {
-      // Launch-time load failure (#1646): honest banner instead of a silent
-      // empty list. Two distinct situations, two distinct messages.
-      if let failure = customWordsCoordinator.wordsLoadFailureAtLaunch {
-        WordsLoadFailureBanner(failure: failure)
-      }
+    VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+      dictionaryBanner(settings: $settings)
 
-      // "Add term" action (the page title + description now live in the page header).
-      HStack {
-        Spacer()
-        // Three page-level actions that were on the system default style, which
-        // on this dark surface renders as the same grey as a disabled control
-        // and gives no hover of its own. Add term is the primary, so it is the
-        // one that fills.
-        SettingsActionButton(
-          title: "Add term", isEnabled: true, emphasis: .filled, systemImage: "plus"
-        ) {
-          sheetRoute = .addTerm
-        }
-        // The ONLY doorway into Custom Words import (epic #1619). Shipped to
-        // release users from v2.4.1 by founder decision, 2026-07-24; every
-        // import PR still carries "adds no second entry point" in its
-        // definition of done, so this stays the single doorway.
-        SettingsActionButton(
-          title: "Import", isEnabled: true, systemImage: "square.and.arrow.down"
-        ) {
-          sheetRoute = .importWords
-        }
-        // Export (#1680). ONE body-render snapshot drives both the count shown
-        // in the save dialog and the array handed to the action, so the number
-        // the user reads and the bytes written cannot come from different
-        // moments (#1697). The sentence itself lives in the dialog, not on this
-        // screen: a paragraph wedged between two buttons competes with them
-        // (#1715).
-        let proposed = CustomWordsExportAction.exportableWords(
-          from: customWordsCoordinator.customWords)
-        SettingsActionButton(
-          title: "Export your words", isEnabled: true,
-          systemImage: "square.and.arrow.up"
-        ) {
-          exportWords(proposed: proposed)
-        }
-      }
+      HStack(alignment: .top, spacing: PolishRailMetrics.columnGap) {
+        DictionaryTabRail(selection: $selectedTab)
+          .frame(width: PolishRailMetrics.railWidth, alignment: .leading)
 
-      // Master toggle (preserves the Enable custom words switch from the old view)
-      BrandedSection {
-        BrandedRow(showDivider: false) {
-          HStack(alignment: .top, spacing: 11) {
-            SettingsRowIcon(systemName: "textformat.abc")
-            VStack(alignment: .leading, spacing: 4) {
-              Toggle(isOn: $settings.wordCorrectionEnabled) {
-                Text("Enable custom words").settingsRowLabel()
-              }
-              .toggleStyle(BrandedToggleStyle())
-              Text(
-                "Automatically fix words the speech engine gets wrong using your custom list below."
-              )
-              .settingsReadingCopy()
-            }
+        ScrollView {
+          VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+            selectedTabContent
           }
+          .padding(.bottom, SettingsLayout.contentBottom)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       }
-
-      // Visibility and the progress numerator both read `pendingEnrichmentCount`
-      // — the observable in-memory count, never `pendingEnrichmentWords()`
-      // (a real locked file read) and never the total's mere presence
-      // (Codex Chunk 2 review finding 5: neither belongs in a SwiftUI
-      // `body`, and the durable total can theoretically lag live state
-      // during the brief self-heal window). The durable total remains the
-      // denominator when available, falling back to the live count itself
-      // as an honest floor if the total is momentarily nil.
-      let pendingCount = customWordsCoordinator.pendingEnrichmentCount
-      if pendingCount > 0 {
-        BulkImportEnrichmentProgressCard(
-          total: customWordsCoordinator.pendingEnrichmentBatchTotal ?? pendingCount,
-          pendingCount: pendingCount,
-          recent: customWordsCoordinator.mostRecentEnrichment,
-          onCancel: { customWordsCoordinator.cancelBulkImportEnrichment?() }
-        )
-      }
-
-      LearningSection()
-      VocabPacksSection()
-      CustomTermsSection()
     }
+    .padding(.top, SettingsLayout.contentTop)
+    .padding(.horizontal, SettingsLayout.contentH)
+    .padding(.bottom, SettingsLayout.contentBottom)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.stPageBg)
+    .tint(.stAccent)
+    // 14pt floor for the whole page, matching `SettingsContentView` (founder
+    // directive 2026-07-03) — this page opts out of that container's ONE
+    // shared ScrollView, not out of its type scale.
+    .font(.stBody)
     .alert(
       exportNotice?.title ?? "",
       isPresented: Binding(
@@ -146,6 +117,160 @@ struct YourWordsView: View {
           )
         )
       }
+    }
+  }
+
+  /// The fixed top banner: icon tile + title + description + the master
+  /// on/off switch, merged into one bar per the founder's mockup feedback on
+  /// #2491/#2492 (was a separate title card, a button row, and a toggle card
+  /// stacked as three pieces).
+  @ViewBuilder
+  private func dictionaryBanner(settings: Bindable<SettingsManager>) -> some View {
+    HStack(spacing: 14) {
+      Image(systemName: "textformat.abc")
+        .font(.system(size: 21, weight: .medium))
+        .foregroundStyle(.stAccent)
+        .frame(width: 46, height: 46)
+        .background(Color.stAccentLight, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(
+          RoundedRectangle(cornerRadius: 12)
+            .strokeBorder(Color.stAccent.opacity(0.28), lineWidth: 1)
+        )
+        .accessibilityHidden(true)
+
+      // .frame(maxWidth: .infinity): claims the HStack's remaining width so
+      // the title row's Spacer below has room to push the toggle to the
+      // banner's trailing edge, rather than the two hugging each other.
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 12) {
+          Text("Dictionary")
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundStyle(.stTextPrimary)
+
+          Spacer(minLength: 8)
+
+          // .fixedSize(): BrandedToggleStyle's internal Spacer otherwise
+          // claims whatever width this HStack hands it, which here would be
+          // the banner's entire remaining row rather than the toggle's own
+          // label-gap-track shape (#2492 review r1).
+          Toggle(isOn: settings.wordCorrectionEnabled) {
+            Text("Enable Dictionary").settingsRowLabel()
+          }
+          .toggleStyle(BrandedToggleStyle())
+          .fixedSize()
+        }
+
+        // One line, guaranteed: at the app's 750pt minimum window this row
+        // has ~460pt after the sidebar and the icon tile, which the fuller
+        // sentence used to overflow. Reads `SettingsSection.wordCorrection`'s
+        // subtitle rather than a second literal — every other settings page's
+        // description lives there (rendered by `SettingsPageHeader`); this
+        // banner is Dictionary's own header, so it reads the same source
+        // instead of forking a duplicate string.
+        Text(SettingsSection.wordCorrection.subtitle)
+          .settingsReadingCopy()
+          .lineLimit(1)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.stSectionBg)
+    .clipShape(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius))
+    .overlay(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+        .strokeBorder(Color.stDivider, lineWidth: 1)
+    )
+  }
+
+  @ViewBuilder
+  private var selectedTabContent: some View {
+    switch selectedTab {
+    case .yourWords:
+      // Launch-time load failure (#1646): honest banner instead of a silent
+      // empty list. Two distinct situations, two distinct messages.
+      if let failure = customWordsCoordinator.wordsLoadFailureAtLaunch {
+        WordsLoadFailureBanner(failure: failure)
+      }
+
+      // ViewThatFits: at the app's 750pt minimum window, the right pane is
+      // roughly 228pt wide after the global sidebar, page padding, the
+      // Dictionary rail, and its gap — one row of three labeled buttons
+      // cannot stay readable there (#2492 review r1). The horizontal row is
+      // tried first and used whenever the width allows it.
+      ViewThatFits(in: .horizontal) {
+        HStack {
+          Spacer()
+          actionButtons
+        }
+        VStack(alignment: .trailing, spacing: 8) {
+          actionButtons
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+      }
+
+      // Visibility and the progress numerator both read `pendingEnrichmentCount`
+      // — the observable in-memory count, never `pendingEnrichmentWords()`
+      // (a real locked file read) and never the total's mere presence
+      // (Codex Chunk 2 review finding 5: neither belongs in a SwiftUI
+      // `body`, and the durable total can theoretically lag live state
+      // during the brief self-heal window). The durable total remains the
+      // denominator when available, falling back to the live count itself
+      // as an honest floor if the total is momentarily nil.
+      let pendingCount = customWordsCoordinator.pendingEnrichmentCount
+      if pendingCount > 0 {
+        BulkImportEnrichmentProgressCard(
+          total: customWordsCoordinator.pendingEnrichmentBatchTotal ?? pendingCount,
+          pendingCount: pendingCount,
+          recent: customWordsCoordinator.mostRecentEnrichment,
+          onCancel: { customWordsCoordinator.cancelBulkImportEnrichment?() }
+        )
+      }
+
+      CustomTermsSection()
+    case .vocabularyPacks:
+      VocabPacksSection()
+    case .learnFrom:
+      LearningSection()
+    }
+  }
+
+  /// The Your Words tab's three page-level actions, factored out so
+  /// `ViewThatFits` can try them in a row and fall back to a column without
+  /// duplicating each button's title, icon, and action closure.
+  @ViewBuilder
+  private var actionButtons: some View {
+    // Three page-level actions that were on the system default style, which
+    // on this dark surface renders as the same grey as a disabled control
+    // and gives no hover of its own. Add word is the primary, so it is the
+    // one that fills.
+    SettingsActionButton(
+      title: "Add word", isEnabled: true, emphasis: .filled, systemImage: "plus"
+    ) {
+      sheetRoute = .addTerm
+    }
+    // The ONLY doorway into Custom Words import (epic #1619). Shipped to
+    // release users from v2.4.1 by founder decision, 2026-07-24; every
+    // import PR still carries "adds no second entry point" in its
+    // definition of done, so this stays the single doorway.
+    SettingsActionButton(
+      title: "Import", isEnabled: true, systemImage: "square.and.arrow.down"
+    ) {
+      sheetRoute = .importWords
+    }
+    // Export (#1680). ONE body-render snapshot drives both the count shown
+    // in the save dialog and the array handed to the action, so the number
+    // the user reads and the bytes written cannot come from different
+    // moments (#1697). The sentence itself lives in the dialog, not on this
+    // screen: a paragraph wedged between two buttons competes with them
+    // (#1715).
+    let proposed = CustomWordsExportAction.exportableWords(
+      from: customWordsCoordinator.customWords)
+    SettingsActionButton(
+      title: "Export your words", isEnabled: true,
+      systemImage: "square.and.arrow.up"
+    ) {
+      exportWords(proposed: proposed)
     }
   }
 
@@ -182,6 +307,79 @@ struct YourWordsView: View {
       return error
     }
     return nil
+  }
+}
+
+/// #2492: the Dictionary page's fixed left sub-menu. Deliberately its own
+/// small view rather than a reuse of `ProviderRail` — that rail's row draws a
+/// provider logo tile and a tagline (`ProviderLogoTile`, `entry.tagline`),
+/// neither of which a Dictionary tab has; forcing this onto that type would
+/// mean widening it with fields only this caller sends.
+private struct DictionaryTabRail: View {
+  @Binding var selection: DictionaryTab
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      ForEach(DictionaryTab.allCases) { tab in
+        DictionaryTabRow(tab: tab, isSelected: selection == tab) {
+          selection = tab
+        }
+      }
+    }
+  }
+}
+
+private struct DictionaryTabRow: View {
+  let tab: DictionaryTab
+  let isSelected: Bool
+  let onSelect: () -> Void
+  /// See `SettingsHover.respondsToPointer`.
+  @Environment(\.isEnabled) private var environmentEnabled
+  @State private var pointerInside = false
+
+  private var hovering: Bool {
+    SettingsHover.respondsToPointer(pointerInside, true, environmentEnabled)
+  }
+
+  var body: some View {
+    Button(action: onSelect) {
+      HStack(spacing: 10) {
+        Image(systemName: tab.icon)
+          .font(.system(size: 15, weight: .medium))
+          .foregroundStyle(isSelected ? Color.stAccent : Color.stTextSecondary)
+          .frame(width: 20)
+          .accessibilityHidden(true)
+        Text(tab.label)
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundStyle(isSelected ? Color.stAccent : Color.stTextPrimary)
+          .lineLimit(1)
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 10)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background {
+        if isSelected {
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(Color.stAccentLight)
+            .overlay(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.stAccent, lineWidth: 1.5)
+            )
+        } else if hovering {
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(Color.stTextPrimary.opacity(0.05))
+        }
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { pointerInside = $0 }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(tab.label)
+    .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    .accessibilityHint("Shows the \(tab.label) Dictionary tab")
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
   }
 }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -64,9 +64,14 @@ struct YourWordsView: View {
     VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
       dictionaryBanner(settings: $settings)
 
-      HStack(alignment: .top, spacing: PolishRailMetrics.columnGap) {
+      HStack(alignment: .top, spacing: 12) {
         DictionaryTabRail(selection: $selectedTab)
-          .frame(width: PolishRailMetrics.railWidth, alignment: .leading)
+          // A dedicated width, not `PolishRailMetrics.railWidth` (216pt) —
+          // that rail's rows carry a provider logo tile and a tagline; a
+          // Dictionary tab is only an icon and one line of text, so it never
+          // needed that width, and every point reclaimed here matters at the
+          // app's 750pt minimum window (cloud review, PR #2499).
+          .frame(width: 168, alignment: .leading)
 
         ScrollView {
           VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {

--- a/Tests/EnviousWisprTests/App/BulkImportEnrichmentCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/BulkImportEnrichmentCoordinatorTests.swift
@@ -329,7 +329,7 @@ struct BulkImportEnrichmentCoordinatorTests {
     bulkCoordinator.requestDrain()
     await bulkCoordinator.awaitDrainForTesting()
 
-    #expect(presented.contains("Importing your words now. Check progress in the Your Words menu."))
+    #expect(presented.contains("Importing your words now. Check progress on the Dictionary page."))
     #expect(
       !presented.contains("Finished importing your words."),
       "a failed checkpoint write must never announce completion")
@@ -396,7 +396,7 @@ struct BulkImportEnrichmentCoordinatorTests {
     #expect(coordinator.pendingEnrichmentCount == 0, "eventually persisted despite the busy repair")
     #expect(
       presented == [
-        "Importing your words now. Check progress in the Your Words menu.",
+        "Importing your words now. Check progress on the Dictionary page.",
         "Finished importing your words.",
       ], "no duplicate pills across the retry")
   }
@@ -436,7 +436,7 @@ struct BulkImportEnrichmentCoordinatorTests {
     #expect(word.aliases == ["k8s"], "the word is eventually persisted despite the busy checkpoint")
     #expect(
       presented == [
-        "Importing your words now. Check progress in the Your Words menu.",
+        "Importing your words now. Check progress on the Dictionary page.",
         "Finished importing your words.",
       ], "the pills are not duplicated by the retry")
   }
@@ -653,7 +653,7 @@ struct BulkImportEnrichmentCoordinatorTests {
 
       #expect(
         presented == [
-          "Importing your words now. Check progress in the Your Words menu.",
+          "Importing your words now. Check progress on the Dictionary page.",
           "Finished importing your words.",
         ],
         "the lingering session must finalize exactly once, with no duplicate start pill")
@@ -669,9 +669,9 @@ struct BulkImportEnrichmentCoordinatorTests {
 
       #expect(
         presented == [
-          "Importing your words now. Check progress in the Your Words menu.",
+          "Importing your words now. Check progress on the Dictionary page.",
           "Finished importing your words.",
-          "Importing your words now. Check progress in the Your Words menu.",
+          "Importing your words now. Check progress on the Dictionary page.",
           "Finished importing your words.",
         ],
         "the new session's start pill must fire, and its own completion must land, not be suppressed"
@@ -815,7 +815,7 @@ struct BulkImportEnrichmentCoordinatorTests {
     await bulkCoordinator.awaitDrainForTesting()
 
     #expect(
-      presented.filter { $0 == "Importing your words now. Check progress in the Your Words menu." }
+      presented.filter { $0 == "Importing your words now. Check progress on the Dictionary page." }
         .count == 1)
     #expect(presented.filter { $0 == "Finished importing your words." }.count == 1)
   }

--- a/Tests/RuntimeUAT/faultInjection.py
+++ b/Tests/RuntimeUAT/faultInjection.py
@@ -1742,7 +1742,7 @@ def _read_setting(key: str) -> Optional[str]:
 def A6_settings_storm(**_) -> dict:
     """User behavior: dictation in progress, user opens Settings and
     flips heart-side toggles whose live-sync runs *during* an active
-    recording — `wordCorrectionEnabled` (Your Words tab) and
+    recording — `wordCorrectionEnabled` (Dictionary tab) and
     `fillerRemovalEnabled` (Transcription tab). These two flow through
     `PipelineSettingsSync` and modify the streaming-time inline post-
     process; the negative control on this scenario specifically names
@@ -1773,12 +1773,12 @@ def A6_settings_storm(**_) -> dict:
         return {"terminal": False, "reason": "could not enter recording", "state": query_state()}
     with _TTSAudio():
         time.sleep(0.5)  # let audio flow into streaming ASR
-        # Storm 1: flip wordCorrectionEnabled twice on the Your Words tab.
-        eyes.nav("Your Words")
+        # Storm 1: flip wordCorrectionEnabled twice on the Dictionary tab.
+        eyes.nav("Dictionary")
         time.sleep(0.4)
-        eyes.tap("Enable custom words")
+        eyes.tap("Enable Dictionary")
         time.sleep(0.25)
-        eyes.tap("Enable custom words")
+        eyes.tap("Enable Dictionary")
         time.sleep(0.25)
         # Storm 2: flip fillerRemovalEnabled twice on the Transcription tab.
         eyes.nav("Transcription")
@@ -1798,10 +1798,10 @@ def A6_settings_storm(**_) -> dict:
     # Restore pre-state so successive runs do not accumulate. The toggles
     # were each flipped twice during the storm so they should already
     # match pre-state, but read defaults to confirm and re-flip if not.
-    eyes.nav("Your Words")
+    eyes.nav("Dictionary")
     time.sleep(0.4)
     if (_read_setting("wordCorrectionEnabled") or "0") != (pre_word_correction or "0"):
-        eyes.tap("Enable custom words")
+        eyes.tap("Enable Dictionary")
         time.sleep(0.3)
     eyes.nav("Transcription")
     time.sleep(0.4)

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -439,31 +439,35 @@ def read_cards(group):
 
 
 def nav(tab):
+    """Open a Settings page. #1296 replaced the sidebar's AXOutline/AXRow
+    list with a ScrollView of AXButton rows (code-conventions.md FACT:
+    view-patterns); this pre-dates the Dictionary rename and blocked
+    every tab, not only this one. Fixed here because the Dictionary
+    diff needed a working nav() to verify itself, and touching the
+    caller string (faultInjection.py) without repairing the callee
+    would have left it silently unreachable."""
     _ensure_connected()
     try:
-        outline = find_element(_app, role="AXOutline")
-        if not outline:
-            w = find_element(_app, role="AXWindow")
-            outline = find_element(w, role="AXOutline") if w else None
-            if not outline:
-                # Auto-open Settings and retry once
-                settings_item = _find_match(_app, "Settings...", "AXMenuItem", exact=True)
-                if settings_item:
-                    perform_action(settings_item, "AXPress")
-                    time.sleep(0.8)
-                    print("Auto-opened Settings")
-                    outline = find_element(_app, role="AXOutline")
-                    if not outline:
-                        w = find_element(_app, role="AXWindow")
-                        outline = find_element(w, role="AXOutline") if w else None
-                if not outline: print("No sidebar found. Is Settings open?"); return False
-        for row in (get_attr(outline,"AXRows") or get_attr(outline,"AXChildren") or []):
-            if get_attr(row,"AXRole") != "AXRow": continue
-            t = _row_text(row)
-            if t and _fuzzy(tab, t):
-                set_attr(row,"AXSelected",True); time.sleep(0.3)
-                print(f"Navigated to {t}"); return True
-        print(f"Tab '{tab}' not found in sidebar"); return False
+        if tap(tab, role="AXButton"):
+            time.sleep(0.3)  # settle: unchanged from the pre-#1296 nav(), let the page swap render
+            print(f"Navigated to {tab}")
+            return True
+
+        settings_item = _find_match(_app, "Settings...", "AXMenuItem", exact=True)
+        if not settings_item:
+            print("No Settings sidebar found. Is Settings available?")
+            return False
+        perform_action(settings_item, "AXPress")
+        time.sleep(0.8)  # settle: unchanged from the pre-#1296 nav(), let the Settings window open
+        print("Auto-opened Settings")
+
+        if tap(tab, role="AXButton"):
+            time.sleep(0.3)  # settle: unchanged from the pre-#1296 nav(), let the page swap render
+            print(f"Navigated to {tab}")
+            return True
+
+        print(f"Tab '{tab}' not found in sidebar")
+        return False
     except Exception as e: print(f"nav error: {e}"); return False
 
 def menu():
@@ -1127,7 +1131,7 @@ def scan(toggle=False):
         # fail every run, and naming none asserts the tab still renders.
         ("AI Polish", [], ["Provider", "Model"],
          ["style"], ["Save", "Clear", "Refresh", "Copy Diagnostics"]),
-        ("Your Words", ["Enable custom words"], [], [], []),
+        ("Dictionary", ["Enable Dictionary"], [], [], []),
         ("Clipboard",
          ["Auto-copy to clipboard", "Restore clipboard after paste"],
          [], [], []),
@@ -1403,19 +1407,11 @@ def switch_backend(name, wait=3.0):
     if name not in _BACKEND_LABELS:
         raise ValueError(f"Unknown backend '{name}'. Use one of: {list(_BACKEND_LABELS)}")
     connect()
-    # nav("Transcription") requires AXOutline and silently no-ops against the
-    # button sidebar (#1296); tap() on the sidebar button itself is reliable
-    # once Settings is open. But nav()'s own auto-open-Settings fallback still
-    # ran before it gave up on the sidebar search, so a caller relying on that
-    # side effect (e.g. after Settings closed between two switch_backend calls)
-    # needs the same explicit open here (Codex code-diff review, 2026-07-22).
-    if not tap("Transcription"):
-        if not tap("Settings..."):
-            raise RuntimeError("Could not open Settings to reach Transcription")
-        time.sleep(0.8)  # settle: mirrors nav()'s own post-auto-open wait for the window to animate in
-        if not tap("Transcription"):
-            raise RuntimeError("Could not tap 'Transcription' in the Settings sidebar")
-    time.sleep(0.3)
+    # nav() now uses the button sidebar directly (#1296 fix, Dictionary
+    # redesign review) and owns the auto-open-Settings fallback, so this
+    # no longer needs its own copy of that logic.
+    if not nav("Transcription"):
+        raise RuntimeError("Could not navigate to Transcription")
     label = _BACKEND_LABELS[name]
     # These two engine buttons carry their label in AXDescription with an EMPTY
     # AXTitle, which `tap()` does not search — so `tap("Fast")` reported


### PR DESCRIPTION
## Summary

Phase 1 of the Dictionary redesign (epic #2491, phased plan in that issue's comments). Rebuilds the "Your Words" settings page into "Dictionary": a fixed banner (title + description + master switch, merged from three stacked pieces into one) and a fixed left sub-menu (Your Words / Vocabulary Packs / Learn from...), with only the selected tab's content scrolling. Renames user-facing copy from "term"/"Your Words" to "word"/"Dictionary" across the touched files — internal Swift symbol names are unchanged, per #2493's explicit scope.

Mockup: https://claude.ai/code/artifact/3c59cca6-990e-433c-8067-d21b69c010fb

Codex-reviewed (grounded against the real diff, `codex exec`); every finding from that round is applied in this PR, including a pre-existing bug in the RuntimeUAT `nav()` helper (it targeted a sidebar shape #1296 already replaced, so it silently could not reach ANY settings tab, not only this one) and a narrow-window layout fix for the app's 750pt minimum supported window.

## Test plan

- [x] `scripts/xcode-test.sh` — 7,162 tests passed, clean verdict
- [x] One unrelated pre-existing failure investigated and confirmed out of scope: `ShippedBackendLatencyTests.whisperKitP95StaysUnderOneSecond()`, a WhisperKit ASR speed benchmark this diff cannot touch (no ASR/pipeline files changed)
- [ ] Live UAT / manual click-through — not yet run this round

Closes #2492
Closes #2493
