### PR TITLE
fix(settings): rebuild the Dictionary rail, top bar, Learn from cards and pack loading

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermListPolicy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermListPolicy.swift
@@ -51,7 +51,13 @@ enum CustomTermListPolicy {
   /// Slice of `filtered` for `page` (0-indexed). Returns empty if page is
   /// out of range. Caller is responsible for clamping `page` after a search
   /// changes the filtered count.
-  static func paged(_ filtered: [CustomWord], page: Int) -> [CustomWord] {
+  ///
+  /// Generic over the element because the vocabulary-pack word list pages by
+  /// the same rule and must not answer "how many words fit on a page" for
+  /// itself — `pageSize` has ONE owner. It was `[CustomWord]` only because the
+  /// Your Words list was the only caller; nothing in the arithmetic ever read
+  /// the element.
+  static func paged<Element>(_ filtered: [Element], page: Int) -> [Element] {
     let start = page * pageSize
     let end = min(start + pageSize, filtered.count)
     guard start < filtered.count else { return [] }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -29,6 +29,11 @@ struct CustomTermsSection<Actions: View>: View {
   }
 
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
+  /// See `EnvironmentValues.dictionaryScrollToTop`. This list has paged since
+  /// it shipped and has always swapped rows under an unchanged scroll offset;
+  /// the cloud review that named it on the pack list applies here too, so both
+  /// are fixed through the one owner rather than one of them.
+  @Environment(\.dictionaryScrollToTop) private var scrollToTop
   @State private var searchQuery: String = ""
   /// #2494: `nil` is "All categories," the default pill. One combined
   /// projection (`filteredWords`) feeds search, this filter, count,
@@ -238,6 +243,10 @@ struct CustomTermsSection<Actions: View>: View {
         }
       }
     }
+    // Every page starts at its first row. Keyed on the page rather than fired
+    // from the buttons, so it also covers the clamps that reset to page one
+    // when a search or category filter shortens the list.
+    .onChange(of: currentPage) { _, _ in scrollToTop() }
     .onChange(of: allWords) { _, newWords in
       // Prune against current ELIGIBILITY, not merely current ID existence:
       // if a live refresh replaces an already-selected ID with a word that

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -15,7 +15,19 @@ private struct BulkDeleteRequest: Identifiable {
 /// when frequency is 0 to avoid the "0 times" looks-like-a-bug case). Bible §10.2.
 /// Bulk select/delete (#1703): a "Select" mode lets several of the user's own
 /// words be checked off and removed in one action.
-struct CustomTermsSection: View {
+struct CustomTermsSection<Actions: View>: View {
+  /// The page-level actions (Add word / Import / Export), rendered on the same
+  /// line as the word count instead of in a band above this card. Passed in
+  /// rather than built here because they belong to `YourWordsView` — they open
+  /// its sheets and use its export plumbing — while the count they sit beside
+  /// is this view's own projection. Taking them as a view keeps that ownership
+  /// and still puts them on one line.
+  @ViewBuilder let actions: Actions
+
+  init(@ViewBuilder actions: () -> Actions) {
+    self.actions = actions()
+  }
+
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var searchQuery: String = ""
   /// #2494: `nil` is "All categories," the default pill. One combined
@@ -68,36 +80,85 @@ struct CustomTermsSection: View {
 
   var body: some View {
     // #2492: no "Your Words" repeated here — the left sub-menu's selected
-    // tab already says it. Keep the count, which is the useful part.
-    BrandedSection(
-      header: "\(filteredWords.count) \(filteredWords.count == 1 ? "word" : "words")"
-    ) {
+    // tab already says it. The count moved INSIDE the card as the first row,
+    // beside the actions, so the eyebrow above the card is gone too.
+    BrandedSection {
+      // The top bar: what you have on the left, what you can do on the right,
+      // one line. Founder, 2026-08-29 — the count and the three buttons "should
+      // all be on one line to create a cleaner UI".
+      BrandedRow(showDivider: true) {
+        // ViewThatFits: at the app's 750pt minimum window this pane is roughly
+        // 180pt after the sidebar, page padding, the 216pt rail and its gap, so
+        // a count plus three labelled buttons cannot share a line there. The
+        // one-line form is tried first and is what the founder's window gets.
+        ViewThatFits(in: .horizontal) {
+          HStack(spacing: 10) {
+            wordCountLabel
+            Spacer(minLength: 12)
+            actions
+          }
+          VStack(alignment: .leading, spacing: 10) {
+            wordCountLabel
+            // `WrappingHStack`, not a second `HStack` — `ViewThatFits` uses its
+            // LAST candidate whether or not that one fits either, so a fallback
+            // that can still overflow is not a fallback. This one wraps onto as
+            // many lines as the width needs, so there is no width at which the
+            // buttons run off the card.
+            WrappingHStack(spacing: 8) { actions }
+              .frame(maxWidth: .infinity, alignment: .leading)
+          }
+        }
+      }
+
       // Search + selection controls
       BrandedRow(showDivider: true) {
-        HStack(spacing: 6) {
-          Image(systemName: "magnifyingglass")
-            .foregroundStyle(.stTextSecondary)
-            .font(.system(size: 12))
-          TextField("Search by name, alias, or category", text: $searchQuery)
-            .textFieldStyle(.plain)
-            .onChange(of: searchQuery) { _, _ in currentPage = 0 }
-            .onChange(of: selectedCategory) { _, _ in currentPage = 0 }
-            .onChange(of: pageCount) { _, newCount in
-              if currentPage >= newCount { currentPage = max(0, newCount - 1) }
+        HStack(spacing: 10) {
+          // A real input box. The field used to be bare text on the card, the
+          // same colour as everything around it, so nothing said where to type
+          // (founder, 2026-08-29: "making it unclear where people need to
+          // type"). `stPageBg` is the recessed surface — darker than the card
+          // in dark mode, tinted below white in light mode — and the accent
+          // hairline is the approved mockup's `.search-row` border.
+          HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+              .foregroundStyle(.stTextSecondary)
+              .font(.system(size: 12))
+              .accessibilityHidden(true)
+            TextField("Search by name, alias, or category", text: $searchQuery)
+              .textFieldStyle(.plain)
+              .onChange(of: searchQuery) { _, _ in currentPage = 0 }
+              .onChange(of: selectedCategory) { _, _ in currentPage = 0 }
+              .onChange(of: pageCount) { _, newCount in
+                if currentPage >= newCount { currentPage = max(0, newCount - 1) }
+              }
+            if !searchQuery.isEmpty {
+              Button {
+                searchQuery = ""
+              } label: {
+                Image(systemName: "xmark.circle.fill")
+                  .foregroundStyle(.stTextSecondary)
+                  .font(.system(size: 12))
+                  .settingsHoverQuiet(inset: 3)
+              }
+              .buttonStyle(.plain)
+              .accessibilityLabel("Clear search")
             }
-          if !searchQuery.isEmpty {
-            Button {
-              searchQuery = ""
-            } label: {
-              Image(systemName: "xmark.circle.fill")
-                .foregroundStyle(.stTextSecondary)
-                .font(.system(size: 12))
-                .settingsHoverQuiet()
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Clear search")
           }
-          Spacer()
+          .padding(.horizontal, 10)
+          .padding(.vertical, 7)
+          .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+              .fill(Color.stPageBg)
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+              .strokeBorder(Color.stAccent.opacity(0.28), lineWidth: 1)
+              // A stroked Shape is still hit-testable, and this one sits over
+              // the text field it decorates (code-gotchas.md
+              // RULE: a-decoration-drawn-over-a-control-swallows-its-clicks).
+              .allowsHitTesting(false)
+          )
+
           selectionControls
         }
       }
@@ -252,6 +313,18 @@ struct CustomTermsSection: View {
     }
   }
 
+  /// The count, in the card's own eyebrow treatment — the same accent
+  /// uppercase `BrandedSection` used to draw above the card, kept so moving it
+  /// inside changed the POSITION and not the voice.
+  private var wordCountLabel: some View {
+    Text("\(filteredWords.count) \(filteredWords.count == 1 ? "word" : "words")".uppercased())
+      .font(.stSectionHeader)
+      .tracking(0.6)
+      .foregroundStyle(.stAccent)
+      .lineLimit(1)
+      .fixedSize(horizontal: true, vertical: false)
+  }
+
   /// #2494: one pill per `WordCategory` plus "All categories," selected
   /// state driven by `selectedCategory`. `WrappingHStack` (not a horizontal
   /// scroller) so the row is fully visible and never hides a category behind
@@ -295,6 +368,12 @@ struct CustomTermsSection: View {
               .allowsHitTesting(false)
           }
         }
+        // These pills were the one clickable thing on the page that stayed
+        // dead under the pointer while the Edit buttons beside them lit up
+        // (founder, 2026-08-29). The shared row treatment, at a radius large
+        // enough that the tint is a capsule and matches the pill it covers —
+        // `RoundedRectangle` clamps the radius to half the shorter side.
+        .settingsHoverRow(cornerRadius: 100)
         .contentShape(Rectangle())
     }
     .buttonStyle(.plain)

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -153,9 +153,9 @@ struct CustomTermsSection<Actions: View>: View {
           .overlay(
             RoundedRectangle(cornerRadius: 9, style: .continuous)
               .strokeBorder(Color.stAccent.opacity(0.28), lineWidth: 1)
-              // A stroked Shape is still hit-testable, and this one sits over
-              // the text field it decorates (code-gotchas.md
-              // RULE: a-decoration-drawn-over-a-control-swallows-its-clicks).
+              // This decoration sits over the text field, and a Shape in an
+              // overlay can take the click. A decoration is never in the hit
+              // path.
               .allowsHitTesting(false)
           )
 
@@ -360,8 +360,7 @@ struct CustomTermsSection<Actions: View>: View {
         .overlay {
           // #2494 review: a filled Shape overlay is hit-testable even where
           // its own fill is invisible, so an undecorated stroke sitting over
-          // the pill's Text can steal the tap from the Button underneath it
-          // (code-gotchas.md RULE: a-decoration-drawn-over-a-control-swallows-its-clicks).
+          // the pill's Text can steal the tap from the Button underneath it.
           if isSelected {
             Capsule()
               .strokeBorder(Color.stAccent.opacity(0.35), lineWidth: 1)

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -2,10 +2,21 @@ import AppKit
 import EnviousWisprServices
 import SwiftUI
 
-/// Learn from... tab of the Dictionary page. Two rows: auto-learn (Phase 7
-/// #629, still "Coming soon") and contacts import (Phase 6 #636, live).
-/// Bible §10.2. #2492: no section header here — the left sub-menu's selected
-/// tab already says "Learn from...".
+/// Learn from... tab of the Dictionary page. Two ways the app can pick up words
+/// without being told each one: auto-learn from transcripts (Phase 7 #629, not
+/// built yet) and Contacts import (Phase 6 #636, live). Bible §10.2.
+///
+/// **Two features, two cards, and that is the fix.** The first build put both
+/// inside one `BrandedSection` as `BrandedRow`s separated by a hairline, so a
+/// title, a paragraph, a status line, a button, a second toggle and a second
+/// paragraph ran together as one column of text with nothing saying where one
+/// feature ended (founder, 2026-08-29: "just blends together with no clear UX
+/// design"). The approved mockup draws each as its own recessed card
+/// (`.learn-row`), and a `COMING SOON` pill on the title line rather than a
+/// grey sentence hanging under the paragraph. "Keep in sync on launch" is not
+/// a peer of those two features — it is a setting BELONGING to Contacts, so it
+/// sits inside that card under a divider, which is what the mockup's
+/// `.sync-row` is.
 struct LearningSection: View {
   @Environment(ContactsImportCoordinator.self) private var contactsImport
   @Environment(SettingsManager.self) private var settings
@@ -13,83 +24,16 @@ struct LearningSection: View {
   var body: some View {
     @Bindable var settings = settings
 
-    BrandedSection {
-      // Row 1: Auto-learn from transcripts (Phase 7 #629)
-      BrandedRow(showDivider: true) {
-        VStack(alignment: .leading, spacing: 4) {
-          HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 2) {
-              Text("Learn from my transcripts")
-                .settingsRowLabel()
-              Text(
-                "EnviousWispr will watch for edits to text it just pasted, to suggest new words. Edits stay on this Mac."
-              )
-              .settingsReadingCopy()
-            }
-            Spacer()
-            Toggle("", isOn: .constant(false))
-              .toggleStyle(BrandedToggleStyle())
-              .disabled(true)
-              .labelsHidden()
-          }
-          Text("Coming soon")
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-            .padding(.top, 2)
-        }
-      }
-
-      // Row 2: Import from Contacts (Phase 6 #636)
-      BrandedRow(showDivider: false) {
-        VStack(alignment: .leading, spacing: 8) {
-          // ViewThatFits: the Dictionary rail (#2492) narrows this row to
-          // roughly 228pt at the app's 750pt minimum window, where the
-          // imported-count pill + button can't share a line with the copy
-          // (cloud review, PR #2499).
-          ViewThatFits(in: .horizontal) {
-            HStack(alignment: .top) {
-              contactsRowLabel
-              Spacer()
-              importControl
-            }
-            VStack(alignment: .leading, spacing: 8) {
-              contactsRowLabel
-              importControl
-            }
-          }
-
-          if case .imported(let count) = contactsImport.phase {
-            Label(addedFeedback(count), systemImage: "checkmark.circle.fill")
-              .font(.stHelper)
-              .foregroundStyle(.stSuccess)
-          }
-          if let progress = contactsImport.enrichmentProgress {
-            Label(
-              "Finding spoken variants… \(progress.done) of \(progress.total)",
-              systemImage: "sparkles"
-            )
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-          }
-          if case .failed(let message) = contactsImport.phase {
-            Text(message)
-              .font(.stHelper)
-              .foregroundStyle(.stError)
-          }
-          if contactsImport.phase == .denied {
-            Text("Contacts access is off. Turn it on in System Settings, then try again.")
-              .font(.stHelper)
-              .foregroundStyle(.stTextSecondary)
-          }
-
-          Toggle(isOn: $settings.contactsSyncOnLaunchEnabled) {
-            Text("Keep in sync on launch").settingsRowLabel()
-          }
-          .toggleStyle(BrandedToggleStyle())
-          .padding(.top, 2)
-          Text("Check for new contacts each time EnviousWispr starts. Off by default.")
-            .settingsReadingCopy()
-        }
+    // The page says what it is for. `BrandedPanel` puts that header INSIDE the
+    // card, so the tab opens with a sentence rather than with a control.
+    BrandedPanel(
+      icon: "sparkle.magnifyingglass",
+      header: "Learn from...",
+      description: "Let EnviousWispr pick up new words on its own, from things you already have."
+    ) {
+      VStack(alignment: .leading, spacing: 12) {
+        transcriptsCard
+        contactsCard(settings: $settings)
       }
     }
     .sheet(isPresented: confirmSheetBinding) {
@@ -102,6 +46,135 @@ struct LearningSection: View {
     }
   }
 
+  /// Auto-learn from transcripts — announced, not built. The disabled toggle
+  /// stays because it shows the SHAPE of the eventual control, and the pill
+  /// says on the title line that it does not work yet, so nobody clicks a dead
+  /// switch and wonders.
+  private var transcriptsCard: some View {
+    learnCard {
+      VStack(alignment: .leading, spacing: 8) {
+        HStack(alignment: .center, spacing: 8) {
+          Text("Learn from my transcripts")
+            .settingsRowLabel()
+          comingSoonPill
+          Spacer(minLength: 8)
+          Toggle("", isOn: .constant(false))
+            .toggleStyle(BrandedToggleStyle())
+            .disabled(true)
+            .labelsHidden()
+            // BrandedToggleStyle's internal Spacer claims whatever width it is
+            // handed, which here is the rest of the row (swift-patterns.md
+            // RULE: plain-button-content-shape, reverse direction).
+            .fixedSize()
+        }
+        Text(
+          "EnviousWispr will watch for edits to text it just pasted, to suggest new words. Edits stay on this Mac."
+        )
+        .settingsReadingCopy()
+        .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+
+  /// Contacts import, plus the one setting that belongs to it.
+  private func contactsCard(settings: Bindable<SettingsManager>) -> some View {
+    learnCard {
+      VStack(alignment: .leading, spacing: 10) {
+        // ViewThatFits: at the app's 750pt minimum window this card is narrow
+        // enough that the imported-count pill and button cannot share a line
+        // with the title (cloud review, PR #2499).
+        ViewThatFits(in: .horizontal) {
+          HStack(alignment: .center, spacing: 10) {
+            contactsRowLabel
+            Spacer(minLength: 8)
+            importControl
+          }
+          VStack(alignment: .leading, spacing: 10) {
+            contactsRowLabel
+            importControl
+          }
+        }
+
+        contactsStatus
+
+        Divider().overlay(Color.stDivider)
+
+        HStack(alignment: .center, spacing: 10) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Keep in sync on launch").settingsRowLabel()
+            Text("Check for new contacts each time EnviousWispr starts. Off by default.")
+              .settingsReadingCopy()
+              .fixedSize(horizontal: false, vertical: true)
+          }
+          Spacer(minLength: 8)
+          Toggle("", isOn: settings.contactsSyncOnLaunchEnabled)
+            .toggleStyle(BrandedToggleStyle())
+            .labelsHidden()
+            .fixedSize()
+            .accessibilityLabel("Keep in sync on launch")
+        }
+      }
+    }
+  }
+
+  /// The import's own feedback, in one place rather than four sibling `if`s in
+  /// the middle of the card's layout.
+  @ViewBuilder private var contactsStatus: some View {
+    if case .imported(let count) = contactsImport.phase {
+      Label(addedFeedback(count), systemImage: "checkmark.circle.fill")
+        .font(.stHelper)
+        .foregroundStyle(.stSuccess)
+    }
+    if let progress = contactsImport.enrichmentProgress {
+      Label(
+        "Finding spoken variants… \(progress.done) of \(progress.total)",
+        systemImage: "sparkles"
+      )
+      .font(.stHelper)
+      .foregroundStyle(.stTextSecondary)
+    }
+    if case .failed(let message) = contactsImport.phase {
+      Text(message)
+        .font(.stHelper)
+        .foregroundStyle(.stError)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    if contactsImport.phase == .denied {
+      Text("Contacts access is off. Turn it on in System Settings, then try again.")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  /// The recessed card each feature sits in. `stPageBg` is the page surface,
+  /// which reads as inset against the panel's `stSectionBg` in both themes —
+  /// the same pairing the search field on the Your Words tab uses.
+  private func learnCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    content()
+      .padding(14)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .fill(Color.stPageBg)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(Color.stDivider, lineWidth: 1)
+      )
+  }
+
+  private var comingSoonPill: some View {
+    Text("COMING SOON")
+      .font(.system(size: 11, weight: .bold))
+      .tracking(0.4)
+      .foregroundStyle(.stTextSecondary)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .background(Capsule().fill(Color.stTextPrimary.opacity(0.07)))
+      .fixedSize()
+  }
+
   private var contactsRowLabel: some View {
     VStack(alignment: .leading, spacing: 2) {
       Text("Import from Contacts")
@@ -110,6 +183,7 @@ struct LearningSection: View {
         "Add the names of people you know to your word list, so dictation spells them right."
       )
       .settingsReadingCopy()
+      .fixedSize(horizontal: false, vertical: true)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -62,9 +62,10 @@ struct LearningSection: View {
             .toggleStyle(BrandedToggleStyle())
             .disabled(true)
             .labelsHidden()
-            // BrandedToggleStyle's internal Spacer claims whatever width it is
-            // handed, which here is the rest of the row (swift-patterns.md
-            // RULE: plain-button-content-shape, reverse direction).
+            // BrandedToggleStyle wraps label-Spacer-track in a content shape so
+            // a labelled row is clickable end to end. With the label hidden its
+            // Spacer claims the whole remaining row, which would make the empty
+            // middle of this card toggle the switch. `fixedSize` collapses it.
             .fixedSize()
         }
         Text(
@@ -161,6 +162,9 @@ struct LearningSection: View {
       .overlay(
         RoundedRectangle(cornerRadius: 12, style: .continuous)
           .strokeBorder(Color.stDivider, lineWidth: 1)
+          // A decoration is never in the hit path — these cards contain
+          // toggles and a button.
+          .allowsHitTesting(false)
       )
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
@@ -88,6 +88,9 @@ struct VocabPacksSection: View {
     .overlay(
       RoundedRectangle(cornerRadius: 12, style: .continuous)
         .strokeBorder(Color.stDivider, lineWidth: 1)
+        // A decoration is never in the hit path — each card contains a
+        // "See all" button and the pack's toggle.
+        .allowsHitTesting(false)
     )
   }
 
@@ -109,8 +112,10 @@ struct VocabPacksSection: View {
       )
       .toggleStyle(BrandedToggleStyle())
       .labelsHidden()
-      // BrandedToggleStyle's internal Spacer otherwise claims the whole
-      // remaining row (swift-patterns.md RULE: plain-button-content-shape).
+      // BrandedToggleStyle wraps label-Spacer-track in a content shape so a
+      // labelled row is clickable end to end. With the label hidden its Spacer
+      // would claim the whole remaining row, making the empty space beside the
+      // pack name toggle the pack. `fixedSize` collapses it.
       .fixedSize()
       .accessibilityLabel("Enable \(id.displayName) pack")
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
@@ -26,56 +26,74 @@ struct VocabPacksSection: View {
   }
 
   private var packList: some View {
-    BrandedSection {
+    BrandedPanel(
+      icon: "shippingbox",
+      header: "Vocabulary Packs",
+      description:
+        "Ready-made word lists for a field. Turn one on and EnviousWispr starts fixing the words it already knows that field gets wrong."
+    ) {
       let ids = packManager.availablePackIDs
       if ids.isEmpty {
-        BrandedRow(showDivider: false) {
-          Text("No vocabulary packs available.")
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-        }
+        Text("No vocabulary packs available.")
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
       } else {
-        ForEach(Array(ids.enumerated()), id: \.element) { index, id in
-          BrandedRow(showDivider: index < ids.count - 1) {
-            // ViewThatFits: the Dictionary rail (#2492) leaves this row roughly
-            // 228pt at the app's 750pt minimum window — enough for the old
-            // full-width page, not for text + a button + a toggle on one line
-            // (cloud review, PR #2499). The horizontal row is tried first.
-            ViewThatFits(in: .horizontal) {
-              HStack(alignment: .center) {
-                packInfo(id)
-                Spacer()
-                packControls(id)
-              }
-              VStack(alignment: .leading, spacing: 8) {
-                packInfo(id)
-                packControls(id)
-              }
-            }
-          }
+        VStack(alignment: .leading, spacing: 10) {
+          ForEach(ids, id: \.self) { packCard($0) }
         }
       }
     }
   }
 
-  @ViewBuilder
-  private func packInfo(_ id: VocabularyPackID) -> some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Text(id.displayName)
-        .font(.body)
+  /// One pack, as its own recessed card.
+  ///
+  /// **The controls are pinned to the TITLE line, and that is the fix.** They
+  /// were previously centred against a three-line block, so "See all" landed
+  /// mid-paragraph at a different horizontal position in every row — the
+  /// button's x followed the intrinsic width of whichever blurb sat beside it
+  /// (founder screenshot, 2026-08-29). Anchoring them to the first line puts
+  /// every button in the same place and next to the thing it acts on.
+  private func packCard(_ id: VocabularyPackID) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      // ViewThatFits: at the app's 750pt minimum window this card is too
+      // narrow for a name, a button and a toggle on one line (cloud review,
+      // PR #2499). The one-line form is tried first.
+      ViewThatFits(in: .horizontal) {
+        HStack(spacing: 10) {
+          Text(id.displayName).settingsRowLabel()
+          Spacer(minLength: 12)
+          packControls(id)
+        }
+        VStack(alignment: .leading, spacing: 8) {
+          Text(id.displayName).settingsRowLabel()
+          packControls(id)
+        }
+      }
+
       Text(id.blurb)
-        .font(.stHelper)
-        .foregroundStyle(.stTextSecondary)
+        .settingsReadingCopy()
+        .fixedSize(horizontal: false, vertical: true)
       Text(rowDetail(for: id))
         .font(.stHelper)
         .foregroundStyle(.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
         .padding(.top, 2)
     }
+    .padding(14)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .fill(Color.stPageBg)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .strokeBorder(Color.stDivider, lineWidth: 1)
+    )
   }
 
   @ViewBuilder
   private func packControls(_ id: VocabularyPackID) -> some View {
-    HStack {
+    HStack(spacing: 10) {
       // No `.controlSize` here: this control owns its own metrics, so the
       // modifier the previous system `Button` needed became a dead line
       // that reads as if it still sizes something.
@@ -91,8 +109,10 @@ struct VocabPacksSection: View {
       )
       .toggleStyle(BrandedToggleStyle())
       .labelsHidden()
+      // BrandedToggleStyle's internal Spacer otherwise claims the whole
+      // remaining row (swift-patterns.md RULE: plain-button-content-shape).
+      .fixedSize()
       .accessibilityLabel("Enable \(id.displayName) pack")
-      .padding(.leading, 6)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -17,6 +17,10 @@ struct VocabularyPackDetailSection: View {
   let id: VocabularyPackID
   let onClose: () -> Void
   @Environment(VocabularyPackManager.self) private var packManager
+  /// See `EnvironmentValues.dictionaryScrollToTop`. Paging swaps the rows
+  /// under an unchanged scroll offset, so without this the next page opens in
+  /// its middle.
+  @Environment(\.dictionaryScrollToTop) private var scrollToTop
   @State private var searchQuery: String = ""
 
   @State private var currentPage: Int = 0
@@ -99,6 +103,10 @@ struct VocabularyPackDetailSection: View {
     .onChange(of: pageCount) { _, newCount in
       if currentPage >= newCount { currentPage = max(0, newCount - 1) }
     }
+    // Every page starts at its first row. Keyed on the page rather than fired
+    // from the buttons, so it also covers the clamp above and a search that
+    // resets to page one.
+    .onChange(of: currentPage) { _, _ in scrollToTop() }
   }
 
   private func pager(page: Int, of pageCount: Int) -> some View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -19,6 +19,8 @@ struct VocabularyPackDetailSection: View {
   @Environment(VocabularyPackManager.self) private var packManager
   @State private var searchQuery: String = ""
 
+  @State private var currentPage: Int = 0
+
   private var words: [VocabularyPackWordDisplay] { packManager.packWords(id) }
 
   private var filteredWords: [VocabularyPackWordDisplay] {
@@ -31,11 +33,14 @@ struct VocabularyPackDetailSection: View {
   }
 
   var body: some View {
-    // Computed ONCE per body evaluation. `filteredWords` re-decodes and
-    // re-sorts the whole pack (`packManager.packWords(id)`) on every access;
-    // reading the computed property three times (emptiness check, ForEach,
-    // divider count) tripled that cost per render for no reason.
+    // Computed ONCE per body evaluation. `filteredWords` re-sorts the whole
+    // pack (`packManager.packWords(id)`) on every access; reading the computed
+    // property three times (emptiness check, ForEach, divider count) tripled
+    // that cost per render for no reason.
     let displayedWords = filteredWords
+    let pageCount = CustomTermListPolicy.pageCount(of: displayedWords.count)
+    let safePage = max(0, min(currentPage, pageCount - 1))
+    let pagedWords = CustomTermListPolicy.paged(displayedWords, page: safePage)
 
     BrandedSection {
       BrandedRow(showDivider: true) { header }
@@ -49,7 +54,7 @@ struct VocabularyPackDetailSection: View {
         }
       }
 
-      if displayedWords.isEmpty {
+      if pagedWords.isEmpty {
         BrandedRow(showDivider: false) {
           Text(
             searchQuery.isEmpty
@@ -60,12 +65,67 @@ struct VocabularyPackDetailSection: View {
           .foregroundStyle(.stTextSecondary)
         }
       } else {
-        ForEach(Array(displayedWords.enumerated()), id: \.element.id) { index, word in
-          BrandedRow(showDivider: index < displayedWords.count - 1) {
-            PackWordRow(packID: id, word: word)
+        // **Paged, and this is what stops the beachball.** Every row here
+        // carries a live `TextField`, a shadowed toggle, and one hover-tracking
+        // area per alias chip, and they were ALL built before the pane could
+        // draw: Brands is 106 words and Medical is 87 words carrying 453
+        // aliases between them (measured 2026-08-29), so opening a pack
+        // constructed several hundred interactive controls on the main thread
+        // and the founder got a spinning wheel. Nothing was cached and nothing
+        // was deferred.
+        //
+        // 50 per page via `CustomTermListPolicy` — the SAME paging the Your
+        // Words tab next door already uses, rather than a second answer to the
+        // same question. `LazyVStack` then defers even those until they scroll
+        // into view.
+        LazyVStack(alignment: .leading, spacing: 0) {
+          ForEach(Array(pagedWords.enumerated()), id: \.element.id) { index, word in
+            BrandedRow(showDivider: index < pagedWords.count - 1 || pageCount > 1) {
+              PackWordRow(packID: id, word: word)
+            }
           }
         }
       }
+
+      if pageCount > 1 {
+        BrandedRow(showDivider: false) {
+          pager(page: safePage, of: pageCount)
+        }
+      }
+    }
+    // A search that shortens the list can strand the reader on a page that no
+    // longer exists; the Your Words tab clamps the same way.
+    .onChange(of: searchQuery) { _, _ in currentPage = 0 }
+    .onChange(of: pageCount) { _, newCount in
+      if currentPage >= newCount { currentPage = max(0, newCount - 1) }
+    }
+  }
+
+  private func pager(page: Int, of pageCount: Int) -> some View {
+    HStack {
+      Button {
+        if currentPage > 0 { currentPage -= 1 }
+      } label: {
+        Image(systemName: "chevron.left")
+          .settingsHoverQuiet(isEnabled: page > 0)
+      }
+      .buttonStyle(.plain)
+      .disabled(page == 0)
+      .accessibilityLabel("Previous page")
+      Spacer()
+      Text("Page \(page + 1) of \(pageCount)")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+      Spacer()
+      Button {
+        if currentPage < pageCount - 1 { currentPage += 1 }
+      } label: {
+        Image(systemName: "chevron.right")
+          .settingsHoverQuiet(isEnabled: page < pageCount - 1)
+      }
+      .buttonStyle(.plain)
+      .disabled(page >= pageCount - 1)
+      .accessibilityLabel("Next page")
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -12,6 +12,24 @@ private enum YourWordsSheetRoute: String, Identifiable {
   var id: Self { self }
 }
 
+/// Scrolls the Dictionary page's content pane back to its first row.
+///
+/// Set by `YourWordsView`, which owns the scroll view; read by every paged
+/// list inside it. The default is a no-op, so a list rendered outside that
+/// pane — a preview, a test — simply does nothing rather than needing a
+/// different code path. Mirrors `settingsNavigate`, the settings window's
+/// other environment-carried action.
+private struct DictionaryScrollToTopKey: EnvironmentKey {
+  static let defaultValue: @MainActor () -> Void = {}
+}
+
+extension EnvironmentValues {
+  var dictionaryScrollToTop: @MainActor () -> Void {
+    get { self[DictionaryScrollToTopKey.self] }
+    set { self[DictionaryScrollToTopKey.self] = newValue }
+  }
+}
+
 /// #2492: the Dictionary page's fixed left sub-menu, one case per tab. Owned
 /// here (not a nested type) so a later phase (#2497, the Quick Add tab) adds
 /// exactly one case rather than inventing a second tab mechanism — the
@@ -77,6 +95,9 @@ enum DictionaryTab: String, CaseIterable, Identifiable {
 /// (#2493 explicitly scopes the terminology pass to user-facing copy, not
 /// Swift symbols).
 struct YourWordsView: View {
+  /// Identity of the zero-height anchor at the top of the scrolling pane.
+  fileprivate static let topAnchor = "dictionaryPaneTop"
+
   @Environment(SettingsManager.self) private var settings
   @Environment(CustomWordsCoordinator.self) private var customWordsCoordinator
   @State private var selectedTab: DictionaryTab = .yourWords
@@ -102,13 +123,38 @@ struct YourWordsView: View {
           // the 750pt minimum the narrower value was defending).
           .frame(width: PolishRailMetrics.railWidth, alignment: .leading)
 
-        ScrollView {
-          VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
-            selectedTabContent
+        // `ScrollViewReader` so a paged list can return to its first row.
+        //
+        // The scroll offset belongs to THIS view — there is one scroll view
+        // for every tab — while the page buttons live two levels down, in
+        // `CustomTermsSection` and `VocabularyPackDetailSection`. Without a way
+        // to reach back up, pressing Next at the bottom of a 50-row page swaps
+        // the rows underneath an unchanged offset, so the next page opens
+        // somewhere in its middle and the reader has to scroll up to find its
+        // start (cloud review, PR #2504).
+        //
+        // Handed down through the environment as ONE action rather than
+        // solved twice: both paged lists are inside this scroll view and the
+        // Your Words list has had the same defect since it shipped.
+        ScrollViewReader { proxy in
+          ScrollView {
+            VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+              selectedTabContent
+            }
+            .padding(.bottom, SettingsLayout.contentBottom)
+            // The anchor the action scrolls to. Zero-height and behind
+            // everything, so it changes nothing about the layout.
+            .overlay(alignment: .top) {
+              Color.clear.frame(height: 0).id(Self.topAnchor)
+            }
           }
-          .padding(.bottom, SettingsLayout.contentBottom)
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+          .environment(\.dictionaryScrollToTop) {
+            withAnimation(.easeOut(duration: 0.18)) {
+              proxy.scrollTo(Self.topAnchor, anchor: .top)
+            }
+          }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       }
     }
     .padding(.top, SettingsLayout.contentTop)

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -43,6 +43,28 @@ enum DictionaryTab: String, CaseIterable, Identifiable {
     case .quickAdd: return "bolt"
     }
   }
+
+  /// One line under the tab name, the way every AI Polish rail row carries a
+  /// tagline under its engine name (`PolishRailProvider.tagline`). A rail row
+  /// that is a bare word makes the reader open each tab to learn what is in
+  /// it; a tagline answers that from the rail.
+  ///
+  /// **Kept to about sixteen characters, and that is a measurement rather than
+  /// a style preference.** The rail is 216pt; after the card's padding, the
+  /// row's padding, the 32pt tile and the gap, a tagline gets roughly 132pt,
+  /// which is about eighteen characters at this size. Longer copy truncates —
+  /// measured 2026-08-29, when "Ready-made word lists" rendered as "Ready-made
+  /// word l...". `ProviderRailRow` has the same constraint and lives with a
+  /// truncated Ollama line; there is no reason to inherit that here when the
+  /// shorter phrasing is just as true.
+  var tagline: String {
+    switch self {
+    case .yourWords: return "Words you added"
+    case .vocabularyPacks: return "Ready-made lists"
+    case .learnFrom: return "Learn as you go"
+    case .quickAdd: return "Add from any app"
+    }
+  }
 }
 
 /// #2492 — the Dictionary page (was "Your Words"). Rebuilt onto a fixed
@@ -69,14 +91,16 @@ struct YourWordsView: View {
     VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
       dictionaryBanner(settings: $settings)
 
-      HStack(alignment: .top, spacing: 12) {
+      HStack(alignment: .top, spacing: PolishRailMetrics.columnGap) {
         DictionaryTabRail(selection: $selectedTab)
-          // A dedicated width, not `PolishRailMetrics.railWidth` (216pt) —
-          // that rail's rows carry a provider logo tile and a tagline; a
-          // Dictionary tab is only an icon and one line of text, so it never
-          // needed that width, and every point reclaimed here matters at the
-          // app's 750pt minimum window (cloud review, PR #2499).
-          .frame(width: 168, alignment: .leading)
+          // `PolishRailMetrics.railWidth`, the SAME 216pt the AI Polish rail
+          // uses, because these rows now carry the same content it does — a
+          // 32pt tile, a name, and a tagline. The previous 168pt was chosen
+          // for a row that was an icon and one word, and it truncated the
+          // longest tab to "Vocabulary P..." at the window size the founder
+          // actually runs (measured 2026-08-29 at 1115pt wide, nowhere near
+          // the 750pt minimum the narrower value was defending).
+          .frame(width: PolishRailMetrics.railWidth, alignment: .leading)
 
         ScrollView {
           VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
@@ -203,22 +227,6 @@ struct YourWordsView: View {
         WordsLoadFailureBanner(failure: failure)
       }
 
-      // ViewThatFits: at the app's 750pt minimum window, the right pane is
-      // roughly 228pt wide after the global sidebar, page padding, the
-      // Dictionary rail, and its gap — one row of three labeled buttons
-      // cannot stay readable there (#2492 review r1). The horizontal row is
-      // tried first and used whenever the width allows it.
-      ViewThatFits(in: .horizontal) {
-        HStack {
-          Spacer()
-          actionButtons
-        }
-        VStack(alignment: .trailing, spacing: 8) {
-          actionButtons
-        }
-        .frame(maxWidth: .infinity, alignment: .trailing)
-      }
-
       // Visibility and the progress numerator both read `pendingEnrichmentCount`
       // — the observable in-memory count, never `pendingEnrichmentWords()`
       // (a real locked file read) and never the total's mere presence
@@ -237,7 +245,14 @@ struct YourWordsView: View {
         )
       }
 
-      CustomTermsSection()
+      // The three page actions are handed to the list card rather than drawn
+      // above it. They used to be their own right-aligned row, with the word
+      // count on a third row below that, so the pane opened as three stacked
+      // bands and the buttons belonged to nothing (founder, 2026-08-29: they
+      // "push the whole UI down, making it look disjointed and not unified").
+      // Count and actions are one bar now: what you have, and what you can do
+      // to it.
+      CustomTermsSection { actionButtons }
     case .vocabularyPacks:
       VocabPacksSection()
     case .learnFrom:
@@ -322,53 +337,95 @@ struct YourWordsView: View {
   }
 }
 
-/// #2492: the Dictionary page's fixed left sub-menu. Deliberately its own
-/// small view rather than a reuse of `ProviderRail` — that rail's row draws a
-/// provider logo tile and a tagline (`ProviderLogoTile`, `entry.tagline`),
-/// neither of which a Dictionary tab has; forcing this onto that type would
-/// mean widening it with fields only this caller sends.
+/// #2492: the Dictionary page's fixed left sub-menu, drawn as a CARD.
+///
+/// **The card is the whole point, and shipping without it is what made this
+/// rail read as unfinished beside AI Polish's** (founder, 2026-08-29: "the sub
+/// menu for dictionary looks janky compared to the ai polish sub menue"). Four
+/// pills floating directly on the page background have no container, so the
+/// empty space beneath the last tab belongs to nothing and the rail stops
+/// looking like an object. `ProviderRail` solves the identical problem with a
+/// `stSectionBg` fill, a `stDivider` border, radius 14 and 10pt of padding, and
+/// the approved mockup (`.subnav-card`, `height:fit-content`) draws exactly
+/// that. These are the same four values, read off `ProviderRail.body`.
+///
+/// Still its own type rather than a reuse of `ProviderRail`: that rail is
+/// hard-wired to `PolishRailCatalog` and `LLMProvider`, and its rows draw a
+/// `ProviderLogoTile` carrying six brand marks. What is shared is the visual
+/// vocabulary, not the data model.
 private struct DictionaryTabRail: View {
   @Binding var selection: DictionaryTab
+  /// One highlight that GLIDES between rows rather than four that blink,
+  /// matching `ProviderRail`'s `selectionNS`.
+  @Namespace private var selectionNS
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 4) {
+    VStack(alignment: .leading, spacing: 5) {
       ForEach(DictionaryTab.allCases) { tab in
-        DictionaryTabRow(tab: tab, isSelected: selection == tab) {
-          selection = tab
+        DictionaryTabRow(tab: tab, isSelected: selection == tab, namespace: selectionNS) {
+          withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.82)) {
+            selection = tab
+          }
         }
       }
     }
+    .padding(10)
+    .background(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius, style: .continuous)
+        .fill(Color.stSectionBg)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius, style: .continuous)
+        .strokeBorder(Color.stDivider, lineWidth: 1)
+    )
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Dictionary section")
   }
 }
 
 private struct DictionaryTabRow: View {
   let tab: DictionaryTab
   let isSelected: Bool
+  let namespace: Namespace.ID
   let onSelect: () -> Void
-  /// See `SettingsHover.respondsToPointer`.
-  @Environment(\.isEnabled) private var environmentEnabled
-  @State private var pointerInside = false
-
-  private var hovering: Bool {
-    SettingsHover.respondsToPointer(pointerInside, true, environmentEnabled)
-  }
 
   var body: some View {
     Button(action: onSelect) {
-      HStack(spacing: 10) {
+      HStack(spacing: 12) {
+        // A 32pt rounded tile, the same object `ProviderLogoTile` draws at the
+        // same size in the AI Polish rail. A bare 15pt glyph beside 14pt text
+        // has no weight of its own, which is the other half of why these rows
+        // read as a list of links rather than a list of destinations.
         Image(systemName: tab.icon)
-          .font(.system(size: 15, weight: .medium))
-          .foregroundStyle(isSelected ? Color.stAccent : Color.stTextSecondary)
-          .frame(width: 20)
+          .font(.system(size: 15, weight: .semibold))
+          .foregroundStyle(isSelected ? Color.white : Color.stAccent)
+          .frame(width: 32, height: 32)
+          .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+              .fill(isSelected ? Color.stAccentSolid : Color.stAccentLight)
+          )
           .accessibilityHidden(true)
-        Text(tab.label)
-          .font(.system(size: 14, weight: .semibold))
-          .foregroundStyle(isSelected ? Color.stAccent : Color.stTextPrimary)
-          .lineLimit(1)
+
+        VStack(alignment: .leading, spacing: 2) {
+          Text(tab.label)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(isSelected ? Color.stAccent : Color.stTextPrimary)
+            .lineLimit(1)
+            // The rail is sized for the longest label, but a user can shrink
+            // the window; shrink the text a little before truncating it, the
+            // way `ProviderRailRow` does for "Apple Intelligence".
+            .minimumScaleFactor(0.85)
+          Text(tab.tagline)
+            .font(.stHelper)
+            .foregroundStyle(Color.stTextSecondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.85)
+        }
         Spacer(minLength: 0)
       }
-      .padding(.horizontal, 12)
-      .padding(.vertical, 10)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 9)
       .frame(maxWidth: .infinity, alignment: .leading)
       .background {
         if isSelected {
@@ -378,15 +435,16 @@ private struct DictionaryTabRow: View {
               RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .strokeBorder(Color.stAccent, lineWidth: 1.5)
             )
-        } else if hovering {
-          RoundedRectangle(cornerRadius: 10, style: .continuous)
-            .fill(Color.stTextPrimary.opacity(0.05))
+            .matchedGeometryEffect(id: "dictionaryTabSelection", in: namespace)
         }
       }
+      // The shared hover treatment rather than a fifth hand-rolled one. It
+      // paints the button's own rectangle, reads the environment's `isEnabled`,
+      // and is not disabled by Reduce Motion — see `SettingsHover`.
+      .settingsHoverRow(cornerRadius: 10)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .onHover { pointerInside = $0 }
     .accessibilityElement(children: .combine)
     .accessibilityLabel(tab.label)
     .accessibilityValue(isSelected ? "Selected" : "Not selected")

--- a/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/YourWordsView.swift
@@ -378,6 +378,11 @@ private struct DictionaryTabRail: View {
     .overlay(
       RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius, style: .continuous)
         .strokeBorder(Color.stDivider, lineWidth: 1)
+        // A decoration is never in the hit path. `strokeBorder` covers only
+        // the 1pt ring, not the interior, so the tab buttons underneath stay
+        // reachable either way — this is the house rule applied rather than a
+        // defect repaired.
+        .allowsHitTesting(false)
     )
     .accessibilityElement(children: .contain)
     .accessibilityLabel("Dictionary section")

--- a/Sources/EnviousWisprPostProcessing/VocabularyPackStore.swift
+++ b/Sources/EnviousWisprPostProcessing/VocabularyPackStore.swift
@@ -51,6 +51,31 @@ public final class VocabularyPackStore: Sendable {
   private let bundle: Bundle
   private static let logger = Logger(subsystem: "com.enviouswispr", category: "VocabularyPackStore")
 
+  /// Decoded packs, kept after the first read.
+  ///
+  /// **A pack's bytes are a bundled resource: they cannot change while the app
+  /// runs, so decoding them more than once is pure waste.** Without this,
+  /// `load(_:)` re-read the file and re-ran `JSONDecoder` on every call, and
+  /// the settings UI calls it from inside SwiftUI `body` evaluations — a
+  /// single render of the pack list costs about twenty decodes, because
+  /// `rowDetail` asks for both a count and examples per pack and `ViewThatFits`
+  /// builds the row twice (measured 2026-08-29: 4.62 ms per body evaluation,
+  /// 0.354 ms per `load(medical)`).
+  ///
+  /// **This is a real waste and it is NOT what made the tab beachball.** Single-
+  /// digit milliseconds cannot stall the main thread visibly; the stall is the
+  /// view tree the detail pane builds. Fixing this does not close that, and
+  /// nobody should read the cache as the answer to the lag.
+  ///
+  /// A lock rather than a `lazy`: the type is `Sendable` and reachable from any
+  /// thread, so an unsynchronised stored dictionary would be a data race. The
+  /// decode runs OUTSIDE the lock, so a slow read never blocks another pack's
+  /// lookup; two threads racing the same miss both decode and the second store
+  /// wins, which is harmless because the result is a pure function of bytes
+  /// that cannot change.
+  private let decoded = OSAllocatedUnfairLock(
+    initialState: [VocabularyPackID: VocabularyPack]())
+
   /// Production: loads from this module's `Bundle.module`.
   public init() {
     self.bundle = .module
@@ -63,7 +88,14 @@ public final class VocabularyPackStore: Sendable {
   }
 
   /// Load one pack's terms, or nil if the resource is missing/corrupt.
+  ///
+  /// Memoized — see `decoded`. A MISSING or CORRUPT pack is deliberately not
+  /// cached: the failure is logged each time rather than silently answered from
+  /// a remembered `nil`, and a fail-open path that has genuinely nothing to
+  /// return costs one bundle lookup, not a decode.
   public func load(_ id: VocabularyPackID) -> VocabularyPack? {
+    if let hit = decoded.withLock({ $0[id] }) { return hit }
+
     guard let raw = loadRaw(id) else { return nil }
     let terms = raw.map { canonical, aliases in
       CustomWord(
@@ -74,7 +106,9 @@ public final class VocabularyPackStore: Sendable {
         source: .pack
       )
     }
-    return VocabularyPack(terms: terms)
+    let pack = VocabularyPack(terms: terms)
+    decoded.withLock { $0[id] = pack }
+    return pack
   }
 
   /// Flattened terms for every enabled pack (deterministic order). Missing

--- a/Tests/EnviousWisprTests/PostProcessing/VocabularyPackStoreCacheTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/VocabularyPackStoreCacheTests.swift
@@ -12,8 +12,8 @@ import Testing
 /// introduces is answering with the wrong or a stale pack, and that is what
 /// these cases check. The speed itself is not a public product promise and gets
 /// no timing assertion — a wall-clock bound would be a measurement of this
-/// machine (`validation-discipline.md`
-/// RULE: measure-with-the-real-tool-never-a-simulation).
+/// machine rather than of the code, and this Mac is far faster than the
+/// slowest supported one.
 ///
 /// These read the REAL bundled packs rather than a fixture, because the defect
 /// class is "the second read disagrees with the first" and a hand-built pack

--- a/Tests/EnviousWisprTests/PostProcessing/VocabularyPackStoreCacheTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/VocabularyPackStoreCacheTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+@testable import EnviousWisprPostProcessing
+
+/// `VocabularyPackStore` memoizes each decoded pack (2026-08-29), because the
+/// settings UI calls `load(_:)` from inside SwiftUI `body` evaluations and was
+/// re-reading and re-decoding the bundled JSON every time.
+///
+/// **What is worth binding here is CORRECTNESS, not speed.** The risk a cache
+/// introduces is answering with the wrong or a stale pack, and that is what
+/// these cases check. The speed itself is not a public product promise and gets
+/// no timing assertion — a wall-clock bound would be a measurement of this
+/// machine (`validation-discipline.md`
+/// RULE: measure-with-the-real-tool-never-a-simulation).
+///
+/// These read the REAL bundled packs rather than a fixture, because the defect
+/// class is "the second read disagrees with the first" and a hand-built pack
+/// would exercise a decode path the shipped resources do not.
+/// Class: **Product Outcome**. Finish the sentence and it finishes cleanly —
+/// when this fails the user sees corrections from a pack they never turned on,
+/// or loses the ones they did. The cache sits directly under
+/// `terms(for:)`, which is what feeds the corrector's vocabulary.
+@Suite("Vocabulary pack store — memoized loads stay correct", .tags(.productOutcome))
+struct VocabularyPackStoreCacheTests {
+
+  @Test("a second load returns the same words as the first, for every shipped pack")
+  func repeatedLoadAgreesWithFirst() throws {
+    let store = VocabularyPackStore()
+    let ids = store.availablePackIDs()
+    // Fail loudly rather than pass vacuously if the bundle resolves nothing.
+    #expect(ids.isEmpty == false)
+
+    for id in ids {
+      let first = try #require(store.load(id), "pack \(id.rawValue) should load")
+      let second = try #require(store.load(id), "pack \(id.rawValue) should load again")
+
+      #expect(first.terms.count == second.terms.count)
+      // Compare the fields the corrector actually consumes, in order. The
+      // deterministic id is included deliberately: it is derived per load, so
+      // a cache returning a re-minted pack would still match on canonical and
+      // aliases alone.
+      let firstKeys = first.terms.map {
+        [$0.id.uuidString, $0.canonical, $0.aliases.joined(separator: "|")]
+      }
+      let secondKeys = second.terms.map {
+        [$0.id.uuidString, $0.canonical, $0.aliases.joined(separator: "|")]
+      }
+      #expect(firstKeys == secondKeys, "pack \(id.rawValue) changed between loads")
+    }
+  }
+
+  @Test("one store answers for each pack independently — no cross-pack bleed")
+  func eachPackKeepsItsOwnWords() throws {
+    let store = VocabularyPackStore()
+    let ids = store.availablePackIDs()
+    #expect(ids.count > 1)
+
+    // Load every pack once so all of them are cached, then read them back in
+    // REVERSE order. A cache keyed wrongly — one shared slot, or a key that
+    // collides — shows up here and cannot show up in a single-pack test.
+    var expected: [VocabularyPackID: [String]] = [:]
+    for id in ids {
+      expected[id] = try #require(store.load(id)).terms.map(\.canonical).sorted()
+    }
+    for id in ids.reversed() {
+      let reread = try #require(store.load(id)).terms.map(\.canonical).sorted()
+      #expect(reread == expected[id], "pack \(id.rawValue) returned another pack's words")
+    }
+
+    // Two different packs must not have been collapsed into one entry.
+    let canonicalSets = ids.map { Set(expected[$0] ?? []) }
+    #expect(Set(canonicalSets.map(\.count)).count > 1 || canonicalSets.count == 1)
+  }
+
+  @Test("enabled-pack terms still flatten to the same set after caching")
+  func termsForEnabledIsUnchangedByCaching() throws {
+    let store = VocabularyPackStore()
+    let ids = Set(store.availablePackIDs())
+    #expect(ids.isEmpty == false)
+
+    let cold = store.terms(for: ids).map(\.canonical)
+    let warm = store.terms(for: ids).map(\.canonical)
+    #expect(cold == warm)
+    #expect(cold.isEmpty == false)
+  }
+}


### PR DESCRIPTION
Founder review of the shipped Dictionary redesign, 2026-08-29. Six visual findings and one performance complaint. Part of #2491.

## What he said, and what each one was

| His words | What it actually was |
|---|---|
| "the sub menu for dictionary looks janky compared to the ai polish sub menue" | The rail had no container. Four pills sat directly on the page background, so the space under the last one belonged to nothing. |
| the actions "push the whole UI down, making it look disjointed and not unified" | Count and buttons were two separate bands stacked above the list card. |
| the search bar is "the same color as the rest of the UI, making it unclear where people need to type" | It was bare text on the card — no fill, no border. |
| the pills "don't light up like the edit buttons do" | They never opted into the shared `settingsHoverRow` treatment. |
| "Learn From ... just blends together with no clear UX design" | Two features as `BrandedRow`s in one card, so six pieces of text ran together as one column with a hairline in the middle. |
| Vocabulary Packs' "See all" drifting | Controls were centred against a three-line block, so each button's x followed the intrinsic width of whichever blurb sat beside it. |
| "Clicking on All Vocabulary Packs ... takes a very long time to load ... the wheel to spin" | See below. Traced, not guessed. |

## The visual work

The rail now draws the same card `ProviderRail` does — `stSectionBg`, `stDivider`, radius 14, 10pt padding — with a 32pt icon tile and a tagline per row, and selection glides via `matchedGeometryEffect`. Width moves to `PolishRailMetrics.railWidth` (216) because the rows now carry what that rail's rows carry; 168pt was truncating "Vocabulary Packs" to "Vocabulary P..." at the window width he actually runs, which is nowhere near the 750pt minimum the narrower value was defending.

Count and actions share one row inside the list card. `CustomTermsSection` takes the actions as a `@ViewBuilder` so they keep their owner — `YourWordsView` presents the sheets and owns the export plumbing — while sitting beside the count, which is this view's own projection.

Learn from... and Vocabulary Packs both become a `BrandedPanel` with a header and a description, then one recessed card per item. `COMING SOON` is a pill on the title line. "Keep in sync on launch" moves inside the Contacts card under a divider, because it is a setting belonging to Contacts rather than a third peer feature.

Taglines are held to about sixteen characters. That is a measurement: after the card padding, row padding, tile and gap, a tagline gets roughly 132pt, and the first draft's "Ready-made word lists" rendered as "Ready-made word l...".

## The lag

Two independent causes, ranked by measurement rather than by which was easiest to see.

**1. The pack word list was built in full before the pane could draw.** Every row carries a live `TextField`, a shadowed toggle, and one hover-tracking area per alias chip. Brands is 106 words / 455 aliases; Medical is 87 words / 453 aliases. Opening a pack therefore constructed several hundred interactive controls on the main thread. Now paged at 50 through `CustomTermListPolicy` — the helper the Your Words tab next door already uses, rather than a second answer to the same question — inside a `LazyVStack`. `CustomTermListPolicy.paged` becomes generic; nothing in its arithmetic ever read the element type.

**2. The bundled pack JSON was re-read and re-decoded on the render path**, with a SHA-256 UUID minted per word per load. One pack-list body evaluation cost about twenty decodes, because `rowDetail` asks for a count and examples per pack and `ViewThatFits` builds each row twice. `VocabularyPackStore` now memoizes decoded packs behind an `OSAllocatedUnfairLock` — the type is `Sendable` and reachable from any thread, and the decode runs outside the lock.

**Measured: Medical opens in 0.15 s on the fixed build.** Stated with its limit — decoding was never the beachball on its own (4.76 ms for all five packs, 0.354 ms per `load(medical)`), so the cache is real waste removed and NOT the fix for the stall; the row count is. The pre-fix build was not re-measured, so "before" here is the founder's report plus the row counts above, not a number taken from a run.

**Two recommendations deliberately not taken**, recorded so nobody re-derives them as missed work: swapping each row's always-present alias `TextField` for a tap-to-open button, and giving `WrappingHStack` a real `Layout` cache. Both were justified by per-row cost the lazy list has already stopped paying, and the first would cost a click on every alias edit.

## Review

Local Codex round found two things. One reproduced, one did not, and they are adjudicated separately in `7faad01e`.

Real: five comments named internal `.md` rule files by bare filename. Those live under the untracked `.claude` directory, so a reader on GitHub or in a fresh clone follows a dead pointer. Reasoning inlined at each site; one of the five predated this branch and is fixed here because the file was already open.

Did not reproduce: "decorative overlays can intercept settings controls." The identical construct already ships in `ProviderRail` and in `BrandedSection`, which wraps every card in the settings window — if it absorbed pointer events, every toggle and button in Settings would be dead today. `strokeBorder` covers the 1pt ring, not the interior; the rule cited is about a `.fill()`ed Shape. `allowsHitTesting(false)` is added anyway on all three new borders because the house rule is that a decoration is never in the hit path, and it is labelled at each site as the rule applied rather than a defect repaired.

## Validation

- Debug lane: **7186 tests, verdict PASS** (7183 before; +3 is the new suite).
- New `VocabularyPackStoreCacheTests` binds what the cache can get WRONG — a second load disagreeing with the first, cross-pack bleed, `terms(for:)` drifting — against the real bundled packs. No timing assertion: a wall-clock bound would measure this machine.
- Rebuilt dev app and inspected every tab on screen at 1115pt.
