### PR TITLE
feat(settings): category filter on the Your Words list

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermListPolicy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermListPolicy.swift
@@ -8,18 +8,24 @@ enum CustomTermListPolicy {
   static let pageSize = 50
 
   /// Filter `all` against `query` (case + diacritic insensitive substring
-  /// across canonical, aliases, category). Empty query returns the full
-  /// list. Sort is alphabetical by canonical, localized + case-insensitive.
-  static func filtered(_ all: [CustomWord], query: String) -> [CustomWord] {
+  /// across canonical, aliases, category) and, independently, against
+  /// `category` (#2494) — a word must satisfy BOTH when both are given.
+  /// `category: nil` means "all categories," matching the filter pill row's
+  /// default. Empty query + nil category returns the full list. Sort is
+  /// alphabetical by canonical, localized + case-insensitive.
+  static func filtered(
+    _ all: [CustomWord], query: String, category: WordCategory? = nil
+  ) -> [CustomWord] {
+    let byCategory = category.map { cat in all.filter { $0.category == cat } } ?? all
     let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else {
-      return all.sorted {
+      return byCategory.sorted {
         $0.canonical.localizedCaseInsensitiveCompare($1.canonical) == .orderedAscending
       }
     }
     let opts: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
     let locale = Locale.current
-    return all.filter { word in
+    return byCategory.filter { word in
       if word.canonical.range(of: trimmed, options: opts, locale: locale) != nil {
         return true
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -18,6 +18,11 @@ private struct BulkDeleteRequest: Identifiable {
 struct CustomTermsSection: View {
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var searchQuery: String = ""
+  /// #2494: `nil` is "All categories," the default pill. One combined
+  /// projection (`filteredWords`) feeds search, this filter, count,
+  /// pagination, selection, and the empty state — never two separate lists
+  /// that could disagree about which words are showing.
+  @State private var selectedCategory: WordCategory?
   @State private var currentPage: Int = 0
   @State private var editingWord: CustomWord?
   @State private var isSelecting = false
@@ -29,7 +34,7 @@ struct CustomTermsSection: View {
   }
 
   private var filteredWords: [CustomWord] {
-    CustomTermListPolicy.filtered(allWords, query: searchQuery)
+    CustomTermListPolicy.filtered(allWords, query: searchQuery, category: selectedCategory)
   }
 
   /// IDs eligible for bulk selection within the current search/filter — never
@@ -48,6 +53,19 @@ struct CustomTermsSection: View {
     return CustomTermListPolicy.paged(filteredWords, page: safePage)
   }
 
+  /// #2494 review: an empty result can mean three different things — say
+  /// which one, don't claim the whole dictionary is empty when it's really
+  /// "no words in this category."
+  private var emptyStateMessage: String {
+    if !searchQuery.isEmpty {
+      return "No matches for \"\(searchQuery)\"."
+    }
+    if selectedCategory != nil {
+      return "No words in this category."
+    }
+    return "No words yet. Add one with the button above."
+  }
+
   var body: some View {
     // #2492: no "Your Words" repeated here — the left sub-menu's selected
     // tab already says it. Keep the count, which is the useful part.
@@ -63,6 +81,7 @@ struct CustomTermsSection: View {
           TextField("Search by name, alias, or category", text: $searchQuery)
             .textFieldStyle(.plain)
             .onChange(of: searchQuery) { _, _ in currentPage = 0 }
+            .onChange(of: selectedCategory) { _, _ in currentPage = 0 }
             .onChange(of: pageCount) { _, newCount in
               if currentPage >= newCount { currentPage = max(0, newCount - 1) }
             }
@@ -81,6 +100,14 @@ struct CustomTermsSection: View {
           Spacer()
           selectionControls
         }
+      }
+
+      // #2494: category filter pills, directly under search. Wraps to a
+      // second line rather than scrolling sideways — this row is short
+      // (6 pills) and the tab pane can be as narrow as ~228pt at the app's
+      // 750pt minimum window.
+      BrandedRow(showDivider: true) {
+        categoryFilterRow
       }
 
       // Bulk-delete action row, shown only once something is selected.
@@ -107,13 +134,9 @@ struct CustomTermsSection: View {
       // List or empty state
       if pagedWords.isEmpty {
         BrandedRow(showDivider: false) {
-          Text(
-            searchQuery.isEmpty
-              ? "No words yet. Add one with the button above."
-              : "No matches for \"\(searchQuery)\"."
-          )
-          .font(.stHelper)
-          .foregroundStyle(.stTextSecondary)
+          Text(emptyStateMessage)
+            .font(.stHelper)
+            .foregroundStyle(.stTextSecondary)
         }
       } else {
         ForEach(Array(pagedWords.enumerated()), id: \.element.id) { idx, word in
@@ -227,6 +250,55 @@ struct CustomTermsSection: View {
         .font(.stHelper)
         .foregroundStyle(.stTextSecondary)
     }
+  }
+
+  /// #2494: one pill per `WordCategory` plus "All categories," selected
+  /// state driven by `selectedCategory`. `WrappingHStack` (not a horizontal
+  /// scroller) so the row is fully visible and never hides a category behind
+  /// a scroll gesture.
+  private var categoryFilterRow: some View {
+    WrappingHStack(spacing: 6) {
+      categoryPill(title: "All categories", isSelected: selectedCategory == nil) {
+        selectedCategory = nil
+      }
+      ForEach(WordCategory.allCases, id: \.self) { category in
+        categoryPill(title: category.rawValue.capitalized, isSelected: selectedCategory == category)
+        {
+          selectedCategory = category
+        }
+      }
+    }
+  }
+
+  private func categoryPill(title: String, isSelected: Bool, action: @escaping () -> Void)
+    -> some View
+  {
+    Button(action: action) {
+      Text(title)
+        .font(.stHelper)
+        .fontWeight(isSelected ? .semibold : .regular)
+        .foregroundStyle(isSelected ? Color.stAccent : Color.stTextSecondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background {
+          Capsule()
+            .fill(isSelected ? Color.stAccentLight : Color.stTextPrimary.opacity(0.04))
+        }
+        .overlay {
+          // #2494 review: a filled Shape overlay is hit-testable even where
+          // its own fill is invisible, so an undecorated stroke sitting over
+          // the pill's Text can steal the tap from the Button underneath it
+          // (code-gotchas.md RULE: a-decoration-drawn-over-a-control-swallows-its-clicks).
+          if isSelected {
+            Capsule()
+              .strokeBorder(Color.stAccent.opacity(0.35), lineWidth: 1)
+              .allowsHitTesting(false)
+          }
+        }
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
   }
 
   /// Trailing controls in the search row: "Select" when idle (only offered

--- a/Tests/EnviousWisprTests/Settings/CustomTermListPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/CustomTermListPolicyTests.swift
@@ -83,6 +83,51 @@ struct CustomTermListPolicyTests {
     #expect(result.isEmpty)
   }
 
+  // MARK: - category filter (#2494)
+
+  @Test("nil category (default) returns every category, matching pre-#2494 behavior")
+  func nilCategoryReturnsAll() {
+    // Omits `category:` entirely — this exercises the DEFAULT argument, not
+    // an explicitly passed `nil`, so it stands in for every existing search-
+    // only call site this diff did not touch (#2494 review).
+    let words = WordCategory.allCases.map { Self.make($0.rawValue, category: $0) }
+    let result = CustomTermListPolicy.filtered(words, query: "")
+    #expect(result.count == WordCategory.allCases.count)
+    for category in WordCategory.allCases {
+      #expect(result.contains { $0.category == category })
+    }
+  }
+
+  @Test("A given category returns only that category, regardless of the others' names")
+  func categoryFiltersToExactMatch() {
+    let words = [
+      Self.make("Anand", category: .person),
+      Self.make("Arvind", category: .person),
+      Self.make("Kubernetes", category: .brand),
+    ]
+    let result = CustomTermListPolicy.filtered(words, query: "", category: .person)
+    #expect(result.map(\.canonical) == ["Anand", "Arvind"])
+  }
+
+  @Test("Category with no members returns empty, not a fallback to all")
+  func categoryWithNoMembersReturnsEmpty() {
+    let words = [Self.make("Anand", category: .person)]
+    let result = CustomTermListPolicy.filtered(words, query: "", category: .acronym)
+    #expect(result.isEmpty)
+  }
+
+  @Test("Query and category combine as AND, not OR")
+  func queryAndCategoryCombineAsAnd() {
+    let words = [
+      Self.make("Anand", category: .person),
+      Self.make("Anand Vaish", category: .general),
+      Self.make("API", category: .acronym),
+    ]
+    // "Anand" matches two words by name, but only one is category .person.
+    let result = CustomTermListPolicy.filtered(words, query: "Anand", category: .person)
+    #expect(result.map(\.canonical) == ["Anand"])
+  }
+
   // MARK: - pageCount
 
   @Test("pageCount: 0 → 1, 50 → 1, 51 → 2, 100 → 2, 101 → 3")


### PR DESCRIPTION
## Summary

Phase 2 of the Dictionary redesign (epic #2491). Adds a category filter row (All categories / General / Person / Brand / Acronym / Domain) directly under the search box on the Your Words tab, combined with search as one filtered projection so count, pagination, selection, and the empty state can never disagree about what's showing.

Mockup: https://claude.ai/code/artifact/3c59cca6-990e-433c-8067-d21b69c010fb

Codex-reviewed (grounded against the real diff). Fixes applied: an empty-state message that claimed the whole dictionary was empty when only the selected category had no words, a decorative selection ring that could have intercepted taps meant for the pill button underneath it, and a test that passed `nil` explicitly instead of exercising the actual default argument.

## Test plan

- [x] `scripts/xcode-test.sh` — 7,166 tests passed, clean verdict

Closes #2494
