### PR TITLE
test(ui): close three gaps the overnight run's own mutants found

### DIFF
--- a/Tests/EnviousWisprTests/App/Overlay/OverlayReducerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayReducerTests.swift
@@ -114,6 +114,42 @@ struct OverlayReducerTests {
     #expect(level == 0.0)
   }
 
+  /// **The case the dedup guard is exempt FOR, and nothing tested it.**
+  /// `reduce` drops a repeated intent, and `isRecordingIntent` exempts
+  /// recordings so metering keeps flowing. `meteringDoesNotChurnIdentity`
+  /// above pushes 0.2, 0.3, 0.9, 0.0 — all DIFFERENT, so each one is a new
+  /// intent and the exemption is never reached.
+  ///
+  /// Two consecutive IDENTICAL levels is not a contrived input: silence is the
+  /// one passage where consecutive audio samples are bit-identical, which is
+  /// the defect #2216 already paid for once — the meter froze mid-shape
+  /// exactly when the user stopped talking. Without the exemption the second
+  /// tick returns `.noChange` and the pill stops updating.
+  ///
+  /// Found by a mutation making `isRecordingIntent` always false, which no
+  /// test in this suite or in `PillRequestParityTests` noticed.
+  @Test("a repeated identical audio level is not deduped away")
+  func aRepeatedIdenticalLevelStillUpdates() {
+    var r = Self.makeReducer()
+    _ = r.startRecordingForTests(audioLevel: 0.4)
+
+    let first = r.reduce(.pipeline(.recording(audioLevel: 0.5)))
+    #expect(first.didChange)
+
+    // The SAME level again. `isNewIntent` is false here, so only the recording
+    // exemption keeps this from being dropped.
+    let repeated = r.reduce(.pipeline(.recording(audioLevel: 0.5)))
+    // A `Comment` takes a literal, so this cannot be a concatenation.
+    #expect(
+      repeated.didChange,
+      "a repeated identical level must still reach the pill: dropping it freezes the meter for as long as the audio is unchanging, which is what silence looks like")
+    guard case .recording(let level, _, _, _)? = r.state.current?.content else {
+      Issue.record("expected a recording pill")
+      return
+    }
+    #expect(level == 0.5)
+  }
+
   @Test("a stale expiry cannot dismiss the presentation that replaced it")
   func staleExpiryIsDropped() {
     var r = Self.makeReducer()

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillChromeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillChromeTests.swift
@@ -93,6 +93,38 @@ struct RecordingPillChromeTests {
     #expect(chrome.isContentSizedVertically)
   }
 
+  /// **The third design, which had no pin at all.** Its two siblings above fix
+  /// every field; the level rail had none, so every value here could move with
+  /// nothing going red. Found by a mutation of `noticeMaxWidth` that neither
+  /// this suite nor `LevelRailDesignTests` noticed — and the source comment at
+  /// that line already said so: "Nothing fails if it keeps the old 232 —
+  /// notices would just wrap 28pt early, for ever, with no test red anywhere."
+  /// A window written down rather than closed (code-design-rules.md
+  /// RULE: close-the-window-never-handle-it); this closes it.
+  @Test("the level rail's chrome is pinned, and its notice cap is derived rather than typed")
+  func levelRailChromeIsPinned() {
+    let chrome = RecordingPillDesign.levelRail.chrome
+    #expect(chrome.header == .clockAndRail)
+    #expect(chrome.stackSpacing == 6)
+    #expect(chrome.rootInsets == EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14))
+    #expect(chrome.cornerStyle == .capsule)
+    #expect(chrome.levelAnimation == .none)
+    #expect(chrome.showsListeningSentence == false)
+    #expect(chrome.noticeInk == .capsuleWhite)
+    #expect(chrome.noticeInsets == EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+    #expect(chrome.wellInsets == EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+    #expect(chrome.wellInk == .capsuleWhite)
+    #expect(chrome.fadesWhenWellIsFull == false)
+
+    // THE ARITHMETIC, NOT THE NUMBER. 260 is the design's own width less the
+    // root inset either side, and the source says so in words. Pinning the
+    // literal would let a width change leave this behind silently, which is
+    // exactly the miss that comment records; pinning the relation makes the
+    // width and the cap move together or go red.
+    let sideInsets = chrome.rootInsets.leading + chrome.rootInsets.trailing
+    #expect(chrome.noticeMaxWidth == RecordingPillDesign.levelRail.width - sideInsets)
+  }
+
   /// **The one field that must never be typed, only derived.** A design that
   /// reserves a fixed box is not content-sized, by definition; two independent
   /// answers to that is how a pill comes to be measured inside the panel being

--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -109,6 +109,18 @@ struct SelectionReaderTests {
   /// The family is CLOSED, and a row per member so adding one without deciding is visible.
   @Test("Only our own identifiers are the app; everything else is somebody's document")
   func theIdentityFamilyIsExactlyOurTwoBuilds() {
+    // THE LITERALS, because the two rows below cannot fail on a rename.
+    // `isOurs(AppBundleIdentity.production)` asks the subject about itself:
+    // change either constant and both sides move together, so the row stays
+    // green while the family stops naming a build that exists. Found by a
+    // mutation that renamed `development` and turned nothing red
+    // (validation-discipline.md
+    // RULE: an-expectation-built-with-the-mechanism-under-test-cannot-fail).
+    //
+    // These strings are `Project.swift:175` and `:201`. That file is the
+    // authority and this is the only place a drift between them goes red.
+    #expect(AppBundleIdentity.production == "com.enviouswispr.app")
+    #expect(AppBundleIdentity.development == "com.enviouswispr.app.dev")
     #expect(AppBundleIdentity.isOurs(AppBundleIdentity.production))
     #expect(AppBundleIdentity.isOurs(AppBundleIdentity.development))
     #expect(AppBundleIdentity.all.count == 2)


### PR DESCRIPTION
## Where these came from

The overnight battery run of 2026-08-30 satisfied `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night's requirement that **the overnight session adds at least one mutant of its OWN per suite** — the filed recipe is the floor.

Six own mutants across five suites. Three were caught. Three were not, and each was then re-run against a SECOND suite that could plausibly cover it, because a survivor in one suite is not a claim about the codebase. All three survived both times.

The three tests below close them. Every one is an assertion ADDED; nothing was loosened.

## 1. The identity family's test could not fail on a rename

`SelectionReaderTests.theIdentityFamilyIsExactlyOurTwoBuilds()` asserted:

```swift
#expect(AppBundleIdentity.isOurs(AppBundleIdentity.production))
#expect(AppBundleIdentity.isOurs(AppBundleIdentity.development))
#expect(AppBundleIdentity.all.count == 2)
```

Both membership rows ask the subject about itself. Renaming either constant moves both sides together and the row stays green — `validation-discipline.md` RULE: an-expectation-built-with-the-mechanism-under-test-cannot-fail.

**Why it matters rather than being tidy.** Those two strings are `Project.swift:175` and `:201`, and this test is the only place a drift between the source and the project file goes red. A renamed `development` silently stops the family naming the dev build, which is exactly the hole #2413 shipped with and cloud review found: a dev build looking at an installed release build.

Mutation `development = "com.enviouswispr.app.beta"` survived `SelectionReaderTests` AND `QuickAddCoordinatorTests`. Now pins both literals.

Note the suite is not weak in general: the paired mutation `isOurs(nil) -> true` was CAUGHT by the same test. It binds behaviour and did not bind the values.

## 2. The pill chrome table pinned two designs of three

`RecordingPillChromeTests` has `classicChromeIsPinned()` and `readingWellChromeIsPinned()`, each fixing every field. `.levelRail` had no pin, so every value on it could move with nothing red. `chromeIsInjectiveOverDesigns()` only checks the three stay distinct, which a uniform shift preserves.

**The source comment at the surviving value already said so**, which makes this a window written down rather than closed (`code-design-rules.md` RULE: close-the-window-never-handle-it):

> **This is the site the round-5 width change nearly missed.** Nothing fails if it keeps the old 232 — notices would just wrap 28pt early, for ever, with no test red anywhere.

Mutation `noticeMaxWidth: 260 -> 300` survived `RecordingPillChromeTests` AND `LevelRailDesignTests`.

`levelRailChromeIsPinned()` now fixes every field, and pins the notice cap as **the arithmetic rather than the number**: the design's own width less the root inset either side. The literal would let a width change leave the cap behind, which is the miss the comment records; the relation cannot.

## 3. The audio meter could freeze on silence, untested

`reduce` drops a repeated intent, and `isRecordingIntent` exempts recordings so metering keeps flowing. `meteringDoesNotChurnIdentity()` pushes `0.2, 0.3, 0.9, 0.0` — all DIFFERENT, so every one is a new intent and the exemption is never reached.

Two consecutive IDENTICAL levels is not a contrived input. **Silence is the one passage where consecutive audio samples are bit-identical**, and #2216 already paid for it: the waveform froze mid-shape exactly when the user stopped talking (`code-design-rules.md` RULE: a-mockup-animates-on-timers, final paragraph).

Mutation `isRecordingIntent` always false survived `PillRequestParityTests` AND `OverlayReducerTests` (44 tests).

`aRepeatedIdenticalLevelStillUpdates()` pushes the same level twice and requires the second to reach the pill.

## Recipe

```json
{
  "rows": [
    {
      "label": "rename the dev identifier, so the family stops naming a build that exists",
      "file": "Sources/EnviousWisprServices/AppBundleIdentity.swift",
      "anchor": "  public static let development = \"com.enviouswispr.app.dev\"",
      "replacement": "  public static let development = \"com.enviouswispr.app.beta\"",
      "suite": "EnviousWisprTests/SelectionReaderTests",
      "expect_fail": "theIdentityFamilyIsExactlyOurTwoBuilds()"
    },
    {
      "label": "move the level rail's notice cap off its own arithmetic",
      "file": "Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift",
      "anchor": "        noticeMaxWidth: 260,",
      "replacement": "        noticeMaxWidth: 300,",
      "suite": "EnviousWisprTests/RecordingPillChromeTests",
      "expect_fail": "levelRailChromeIsPinned()"
    },
    {
      "label": "no intent is ever a recording, so a repeated identical level is deduped away",
      "file": "Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift",
      "anchor": "    if case .recording = intent { return true }\n    return false",
      "replacement": "    return false",
      "suite": "EnviousWisprTests/OverlayReducerTests",
      "expect_fail": "aRepeatedIdenticalLevelStillUpdates()"
    }
  ]
}
```

Each row is the exact mutation that survived, aimed at the test written to catch it. Running it is the proof the fix works; a test added without watching its mutant die is not evidence.

Tier: SMALL | Test: added (3) | Modules: Tests only, no source change
Lane: Code

Ref: overnight run 2026-08-30 against `9b50e0f3`; #2419's own-mutant obligation.
