### PR TITLE
fix(build): stop the phase 5 UAT harness driving a worktree that no longer exists

### DIFF
--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -204,7 +204,20 @@ def visible_overlays(pid):
 
 
 def stop_app(timeout=30.0):
-    """TERM every dev instance and wait for the process table to agree it is gone."""
+    """TERM every dev instance and wait for the process table to agree it is gone.
+
+    REFUSES FIRST when this checkout has no build. Putting the check only in
+    `start_app` was too late: every caller in this family stops before it
+    starts, so a missing build still cost the running instance and only then
+    raised — the earlier path keeping the old behaviour while the one I was
+    reading looked fixed.
+
+    Safe for every caller here because each `stop_app` in this family is
+    immediately followed by a relaunch; the one mode that does neither
+    (`phase5_language_hover` inheriting a running instance) reaches neither
+    function.
+    """
+    require_bundle()
     for p in dev_pids():
         subprocess.run(["kill", "-TERM", str(p)], capture_output=True)
     deadline = time.time() + timeout

--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -56,7 +56,32 @@ SHOTS = UAT / "geometry-relaunch"
 SHOTS.mkdir(parents=True, exist_ok=True)
 LOG = pathlib.Path.home() / "Library/Logs/EnviousWispr/app.log"
 DOMAIN = "com.enviouswispr.app"
-BUNDLE = "/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr-2377-phase5/build/EnviousWispr Local.app"
+# **THE BUNDLE IS DERIVED FROM THIS CHECKOUT, NOT PINNED TO A WORKTREE.** It used
+# to name `EnviousWispr-2377-phase5`, the worktree #2377 was written in, which
+# `post-sync-cleanup.sh` removed on the fetch after that PR merged. Every row
+# that opens `BUNDLE` — this file, `phase5_warning_morph`, `phase5_recovery_rail`
+# and `phase5_language_hover` — has been unrunnable since, and the failure is
+# late and misleading: `stop_app()` kills the running instance FIRST, the `open`
+# then fails against a path that is not there, and the harness reports
+# `ABORT_NO_INSTANCE`, which reads as "the app would not start".
+#
+# A hardcoded absolute path is not a pinned oracle (tools-and-apps.md
+# RULE: cwd-is-sticky-never-cd-for-a-one-off): it pins whatever branch some other
+# tree happens to be on, and this repo's rules put feature work in worktrees that
+# are deleted on merge. Deriving it from `__file__` drives the build belonging to
+# the checkout the harness itself came from, which is the tree whose change is
+# under test.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BUNDLE = str(_REPO_ROOT / "build" / "EnviousWispr Local.app")
+
+# FAIL LOUDLY AND EARLY, before anything is killed. A missing build and an app
+# that will not launch are the same `ABORT_NO_INSTANCE` to every caller, and only
+# one of them is a product finding.
+if not pathlib.Path(BUNDLE).exists():
+    raise SystemExit(
+        f"phase5 harness: no dev build at {BUNDLE}\n"
+        "Run scripts/build-dev-app.sh in THIS checkout first. Refusing rather than "
+        "terminating the running instance for a run that cannot start.")
 KEYS = ["livePreviewEnabled", "recordingPillDesignWithoutWords"]
 
 # **WRITE A BOOL AS A BOOL.** `livePreviewEnabled` is read as

--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -214,18 +214,15 @@ def visible_overlays(pid):
 def stop_app(timeout=30.0):
     """TERM every dev instance and wait for the process table to agree it is gone.
 
-    REFUSES FIRST when this checkout has no build. Putting the check only in
-    `start_app` was too late: every caller in this family stops before it
-    starts, so a missing build still cost the running instance and only then
-    raised — the earlier path keeping the old behaviour while the one I was
-    reading looked fixed.
+    DOES NOT require a bundle, deliberately. Stopping needs no build, and
+    TEARDOWN calls this: `phase5_language_hover` deletes its state keys, stops,
+    and restores them in `finally` — so a refusal raised from here skips the
+    restore and leaves the founder's dev preferences deleted. That is worse
+    than the failure it would be reporting.
 
-    Safe for every caller here because each `stop_app` in this family is
-    immediately followed by a relaunch; the one mode that does neither
-    (`phase5_language_hover` inheriting a running instance) reaches neither
-    function.
+    The precondition belongs at the START of a run, before anything is stopped
+    OR written, and each harness's `main` asks for it there.
     """
