### PR TITLE
test(settings): bind the live-preview state choice and split the provenance pair

### DIFF
--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -197,12 +197,24 @@ struct LivePreviewStatusBarPresentationTests {
   /// `activeSource` shipped and had to withdraw.
   @Test("Provenance names the Mac on Auto and the user on a lock")
   func provenanceDistinguishesAutoFromLocked() {
-    #expect(
-      bar(.active, languageMode: .auto).language?.provenance
-        == LivePreviewSettingsCopy.languageProvenanceFromMac)
-    #expect(
-      bar(.active, languageMode: .locked("de")).language?.provenance
-        == LivePreviewSettingsCopy.languageProvenanceUserPicked)
+    let auto = bar(.active, languageMode: .auto).language?.provenance
+    let locked = bar(.active, languageMode: .locked("de")).language?.provenance
+
+    // **THE ROWS BELOW CANNOT FAIL ON A COPY CHANGE, WHICH IS WHY THIS ONE IS
+    // FIRST.** They compare the bar's answer against the same constant the bar
+    // read to produce it, so editing either sentence moves both sides together.
+    // A #2441 mutation making the two provenances IDENTICAL — the one thing
+    // this test's name promises to prevent — survived. DISTINCTNESS is the
+    // property, and no constant can satisfy it vacuously.
+    #expect(auto != nil)
+    #expect(auto != locked, "auto and locked must not say the same thing")
+
+    // And one literal, so the pair cannot drift together into wording that
+    // distinguishes nothing a reader would notice.
+    #expect(auto == "from your Mac")
+
+    #expect(auto == LivePreviewSettingsCopy.languageProvenanceFromMac)
+    #expect(locked == LivePreviewSettingsCopy.languageProvenanceUserPicked)
   }
 
   @Test("No language is named while nothing can run, on either engine")

--- a/Tests/EnviousWisprTests/App/LivePreviewStatusMappingTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusMappingTests.swift
@@ -50,6 +50,46 @@ struct LivePreviewStatusMappingTests {
       activeDescribesAnotherLanguage: activeDescribesAnotherLanguage)
   }
 
+  // MARK: - The KIND itself, which decides which remedy the card offers
+
+  /// **Nothing bound which `Kind` this mapping picks, in either suite.** Two
+  /// mutations from #2441 — `.needsLanguage(name:)` becoming `.needsDownload`,
+  /// and `.off` becoming `.checking` — survived here AND in
+  /// `LivePreviewStatusBarPresentationTests`, which is where they were aimed.
+  /// They could not be caught there: that suite hands a `Kind` in and asserts
+  /// what is RENDERED, so it never exercises the code that CHOOSES one. This
+  /// suite is the right home and had no case for either state.
+  ///
+  /// The consequence is user-facing, not tidiness. `.needsLanguage` is the ONLY
+  /// kind carrying an action at all — `action(for:)` returns
+  /// `.browseDownloads(initialSearch: name)` for it and `nil` for every other
+  /// case — so choosing `.needsDownload` instead leaves someone who is missing a
+  /// language looking at a card with no way forward.
+  @Test("A language this Mac lacks is needsLanguage, named, and not the model's own download state")
+  func aMissingLanguageIsNeedsLanguageAndNamesIt() {
+    #expect(
+      summary(active: .needsDownload(name: "German")).kind == .needsLanguage(name: "German"))
+    // The NAME travels, because the remedy is seeded with it. A kind that
+    // carried the wrong name would still satisfy an `if case` check.
+    #expect(
+      summary(active: .needsDownload(name: "Japanese")).kind == .needsLanguage(name: "Japanese"))
+    // PAIRED, or "always needsLanguage" satisfies the rows above: an install in
+    // flight refuses to answer instead, because the input is stale by
+    // construction during that window.
+    #expect(
+      summary(active: .needsDownload(name: "German"), anInstallIsInFlight: true).kind
+        == .checking)
+  }
+
+  /// The switch being off is its own answer and must not read as `.checking`,
+  /// which is what the card says while it genuinely cannot tell.
+  @Test("Off is off, not checking")
+  func offIsItsOwnKind() {
+    #expect(summary(isEnabled: false).kind == .off)
+    // Paired: the same inputs with the switch ON are not `.off`.
+    #expect(summary(isEnabled: true).kind != .off)
+  }
+
   // MARK: - The two answers that must never be wrong
 
   @Test("Ready means ready, on either engine, and both say it the same way")
@@ -294,8 +334,9 @@ struct LivePreviewStatusMappingTests {
   /// downloads — otherwise every download would blank a working status.
   @Test("A download elsewhere does not disturb an already-ready language")
   func installInFlightDoesNotDisturbReady() {
-    let s = summary(engine: .apple, active: .ready(tag: "en-US", name: "English"),
-                    anInstallIsInFlight: true)
+    let s = summary(
+      engine: .apple, active: .ready(tag: "en-US", name: "English"),
+      anInstallIsInFlight: true)
     #expect(s.chip.tone == .ready)
   }
 


### PR DESCRIPTION
Two tests that could not fail, both found by running #2441's frozen mutation battery.

## The mapping's choice was unbound

`LivePreviewStatusMapping` decides which state the live-preview card is in. `LivePreviewStatusBarPresentationTests` is handed a state and asserts what is RENDERED, so it never runs the deciding code — its own header says so. Two rows aimed there survived, and re-aimed at `LivePreviewStatusMappingTests` they survived too: that suite mentioned neither `installRequired` nor `needsLanguage`.

`.needsLanguage` is the only kind carrying an action at all. `action(for:)` returns `.browseDownloads(initialSearch: name)` for it and `nil` for every other case, so turning it into `.needsDownload` leaves someone missing a language looking at a card with no way forward — and `onlyMissingLanguageOffersARemedy`, the test written to prevent exactly that, is testing the other half.

Two paired cases now bind it. Paired because a single-input assertion is satisfied by an implementation that returns one answer for everything.

## The provenance test compared the subject against itself

```swift
#expect(bar(.active, languageMode: .auto).language?.provenance
        == LivePreviewSettingsCopy.languageProvenanceFromMac)
```

The bar reads that constant to produce its answer; the expectation reads the same constant. Edit either sentence and both sides move together. A mutation making the two provenances IDENTICAL — the one thing the test's name promises to prevent — stayed green.

It now asserts they DIFFER, which no copy edit can satisfy vacuously, and pins one literal so the pair cannot drift together. The two original rows are kept below it, labelled as unable to fail on a copy change, because they still bind which constant the bar reads.

## Evidence

Each new case verified by re-running its mutant against this tree: 3/3 matched, baseline green before and after.

```
[ EXP  ] row 1: missing language becomes a missing model
[ EXP  ] row 2: off becomes checking
[ EXP  ] row 3: both provenances become one sentence
```

Both suites green: `LivePreviewStatusMappingTests` 23/23, `LivePreviewStatusBarPresentationTests` 10/10.

All three findings classified REPRODUCIBLE: each is demonstrable by editing one line of shipped source and observing the named suite stay green.

Frozen recipe for the three new cases: #2516.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprAppKit`
`Lane: Code`

Part of #2441.
