### PR TITLE
feat(settings): make vocabulary packs editable per word

### DIFF
--- a/Sources/EnviousWisprAppKit/App/VocabularyPackManager.swift
+++ b/Sources/EnviousWisprAppKit/App/VocabularyPackManager.swift
@@ -5,18 +5,22 @@ import Observation
 
 /// Owns which vocabulary packs (#633 Phase 9) are enabled and feeds their terms
 /// into the corrector lane. Single responsibility: enabled-pack state +
-/// merge-and-rebroadcast. Read-only bundled data; not user-editable persistence
-/// (that is `CustomWordsManager`). Enabled set persists in UserDefaults;
-/// default OFF for every pack.
+/// per-word overrides (#2495) + merge-and-rebroadcast. Bundled pack DATA stays
+/// read-only (`VocabularyPackStore`); what a person changes about one word
+/// lives in `overridesStore`, never folded into `CustomWordsManager`, which
+/// persists a different thing (the user's own words) under different rules.
+/// Enabled set persists in UserDefaults; default OFF for every pack.
 ///
 /// Wiring (`wireCustomWords`) sets `currentUserWords` and `rebroadcast`: the
 /// corrector lane is always `currentUserWords + enabledPackTerms()`. Toggling a
-/// pack or a user-word edit funnels through the same `rebroadcast` so the
-/// propagator pushes a fresh generation and the step's lookup cache invalidates.
+/// pack, editing a pack word, or a user-word edit all funnel through the same
+/// `rebroadcast` so the propagator pushes a fresh generation and the step's
+/// lookup cache invalidates.
 @MainActor
 @Observable
 final class VocabularyPackManager {
   private let store: VocabularyPackStore
+  private let overridesStore: VocabularyPackOverridesStore
   private let defaults: UserDefaults
   private static let defaultsKey = "vocabularyPacks.enabled.v1"
 
@@ -28,10 +32,23 @@ final class VocabularyPackManager {
   @ObservationIgnored var rebroadcast: () -> Void = {}
 
   private(set) var enabled: Set<VocabularyPackID>
+  /// In-memory mirror of the overrides file, refreshed on every mutation so
+  /// SwiftUI observation sees a change without re-reading disk on every render.
+  private var overrides: VocabularyPackOverridesFile
+  /// Set when a pack-word mutation's locked save failed (lock contention or a
+  /// disk error) — the UI shows this rather than silently discarding the
+  /// edit. Cleared by the next successful mutation.
+  private(set) var persistenceError: String?
 
-  init(store: VocabularyPackStore = VocabularyPackStore(), defaults: UserDefaults = .standard) {
+  init(
+    store: VocabularyPackStore = VocabularyPackStore(),
+    overridesStore: VocabularyPackOverridesStore = VocabularyPackOverridesStore(),
+    defaults: UserDefaults = .standard
+  ) {
     self.store = store
+    self.overridesStore = overridesStore
     self.defaults = defaults
+    self.overrides = overridesStore.load()
     if let raw = defaults.array(forKey: Self.defaultsKey) as? [String] {
       self.enabled = Set(raw.compactMap(VocabularyPackID.init(rawValue:)))
     } else {
@@ -47,8 +64,30 @@ final class VocabularyPackManager {
 
   func isEnabled(_ id: VocabularyPackID) -> Bool { enabled.contains(id) }
 
-  /// Terms for all enabled packs (source: .pack).
-  func enabledPackTerms() -> [CustomWord] { store.terms(for: enabled) }
+  /// Terms for all enabled packs, with every per-word override (#2495)
+  /// applied: a disabled word is dropped entirely, an aliases override
+  /// replaces the shipped aliases, and an untouched word passes through
+  /// unchanged. This is the ONE place pack overrides reach the correction
+  /// lane — `WordCorrector` never reads the overrides file itself.
+  func enabledPackTerms() -> [CustomWord] {
+    enabled.sorted { $0.rawValue < $1.rawValue }.flatMap { id -> [CustomWord] in
+      guard let pack = store.load(id) else { return [] }
+      let packOverrides = overrides.packs[id.rawValue] ?? [:]
+      return pack.terms.compactMap { term in
+        guard let override = packOverrides[Self.overrideKey(for: term.canonical)] else {
+          return term
+        }
+        if override.isEnabled == false { return nil }
+        guard let aliases = override.aliases else { return term }
+        return CustomWord(
+          id: term.id, canonical: term.canonical, aliases: aliases, category: term.category,
+          priority: term.priority, forceReplace: term.forceReplace,
+          caseSensitive: term.caseSensitive, source: term.source,
+          frequencyUsed: term.frequencyUsed, lastUsed: term.lastUsed,
+          minSimilarityOverride: term.minSimilarityOverride)
+      }
+    }
+  }
 
   /// Toggle a pack, persist, and rebroadcast the merged corrector lane.
   func setEnabled(_ id: VocabularyPackID, _ on: Bool) {
@@ -59,7 +98,9 @@ final class VocabularyPackManager {
 
   // MARK: - UI metadata
 
-  /// Number of correctable terms in a pack (for the Settings row).
+  /// Number of correctable terms in a pack (for the Settings row). Not
+  /// override-adjusted — this is the shipped pack size, shown before anyone
+  /// has opened the pack to edit anything.
   func termCount(_ id: VocabularyPackID) -> Int { store.load(id)?.terms.count ?? 0 }
 
   /// A few example "fix" canonicals for the Settings row blurb.
@@ -68,13 +109,121 @@ final class VocabularyPackManager {
     return pack.terms.map(\.canonical).sorted().prefix(limit).map { $0 }
   }
 
-  /// Every term in a pack — the correct word plus the spoken variants (aliases)
-  /// it catches — sorted alphabetically by word (case-insensitive), for the
-  /// pack-detail list. Fail-open: missing pack yields an empty list.
-  func packTerms(_ id: VocabularyPackID) -> [CustomWord] {
+  // MARK: - Pack word overrides (#2495)
+
+  /// Every word in a pack, with each one's effective (override-applied)
+  /// state for the pack-detail screen: whether it's on, its effective
+  /// aliases, and whether it differs from shipped. Includes DISABLED words
+  /// (unlike `enabledPackTerms()`) — the detail screen is where a disabled
+  /// word gets found again and restored. Sorted alphabetically, case-insensitive.
+  func packWords(_ id: VocabularyPackID) -> [VocabularyPackWordDisplay] {
     guard let pack = store.load(id) else { return [] }
-    return pack.terms.sorted {
+    let packOverrides = overrides.packs[id.rawValue] ?? [:]
+    return pack.terms.map { term in
+      let override = packOverrides[Self.overrideKey(for: term.canonical)]
+      let effectiveAliases = override?.aliases ?? term.aliases
+      let isEnabled = override?.isEnabled ?? true
+      return VocabularyPackWordDisplay(
+        id: term.id,
+        canonical: term.canonical,
+        shippedAliases: term.aliases,
+        aliases: effectiveAliases,
+        isEnabled: isEnabled,
+        // Computed from the EFFECTIVE state, not from "does an override
+        // record exist" — an aliases override that has drifted back to
+        // equal the shipped list (added then removed again) must read as
+        // unedited, and `mutateOverride` already clears that case at write
+        // time, but this reads the same way even if it somehow didn't.
+        isEdited: !isEnabled || effectiveAliases != term.aliases
+      )
+    }.sorted {
       $0.canonical.localizedCaseInsensitiveCompare($1.canonical) == .orderedAscending
     }
   }
+
+  /// Turn one pack word on or off, independent of the whole pack's toggle.
+  func setWordEnabled(_ id: VocabularyPackID, canonical: String, enabled isOn: Bool) {
+    mutateOverride(id, canonical: canonical) { $0.isEnabled = isOn ? nil : false }
+  }
+
+  /// Replace a pack word's effective aliases with `aliases` — the complete
+  /// list, not a delta, matching how the alias editor already works for the
+  /// user's own words. Clears the override back to `nil` when `aliases`
+  /// turns out to equal the shipped list (e.g. add then remove the same
+  /// alias again), so the EDITED badge doesn't stick around for a no-op edit.
+  func setWordAliases(_ id: VocabularyPackID, canonical: String, aliases: [String]) {
+    let key = Self.overrideKey(for: canonical)
+    guard
+      let shippedAliases = store.load(id)?.terms.first(where: {
+        Self.overrideKey(for: $0.canonical) == key
+      })?.aliases
+    else { return }
+    mutateOverride(id, canonical: canonical) {
+      $0.aliases = aliases == shippedAliases ? nil : aliases
+    }
+  }
+
+  /// Put one pack word back to its shipped default — clears BOTH the
+  /// enabled/disabled override and any alias edit, in one action, rather
+  /// than requiring two separate "restores." A no-op (nothing was ever
+  /// edited) skips the disk write entirely.
+  func restoreWord(_ id: VocabularyPackID, canonical: String) {
+    let key = Self.overrideKey(for: canonical)
+    guard overrides.packs[id.rawValue]?[key] != nil else { return }
+    mutateOverride(id, canonical: canonical) { $0 = VocabularyPackWordOverride() }
+  }
+
+  /// The one path every pack-word mutation takes: a locked load-transform-
+  /// save transaction (`VocabularyPackOverridesStore.update(_:)`), never a
+  /// save built from this instance's own possibly-stale `overrides` snapshot
+  /// — another running EnviousWispr process (a second worktree's dev build,
+  /// or dev alongside production) could have changed the file since this
+  /// process last read it.
+  private func mutateOverride(
+    _ id: VocabularyPackID, canonical: String,
+    _ transform: (inout VocabularyPackWordOverride) -> Void
+  ) {
+    let key = Self.overrideKey(for: canonical)
+    guard
+      let saved = overridesStore.update({ file in
+        var packDict = file.packs[id.rawValue] ?? [:]
+        let before = packDict
+        var entry = packDict[key] ?? VocabularyPackWordOverride()
+        transform(&entry)
+        if entry.isEmpty {
+          packDict.removeValue(forKey: key)
+        } else {
+          packDict[key] = entry
+        }
+        if packDict.isEmpty {
+          file.packs.removeValue(forKey: id.rawValue)
+        } else {
+          file.packs[id.rawValue] = packDict
+        }
+        return packDict != before
+      })
+    else {
+      persistenceError = "Couldn't save this pack change. Nothing was changed. Try again."
+      return
+    }
+    overrides = saved
+    persistenceError = nil
+    rebroadcast()
+  }
+
+  private static func overrideKey(for canonical: String) -> String { canonical.lowercased() }
+}
+
+/// One pack word as the pack-detail screen shows it: shipped identity plus
+/// whatever a person has changed about it (#2495).
+struct VocabularyPackWordDisplay: Identifiable, Equatable {
+  let id: UUID
+  let canonical: String
+  /// The pack's own aliases, before any override — needed so "Add alias" /
+  /// "Remove alias" in the detail screen can build the next full list
+  /// without re-reading the pack file.
+  let shippedAliases: [String]
+  let aliases: [String]
+  let isEnabled: Bool
+  let isEdited: Bool
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
@@ -11,9 +11,21 @@ import SwiftUI
 /// title rendered twice.
 struct VocabPacksSection: View {
   @Environment(VocabularyPackManager.self) private var packManager
+  /// #2495 UI decision (recorded on issue #2495): "See all" fills the whole
+  /// Vocabulary Packs pane instead of opening a small popup, so the per-word
+  /// editing controls have room. `selectedPack` therefore switches this
+  /// view's own content rather than presenting a `.sheet`.
   @State private var selectedPack: VocabularyPackID?
 
   var body: some View {
+    if let selectedPack {
+      VocabularyPackDetailSection(id: selectedPack, onClose: { self.selectedPack = nil })
+    } else {
+      packList
+    }
+  }
+
+  private var packList: some View {
     BrandedSection {
       let ids = packManager.availablePackIDs
       if ids.isEmpty {
@@ -43,9 +55,6 @@ struct VocabPacksSection: View {
           }
         }
       }
-    }
-    .sheet(item: $selectedPack) { id in
-      VocabularyPackDetailSheet(id: id, terms: packManager.packTerms(id))
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -2,139 +2,288 @@ import EnviousWisprCore
 import EnviousWisprPostProcessing
 import SwiftUI
 
-/// Read-only browser for a vocabulary pack's full term list (#992). Opens from a
-/// pack row's "See all" button. A pinned search box filters an alphabetical list
-/// of every word the pack fixes; each row shows the correct word plus the spoken
-/// variants (aliases) it catches, as pills (mirroring the Custom Word edit sheet).
-/// No editing — bundled packs are read-only.
-struct VocabularyPackDetailSheet: View {
+/// Full-pane editor for one vocabulary pack's word list (#2495). Opens from a
+/// pack row's "See all" button, replacing the pack list in `VocabPacksSection`
+/// (recorded UI decision on issue #2495: this used to be a small popup — it
+/// now fills the same space the pack list sits in, so the per-word toggle,
+/// alias editor, and Restore button have room). Every word can be turned off
+/// individually, have its spoken variants (aliases) edited, and — once
+/// changed — restored back to what the pack shipped.
+///
+/// File kept under its original name (`VocabularyPackDetailSheet.swift`) so
+/// the git history for this feature stays in one file rather than a
+/// delete-and-recreate; the type itself is no longer a sheet.
+struct VocabularyPackDetailSection: View {
   let id: VocabularyPackID
-  /// Pack terms (word + aliases), alphabetical by word, supplied by the section.
-  let terms: [CustomWord]
+  let onClose: () -> Void
+  @Environment(VocabularyPackManager.self) private var packManager
   @State private var searchQuery: String = ""
-  @Environment(\.dismiss) private var dismiss
 
-  /// Rows whose word OR any alias contains the query (case-insensitive).
-  private var filteredTerms: [CustomWord] {
+  private var words: [VocabularyPackWordDisplay] { packManager.packWords(id) }
+
+  private var filteredWords: [VocabularyPackWordDisplay] {
     let query = searchQuery.trimmingCharacters(in: .whitespaces)
-    guard !query.isEmpty else { return terms }
-    return terms.filter { term in
-      term.canonical.localizedCaseInsensitiveContains(query)
-        || term.aliases.contains { $0.localizedCaseInsensitiveContains(query) }
+    guard !query.isEmpty else { return words }
+    return words.filter { word in
+      word.canonical.localizedCaseInsensitiveContains(query)
+        || word.aliases.contains { $0.localizedCaseInsensitiveContains(query) }
     }
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 14) {
-      // Title + count
-      VStack(alignment: .leading, spacing: 2) {
-        Text(id.displayName)
-          .font(.headline)
-        Text(
-          "\(terms.count) \(terms.count == 1 ? "word" : "words") · the variants under each are examples of the mistakes it catches, not the full set"
-        )
-        .font(.stHelper)
-        .foregroundStyle(.stTextSecondary)
-        .fixedSize(horizontal: false, vertical: true)
-      }
+    // Computed ONCE per body evaluation. `filteredWords` re-decodes and
+    // re-sorts the whole pack (`packManager.packWords(id)`) on every access;
+    // reading the computed property three times (emptiness check, ForEach,
+    // divider count) tripled that cost per render for no reason.
+    let displayedWords = filteredWords
 
-      // Search
-      HStack(spacing: 6) {
-        Image(systemName: "magnifyingglass")
-          .foregroundStyle(.stTextSecondary)
-          .font(.system(size: 12))
-        TextField("Search words or variants", text: $searchQuery)
-          .textFieldStyle(.plain)
-        if !searchQuery.isEmpty {
-          Button {
-            searchQuery = ""
-          } label: {
-            Image(systemName: "xmark.circle.fill")
-              .foregroundStyle(.stTextSecondary)
-              .font(.system(size: 12))
-              .settingsHoverQuiet()
-          }
-          .buttonStyle(.plain)
-          .accessibilityLabel("Clear search")
+    BrandedSection {
+      BrandedRow(showDivider: true) { header }
+      BrandedRow(showDivider: true) { searchRow }
+
+      if let persistenceError = packManager.persistenceError {
+        BrandedRow(showDivider: true) {
+          Label(persistenceError, systemImage: "exclamationmark.triangle.fill")
+            .font(.stHelper)
+            .foregroundStyle(.stError)
         }
       }
-      .padding(.horizontal, 10)
-      .padding(.vertical, 7)
-      .background(Color.stPageBg)
-      .clipShape(RoundedRectangle(cornerRadius: 8))
-      .overlay(
-        RoundedRectangle(cornerRadius: 8)
-          .strokeBorder(Color.stDivider, lineWidth: 1)
-      )
 
-      // Term list (or empty state)
-      if filteredTerms.isEmpty {
-        Spacer()
-        Text(
-          searchQuery.isEmpty
-            ? "This pack has no words."
-            : "No matches for \"\(searchQuery)\"."
-        )
-        .font(.stHelper)
-        .foregroundStyle(.stTextSecondary)
-        .frame(maxWidth: .infinity, alignment: .center)
-        Spacer()
-      } else {
-        ScrollView {
-          VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(filteredTerms.enumerated()), id: \.element.id) { index, term in
-              termRow(term)
-              if index < filteredTerms.count - 1 {
-                Divider().overlay(Color.stDivider)
-              }
-            }
-          }
-        }
-        .frame(maxWidth: .infinity)
-      }
-
-      // Done
-      HStack {
-        Spacer()
-        SettingsActionButton(
-          title: "Done", isEnabled: true, emphasis: .filled, shortcut: .cancelAction
-        ) {
-          dismiss()
-        }
-      }
-    }
-    .padding(20)
-    .frame(width: 420, height: 520)
-  }
-
-  /// One word + its alias pills.
-  @ViewBuilder
-  private func termRow(_ term: CustomWord) -> some View {
-    VStack(alignment: .leading, spacing: 5) {
-      Text(term.canonical)
-        .settingsRowLabel()
-      if term.aliases.isEmpty {
-        Text("No spoken variants")
+      if displayedWords.isEmpty {
+        BrandedRow(showDivider: false) {
+          Text(
+            searchQuery.isEmpty
+              ? "This pack has no words."
+              : "No matches for \"\(searchQuery)\"."
+          )
           .font(.stHelper)
           .foregroundStyle(.stTextSecondary)
+        }
       } else {
-        WrappingHStack(spacing: 6) {
-          ForEach(sortedAliases(term), id: \.self) { alias in
-            Text(alias)
-              .font(.stHelper)
-              .padding(.horizontal, 6)
-              .padding(.vertical, 3)
-              .background(Color.stAccentLight)
-              .clipShape(RoundedRectangle(cornerRadius: 4))
+        ForEach(Array(displayedWords.enumerated()), id: \.element.id) { index, word in
+          BrandedRow(showDivider: index < displayedWords.count - 1) {
+            PackWordRow(packID: id, word: word)
           }
         }
       }
     }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(.vertical, 8)
   }
 
-  private func sortedAliases(_ term: CustomWord) -> [String] {
-    term.aliases.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+  private var header: some View {
+    HStack(alignment: .top, spacing: 12) {
+      Button(action: onClose) {
+        HStack(spacing: 4) {
+          Image(systemName: "chevron.left")
+            .font(.system(size: 11, weight: .semibold))
+          Text("Packs")
+        }
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+      }
+      .buttonStyle(.plain)
+      .settingsHoverQuiet()
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(id.displayName)
+          .settingsRowTitle()
+        Text("\(packManager.termCount(id)) words")
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+      }
+
+      Spacer(minLength: 8)
+
+      HStack(spacing: 8) {
+        Text("Pack on")
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+        Toggle(
+          "",
+          isOn: Binding(
+            get: { packManager.isEnabled(id) },
+            set: { packManager.setEnabled(id, $0) }
+          )
+        )
+        .toggleStyle(BrandedToggleStyle())
+        .labelsHidden()
+        .accessibilityLabel("Enable \(id.displayName) pack")
+      }
+      .fixedSize()
+
+      Button(action: onClose) {
+        Image(systemName: "xmark")
+          .font(.system(size: 12, weight: .semibold))
+          .settingsHoverQuiet()
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Close \(id.displayName) pack")
+    }
+  }
+
+  private var searchRow: some View {
+    HStack(spacing: 6) {
+      Image(systemName: "magnifyingglass")
+        .foregroundStyle(.stTextSecondary)
+        .font(.system(size: 12))
+      TextField("Search \(id.displayName) words", text: $searchQuery)
+        .textFieldStyle(.plain)
+      if !searchQuery.isEmpty {
+        Button {
+          searchQuery = ""
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+            .foregroundStyle(.stTextSecondary)
+            .font(.system(size: 12))
+            .settingsHoverQuiet()
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Clear search")
+      }
+    }
+  }
+}
+
+/// One pack word's row: name, an EDITED badge once it differs from shipped,
+/// its alias chips (removable) plus an add-alias field, a per-word on/off
+/// toggle, and — only once edited — a Restore button.
+private struct PackWordRow: View {
+  let packID: VocabularyPackID
+  let word: VocabularyPackWordDisplay
+  @Environment(VocabularyPackManager.self) private var packManager
+  @State private var newAlias: String = ""
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(alignment: .top, spacing: 12) {
+        info
+        Spacer(minLength: 8)
+        controls
+      }
+      VStack(alignment: .leading, spacing: 8) {
+        info
+        controls
+      }
+    }
+    .opacity(word.isEnabled ? 1 : 0.5)
+  }
+
+  private var info: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 8) {
+        Text(word.canonical)
+          .settingsRowLabel()
+        if word.isEdited {
+          Text("EDITED")
+            .font(.system(size: 10, weight: .bold))
+            .foregroundStyle(.stWarning)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.stWarningSoft, in: Capsule())
+        }
+      }
+      aliasChips
+      addAliasRow
+    }
+  }
+
+  private var controls: some View {
+    HStack(spacing: 10) {
+      if word.isEdited {
+        SettingsActionButton(title: "Restore", isEnabled: true) {
+          packManager.restoreWord(packID, canonical: word.canonical)
+        }
+      }
+      Toggle(
+        "",
+        isOn: Binding(
+          get: { word.isEnabled },
+          set: { packManager.setWordEnabled(packID, canonical: word.canonical, enabled: $0) }
+        )
+      )
+      .toggleStyle(BrandedToggleStyle())
+      .labelsHidden()
+      // BrandedToggleStyle's internal Spacer otherwise claims whatever width
+      // this row hands it — with an empty label there is nothing to push
+      // against, so the whole row's blank space becomes clickable.
+      .fixedSize()
+      .accessibilityLabel("Enable \(word.canonical)")
+    }
+  }
+
+  private var sortedAliases: [String] {
+    word.aliases.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+  }
+
+  @ViewBuilder
+  private var aliasChips: some View {
+    if word.aliases.isEmpty {
+      Text("No spoken variants")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+    } else {
+      WrappingHStack(spacing: 6) {
+        ForEach(sortedAliases, id: \.self) { alias in
+          HStack(spacing: 3) {
+            Text(alias)
+              .font(.stHelper)
+              .fixedSize(horizontal: false, vertical: true)
+            Button {
+              removeAlias(alias)
+            } label: {
+              Image(systemName: "xmark")
+                .font(.system(size: 8, weight: .bold))
+                .settingsHoverQuiet(inset: 2, tint: .stError)
+            }
+            .buttonStyle(.plain)
+            .fixedSize()
+            .accessibilityLabel("Remove alias \(alias)")
+          }
+          .padding(.horizontal, 6)
+          .padding(.vertical, 3)
+          .background(Color.stAccentLight)
+          .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+      }
+    }
+  }
+
+  private var addAliasRow: some View {
+    HStack(spacing: 6) {
+      TextField("Add alias (e.g. a mishearing you've noticed)", text: $newAlias)
+        .textFieldStyle(.plain)
+        .font(.stHelper)
+        .onSubmit(addAlias)
+      SettingsActionButton(
+        title: "Add", isEnabled: !newAlias.trimmingCharacters(in: .whitespaces).isEmpty
+      ) {
+        addAlias()
+      }
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 5)
+    .background(Color.stPageBg)
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .strokeBorder(Color.stDivider, lineWidth: 1)
+    )
+  }
+
+  private func addAlias() {
+    let trimmed = newAlias.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return }
+    guard !word.aliases.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame })
+    else {
+      newAlias = ""
+      return
+    }
+    packManager.setWordAliases(packID, canonical: word.canonical, aliases: word.aliases + [trimmed])
+    newAlias = ""
+  }
+
+  private func removeAlias(_ alias: String) {
+    var next = word.aliases
+    next.removeAll { $0 == alias }
+    packManager.setWordAliases(packID, canonical: word.canonical, aliases: next)
   }
 }

--- a/Sources/EnviousWisprPostProcessing/VocabularyPackOverridesStore.swift
+++ b/Sources/EnviousWisprPostProcessing/VocabularyPackOverridesStore.swift
@@ -1,0 +1,176 @@
+import EnviousWisprCore
+import Foundation
+import os
+
+/// A per-word change from a pack's shipped default (#2495): the word turned
+/// off, its aliases edited, or both. `nil` fields mean "unchanged from
+/// shipped" — a word nobody has touched has no entry in the file at all, so
+/// this store only ever holds what a person actually changed.
+package struct VocabularyPackWordOverride: Codable, Sendable, Equatable {
+  /// `false` = the word is turned off. Absent (`nil`) = enabled, the shipped
+  /// default. Never `true` explicitly — an enabled, otherwise-untouched word
+  /// has no reason to carry an override at all.
+  package var isEnabled: Bool?
+  /// The full replacement alias list, or `nil` if aliases are unchanged from
+  /// the shipped pack. A full replacement (not an add/remove delta) because
+  /// the editor already works with the complete list, and a delta would need
+  /// its own conflict rules if the shipped pack's aliases ever change under it.
+  package var aliases: [String]?
+
+  package init(isEnabled: Bool? = nil, aliases: [String]? = nil) {
+    self.isEnabled = isEnabled
+    self.aliases = aliases
+  }
+
+  /// True once either field has a real value — an override that reduces to
+  /// "isEnabled: nil, aliases: nil" carries no information and should have
+  /// been removed instead of kept.
+  package var isEmpty: Bool { isEnabled == nil && aliases == nil }
+}
+
+/// Sparse per-pack, per-word overrides, keyed by pack id then the word's
+/// lowercased canonical spelling (stable across relaunches; a pack's terms
+/// are keyed the same way pack term identity already works in
+/// `VocabularyPackStore.deterministicID`, so this file and that seed use the
+/// same two-part key without needing to share a type).
+package struct VocabularyPackOverridesFile: Codable, Sendable {
+  package var version: Int
+  package var packs: [String: [String: VocabularyPackWordOverride]]
+
+  package init(version: Int, packs: [String: [String: VocabularyPackWordOverride]]) {
+    self.version = version
+    self.packs = packs
+  }
+
+  package static let empty = VocabularyPackOverridesFile(version: 1, packs: [:])
+}
+
+/// Persists per-word edits to vocabulary packs (#2495): turning a pack word
+/// off, editing its aliases, and restoring it to the shipped default.
+///
+/// **Every running EnviousWispr app process constructs its own
+/// `VocabularyPackManager`, and every process resolves the same Application
+/// Support file** (dev and production builds can run side by side, and even
+/// two dev worktrees share it) — so this is NOT single-writer the way an
+/// earlier version of this file claimed. What it does NOT need is
+/// `CustomWordsManager`'s corruption-recovery machinery, which exists for a
+/// different reason (that file survives a damaged/undecodable disk copy by
+/// archiving it aside); this store's fail-open-to-empty on a bad read already
+/// covers that case just as safely, because losing an override is recoverable
+/// (re-edit the word) in a way losing the user's own word list is not.
+///
+/// What contention DOES require: every mutation goes through `update(_:)`,
+/// which takes an exclusive `flock` on a companion lock file, then performs
+/// ONE load-transform-save transaction — never a bare `save()` built from a
+/// snapshot some other process could have already invalidated. `flock` is
+/// process-exclusive but not currently reentrant-safe within one process;
+/// `VocabularyPackManager` only ever calls it from the main actor, so that
+/// does not arise here. The ASR XPC service does not read or write this file.
+package final class VocabularyPackOverridesStore: Sendable {
+  private let fileURL: URL
+  private static let logger = Logger(
+    subsystem: "com.enviouswispr", category: "VocabularyPackOverridesStore")
+
+  nonisolated package static var liveFileURL: URL? {
+    FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+      .appendingPathComponent("EnviousWispr", isDirectory: true)
+      .appendingPathComponent("vocabulary-pack-overrides.json")
+  }
+
+  package init() {
+    guard let url = Self.liveFileURL else {
+      // Application Support is always available on macOS; fall back defensively.
+      let fallback = FileManager.default.temporaryDirectory
+        .appendingPathComponent("EnviousWispr", isDirectory: true)
+        .appendingPathComponent("vocabulary-pack-overrides.json")
+      Self.prepareDirectory(at: fallback.deletingLastPathComponent())
+      self.fileURL = fallback
+      return
+    }
+    Self.prepareDirectory(at: url.deletingLastPathComponent())
+    self.fileURL = url
+  }
+
+  /// Test seam: inject an explicit file URL so unit tests hit a per-test temp
+  /// file instead of the production Application Support path.
+  package init(fileURL: URL) {
+    self.fileURL = fileURL
+    Self.prepareDirectory(at: fileURL.deletingLastPathComponent())
+  }
+
+  private static func prepareDirectory(at url: URL) {
+    let fm = FileManager.default
+    try? fm.createDirectory(at: url, withIntermediateDirectories: true)
+    try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+  }
+
+  /// The full override set. Fail-open: a missing file (the common case — no
+  /// pack word has ever been edited) or an unreadable/corrupt one both read
+  /// as empty, never thrown. Safe to call without the lock — a mutation
+  /// always re-reads under `update(_:)`, so a caller reading here for
+  /// DISPLAY only ever sees a slightly-stale snapshot, never a torn one
+  /// (`save` replaces atomically).
+  package func load() -> VocabularyPackOverridesFile {
+    guard let data = try? Data(contentsOf: fileURL) else { return .empty }
+    guard let file = try? JSONDecoder().decode(VocabularyPackOverridesFile.self, from: data)
+    else {
+      Self.logger.error("Vocabulary pack overrides file was unreadable; treating as empty")
+      return .empty
+    }
+    return file
+  }
+
+  /// Locked load-transform-save: the only way this store is ever mutated.
+  /// `transform` reads the CURRENT on-disk file (not a caller-held snapshot
+  /// from before the lock), mutates it in place, and returns whether
+  /// anything actually changed — `false` skips the write entirely, so a
+  /// no-op mutation (e.g. restoring a word that was never edited) never
+  /// touches disk. Returns the saved file on success, `nil` if the lock
+  /// could not be taken or the write failed — the caller must treat `nil` as
+  /// "nothing changed," never as "the old value is still correct," since a
+  /// concurrent writer may have changed the file just before this call.
+  package func update(
+    _ transform: (inout VocabularyPackOverridesFile) -> Bool
+  ) -> VocabularyPackOverridesFile? {
+    let lockURL = fileURL.appendingPathExtension("lock")
+    let fd = lockURL.path.withCString { open($0, O_RDWR | O_CREAT | O_CLOEXEC, 0o600) }
+    guard fd >= 0 else {
+      Self.logger.error("Vocabulary pack overrides lock file could not be opened")
+      return nil
+    }
+    defer { close(fd) }
+    guard flock(fd, LOCK_EX) == 0 else {
+      Self.logger.error("Vocabulary pack overrides file lock failed")
+      return nil
+    }
+    defer { _ = flock(fd, LOCK_UN) }
+
+    var file = load()
+    guard transform(&file) else { return file }
+    guard saveWhileLocked(file) else { return nil }
+    return file
+  }
+
+  /// Atomic replace: write to a sibling temp file, then rename over the live
+  /// one. A crash mid-write leaves the OLD file intact rather than a
+  /// half-written one. Callers MUST already hold the lock from `update(_:)`
+  /// — this is not exposed on its own, so a mutation can never bypass the
+  /// load-transform-save transaction.
+  private func saveWhileLocked(_ file: VocabularyPackOverridesFile) -> Bool {
+    guard let data = try? JSONEncoder().encode(file) else { return false }
+    let tempURL = fileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
+    do {
+      try data.write(to: tempURL, options: .atomic)
+      _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+      return true
+    } catch {
+      Self.logger.error(
+        "Vocabulary pack overrides save failed: \(error.localizedDescription, privacy: .public)")
+      try? FileManager.default.removeItem(at: tempURL)
+      return false
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/VocabularyPackOverridesStore.swift
+++ b/Sources/EnviousWisprPostProcessing/VocabularyPackOverridesStore.swift
@@ -162,7 +162,16 @@ package final class VocabularyPackOverridesStore: Sendable {
     let tempURL = fileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
     do {
       try data.write(to: tempURL, options: .atomic)
-      _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+      // `replaceItemAt` requires an existing destination — the FIRST word
+      // anyone ever edits hits this while `fileURL` has never been created,
+      // and every subsequent edit would silently fail the same way (cloud
+      // review, PR #2501). `moveItem` covers that first-write case; every
+      // write after it takes the atomic-replace path.
+      if FileManager.default.fileExists(atPath: fileURL.path) {
+        _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+      } else {
+        try FileManager.default.moveItem(at: tempURL, to: fileURL)
+      }
       try? FileManager.default.setAttributes(
         [.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
       return true

--- a/Tests/EnviousWisprTests/App/VocabularyPackManagerOverridesTests.swift
+++ b/Tests/EnviousWisprTests/App/VocabularyPackManagerOverridesTests.swift
@@ -1,0 +1,182 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2495 — per-word pack overrides (toggle, alias edit, restore), against the
+/// REAL bundled Tech pack rather than a fake one. `VocabularyPackManager` has
+/// no injectable pack store seam and none is warranted here: overlaying
+/// overrides onto whatever the pack actually ships is exactly the behavior
+/// worth proving, and the real pack is small and stable.
+@Suite("VocabularyPackManager — per-word overrides (#2495)", .tags(.productOutcome))
+@MainActor
+struct VocabularyPackManagerOverridesTests {
+
+  private func makeManager() -> (VocabularyPackManager, String) {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("vpo-mgr-test-\(UUID().uuidString).json")
+    let manager = VocabularyPackManager(overridesStore: VocabularyPackOverridesStore(fileURL: url))
+    manager.setEnabled(.tech, true)
+    guard let firstWord = manager.packWords(.tech).first else {
+      Issue.record("Tech pack loaded no words — bundle problem")
+      return (manager, "")
+    }
+    return (manager, firstWord.canonical)
+  }
+
+  @Test("An untouched word is enabled, unedited, and shows its shipped aliases")
+  func untouchedWordIsUnedited() {
+    let (manager, canonical) = makeManager()
+    let word = manager.packWords(.tech).first { $0.canonical == canonical }
+    #expect(word?.isEnabled == true)
+    #expect(word?.isEdited == false)
+    #expect(word?.aliases == word?.shippedAliases)
+  }
+
+  @Test("Disabling a word marks it disabled and edited, without touching its aliases")
+  func disablingMarksEditedWithoutTouchingAliases() {
+    let (manager, canonical) = makeManager()
+    let before = manager.packWords(.tech).first { $0.canonical == canonical }!
+
+    manager.setWordEnabled(.tech, canonical: canonical, enabled: false)
+
+    let after = manager.packWords(.tech).first { $0.canonical == canonical }!
+    #expect(after.isEnabled == false)
+    #expect(after.isEdited == true)
+    #expect(after.aliases == before.aliases)
+  }
+
+  @Test("Disabled words are dropped from enabledPackTerms, but stay listed in packWords")
+  func disabledWordDroppedFromCorrectionLaneNotFromTheList() {
+    let (manager, canonical) = makeManager()
+    manager.setWordEnabled(.tech, canonical: canonical, enabled: false)
+
+    #expect(!manager.enabledPackTerms().contains { $0.canonical == canonical })
+    #expect(manager.packWords(.tech).contains { $0.canonical == canonical })
+  }
+
+  @Test("Editing aliases replaces the effective list and reaches enabledPackTerms")
+  func editingAliasesReachesCorrectionLane() {
+    let (manager, canonical) = makeManager()
+    let newAliases = ["a totally new mishearing"]
+
+    manager.setWordAliases(.tech, canonical: canonical, aliases: newAliases)
+
+    let word = manager.packWords(.tech).first { $0.canonical == canonical }!
+    #expect(word.aliases == newAliases)
+    #expect(word.isEdited == true)
+    let corrected = manager.enabledPackTerms().first { $0.canonical == canonical }
+    #expect(corrected?.aliases == newAliases)
+  }
+
+  @Test("Restore clears BOTH the enabled and alias overrides in one action")
+  func restoreClearsBothOverrides() {
+    let (manager, canonical) = makeManager()
+    let shipped = manager.packWords(.tech).first { $0.canonical == canonical }!.shippedAliases
+    manager.setWordEnabled(.tech, canonical: canonical, enabled: false)
+    manager.setWordAliases(.tech, canonical: canonical, aliases: ["edited alias"])
+
+    manager.restoreWord(.tech, canonical: canonical)
+
+    let word = manager.packWords(.tech).first { $0.canonical == canonical }!
+    #expect(word.isEnabled == true)
+    #expect(word.isEdited == false)
+    #expect(word.aliases == shipped)
+  }
+
+  @Test("Overrides persist across a fresh manager reading the same file")
+  func overridesPersistAcrossRelaunch() {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("vpo-mgr-persist-\(UUID().uuidString).json")
+    let first = VocabularyPackManager(overridesStore: VocabularyPackOverridesStore(fileURL: url))
+    first.setEnabled(.tech, true)
+    guard let canonical = first.packWords(.tech).first?.canonical else {
+      Issue.record("Tech pack loaded no words — bundle problem")
+      return
+    }
+    first.setWordEnabled(.tech, canonical: canonical, enabled: false)
+
+    let second = VocabularyPackManager(overridesStore: VocabularyPackOverridesStore(fileURL: url))
+    let word = second.packWords(.tech).first { $0.canonical == canonical }
+    #expect(word?.isEnabled == false)
+  }
+
+  @Test("Overrides are scoped per pack — a word disabled in one pack stays untouched in another")
+  func overridesAreScopedPerPack() {
+    let (manager, techCanonical) = makeManager()
+    manager.setEnabled(.medical, true)
+    guard let medicalCanonical = manager.packWords(.medical).first?.canonical else {
+      Issue.record("Medical pack loaded no words — bundle problem")
+      return
+    }
+
+    manager.setWordEnabled(.tech, canonical: techCanonical, enabled: false)
+
+    let medicalWord = manager.packWords(.medical).first { $0.canonical == medicalCanonical }
+    #expect(medicalWord?.isEnabled == true)
+    #expect(medicalWord?.isEdited == false)
+  }
+
+  @Test("An override affects only one of two packs carrying the same canonical")
+  func duplicateCanonicalOverridesStayPackScoped() throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("vpo-mgr-duplicate-\(UUID().uuidString).json")
+    let manager = VocabularyPackManager(overridesStore: VocabularyPackOverridesStore(fileURL: url))
+    manager.setEnabled(.tech, true)
+    manager.setEnabled(.brands, true)
+
+    // "OpenAI" ships in both the real Tech and Brands packs — the exact
+    // shape the corrector's own duplicate-canonical test (VocabularyPackTests
+    // "duplicate pack canonicals across packs do NOT self-compete") exists for.
+    let techWord = try #require(
+      manager.packWords(.tech).first {
+        $0.canonical.caseInsensitiveCompare("OpenAI") == .orderedSame
+      }
+    )
+    let brandsWord = try #require(
+      manager.packWords(.brands).first {
+        $0.canonical.caseInsensitiveCompare("OpenAI") == .orderedSame
+      })
+
+    manager.setWordAliases(.tech, canonical: techWord.canonical, aliases: ["tech-only alias"])
+
+    var matching = manager.enabledPackTerms().filter {
+      $0.canonical.caseInsensitiveCompare("OpenAI") == .orderedSame
+    }
+    #expect(matching.count == 2)
+    #expect(matching.first { $0.id == techWord.id }?.aliases == ["tech-only alias"])
+    #expect(matching.first { $0.id == brandsWord.id }?.aliases == brandsWord.aliases)
+
+    manager.setWordEnabled(.tech, canonical: techWord.canonical, enabled: false)
+
+    matching = manager.enabledPackTerms().filter {
+      $0.canonical.caseInsensitiveCompare("OpenAI") == .orderedSame
+    }
+    #expect(matching.map(\.id) == [brandsWord.id])
+  }
+
+  @Test("Returning aliases to the shipped list clears the edited state")
+  func returningToShippedAliasesClearsEditedState() {
+    let (manager, canonical) = makeManager()
+    let shipped = manager.packWords(.tech).first { $0.canonical == canonical }!.shippedAliases
+
+    manager.setWordAliases(.tech, canonical: canonical, aliases: shipped + ["temporary alias"])
+    manager.setWordAliases(.tech, canonical: canonical, aliases: shipped)
+
+    let word = manager.packWords(.tech).first { $0.canonical == canonical }
+    #expect(word?.aliases == shipped)
+    #expect(word?.isEdited == false)
+  }
+
+  @Test("Restoring a word that was never edited is a no-op, not an error")
+  func restoringUneditedWordIsNoOp() {
+    let (manager, canonical) = makeManager()
+    manager.restoreWord(.tech, canonical: canonical)
+    let word = manager.packWords(.tech).first { $0.canonical == canonical }
+    #expect(word?.isEnabled == true)
+    #expect(word?.isEdited == false)
+    #expect(manager.persistenceError == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/VocabularyPackOverridesStoreTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/VocabularyPackOverridesStoreTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #2495 — the sparse per-word override store. Pure disk round-trip; the
+/// merge-with-shipped-defaults logic lives in `VocabularyPackManager` and is
+/// covered by `VocabularyPackManagerOverridesTests`, since it needs a real pack.
+@Suite("VocabularyPackOverridesStore — disk round-trip", .tags(.productOutcome))
+struct VocabularyPackOverridesStoreTests {
+
+  private func tempStore() -> (VocabularyPackOverridesStore, URL) {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("vpo-test-\(UUID().uuidString).json")
+    return (VocabularyPackOverridesStore(fileURL: url), url)
+  }
+
+  @Test("A missing file loads as empty, never throws")
+  func missingFileLoadsEmpty() {
+    let (store, _) = tempStore()
+    let file = store.load()
+    #expect(file.packs.isEmpty)
+  }
+
+  @Test("update() then load round-trips exactly")
+  func updateThenLoadRoundTrips() {
+    let (store, _) = tempStore()
+    let saved = store.update { file in
+      file.packs["tech"] = [
+        "docker": VocabularyPackWordOverride(isEnabled: false),
+        "kubernetes": VocabularyPackWordOverride(aliases: ["coobernetties", "kate ess"]),
+      ]
+      return true
+    }
+    #expect(saved != nil)
+
+    let reloaded = store.load()
+    #expect(reloaded.packs["tech"]?["docker"]?.isEnabled == false)
+    #expect(reloaded.packs["tech"]?["kubernetes"]?.aliases == ["coobernetties", "kate ess"])
+  }
+
+  @Test("A corrupt file loads as empty rather than throwing")
+  func corruptFileLoadsEmpty() throws {
+    let (store, url) = tempStore()
+    try Data("not valid json{{{".utf8).write(to: url)
+    let file = store.load()
+    #expect(file.packs.isEmpty)
+  }
+
+  @Test("A second update accumulates onto the first — it does not clobber it")
+  func secondUpdateAccumulatesOntoFirst() {
+    // This is the exact bug the locked `update(_:)` transaction exists to
+    // prevent: a naive whole-file `save()` built from a caller-held snapshot
+    // would have made this second write silently erase the first pack's
+    // overrides. Because `update` reloads current disk state before every
+    // transform, both writes survive.
+    let (store, _) = tempStore()
+    _ = store.update { file in
+      file.packs["tech"] = ["docker": VocabularyPackWordOverride(isEnabled: false)]
+      return true
+    }
+    _ = store.update { file in
+      file.packs["medical"] = ["metformin": VocabularyPackWordOverride(isEnabled: false)]
+      return true
+    }
+
+    let reloaded = store.load()
+    #expect(reloaded.packs["tech"]?["docker"]?.isEnabled == false)
+    #expect(reloaded.packs["medical"]?["metformin"]?.isEnabled == false)
+  }
+
+  @Test("update() reads the CURRENT on-disk file, not a caller-held snapshot")
+  func updateReadsCurrentDiskStateNotAStaleCapture() {
+    let (store, _) = tempStore()
+    _ = store.update { file in
+      file.packs["tech"] = ["docker": VocabularyPackWordOverride(isEnabled: false)]
+      return true
+    }
+    // A second "process" writes to the SAME store instance's underlying
+    // file directly between these two calls.
+    _ = store.update { file in
+      file.packs["medical"] = ["metformin": VocabularyPackWordOverride(isEnabled: false)]
+      return true
+    }
+    // A third mutation must see BOTH prior writes, because each `update`
+    // starts from a fresh `load()`, never a value carried across calls.
+    let final = store.update { file in
+      file.packs["tech"]?["docker"] != nil && file.packs["medical"]?["metformin"] != nil
+    }
+    #expect(final != nil)
+    #expect(final?.packs["tech"]?["docker"]?.isEnabled == false)
+    #expect(final?.packs["medical"]?["metformin"]?.isEnabled == false)
+  }
+
+  @Test("update() returning false skips the write")
+  func updateReturningFalseSkipsWrite() {
+    let (store, url) = tempStore()
+    let before = FileManager.default.fileExists(atPath: url.path)
+    let result = store.update { _ in false }
+    #expect(result != nil)
+    #expect(before == false)
+    // A `false` transform must not have created the file at all.
+    #expect(FileManager.default.fileExists(atPath: url.path) == false)
+  }
+
+  @Test("VocabularyPackWordOverride.isEmpty is true only with both fields nil")
+  func overrideIsEmptyReflectsBothFields() {
+    #expect(VocabularyPackWordOverride().isEmpty)
+    #expect(!VocabularyPackWordOverride(isEnabled: false).isEmpty)
+    #expect(!VocabularyPackWordOverride(aliases: []).isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Dictionary redesign (epic #2491), the biggest piece. Vocabulary packs (Tech/Medical/Legal/Brands/Names) were read-only — a pack was on or off, nothing more. This adds per-word editing: turn one word off without disabling the whole pack, edit its aliases (the mishearings it catches), and restore a changed word back to what the pack shipped. "See all" now opens a full-pane editor in place of the pack list, instead of a small popup (recorded UI decision on #2495).

Mockup: https://claude.ai/code/artifact/3c59cca6-990e-433c-8067-d21b69c010fb

## Architecture

New `VocabularyPackOverridesStore` (`Sources/EnviousWisprPostProcessing`) persists only sparse differences from the shipped pack — nothing is written for a word nobody touched. It is a separate file from the founder's own word list (`CustomWordsManager`), which stores a different thing under different rules. `VocabularyPackManager.enabledPackTerms()` is the one place overrides reach live dictation correction.

Codex-reviewed across two rounds. The first pass's design comment claimed pack overrides were single-process and needed no lock — that was wrong: multiple running app instances (dev + production, or two worktrees) resolve the same file. Fixed: every mutation now takes an exclusive lock and performs one load-transform-save transaction, never a save built from a possibly-stale in-memory snapshot. Also fixed: a badge that stayed showing "Edited" after an edit was undone back to the shipped value, hundreds of redundant pack reloads per screen render, and a toggle with an oversized invisible tap target.

## Test plan

- [x] `scripts/xcode-test.sh` — 7,183 tests passed, clean verdict
- [x] New tests exercise the real bundled Tech/Medical/Brands pack data, not fakes, including a duplicate-canonical-across-packs case ("OpenAI" ships in both Tech and Brands) matching the corrector's own existing precedence test

Closes #2495