-    require_bundle()
     for p in dev_pids():
         subprocess.run(["kill", "-TERM", str(p)], capture_output=True)
     deadline = time.time() + timeout
@@ -367,6 +364,9 @@ def measure_row(name, pid, since_bytes):
 
 
 def main():
+    # BEFORE ANY MUTATION OR STOP. This row relaunches, so it needs this
+    # checkout's build; asking here means a missing one costs nothing.
+    require_bundle()
     snapshot = {k: read_default(k) for k in KEYS}
     # Recorded, not refused: every frame this row takes is captured BY WINDOW ID,
     # which the lock cannot substitute. A row taking a full-SCREEN artifact still

--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -39,6 +39,7 @@ RULE: a-harness-that-ACTS-on-a-shared-resource-must-refuse-not-choose.
 """
 
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -87,9 +88,16 @@ def require_bundle():
     checkout's bundle at all — `phase5_language_hover` has exactly that mode,
     and an import-time check aborted it.
     """
-    if not pathlib.Path(BUNDLE).exists():
+    # THE EXECUTABLE, NOT THE DIRECTORY. `build-dev-app.sh` copies INTO the
+    # bundle rather than replacing it atomically, so an interrupted deploy
+    # leaves a `.app` that exists and cannot run — and a directory check passes,
+    # kills every dev instance, and only then fails to launch, which is the
+    # behaviour this refusal exists to prevent. Existence is not function.
+    executable = pathlib.Path(BUNDLE) / "Contents" / "MacOS" / "EnviousWispr"
+    if not os.access(executable, os.X_OK):
         raise SystemExit(
-            f"phase5 harness: no dev build at {BUNDLE}\n"
+            f"phase5 harness: no runnable dev build at {BUNDLE}\n"
+            f"(looked for an executable at {executable})\n"
             "Run scripts/build-dev-app.sh in THIS checkout first. Refusing rather than "
             "terminating the running instance for a run that cannot start.")
 KEYS = ["livePreviewEnabled", "recordingPillDesignWithoutWords"]

--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -65,23 +65,33 @@ DOMAIN = "com.enviouswispr.app"
 # then fails against a path that is not there, and the harness reports
 # `ABORT_NO_INSTANCE`, which reads as "the app would not start".
 #
-# A hardcoded absolute path is not a pinned oracle (tools-and-apps.md
-# RULE: cwd-is-sticky-never-cd-for-a-one-off): it pins whatever branch some other
-# tree happens to be on, and this repo's rules put feature work in worktrees that
-# are deleted on merge. Deriving it from `__file__` drives the build belonging to
-# the checkout the harness itself came from, which is the tree whose change is
-# under test.
+# A hardcoded absolute path pins whatever branch some other tree happens to be
+# on, and feature work here lives in worktrees that are deleted on merge, so the
+# same rot recurs on every feature. Deriving it from `__file__` drives the build
+# belonging to the checkout the harness itself came from, which is the tree whose
+# change is under test.
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 BUNDLE = str(_REPO_ROOT / "build" / "EnviousWispr Local.app")
 
-# FAIL LOUDLY AND EARLY, before anything is killed. A missing build and an app
-# that will not launch are the same `ABORT_NO_INSTANCE` to every caller, and only
-# one of them is a product finding.
-if not pathlib.Path(BUNDLE).exists():
-    raise SystemExit(
-        f"phase5 harness: no dev build at {BUNDLE}\n"
-        "Run scripts/build-dev-app.sh in THIS checkout first. Refusing rather than "
-        "terminating the running instance for a run that cannot start.")
+
+def require_bundle():
+    """Refuse BEFORE anything is killed when this checkout has no dev build.
+
+    A missing build and an app that will not launch are the same
+    `ABORT_NO_INSTANCE` to every caller, and only one of them is a product
+    finding. The old shape terminated the running instance and only then
+    discovered it had nothing to launch.
+
+    Called from `start_app` rather than at import, because a row that INHERITS
+    an already-running instance never relaunches and does not need this
+    checkout's bundle at all — `phase5_language_hover` has exactly that mode,
+    and an import-time check aborted it.
+    """
+    if not pathlib.Path(BUNDLE).exists():
+        raise SystemExit(
+            f"phase5 harness: no dev build at {BUNDLE}\n"
+            "Run scripts/build-dev-app.sh in THIS checkout first. Refusing rather than "
+            "terminating the running instance for a run that cannot start.")
 KEYS = ["livePreviewEnabled", "recordingPillDesignWithoutWords"]
 
 # **WRITE A BOOL AS A BOOL.** `livePreviewEnabled` is read as
