### PR TITLE
perf(settings): make the vocabulary pack screens scale to 30 packs

### DIFF
--- a/Sources/EnviousWisprAppKit/App/VocabularyPackManager.swift
+++ b/Sources/EnviousWisprAppKit/App/VocabularyPackManager.swift
@@ -40,6 +40,37 @@ final class VocabularyPackManager {
   /// edit. Cleared by the next successful mutation.
   private(set) var persistenceError: String?
 
+  /// Packs that resolve in the bundle, in display order. Resolved ONCE.
+  ///
+  /// This was a computed property doing one `Bundle.url(forResource:)` per
+  /// pack, and it is read inside a SwiftUI `body`, so every render of the pack
+  /// list paid a bundle lookup per pack. What is inside the app bundle cannot
+  /// change while the app runs, so the answer is fixed at launch. At the five
+  /// packs that ship today this was invisible; the founder intends 25 to 30,
+  /// and this is the kind of cost that only ever grows.
+  let availablePackIDs: [VocabularyPackID]
+
+  /// The pack list row's two numbers, computed ONCE per pack.
+  ///
+  /// The row used to ask `termCount` and `exampleCanonicals` separately, and
+  /// each call walked the pack — `exampleCanonicals` sorted every canonical in
+  /// the pack in order to take three of them. Two questions per card, and
+  /// `ViewThatFits` builds each card twice, so a 30-pack list asked 120 of
+  /// them per render pass (grounded review, 2026-08-29). One value, built
+  /// lazily on first display and kept.
+  struct PackSummary: Equatable {
+    let termCount: Int
+    let examples: [String]
+  }
+  @ObservationIgnored private var summaries: [VocabularyPackID: PackSummary] = [:]
+
+  /// Display rows per pack, memoized. Invalidated by `mutateOverride` — the
+  /// only thing that can change them — so the detail screen's search box no
+  /// longer rebuilds and re-sorts the whole pack on every keystroke.
+  @ObservationIgnored private var wordDisplayCache:
+    [VocabularyPackID: [VocabularyPackWordDisplay]] =
+      [:]
+
   init(
     store: VocabularyPackStore = VocabularyPackStore(),
     overridesStore: VocabularyPackOverridesStore = VocabularyPackOverridesStore(),
@@ -49,17 +80,13 @@ final class VocabularyPackManager {
     self.overridesStore = overridesStore
     self.defaults = defaults
     self.overrides = overridesStore.load()
+    let present = Set(store.availablePackIDs())
+    self.availablePackIDs = VocabularyPackID.allCases.filter { present.contains($0) }
     if let raw = defaults.array(forKey: Self.defaultsKey) as? [String] {
       self.enabled = Set(raw.compactMap(VocabularyPackID.init(rawValue:)))
     } else {
       self.enabled = []  // default OFF
     }
-  }
-
-  /// Packs that resolve in the bundle, in display order.
-  var availablePackIDs: [VocabularyPackID] {
-    let present = Set(store.availablePackIDs())
-    return VocabularyPackID.allCases.filter { present.contains($0) }
   }
 
   func isEnabled(_ id: VocabularyPackID) -> Bool { enabled.contains(id) }
@@ -98,16 +125,28 @@ final class VocabularyPackManager {
 
   // MARK: - UI metadata
 
-  /// Number of correctable terms in a pack (for the Settings row). Not
-  /// override-adjusted — this is the shipped pack size, shown before anyone
-  /// has opened the pack to edit anything.
-  func termCount(_ id: VocabularyPackID) -> Int { store.load(id)?.terms.count ?? 0 }
-
-  /// A few example "fix" canonicals for the Settings row blurb.
-  func exampleCanonicals(_ id: VocabularyPackID, limit: Int = 3) -> [String] {
-    guard let pack = store.load(id) else { return [] }
-    return pack.terms.map(\.canonical).sorted().prefix(limit).map { $0 }
+  /// The pack list row's count and examples, in ONE lookup, memoized.
+  ///
+  /// Not override-adjusted: this is the shipped pack size and shipped
+  /// examples, shown before anyone has opened the pack to edit anything, so
+  /// nothing a user does can invalidate it and it never needs clearing.
+  func summary(_ id: VocabularyPackID, exampleLimit: Int = 3) -> PackSummary {
+    if let hit = summaries[id] { return hit }
+    guard let pack = store.load(id) else {
+      let empty = PackSummary(termCount: 0, examples: [])
+      summaries[id] = empty
+      return empty
+    }
+    let examples = pack.terms.map(\.canonical).sorted().prefix(exampleLimit).map { $0 }
+    let value = PackSummary(termCount: pack.terms.count, examples: examples)
+    summaries[id] = value
+    return value
   }
+
+  /// Number of correctable terms in a pack. Kept as the narrow question some
+  /// callers actually ask; it reads the same memoized summary rather than
+  /// walking the pack again.
+  func termCount(_ id: VocabularyPackID) -> Int { summary(id).termCount }
 
   // MARK: - Pack word overrides (#2495)
 
@@ -116,18 +155,41 @@ final class VocabularyPackManager {
   /// aliases, and whether it differs from shipped. Includes DISABLED words
   /// (unlike `enabledPackTerms()`) — the detail screen is where a disabled
   /// word gets found again and restored. Sorted alphabetically, case-insensitive.
+  /// Memoized. The detail screen reads this from inside `body`, and its search
+  /// box filters the result, so before this every keystroke rebuilt every
+  /// display row for the pack and re-sorted them. `mutateOverride` is the only
+  /// thing that can change the answer and it clears this.
   func packWords(_ id: VocabularyPackID) -> [VocabularyPackWordDisplay] {
+    if let hit = wordDisplayCache[id] { return hit }
+    let built = buildPackWords(id)
+    wordDisplayCache[id] = built
+    return built
+  }
+
+  private func buildPackWords(_ id: VocabularyPackID) -> [VocabularyPackWordDisplay] {
     guard let pack = store.load(id) else { return [] }
     let packOverrides = overrides.packs[id.rawValue] ?? [:]
     return pack.terms.map { term in
       let override = packOverrides[Self.overrideKey(for: term.canonical)]
       let effectiveAliases = override?.aliases ?? term.aliases
       let isEnabled = override?.isEnabled ?? true
+      // Sorted HERE, once, rather than in the row's body. `PackWordRow` had a
+      // `sortedAliases` computed property, so every visible row re-ran a
+      // localized sort of its aliases on every body evaluation, and a
+      // localized compare is not cheap (grounded review, 2026-08-29).
+      //
+      // Into its OWN field. `aliases` keeps its stored order because
+      // `setWordAliases` compares it against the shipped array to decide
+      // whether an edit has returned to the default.
+      let displayAliases = effectiveAliases.sorted {
+        $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+      }
       return VocabularyPackWordDisplay(
         id: term.id,
         canonical: term.canonical,
         shippedAliases: term.aliases,
         aliases: effectiveAliases,
+        displayAliases: displayAliases,
         isEnabled: isEnabled,
         // Computed from the EFFECTIVE state, not from "does an override
         // record exist" — an aliases override that has drifted back to
@@ -207,6 +269,14 @@ final class VocabularyPackManager {
       return
     }
     overrides = saved
+    // The display rows are derived from `overrides`, so they are stale the
+    // instant it changes. Cleared for EVERY pack rather than just `id`: the
+    // store's `update` returns the whole file as saved, which can carry a
+    // concurrent writer's change to another pack, so clearing only this one
+    // would leave that pack's rows wrong on screen. Rebuilding a pack costs
+    // well under a millisecond, so the wider clear is the cheap side of the
+    // trade as well as the correct one.
+    wordDisplayCache.removeAll(keepingCapacity: true)
     persistenceError = nil
     rebroadcast()
   }
@@ -223,7 +293,17 @@ struct VocabularyPackWordDisplay: Identifiable, Equatable {
   /// "Remove alias" in the detail screen can build the next full list
   /// without re-reading the pack file.
   let shippedAliases: [String]
+  /// The effective alias list, IN ITS STORED ORDER. This is the value the
+  /// editor reads to build the next list, and `setWordAliases` decides whether
+  /// an edit has returned to the shipped default by comparing against the
+  /// shipped array — an ORDER-SENSITIVE comparison. Sorting this field would
+  /// mean an add-then-remove round trip wrote back a reordered list that no
+  /// longer equalled the shipped one, so the word would stay marked EDITED
+  /// forever. Display order is a separate concern; see `displayAliases`.
   let aliases: [String]
+  /// The same aliases, sorted for the chip row, computed ONCE here rather than
+  /// in every row's body on every render.
+  let displayAliases: [String]
   let isEnabled: Bool
   let isEdited: Bool
 }

--- a/Sources/EnviousWisprAppKit/App/VocabularyPackManager.swift
+++ b/Sources/EnviousWisprAppKit/App/VocabularyPackManager.swift
@@ -62,6 +62,21 @@ final class VocabularyPackManager {
     let termCount: Int
     let examples: [String]
   }
+
+  /// How many example canonicals a pack row shows.
+  ///
+  /// A CONSTANT, not a parameter, and that is the fix for a real defect rather
+  /// than a style choice. This began as `summary(_:exampleLimit:)` carried over
+  /// from the old `exampleCanonicals(_:limit:)`, while the memo below is keyed
+  /// on the pack id ALONE — so the first caller's limit would have been baked
+  /// in for the life of the process, and every later caller asking for a
+  /// different count would have silently received the first one's answer
+  /// (cloud review, PR #2505). No caller ever varied it; a defaulted parameter
+  /// nobody varies is a parameter no test checks. Removing it deletes the
+  /// class instead of keying the cache on a tuple to preserve a knob nothing
+  /// turns.
+  private static let exampleLimit = 3
+
   @ObservationIgnored private var summaries: [VocabularyPackID: PackSummary] = [:]
 
   /// Display rows per pack, memoized. Invalidated by `mutateOverride` — the
@@ -130,14 +145,14 @@ final class VocabularyPackManager {
   /// Not override-adjusted: this is the shipped pack size and shipped
   /// examples, shown before anyone has opened the pack to edit anything, so
   /// nothing a user does can invalidate it and it never needs clearing.
-  func summary(_ id: VocabularyPackID, exampleLimit: Int = 3) -> PackSummary {
+  func summary(_ id: VocabularyPackID) -> PackSummary {
     if let hit = summaries[id] { return hit }
     guard let pack = store.load(id) else {
       let empty = PackSummary(termCount: 0, examples: [])
       summaries[id] = empty
       return empty
     }
-    let examples = pack.terms.map(\.canonical).sorted().prefix(exampleLimit).map { $0 }
+    let examples = pack.terms.map(\.canonical).sorted().prefix(Self.exampleLimit).map { $0 }
     let value = PackSummary(termCount: pack.terms.count, examples: examples)
     summaries[id] = value
     return value

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -594,20 +594,46 @@ struct BrandedStatusRow: View {
 // MARK: - Wrapping HStack (flow layout for chips)
 
 /// Layout that wraps items to the next line when they exceed the available width.
+///
+/// **Caches its flow computation, keyed on the width it was computed for.**
+/// SwiftUI calls `sizeThatFits` and then `placeSubviews` for the same pass, and
+/// with no cache this ran the whole flow twice — each run calling
+/// `sizeThatFits` on every chip. A pack word row can carry ten alias chips and
+/// a pack can carry hundreds of aliases, so the duplicate pass was paid per
+/// row, per layout (grounded review, 2026-08-29).
+///
+/// The key is the WIDTH, not a counter. SwiftUI calls `updateCache` whenever
+/// the subviews change, which is where the stored result is dropped; a width
+/// mismatch drops it too, so a resized window recomputes rather than placing
+/// chips at coordinates measured for a different width. Both conditions are
+/// checked before the cached positions are used, so a stale entry can only
+/// cause a recompute, never a wrong placement.
 struct WrappingHStack: Layout {
   var spacing: CGFloat = 6
 
-  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-    layout(proposal: proposal, subviews: subviews).size
+  struct Cache {
+    /// The proposal width `result` was computed for. `nil` means empty.
+    var width: CGFloat?
+    var result: (size: CGSize, positions: [CGPoint], sizes: [CGSize])?
+  }
+
+  func makeCache(subviews: Subviews) -> Cache { Cache() }
+
+  /// Called by SwiftUI when the subviews change. Anything cached described the
+  /// OLD set, so it goes.
+  func updateCache(_ cache: inout Cache, subviews: Subviews) {
+    cache.width = nil
+    cache.result = nil
+  }
+
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Cache) -> CGSize {
+    resolved(width: proposal.width, subviews: subviews, cache: &cache).size
   }
 
   func placeSubviews(
-    in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+    in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Cache
   ) {
-    let result = layout(
-      proposal: ProposedViewSize(width: bounds.width, height: nil),
-      subviews: subviews
-    )
+    let result = resolved(width: bounds.width, subviews: subviews, cache: &cache)
     for (index, position) in result.positions.enumerated() {
       let size = result.sizes[index]
       subviews[index].place(
@@ -615,6 +641,29 @@ struct WrappingHStack: Layout {
         proposal: ProposedViewSize(width: size.width, height: size.height)
       )
     }
+  }
+
+  /// The cached flow for `width`, computing it only on a miss.
+  ///
+  /// Guards on the subview COUNT as well as the width. `updateCache` is the
+  /// documented invalidation point and this does not rely on it alone: placing
+  /// N positions against a different number of subviews would be an index
+  /// crash, so the count is checked where it is used rather than trusted from
+  /// a callback.
+  private func resolved(
+    width: CGFloat?, subviews: Subviews, cache: inout Cache
+  ) -> (size: CGSize, positions: [CGPoint], sizes: [CGSize]) {
+    if let cachedWidth = cache.width, let result = cache.result,
+      cachedWidth == width ?? .infinity, result.positions.count == subviews.count
+    {
+      return result
+    }
+    let proposal =
+      width.map { ProposedViewSize(width: $0, height: nil) } ?? ProposedViewSize.unspecified
+    let computed = layout(proposal: proposal, subviews: subviews)
+    cache.width = width ?? .infinity
+    cache.result = computed
+    return computed
   }
 
   private func layout(
@@ -780,7 +829,8 @@ struct EngineCard<Footer: View>: View {
         .frame(
           maxWidth: .infinity,
           maxHeight: fillsHeight ? .infinity : nil,
-          alignment: .topLeading)
+          alignment: .topLeading
+        )
         // Applied to the LABEL, inside the same frame the hit region uses, so
         // the tint and the target are one rectangle and stay one rectangle when
         // `fillsHeight` grows them. On a card that carries a footer button the
@@ -1012,9 +1062,9 @@ struct SettingsActionButton: View {
   var body: some View {
     shortcutBound(button)
       .buttonStyle(.plain)
-    .disabled(!isEnabled)
-    .onHover { pointerInside = $0 }
-    .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
+      .disabled(!isEnabled)
+      .onHover { pointerInside = $0 }
+      .animation(reduceMotion ? nil : SettingsHover.animation, value: hovering)
   }
 
   private var button: some View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabPacksSection.swift
@@ -38,7 +38,12 @@ struct VocabPacksSection: View {
           .font(.stHelper)
           .foregroundStyle(.stTextSecondary)
       } else {
-        VStack(alignment: .leading, spacing: 10) {
+        // Lazy, for the same reason the word list inside a pack is lazy: this
+        // list is about to grow. Five cards today, and the founder intends 25
+        // to 30 — at which point an eager stack builds every card, and each
+        // card's `ViewThatFits` builds two candidate subtrees, before the tab
+        // can draw anything (grounded review, 2026-08-29).
+        LazyVStack(alignment: .leading, spacing: 10) {
           ForEach(ids, id: \.self) { packCard($0) }
         }
       }
@@ -122,11 +127,15 @@ struct VocabPacksSection: View {
   }
 
   /// "248 fixes · e.g. async, bazel, cypress"
+  ///
+  /// ONE lookup, not two. This asked `termCount` and `exampleCanonicals`
+  /// separately, and each walked the pack — the examples call sorted every
+  /// canonical in the pack to take three. Two questions per card, doubled by
+  /// `ViewThatFits`, is 120 of them for a 30-pack list per render pass.
   private func rowDetail(for id: VocabularyPackID) -> String {
-    let count = packManager.termCount(id)
-    let examples = packManager.exampleCanonicals(id, limit: 3)
-    let countText = "\(count) \(count == 1 ? "fix" : "fixes")"
-    guard !examples.isEmpty else { return countText }
-    return "\(countText) · e.g. \(examples.joined(separator: ", "))"
+    let summary = packManager.summary(id)
+    let countText = "\(summary.termCount) \(summary.termCount == 1 ? "fix" : "fixes")"
+    guard !summary.examples.isEmpty else { return countText }
+    return "\(countText) · e.g. \(summary.examples.joined(separator: ", "))"
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -278,10 +278,6 @@ private struct PackWordRow: View {
     }
   }
 
-  private var sortedAliases: [String] {
-    word.aliases.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
-  }
-
   @ViewBuilder
   private var aliasChips: some View {
     if word.aliases.isEmpty {
@@ -289,8 +285,13 @@ private struct PackWordRow: View {
         .font(.stHelper)
         .foregroundStyle(.stTextSecondary)
     } else {
+      // `displayAliases` arrives already sorted — `VocabularyPackManager`
+      // sorts once when it builds the row. This used to be a `sortedAliases`
+      // computed property, so every visible row re-ran a localized sort on
+      // every body evaluation. The mutation helpers below still read
+      // `word.aliases`, whose ORDER is load-bearing for edit detection.
       WrappingHStack(spacing: 6) {
-        ForEach(sortedAliases, id: \.self) { alias in
+        ForEach(word.displayAliases, id: \.self) { alias in
           HStack(spacing: 3) {
             Text(alias)
               .font(.stHelper)

--- a/Tests/EnviousWisprTests/App/VocabularyPackManagerOverridesTests.swift
+++ b/Tests/EnviousWisprTests/App/VocabularyPackManagerOverridesTests.swift
@@ -267,5 +267,11 @@ struct VocabularyPackManagerOverridesTests {
     #expect(summary.examples == summary.examples.sorted())
     // Repeating the call must not change the answer — it is memoized.
     #expect(manager.summary(.tech) == summary)
+    // The example count is a constant, so a call that arrives AFTER
+    // `termCount` primed the memo still sees the full set. This is the shape
+    // the cloud review caught while `summary` still took an `exampleLimit`
+    // the memo was not keyed on.
+    _ = manager.termCount(.medical)
+    #expect(manager.summary(.medical).examples.count == min(3, manager.packWords(.medical).count))
   }
 }

--- a/Tests/EnviousWisprTests/App/VocabularyPackManagerOverridesTests.swift
+++ b/Tests/EnviousWisprTests/App/VocabularyPackManagerOverridesTests.swift
@@ -179,4 +179,93 @@ struct VocabularyPackManagerOverridesTests {
     #expect(word?.isEdited == false)
     #expect(manager.persistenceError == nil)
   }
+
+  // MARK: - Memoization (2026-08-29)
+  //
+  // `packWords` is now cached per pack, because the detail screen calls it from
+  // inside `body` and its search box filters the result — so every keystroke
+  // was rebuilding and re-sorting every row in the pack. The risk a cache adds
+  // is showing a STALE row after an edit, which is what these bind.
+
+  @Test("An edit is visible in the very next read — the row cache cannot go stale")
+  func packWordsReflectsAnEditImmediately() {
+    let (manager, canonical) = makeManager()
+    // Prime the cache first. Without this read the test would pass against a
+    // cache that never populated, which is not the thing being checked.
+    let primed = manager.packWords(.tech).first { $0.canonical == canonical }!
+    #expect(primed.isEnabled == true)
+
+    manager.setWordEnabled(.tech, canonical: canonical, enabled: false)
+
+    let after = manager.packWords(.tech).first { $0.canonical == canonical }!
+    #expect(after.isEnabled == false, "a cached row survived an edit that should have cleared it")
+  }
+
+  @Test("Editing one pack does not leave another pack's cached rows stale")
+  func editingOnePackDoesNotStrandAnother() {
+    let (manager, canonical) = makeManager()
+    // Prime BOTH packs, then edit only Tech. Medical's rows must still be
+    // correct afterwards — this fails if invalidation is keyed too narrowly
+    // AND if it is keyed too widely in a way that drops correctness.
+    let medicalBefore = manager.packWords(.medical)
+    #expect(medicalBefore.isEmpty == false)
+
+    manager.setWordEnabled(.tech, canonical: canonical, enabled: false)
+
+    let medicalAfter = manager.packWords(.medical)
+    #expect(medicalAfter.map(\.canonical) == medicalBefore.map(\.canonical))
+    #expect(
+      medicalAfter.allSatisfy { $0.isEnabled }, "an unrelated pack was altered by a Tech edit")
+  }
+
+  // MARK: - Display order is separate from stored order
+  //
+  // `displayAliases` is sorted for the chip row; `aliases` keeps its stored
+  // order because `setWordAliases` compares it against the shipped array to
+  // decide whether an edit has returned to the default. Sorting the wrong one
+  // makes a word read EDITED forever after an add-then-remove round trip.
+
+  @Test("displayAliases is sorted while aliases keeps its stored order")
+  func displayOrderIsSeparateFromStoredOrder() {
+    let (manager, _) = makeManager()
+    // Pick a word with enough aliases for order to be observable at all.
+    guard let word = manager.packWords(.tech).first(where: { $0.aliases.count > 1 }) else {
+      Issue.record("Tech pack has no word with two or more aliases — fixture assumption broken")
+      return
+    }
+    let expected = word.aliases.sorted {
+      $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+    }
+    #expect(word.displayAliases == expected)
+    #expect(Set(word.displayAliases) == Set(word.aliases), "display dropped or invented an alias")
+  }
+
+  @Test("Add then remove the same alias returns the word to unedited")
+  func addThenRemoveReturnsToUnedited() {
+    let (manager, canonical) = makeManager()
+    let before = manager.packWords(.tech).first { $0.canonical == canonical }!
+    #expect(before.isEdited == false)
+
+    manager.setWordAliases(.tech, canonical: canonical, aliases: before.aliases + ["zzz probe"])
+    manager.setWordAliases(.tech, canonical: canonical, aliases: before.aliases)
+
+    let after = manager.packWords(.tech).first { $0.canonical == canonical }!
+    #expect(
+      after.isEdited == false,
+      "the word stayed marked edited — the stored alias order was not preserved")
+  }
+
+  // MARK: - Merged pack metadata
+
+  @Test("summary reports the shipped pack size and its first examples")
+  func summaryMatchesTheShippedPack() {
+    let (manager, _) = makeManager()
+    let summary = manager.summary(.tech)
+    #expect(summary.termCount == manager.packWords(.tech).count)
+    #expect(summary.termCount == manager.termCount(.tech))
+    #expect(summary.examples.count <= 3)
+    #expect(summary.examples == summary.examples.sorted())
+    // Repeating the call must not change the answer — it is memoized.
+    #expect(manager.summary(.tech) == summary)
+  }
 }


### PR DESCRIPTION
The founder judged the shipped Dictionary fix "still seems inefficient" and added a constraint: 10 to 20 more vocabulary packs are coming. So this targets 25 to 30 packs and roughly 3,000 words rather than today's 5 and 390.

## Method, because it changed the answer

Two frontier models advised with **no repo access**, then Codex adjudicated their recommendations **against the actual files**. That order is why this PR is smaller than the advice was:

| Advice | Grounded verdict | Evidence |
|---|---|---|
| "Stop rebuilding the corrector vocabulary per dictation" — ranked #1 by BOTH | **Already done.** Not a finding. | `WordCorrectionStep.swift:142-147` reuses cached lookups for the same generation; `CustomWordsPropagator` bumps that generation only on a real change. Codex CONFIRMED. |
| "DELETE the pagination you just shipped" — both | **REJECTED.** Pagination stays. | It caps the data handed to the `LazyVStack` at 50 complex rows. Laziness alone gives no such ceiling. |
| "The lock cache is over-built" — both | **REJECTED.** The lock stays. | `VocabularyPackStore` is `Sendable` and reachable from more than one thread; removing synchronisation from mutable cache state trades a speed problem for a correctness one. |

Two of the three strongest external recommendations do not survive contact with this codebase. That is the argument for grounding rather than voting.

## What shipped

1. **Pack LIST is a `LazyVStack`** (`VocabPacksSection.swift`). It was eager, and each card wraps its title row in a `ViewThatFits`, so 30 packs meant 30 cards and 60 candidate subtrees built before the tab could draw.
2. **`availablePackIDs` resolved once in `init`** (`VocabularyPackManager.swift`). It was computed, doing one `Bundle.url(forResource:)` per pack, and it is read inside `body`.
3. **`summary(_:)` replaces `termCount` + `exampleCanonicals`**, memoized. The examples call sorted every canonical in a pack to take three of them; two questions per card, doubled by `ViewThatFits`, is 120 per render pass at 30 packs.
4. **`packWords(_:)` memoized**, cleared in `mutateOverride`. The detail screen reads it from `body` and filters it, so every keystroke in the search box rebuilt and re-sorted every row in the pack. Cleared for **every** pack rather than just the edited one: the overrides store returns the whole file as saved and can carry a concurrent writer's change to another pack, so a narrow clear would leave that pack's rows wrong on screen.
5. **Alias display order computed once** in the manager, not per row per render.
6. **`WrappingHStack` has a real `Layout.Cache`** keyed on width (`SettingsComponents.swift`). With `Cache == ()` it ran its whole flow in `sizeThatFits` and again in `placeSubviews`, each pass measuring every chip. The cache is checked on width **and** subview count before use, so a stale entry can only cause a recompute, never a wrong placement.

## A defect this change introduced, and closed

Sorting the alias list looked free and was not. `setWordAliases` decides whether an edit has returned to the shipped default by comparing the array against the shipped array — an **order-sensitive** comparison — and the detail view builds its next list from that same field. Sorting it meant an add-then-remove round trip wrote back a reordered list that no longer equalled the shipped one, so the word would read EDITED forever.

Display order now lives in its own `displayAliases` field; `aliases` keeps its stored order, with the reason recorded at the declaration. `addThenRemoveReturnsToUnedited` fails if anyone re-merges them.

## Not done, deliberately

The per-row `TextField`, the per-row shadow, and the per-chip `onHover` are untouched — both advisors and Codex agreed not to touch them without a profile implicating them, and the lazy list already stopped paying that cost per row. Neither screen moves to `List`: both use custom branded containers, and the detail screen's inline navigation and dividers are exactly what `List` would reshape.

## Validation

- Debug lane: **7191 tests, verdict PASS** (7186 before; +5).
- The new cases bind what memoization can get **wrong**, not how fast it is: a cached row surviving an edit, one pack's edit stranding another pack's rows, display order diverging from stored order, and the add-then-remove round trip above.
- `packWordsReflectsAnEditImmediately` primes the cache before mutating, so it cannot pass against a cache that never populated.
- No timing assertions: a wall-clock bound would measure this M5 Max rather than the slowest supported machine.
