### PR TITLE
fix(settings): keep a pack word's on/off switch on its title line

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -221,36 +221,45 @@ private struct PackWordRow: View {
   @State private var newAlias: String = ""
 
   var body: some View {
-    ViewThatFits(in: .horizontal) {
-      HStack(alignment: .top, spacing: 12) {
-        info
-        Spacer(minLength: 8)
-        controls
-      }
-      VStack(alignment: .leading, spacing: 8) {
-        info
-        controls
-      }
-    }
-    .opacity(word.isEnabled ? 1 : 0.5)
-  }
-
-  private var info: some View {
+    // The on/off switch stays on the word's TITLE line however many aliases
+    // the word carries. `ViewThatFits` used to compare a horizontal candidate
+    // that INCLUDED the wrapping alias chips, so `amoxicillin` (11 aliases)
+    // made that candidate too wide and the switch fell to the fallback's
+    // bottom left — under the "Add alias" field, reading as a control for
+    // that field rather than for the word (#2507). The chips and the add
+    // field now sit BENEATH the title row instead of competing with it for
+    // the same width, and `ViewThatFits` governs only the title row, which is
+    // the case the fallback was written for: a genuinely narrow window.
     VStack(alignment: .leading, spacing: 6) {
-      HStack(spacing: 8) {
-        Text(word.canonical)
-          .settingsRowLabel()
-        if word.isEdited {
-          Text("EDITED")
-            .font(.system(size: 10, weight: .bold))
-            .foregroundStyle(.stWarning)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(Color.stWarningSoft, in: Capsule())
+      ViewThatFits(in: .horizontal) {
+        HStack(alignment: .top, spacing: 12) {
+          titleRow
+          Spacer(minLength: 8)
+          controls
+        }
+        VStack(alignment: .leading, spacing: 8) {
+          titleRow
+          controls
         }
       }
       aliasChips
       addAliasRow
+    }
+    .opacity(word.isEnabled ? 1 : 0.5)
+  }
+
+  private var titleRow: some View {
+    HStack(spacing: 8) {
+      Text(word.canonical)
+        .settingsRowLabel()
+      if word.isEdited {
+        Text("EDITED")
+          .font(.system(size: 10, weight: .bold))
+          .foregroundStyle(.stWarning)
+          .padding(.horizontal, 6)
+          .padding(.vertical, 2)
+          .background(Color.stWarningSoft, in: Capsule())
+      }
     }
   }
 


### PR DESCRIPTION
## What the user sees

Open a vocabulary pack ("See all") and a word with many aliases used to drop its on/off switch to the bottom left of its row, underneath the alias chips and the "Add alias" field, where it read as a control belonging to that field rather than to the word. Reproduced on the shipped build at `9b50e0f3`: Medical → `amoxicillin`, which carries 11 aliases, while `acetaminophen` (3) and `acne` (1) in the same list drew correctly on the right.

The switch is what turns a single word off. Detached from its word and sitting under a text field, a user could reasonably believe they are disabling the thing they just typed.

Now the switch stays level with the word at every alias count.

## Cause

`PackWordRow` was a `ViewThatFits(in: .horizontal)` whose horizontal candidate carried the whole `info` column — title, wrapping alias chips, and the add-alias field. Enough chips made that candidate too wide at any window width, so the column fallback won and stacked the controls underneath, leading-aligned and beside nothing.

The fallback is right for a genuinely narrow window. It was wrong here, because the row only failed to fit on its own chips.

## Fix

The row is a `VStack` of (title + controls) then (chips, add field), and `ViewThatFits` governs only the title row. The column fallback is now reachable only when the title, Restore and the switch genuinely cannot share a line, which is the case it was written for.

## Sibling checked, not assumed

The Your Words edit sheet has an alias chip row too (`CustomWordEditSheet.swift:108`) and contains no `ViewThatFits`, so it cannot produce this. The other `ViewThatFits` sites in Settings govern button rows and cards, not a control beside wrapping chips.

## Test

No unit test. This is SwiftUI layout with no logic change, runtime-only under `code-design-rules.md` RULE: test-obligations. No test target references this view, and `PackWordRow` is a private view needing a `VocabularyPackManager` home, so binding it would mean widening visibility for a layout assertion.

## Verified by MEASURING the switch, both ways

A screenshot shows the fix; it cannot show that the old build was different. Both builds were driven down the identical path — Dictionary → Vocabulary Packs → Medical → See all — and every word toggle's `AXFrame` was read. `swift-patterns.md` RULE: plain-button-content-shape says the check for this class is to measure the rectangle, never to look at it.

| word | aliases | x BEFORE (`main` @ 9b50e0f3) | x AFTER |
|---|---|---|---|
| acetaminophen | 3 | 1221 | 1221 |
| acne | 1 | 1221 | 1221 |
| **amoxicillin** | **11** | **702** | **1221** |
| ankle | 2 | 1221 | 1221 |
| **appendectomy** | **many** | **702** | **1221** |
| ascites | — | 1221 | 1221 |
| bisacodyl | — | 1221 | 1221 |
| brainstem | — | 1221 | 1221 |

**The control found a second broken row the report did not name.** `appendectomy` was displaced by the same 519pt as `amoxicillin`, in the first eight rows of one pack. So this was not one unusual word — it is every word whose chips make the row's horizontal candidate too wide, and the fix moves both back.

Screenshots of both states were captured alongside the measurements.

## Review

Codex diff review: clean. A second behavioural pass over ten runtime questions (two sources for one fact, a path that skips the guard, failure paths, environment, user-changeable constants, over-wide claims, input shape, ordering, leftover state, reachability) returned no findings, with the axis list attached rather than a bare verdict.

Tier: SMALL | Lane: Code | Modules: EnviousWisprAppKit views

Closes #2507