@@ -204,6 +214,9 @@ def stop_app(timeout=30.0):
 
 
 def start_app(timeout=30.0):
+    # Every relaunch funnels through here, so the refusal cannot be forgotten at
+    # a call site.
+    require_bundle()
     subprocess.run(["open", "-n", BUNDLE], capture_output=True)
     deadline = time.time() + timeout
     while time.time() < deadline:

--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -259,13 +259,18 @@ def start_app(timeout=30.0):
         if len(pids) == 1:
             return pids[0]
         time.sleep(0.2)  # test-fixture-timer: process-table polling for the new instance
+    # STATES THE OBSERVATION, NOT THE CAUSE. An earlier draft ended "this is NOT
+    # a product finding: rebuild" — which is a causal claim about a state with
+    # more than one producer, and the other producer is the app CRASHING during
+    # startup. That wording would send an operator to rebuild past a real
+    # startup regression. Name both producers and where to look.
     raise SystemExit(
         f"phase5 harness: LAUNCH FAILED and the previous instance is already stopped.\n"
         f"bundle: {BUNDLE}\n"
-        "The build is present but did not produce a running instance within "
-        f"{timeout:.0f}s — an incomplete or unsignable deploy looks exactly like this. "
-        "Rebuild with scripts/build-dev-app.sh in THIS checkout. This is NOT a product "
-        "finding: nothing was measured.")
+        f"The build is present but no instance appeared within {timeout:.0f}s. That has more "
+        "than one cause — an incomplete or unsignable deploy, or the app failing during "
+        "startup — so read ~/Library/Logs/EnviousWispr/app.log and the crash reporter before "
+        "classifying it. No UAT result was produced either way.")
 
 
 def await_idle(timeout=60.0):

--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -235,8 +235,22 @@ def stop_app(timeout=30.0):
 
 
 def start_app(timeout=30.0):
-    # Every relaunch funnels through here, so the refusal cannot be forgotten at
-    # a call site.
+    """Launch this checkout's build and return its pid.
+
+    RAISES rather than returning None when the launch fails, because by the time
+    this is called the running instance is already gone and `None` reaches the
+    caller as `ABORT_NO_INSTANCE` — the same words an app that crashes on launch
+    produces, and a reader cannot tell "there was nothing to launch" from "the
+    product would not start".
+
+    NO STATIC CHECK CAN PROVE A BUNDLE WILL LAUNCH, and four review rounds each
+    found a subtler partial state than the last: a missing directory, then a
+    directory with no executable, then an executable inside an incomplete
+    bundle. That is a set with no closing member, so `require_bundle` stays a
+    cheap FAST FAIL for the common case and is not asked to be exhaustive. The
+    exact question — did it launch, and had something been stopped first — is
+    answered here, after the fact, where the answer set is closed.
+    """
     require_bundle()
     subprocess.run(["open", "-n", BUNDLE], capture_output=True)
     deadline = time.time() + timeout
@@ -245,7 +259,13 @@ def start_app(timeout=30.0):
         if len(pids) == 1:
             return pids[0]
         time.sleep(0.2)  # test-fixture-timer: process-table polling for the new instance
-    return None
+    raise SystemExit(
+        f"phase5 harness: LAUNCH FAILED and the previous instance is already stopped.\n"
+        f"bundle: {BUNDLE}\n"
+        "The build is present but did not produce a running instance within "
+        f"{timeout:.0f}s — an incomplete or unsignable deploy looks exactly like this. "
+        "Rebuild with scripts/build-dev-app.sh in THIS checkout. This is NOT a product "
+        "finding: nothing was measured.")
 
 
 def await_idle(timeout=60.0):
@@ -360,10 +380,13 @@ def main():
                 write_default(k, v)
             observed = {k: read_default(k) for k in settings}
             wanted = {k: expected_read(k, v) for k, v in settings.items()}
