### PR TITLE
fix(build): stop the delivery log line stuttering its own category

### DIFF
--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -931,10 +931,26 @@ public actor ModelDeliveryController {
     /// `Model delivery admitted` and `Model delivery failed` reproduce the
     /// wording of the two ad-hoc lines this replaces, verbatim, because those
     /// are what someone greps for today.
+    ///
+    /// THE STRING RETURNED HERE IS NOT THE LINE A READER SEES. `AppLogger`
+    /// prefixes a timestamp, a level and the CATEGORY before writing
+    /// (`AppLogger.swift`, `writeRendered`), and this event's category is
+    /// `Delivery` — see the `AppLogger.shared.log(... category: "Delivery")`
+    /// call a few lines above. So the composed line reads:
+    ///
+    ///     [2026-08-25T01:14:02-0400] [INFO] [Delivery] [#1] Model delivery admitted …
+    ///
+    /// The sequence prefix is therefore `[#N]` and not `[delivery #N]`: the
+    /// category token already says Delivery, and the longer form stuttered the
+    /// word three times in two adjacent bracketed tokens (#2399). Anyone
+    /// editing this prefix is editing the middle of that composed line, which
+    /// nothing at this declaration would otherwise say — the unit test below
+    /// pins THIS string and is downstream of the wrapper, so it cannot see the
+    /// composed form at all.
     package static func deliveryLogLine(
       identity: ModelIdentity, event: DeliveryEvent, sequence: UInt64
     ) -> String {
-      let prefix = "[delivery #\(sequence)]"
+      let prefix = "[#\(sequence)]"
       let key = identity.cacheKey
       switch event {
       case .attemptStarted(let resumed):

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryLocalLogTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryLocalLogTests.swift
@@ -54,56 +54,56 @@ import Testing
 
       #expect(
         line(.attemptStarted(resumed: true))
-          == "[delivery #1] Model delivery attempt started \(key): resumed=true")
+          == "[#1] Model delivery attempt started \(key): resumed=true")
 
       #expect(
         line(
           .attemptCompleted(
             durationBucket: "10_30s", bytesDownloadedBucket: "100_500mb", sourcesUsed: 2,
             finalSourceID: "backup", repairedComponentsCount: 1))
-          == "[delivery #1] Model delivery admitted \(key): duration=10_30s "
+          == "[#1] Model delivery admitted \(key): duration=10_30s "
             + "bytes=100_500mb sources=2 final_source=backup repaired=1")
 
       #expect(
         line(
           .attemptFailed(
             reason: .sourceTimeout, failingSourceID: "primary", detail: "read_timeout"))
-          == "[delivery #1] Model delivery failed \(key): source_timeout (read_timeout) "
+          == "[#1] Model delivery failed \(key): source_timeout (read_timeout) "
             + "source=primary")
 
       #expect(
         line(.attemptFailed(reason: .insufficientDisk, failingSourceID: nil, detail: nil))
-          == "[delivery #1] Model delivery failed \(key): insufficient_disk",
+          == "[#1] Model delivery failed \(key): insufficient_disk",
         "an absent source and detail must add nothing, not empty parentheses")
 
       #expect(
         line(
           .sourceFailover(reason: .source5xx, fromSourceID: "primary", toSourceID: "backup"))
-          == "[delivery #1] Model delivery source failover \(key): primary -> backup, "
+          == "[#1] Model delivery source failover \(key): primary -> backup, "
             + "reason=source_5xx",
         "naming the transition IS the diagnostic: reason alone cannot say which mirror fell over")
 
       #expect(
         line(.validationRepair(componentsCount: 3, trigger: .loadMiss))
-          == "[delivery #1] Model delivery validation repair \(key): components=3 "
+          == "[#1] Model delivery validation repair \(key): components=3 "
             + "trigger=load_miss")
 
       #expect(
         line(.cancel(phaseAtCancel: "downloading", resumable: true))
-          == "[delivery #1] Model delivery cancelled \(key): phase=downloading resumable=true")
+          == "[#1] Model delivery cancelled \(key): phase=downloading resumable=true")
 
       #expect(
         line(.flagActive(flag: "modelDelivery.parakeet.sourceOrder", value: "backup_first"))
-          == "[delivery #1] Model delivery flag active \(key): "
+          == "[#1] Model delivery flag active \(key): "
             + "modelDelivery.parakeet.sourceOrder=backup_first")
 
       #expect(
         line(.admittedWithoutFetch(reason: .markerFastPath))
-          == "[delivery #1] Model delivery admitted \(key) without fetch: "
+          == "[#1] Model delivery admitted \(key) without fetch: "
             + "reason=marker_fast_path")
 
       #expect(
-        line(.attemptStarted(resumed: false), 42).hasPrefix("[delivery #42] "),
+        line(.attemptStarted(resumed: false), 42).hasPrefix("[#42] "),
         "the sequence is the line's own, not a constant")
     }
 


### PR DESCRIPTION
## What a user of the log sees

Before:

```
[2026-08-25T01:14:02-0400] [INFO] [Delivery] [delivery #1] Model delivery admitted parakeet-…
```

After:

```
[2026-08-25T01:14:02-0400] [INFO] [Delivery] [#1] Model delivery admitted parakeet-…
```

`AppLogger` composes the timestamp, the level and the CATEGORY, and this event's category is `Delivery`. The renderer added `[delivery #N]` on top, so the word appeared three times, twice as adjacent bracketed tokens.

`Model delivery admitted` and `Model delivery failed` are untouched. Those are the phrases people grep for and #2135 preserved them on purpose.

## The durable half

The prefix change fixes today's string. On its own it leaves the next person editing that prefix exactly as blind as this one was, because nothing at the renderer said which wrapper its output travels through.

The doc comment now states the composed form and names the wrapper, and says why the unit test cannot see it: `DeliveryLocalLogTests` pins the renderer's own string and runs downstream of `AppLogger`'s private writer.

## Test

No new test. Asserting the composed form means reaching a private path inside `AppLogger` or reading the real `app.log`, which two processes write with no rotation lock (#2159) and which #2135 deliberately avoided. The ten existing assertions move to the new prefix.

`scripts/xcode-test.sh --filter EnviousWisprTests/DeliveryLocalLogTests` — `Debug lane verdict: PASS`, 2 tests, all accepted.

## Sweep

`/usr/bin/grep -rn "\[delivery #" Sources/ Tests/ docs/ .claude/ workers/ website/ scripts/` — no live occurrence remains in `Sources/` or `Tests/`. The other hits are under `docs/audits/` and `docs/feature-requests/`, which are dated records of what the line was on the day they were written, plus one quotation of the old form inside the new comment explaining the change. `[#` is not emitted as a prefix by any other renderer in `Sources/`.

## Classification

REPRODUCIBLE. Any delivery event written while Debug Mode is on.

Tier: SMALL | Lane: Code | Modules: EnviousWisprModelDelivery

Closes #2399