+            # `start_app` RAISES when the launch fails, so there is no None to
+            # test. That aborts the whole run rather than skipping this row, and
+            # that is the intended change: an app that will not launch fails
+            # every remaining row too, and the old per-row error said
+            # "relaunch produced no single instance" for a build that was never
+            # there.
             pid = start_app()
-            if not pid:
-                report["rows"][name] = {"error": "relaunch produced no single instance"}
-                continue
             if not await_idle():
                 report["rows"][name] = {
                     "pid": pid, "settings": {k: str(v) for k, v in settings.items()},

--- a/Tests/RuntimeUAT/phase5_language_hover.py
+++ b/Tests/RuntimeUAT/phase5_language_hover.py
@@ -271,6 +271,11 @@ def main():
         print(json.dumps({"verdict": "ABORT_SCREEN_LOCKED"}))
         return
 
+    # BEFORE ANY MUTATION OR STOP, and after the lock check so the lock
+    # verdict still comes first. This row relaunches, so it needs this
+    # checkout's build; asking here means a missing one costs nothing.
+    g.require_bundle()
+
     pids = g.dev_pids()
     if len(pids) != 1:
         print(json.dumps({"verdict": "ABORT_INSTANCE", "found": pids}))

--- a/Tests/RuntimeUAT/phase5_language_hover.py
+++ b/Tests/RuntimeUAT/phase5_language_hover.py
@@ -293,10 +293,9 @@ def main():
             g.stop_app()
             subprocess.run(["defaults", "write", SHARED_DOMAIN, "selectedBackend",
                             REQUIRED_BACKEND], check=True)
+            # `start_app` raises with the exact cause; `ABORT_NO_INSTANCE` here
+            # could not tell a missing build from an app that crashes on launch.
             pid = g.start_app()
-            if not pid:
-                print(json.dumps({"verdict": "ABORT_NO_INSTANCE"}))
-                return
             report["pid"] = pid
         g.await_idle()
 

--- a/Tests/RuntimeUAT/phase5_language_hover.py
+++ b/Tests/RuntimeUAT/phase5_language_hover.py
@@ -333,7 +333,14 @@ def main():
             g.stop_app()
             subprocess.run(["defaults", "write", SHARED_DOMAIN, "selectedBackend",
                             backend_before], check=True)
-            g.start_app()
+            # A FAILED RELAUNCH MUST NOT ABORT THE RESTORE. `start_app` raises,
+            # and this is inside `finally`, so an unguarded call would skip the
+            # `STATE_KEYS` restore below and leave the founder's dev preferences
+            # deleted — worse than the failure it is reporting.
+            try:
+                g.start_app()
+            except SystemExit as exc:
+                report["relaunch_error"] = str(exc)
         report["backend_restored"] = subprocess.run(
             ["defaults", "read", SHARED_DOMAIN, "selectedBackend"],
             capture_output=True, text=True).stdout.strip() or None

--- a/Tests/RuntimeUAT/phase5_language_hover.py
+++ b/Tests/RuntimeUAT/phase5_language_hover.py
@@ -271,10 +271,6 @@ def main():
         print(json.dumps({"verdict": "ABORT_SCREEN_LOCKED"}))
         return
 
-    # BEFORE ANY MUTATION OR STOP, and after the lock check so the lock
-    # verdict still comes first. This row relaunches, so it needs this
-    # checkout's build; asking here means a missing one costs nothing.
-    g.require_bundle()
 
     pids = g.dev_pids()
     if len(pids) != 1:
@@ -295,6 +291,11 @@ def main():
         # the app STOPPED so the write is not overwritten by the instance it
         # replaces.
         if backend_before != REQUIRED_BACKEND:
+            # ONLY THIS BRANCH NEEDS A BUILD. The other mode inherits a running
+            # instance and never relaunches, so an unconditional check at the
+            # top of `main` refused valid runs on a checkout that simply had not
+            # been built. Asked here, before the first stop and the first write.
+            g.require_bundle()
             g.stop_app()
             subprocess.run(["defaults", "write", SHARED_DOMAIN, "selectedBackend",
                             REQUIRED_BACKEND], check=True)

--- a/Tests/RuntimeUAT/phase5_recovery_rail.py
+++ b/Tests/RuntimeUAT/phase5_recovery_rail.py
@@ -121,6 +121,11 @@ def main():
         print(json.dumps({"verdict": "ABORT_SCREEN_LOCKED"}))
         return
 
+    # BEFORE ANY MUTATION OR STOP, and after the lock check so the lock
+    # verdict still comes first. This row relaunches, so it needs this
+    # checkout's build; asking here means a missing one costs nothing.
+    g.require_bundle()
+
     if len(g.dev_pids()) != 1:
         print(json.dumps({"verdict": "ABORT_INSTANCE", "found": g.dev_pids()}))
         return

--- a/Tests/RuntimeUAT/phase5_recovery_rail.py
+++ b/Tests/RuntimeUAT/phase5_recovery_rail.py
@@ -135,10 +135,9 @@ def main():
     subprocess.run(["defaults", "write", DOMAIN, "cancelModifiersRaw", "-int", "0"], check=True)
     subprocess.run(["defaults", "write", DOMAIN, "escapeRecoveryEnabled", "-bool", "YES"], check=True)
     try:
+        # `start_app` raises with the exact cause; `ABORT_NO_INSTANCE` here
+        # could not tell a missing build from an app that crashes on launch.
         pid = g.start_app()
-        if not pid:
-            report["verdict"] = "ABORT_NO_INSTANCE"
-            return report
         report["pid"] = pid
 
         pt.ensure()  # best effort; a missing paste target never blocks a row

--- a/Tests/RuntimeUAT/phase5_recovery_rail.py
+++ b/Tests/RuntimeUAT/phase5_recovery_rail.py
@@ -259,7 +259,12 @@ def main():
         report["restore_ok"] = bool(eru.restore(before))
         report["settings_after"] = {k: v[0] for k, v in eru.snapshot(REBIND_KEYS).items()}
         report["restore_clean"] = report["settings_after"] == report["settings_before"]
-        g.start_app()
+        # Guarded for the same reason as language-hover: an unguarded raise here
+        # would lose the report that records whether the restore succeeded.
+        try:
+            g.start_app()
+        except SystemExit as exc:
+            report["relaunch_error"] = str(exc)
         report.setdefault("verdict", "REFUSED")
         if report["verdict"] == "PASS" and not report["restore_clean"]:
             report["verdict"] = "REFUSED_RESTORE_FAILED"

--- a/Tests/RuntimeUAT/phase5_warning_morph.py
+++ b/Tests/RuntimeUAT/phase5_warning_morph.py
@@ -233,6 +233,9 @@ def main():
             subprocess.run(["defaults", "write", DEV_DOMAIN, k, "-float", str(v)], check=True)
         report["overrides_written"] = {k: read_dev_default(k) for k in OVERRIDES}
 
+        # This row opens the bundle itself rather than through `start_app`, so it
+        # asks for the same refusal explicitly.
+        g.require_bundle()
         # `open` does not pass env vars, so the endpoint is armed with --env.
         subprocess.run(["open", "-n", "--env", "EW_FAULT_INJECTION=1", g.BUNDLE],
                        capture_output=True)

--- a/Tests/RuntimeUAT/phase5_warning_morph.py
+++ b/Tests/RuntimeUAT/phase5_warning_morph.py
@@ -220,6 +220,8 @@ def _terminal_after_start():
 
 
 def main():
+    # BEFORE ANY MUTATION OR STOP (see phase5_geometry_relaunch.require_bundle).
+    g.require_bundle()
     snapshot = {k: read_dev_default(k) for k in OVERRIDES}
     report = {"snapshot": snapshot, "screen_locked": g.screen_is_locked(),
               "cap_seconds": CAP_SECONDS,

--- a/Tests/RuntimeUAT/phase5_warning_morph.py
+++ b/Tests/RuntimeUAT/phase5_warning_morph.py
@@ -247,7 +247,12 @@ def main():
                 break
             time.sleep(0.2)  # test-fixture-timer: process-table polling
         if not pid:
-            print(json.dumps({"verdict": "ABORT_NO_INSTANCE"}))
+            # NAMES THE CAUSE. This row opens the bundle itself rather than
+            # through `start_app`, so it carries the same distinction by hand:
+            # the build was present at `require_bundle` and still produced no
+            # instance, which is an incomplete or unsignable deploy — not the
+            # product failing to start. Nothing was measured either way.
+            print(json.dumps({"verdict": "ABORT_LAUNCH_FAILED", "bundle": g.BUNDLE}))
             return
         report["pid"] = pid
         g.await_idle()


### PR DESCRIPTION
## What was broken

`phase5_geometry_relaunch.BUNDLE` was a hardcoded absolute path to `EnviousWispr-2377-phase5/build/EnviousWispr Local.app` — the worktree #2377 was written in, which `post-sync-cleanup.sh` removed on the fetch after that PR merged. **The path has not existed since.**

Blast radius is three rows, not one: `phase5_warning_morph`, `phase5_recovery_rail` and `phase5_language_hover` all open that constant. #2431's manual mutation control is written against `phase5_warning_morph`, so it could not have been run as filed.

**The failure is late and misleading, which is why this is a change rather than a note.** `stop_app()` TERMs the running instance FIRST, the `open` then fails against a path that is not there, no new instance appears, and the harness reports `ABORT_NO_INSTANCE` — which reads as "the app would not start", a product finding, on a run that never had a build to launch. It also leaves the dev-app slot empty for whoever comes next.

A hardcoded absolute path is not a pinned oracle (`tools-and-apps.md` RULE: cwd-is-sticky-never-cd-for-a-one-off): it pins whatever branch some other tree happens to be on, and this repo's rules put feature work in worktrees that are deleted on merge — so the same rot recurs on every feature.

## What it does now

`BUNDLE` is derived from the harness's own checkout via `__file__`, so it drives the build belonging to the tree whose change is under test.

`require_bundle()` refuses when that build is missing, and **the placement is the part that took the work**. It has been in four places across eight review rounds — import, `start_app`, `stop_app`, `main` — and each move fixed the previous round and broke a different caller:

| where | what it fixed | what it broke |
|---|---|---|
| import | the common case, cheaply | `phase5_language_hover`'s supported inherit-only mode, which never relaunches |
| `start_app` | the inherit mode | every caller stops BEFORE it starts, so the app still died first |
| `stop_app` | the ordering | teardown also stops, so a missing build raised from `finally` and left dev preferences DELETED |
| `main` | teardown | the inherit-only mode again |

**The stable answer is not a location, it is a question: which BRANCH needs a build.** Only that branch asks. Three harnesses relaunch on every path and ask in `main`; `phase5_language_hover` asks inside `if backend_before != REQUIRED_BACKEND`, before that branch's first stop and first write.

## Two things that are not the bundle check

**`start_app` raises instead of returning `None`.** No static check can prove a bundle will launch — three rounds each found a subtler partial deploy than the last, which is a set with no closing member. "Will it launch" is not answerable statically; "did it launch, and had something been stopped first" is, afterwards, with two booleans. So the cheap check stopped pretending to be exhaustive and the exact answer moved to where it can be given.

**The failure message states the observation, not a cause.** An earlier draft ended "This is NOT a product finding: rebuild". No instance appearing has more than one producer, and the other one is the app crashing during startup — that wording would send an operator past a real startup regression. It now names both producers and points at the app log and the crash reporter, keeping only what is established: no UAT result was produced.

**Cleanup can no longer be aborted.** `phase5_language_hover` and `phase5_recovery_rail` relaunch inside their cleanup; both catch the raise, record `relaunch_error`, and finish restoring. Those two are the complete set — `phase5_geometry_relaunch`'s own `finally` restores defaults and never relaunches, and `phase5_warning_morph` does not use `start_app`.

## Behaviour change, stated rather than buried

The three `if not pid` branches are unreachable now and are removed, so no dead guard remains. In `phase5_geometry_relaunch`'s row loop that turns a skipped row into a stopped run — intended, because an app that will not launch fails every remaining row too, and the old per-row message said "relaunch produced no single instance" for a build that was never there.

## Review

Eight local Codex rounds. Every round found something real; three of them were defects an earlier round's fix had introduced. Round eight: clean.

## Routed, not folded in

Three PRE-EXISTING bare `.md` citations remain in `phase5_geometry_relaunch.py` — the same violation as the one review made me remove, but each carries real justification rather than attribution, so the remedy is to inline three load-bearing comments. Filed as #2514 rather than ridden in on a behaviour fix.

Tier: SMALL | Lane: Code | Modules: Tests/RuntimeUAT

Unblocks #2431.
