### PR TITLE
test(settings): bind which chrome an appearance tile draws

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/RecordingPillAppearancePanel.swift
@@ -255,7 +255,6 @@ struct RecordingPillPreviewTile: View {
   /// the pictures comparable to each other, which is the property that actually
   /// mattered underneath the life-size argument.
 
-
   /// The same rule against a REAL card width, which is what the view uses.
   ///
   /// Split out so a test can ask the question at any width rather than only at the
@@ -500,7 +499,13 @@ private struct RecordingPillPreview: View {
       recordingElapsedProvider: { RecordingPillPreviewTile.sampleElapsed },
       livePreviewProvider: { display },
       onContentHeightChange: { _ in },
-      chrome: design.chrome,
+      // **`self.` is required here and is not a style choice.** A bare `design`
+      // is whatever is nearest in scope, so a local of that name introduced above
+      // this line would make every card draw one design while this line still
+      // reads correctly. `self.design` cannot be shadowed, so writing it is what
+      // lets `theTileDrawsItsOwnChrome` be an exact question instead of a
+      // name-resolution guess.
+      chrome: self.design.chrome,
       // Hands free is not what is being chosen here, and the locked variants
       // differ per design, so a picker showing ONE mode is the honest one.
       isLocked: false,

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -770,48 +770,55 @@ struct RecordingPillPreviewWiringTests {
       """)
 
     // **The row above reads the NAME, so it cannot see what the name binds to.**
-    // A `let design = RecordingPillDesign.classic` introduced before the
-    // construction leaves `chrome: design.chrome` spelled exactly as required
-    // while every card draws one design — the same failure the row exists to
-    // prevent, passing it. So the binding is checked separately: the tile
-    // declares `design` once, as its own stored property, and nothing inside it
-    // shadows that name.
+    // A `let design = RecordingPillDesign.classic` ahead of the construction
+    // leaves `chrome: design.chrome` spelled exactly as required while every card
+    // draws one design — the failure this row exists to prevent, passing it.
+    //
+    // Chasing the SHAPES a shadow can take is the wrong shape of answer: a local
+    // `let`, a closure parameter, a capture and a `for` binding are four members
+    // of a set with no last member, and two review rounds each returned a new one.
+    // So the question below is a CLOSED one instead, and it is closed because the
+    // enum enumerates it: this tile knows no design BY NAME. A shadow that does
+    // damage has to bind some particular design, and naming one is exactly what
+    // this refuses — whatever syntax carries it.
+    //
+    // `allCases` is the producer, so a design added later is covered with no edit
+    // here.
     let text = try String(
       contentsOf: RepoRoot.url.appending(path: Self.panel), encoding: .utf8)
     let tile = try #require(
       Self.structDecl(named: "RecordingPillPreview", in: Parser.parse(source: text)),
       "RecordingPillPreview is not in \(Self.panel) — this guard is pointed at the wrong type")
-    let bindings = Self.bindingsNamed("design", in: tile)
 
+    let caseNames = Set(RecordingPillDesign.allCases.map { String(describing: $0) })
     #expect(
-      bindings == 1,
+      caseNames.count == RecordingPillDesign.allCases.count,
+      "two designs describe themselves identically, so the sweep below cannot tell them apart")
+
+    let named = Self.memberNames(in: tile).intersection(caseNames).sorted()
+    #expect(
+      named.isEmpty,
       """
-      RecordingPillPreview declares `design` \(bindings) times. One is the stored \
-      property every row above assumes; a second SHADOWS it, so `chrome: design.chrome` \
-      can read a fixed design while still being spelled correctly.
+      RecordingPillPreview names \(named.joined(separator: ", ")). This tile draws \
+      whatever design it is handed and must know none by name — a named one is how a \
+      fixed chrome reaches the card while `chrome: design.chrome` still reads correctly.
       """)
   }
 
-  /// Every `let`/`var` binding of one name anywhere inside a declaration, the
-  /// stored property included. Used as a count rather than a lookup: the answer
-  /// that matters is whether the name is declared more than once.
-  private final class BindingCounter: SyntaxVisitor {
-    let wanted: String
-    private(set) var count = 0
-    init(_ wanted: String) {
-      self.wanted = wanted
-      super.init(viewMode: .sourceAccurate)
-    }
-    override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
-      if node.identifier.text == wanted { count += 1 }
+  /// Every member name accessed anywhere inside a declaration — `a.b` and a bare
+  /// `.b` alike. Comments and strings are not members, so they cannot trip it.
+  private final class MemberNameFinder: SyntaxVisitor {
+    private(set) var names: Set<String> = []
+    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+      names.insert(node.declName.baseName.text)
       return .visitChildren
     }
   }
 
-  private static func bindingsNamed(_ name: String, in decl: StructDeclSyntax) -> Int {
-    let counter = BindingCounter(name)
-    counter.walk(decl)
-    return counter.count
+  private static func memberNames(in decl: StructDeclSyntax) -> Set<String> {
+    let finder = MemberNameFinder(viewMode: .sourceAccurate)
+    finder.walk(decl)
+    return finder.names
   }
 
   /// **THE CLOSURE ROW. Every piece of `@State` the poll writes must be seedable,

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -804,6 +804,24 @@ struct RecordingPillPreviewWiringTests {
     // fixed design handed in from another type. This is a drift guard, so the
     // threat is an accidental edit, not code written to get past it.
     //
+    // **THE TWO ROWS BELOW SPLIT ONE QUESTION ON THE GRAMMAR'S OWN TWO-STATE
+    // BASE, so this axis is closed rather than described.** A reach with NO base
+    // resolves against the contextual type and is judged by case name; a reach
+    // WITH one names a type and is judged by whether that type is this one.
+    // There is no third state, so the list cannot grow a member.
+    //
+    // The closure is falsifiable, which is the point of writing it down: a next
+    // finding on this axis would have to be a reach that is neither an implicit
+    // member nor a reference to the type name. Every such reach known to us goes
+    // through `type(of:)` or through another type's stored value, and both are
+    // already declared out of scope above. A finding inside the scope would mean
+    // this paragraph is wrong, not that the list needs extending.
+    //
+    // The two rounds that produced this were FALSE POSITIVES, not evasions —
+    // an explicit initializer, and an unrelated `SomeStyle.classic`. Both were
+    // one unqualified text match reading more than it meant to, in the direction
+    // that accuses innocent work.
+    //
     // The structural fix that would end the class — the leaf deriving chrome from
     // the design it is already given, so there is no argument to get wrong at
     // either call site — is #2520, and it changes shipped source rather than a
@@ -840,7 +858,12 @@ struct RecordingPillPreviewWiringTests {
       short list and would pass on a design it never checked.
       """)
 
-    let named = Self.memberNames(in: tile).intersection(caseNames).sorted()
+    // **BARE `.classic`, not `Other.classic`** — see `implicitMemberNames`. The
+    // two rows are one question split on the grammar's own two-state base: a
+    // reach with no base is a contextual design, and a reach with one is a named
+    // type, which the row below refuses when that type is this one. Counting
+    // every member name spelled like a case blamed an unrelated `SomeStyle.classic`.
+    let named = Self.implicitMemberNames(in: tile).intersection(caseNames).sorted()
     #expect(
       named.isEmpty,
       """
@@ -956,18 +979,30 @@ struct RecordingPillPreviewWiringTests {
     return false
   }
 
-  /// Every member name accessed anywhere inside a declaration — `a.b` and a bare
-  /// `.b` alike. Comments and strings are not members, so they cannot trip it.
-  private final class MemberNameFinder: SyntaxVisitor {
+  /// Member names reached with NO base — a bare `.classic`, never `Other.classic`.
+  ///
+  /// **The base is the whole discriminator, and it has two states, so this axis
+  /// is closed rather than described.** An implicit member resolves against the
+  /// CONTEXTUAL type, and the only contextual type in this struct carrying a
+  /// design's case names is the design type, so a bare `.classic` here is always
+  /// a fixed design. An explicit base names a type, and that type is either the
+  /// design type — which `typeReaches` already refuses — or an unrelated one that
+  /// happens to spell a member the same way, which is innocent and must not be
+  /// blamed.
+  ///
+  /// Counting both is what a review round found: an unrelated `SomeStyle.classic`
+  /// would have failed the row while `chrome: design.chrome` stayed correct.
+  /// Comments and strings are not members, so they cannot trip it either way.
+  private final class ImplicitMemberFinder: SyntaxVisitor {
     private(set) var names: Set<String> = []
     override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-      names.insert(node.declName.baseName.text)
+      if node.base == nil { names.insert(node.declName.baseName.text) }
       return .visitChildren
     }
   }
 
-  private static func memberNames(in decl: StructDeclSyntax) -> Set<String> {
-    let finder = MemberNameFinder(viewMode: .sourceAccurate)
+  private static func implicitMemberNames(in decl: StructDeclSyntax) -> Set<String> {
+    let finder = ImplicitMemberFinder(viewMode: .sourceAccurate)
     finder.walk(decl)
     return finder.names
   }

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -761,154 +761,49 @@ struct RecordingPillPreviewWiringTests {
     #expect(
       member.declName.baseName.text == "chrome",
       "chrome is \(expr.trimmedDescription), which does not read a design's chrome at all")
-    // **BOTH SPELLINGS OF THE SAME REFERENCE.** `design` and `self.design` are one
-    // thing to the compiler, and rejecting the explicit form would fail a correct
-    // rewrite — a guard that refuses innocent work is how bypasses get trained
-    // (`validation-discipline.md` RULE: false-positives-not-gates-train-evasion).
-    // Spelling axes are finite, so this is normalised in ONE place rather than
-    // matched at each site.
-    #expect(
-      Self.readsTheTilesOwnDesign(member.base),
-      """
-      chrome is \(expr.trimmedDescription), which is a fixed design's chrome rather than \
-      this tile's own. Every card would then draw the same pill and the picker would \
-      offer three pictures of one design.
-      """)
-
-    // **THE ROW ABOVE READS A NAME; THIS ONE ANSWERS WHAT THE NAME BINDS TO.**
+    // **THE EXPLICIT `self.` FORM IS REQUIRED, and that is the whole guard now.**
     //
-    // Nine review rounds landed on this guard and every finding was one shape: a
-    // local `design` introduced ahead of the construction, so `chrome:
-    // design.chrome` stays spelled exactly as required while every card draws one
-    // design. The rounds differed only in where the fixed design came from — a
-    // case, a closure capture, `allCases[0]`, `type(of: self.design).allCases[0]`,
-    // and finally `.canonicalWithoutWords`, a static member that already exists in
-    // `PillDefinition.swift` and is neither a case nor a mention of the type.
+    // Ten review rounds landed here and every finding was the same shape: a local
+    // `design` introduced near the construction, so `chrome: design.chrome` stays
+    // spelled exactly as required while every card draws one design. Only the
+    // source of the fixed design varied — a case, a capture, `allCases[0]`,
+    // `type(of:)`, a static on another type, and a backquoted `` `design` `` that
+    // reads as `design` but does not compare equal to it.
     //
-    // **Two text sweeps stood here and both are gone.** One matched case
-    // spellings, the other the type name, and each was a DESCRIPTION of where a
-    // design can come from. A description always has a next member, which is why
-    // the rounds kept producing one, and the last one walked past both.
+    // Three answers were tried and each was the same kind of thing: a text sweep
+    // over case spellings, a sweep over the type name, then a walk for anything
+    // BINDING the name. The last was closer, because it asked about scope rather
+    // than spelling — and the round that followed showed why it still could not
+    // be right. Deciding whether a binding is VISIBLE at an expression is name
+    // resolution, so a syntax test doing it is a small compiler, and the round
+    // returned exactly the errors a small compiler makes: a binding AFTER the
+    // call and a parameter in an unrelated closure counted as shadows, and a
+    // backquoted declaration did not.
     //
-    // **THE CLOSED QUESTION IS THE ONE SWIFT ITSELF ASKS: is anything named
-    // `design` in scope at the construction other than the stored property?** If
-    // nothing is, then a bare `design` there IS the stored property, whatever a
-    // hypothetical shadow's right-hand side would have been. That settles every
-    // shape at once, including the two previously declared out of scope, and it
-    // stops caring what a fixed design is spelled like.
+    // **So the ambiguity is removed rather than resolved.** `self.design` cannot
+    // be shadowed — Swift does not let anything rebind `self` — so the panel is
+    // asked to write it, and the guard becomes one exact comparison with no
+    // scope walk, no spelling list, and nothing to normalise. Every attack above
+    // stops mattering rather than being detected: a local named `design` can
+    // exist and the line still reads the stored property.
     //
-    // Scoped to the DECLARATION the construction sits in, not to the whole
-    // struct, and the scoping is load-bearing in both directions: a binding
-    // anywhere else cannot reach this expression, and an ordinary
-    // `init(design:)` parameter is named `design` on purpose and must not be
-    // blamed for it. A round already found that false positive in the previous
-    // shape of this guard.
+    // The cost is stated because it is real: a correct author who writes bare
+    // `design` gets a red. The message says what to write, the fix is five
+    // characters, and it buys a question that cannot grow a new member.
     //
-    // The binding forms are closed because the GRAMMAR closes them, not because
-    // the list looked complete: a simple name enters scope through a pattern, a
-    // function parameter, a closure parameter in either spelling, or a capture.
-    // `IdentifierPatternSyntax` is `let`, `var`, `guard let`, `if let`, `for` and
-    // `case let` at once, which is why an earlier round's four-member list was
-    // the wrong unit to be counting.
-    //
-    // NOT COVERED, and stated rather than implied: a design handed in from
-    // another type through a differently-named property. That needs the stored
-    // property to stop being the thing the preview reads, which the row above
-    // already refuses. The structural fix that would end the whole class — the
-    // leaf deriving chrome from the design it is already given, so there is no
+    // The structural fix that would delete this guard entirely — the leaf
+    // deriving chrome from the design it is already given, so there is no
     // argument to get wrong at either call site — is #2520, and it changes
     // shipped source rather than a test.
-    let scope = try #require(
-      Self.enclosingDeclaration(of: call),
-      "the chrome argument sits in no declaration, so this guard cannot say what is in scope")
-    let shadows = Self.bindings(named: "design", in: scope).sorted()
+    let base = member.base?.as(MemberAccessExprSyntax.self)
     #expect(
-      shadows.isEmpty,
+      base?.declName.baseName.text == "design"
+        && base?.base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "self",
       """
-      \(shadows.joined(separator: ", ")) named `design` where the preview is built, so \
-      `chrome: design.chrome` reads that instead of the design this tile was handed. \
-      Every card would draw the same pill and the picker would offer three pictures \
-      of one design.
+      chrome is \(expr.trimmedDescription). It must be exactly `self.design.chrome`: \
+      anything else is either a fixed design, which makes every card draw the same \
+      pill, or a bare name that some later local could quietly take over.
       """)
-  }
-
-  /// The declaration an expression sits inside — the property or function whose
-  /// body holds it. Scope for a bare name starts here, so this is what a shadow
-  /// has to be inside to reach that name.
-  private static func enclosingDeclaration(of node: some SyntaxProtocol) -> Syntax? {
-    var current = node.parent
-    while let here = current {
-      if here.is(VariableDeclSyntax.self) || here.is(FunctionDeclSyntax.self)
-        || here.is(InitializerDeclSyntax.self)
-      {
-        return here
-      }
-      current = here.parent
-    }
-    return nil
-  }
-
-  /// Every site inside a declaration that brings `name` into scope, described in
-  /// the words of the form that does it.
-  ///
-  /// The forms are the grammar's rather than a guess. `IdentifierPatternSyntax`
-  /// covers `let`, `var`, `guard let`, `if let`, `for` and `case let` in one
-  /// node; the other four are the parameter and capture spellings. A name cannot
-  /// enter scope any other way, which is what makes this a closed question
-  /// instead of a list that grows a member every review round.
-  private final class BindingFinder: SyntaxVisitor {
-    let wanted: String
-    private(set) var sites: Set<String> = []
-
-    init(_ wanted: String) {
-      self.wanted = wanted
-      super.init(viewMode: .sourceAccurate)
-    }
-
-    override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
-      note(node.identifier, "a local binding")
-      return .visitChildren
-    }
-    override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
-      note(node.secondName ?? node.firstName, "a parameter")
-      return .visitChildren
-    }
-    override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
-      note(node.secondName ?? node.firstName, "a closure parameter")
-      return .visitChildren
-    }
-    override func visit(_ node: ClosureShorthandParameterSyntax) -> SyntaxVisitorContinueKind {
-      note(node.name, "a closure parameter")
-      return .visitChildren
-    }
-    override func visit(_ node: ClosureCaptureSyntax) -> SyntaxVisitorContinueKind {
-      note(node.name, "a capture")
-      return .visitChildren
-    }
-
-    private func note(_ token: TokenSyntax, _ form: String) {
-      if token.text == wanted { sites.insert(form) }
-    }
-  }
-
-  private static func bindings(named name: String, in decl: Syntax) -> Set<String> {
-    let finder = BindingFinder(name)
-    finder.walk(decl)
-    return finder.sites
-  }
-
-  /// Whether an expression is this tile reading its OWN `design` — `design` or
-  /// `self.design`, which the compiler treats as one thing. The two spellings are
-  /// the whole set: an implicit member reference and an explicit `self` one.
-  private static func readsTheTilesOwnDesign(_ expr: ExprSyntax?) -> Bool {
-    if expr?.as(DeclReferenceExprSyntax.self)?.baseName.text == "design" { return true }
-    if let explicit = expr?.as(MemberAccessExprSyntax.self),
-      explicit.declName.baseName.text == "design",
-      explicit.base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "self"
-    {
-      return true
-    }
-    return false
   }
 
   /// **THE CLOSURE ROW. Every piece of `@State` the poll writes must be seedable,

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -850,38 +850,65 @@ struct RecordingPillPreviewWiringTests {
       """)
 
     // The TYPE, which is the other half and the one `allCases[0]` walks through.
-    // Exactly one mention is allowed and it is the stored property's annotation,
-    // so this also fails loudly if that property is ever removed or retyped.
+    //
+    // **REACHES THROUGH THE TYPE, NOT MENTIONS OF IT.** Counting every token
+    // spelled `RecordingPillDesign` counted the stored property's own
+    // ANNOTATION, so it allowed exactly one — and an ordinary explicit
+    // `init(design: RecordingPillDesign)`, which keeps `chrome: design.chrome`
+    // wired correctly, would have made it two and failed this row. That is the
+    // class the spelling row above already normalises: a guard refusing innocent
+    // work is how bypasses get trained
+    // (`validation-discipline.md` RULE: false-positives-not-gates-train-evasion).
+    //
+    // The grammar separates the two for free, so this needs no list of allowed
+    // annotation sites: an ANNOTATION is a type node, a REACH is an expression
+    // node. `\(RecordingPillDesign.self).allCases[0]` is the second; every
+    // property, parameter and return annotation is the first, however many the
+    // struct grows.
+    //
+    // The old row also claimed to fail loudly if the stored property were
+    // removed or retyped. Dropping that claim costs nothing, because the
+    // COMPILER owns it: `design.chrome` does not build without a `design` that
+    // has chrome.
     let type = "\(RecordingPillDesign.self)"
-    let mentions = Self.identifierCount(type, in: tile)
+    let reaches = Self.typeReaches(type, in: tile).sorted()
     #expect(
-      mentions == 1,
+      reaches.isEmpty,
       """
-      RecordingPillPreview mentions \(type) \(mentions) times. One is the stored \
-      property's own type; any other is a way to reach a fixed design without naming \
-      a case — `\(type).allCases[0]` is the one that prompted this row.
+      RecordingPillPreview reaches through \(type) at \(reaches.joined(separator: ", ")). \
+      This tile draws whatever design it is handed, so any reach through the type is a \
+      way to a fixed design without naming a case — `\(type).allCases[0]` is the one \
+      that prompted this row. Annotations are not counted.
       """)
   }
 
-  /// How many times one identifier appears as a TOKEN inside a declaration.
-  /// Tokens, so comments and string literals are not counted.
-  private final class IdentifierCounter: SyntaxVisitor {
+  /// Every place a TYPE NAME is used as an EXPRESSION inside a declaration —
+  /// `RecordingPillDesign.allCases`, never `let design: RecordingPillDesign`.
+  /// `DeclReferenceExprSyntax` is the expression node, so annotations, parameter
+  /// types and return types are invisible here by construction rather than by an
+  /// allow-list that would need extending every time the struct grew one.
+  ///
+  /// Each hit is reported as the expression AROUND it, since the type name alone
+  /// would say nothing about which reach was found.
+  private final class TypeReachFinder: SyntaxVisitor {
     let wanted: String
-    private(set) var count = 0
+    private(set) var reaches: Set<String> = []
     init(_ wanted: String) {
       self.wanted = wanted
       super.init(viewMode: .sourceAccurate)
     }
-    override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
-      if node.tokenKind == .identifier(wanted) { count += 1 }
+    override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+      if node.baseName.text == wanted {
+        reaches.insert(node.parent?.trimmedDescription ?? node.trimmedDescription)
+      }
       return .visitChildren
     }
   }
 
-  private static func identifierCount(_ name: String, in decl: StructDeclSyntax) -> Int {
-    let counter = IdentifierCounter(name)
-    counter.walk(decl)
-    return counter.count
+  private static func typeReaches(_ name: String, in decl: StructDeclSyntax) -> Set<String> {
+    let finder = TypeReachFinder(name)
+    finder.walk(decl)
+    return finder.reaches
   }
 
   static let designEnum = "Sources/EnviousWisprCore/SettingsEnums.swift"

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -776,14 +776,24 @@ struct RecordingPillPreviewWiringTests {
     //
     // Chasing the SHAPES a shadow can take is the wrong shape of answer: a local
     // `let`, a closure parameter, a capture and a `for` binding are four members
-    // of a set with no last member, and two review rounds each returned a new one.
-    // So the question below is a CLOSED one instead, and it is closed because the
-    // enum enumerates it: this tile knows no design BY NAME. A shadow that does
-    // damage has to bind some particular design, and naming one is exactly what
-    // this refuses — whatever syntax carries it.
+    // of a set with no last member, and three review rounds each returned a new
+    // one — the third being `RecordingPillDesign.allCases[0]`, which names no case
+    // at all. So the two rows below are CLOSED questions instead of a list.
     //
-    // `allCases` is the producer, so a design added later is covered with no edit
-    // here.
+    // THE CLOSURE ARGUMENT, stated so it can be held to: to bind a fixed design
+    // inside this struct you must obtain a value of that type, and within one
+    // struct there are exactly two ways to reach one — name a CASE, or name the
+    // TYPE. The first row refuses every case name, enumerated from `allCases` so a
+    // design added later is covered with no edit here. The second refuses every
+    // mention of the type beyond the stored property's own annotation, which is
+    // what `allCases`, a static, an initialiser and a type alias all need.
+    //
+    // WHAT A FOURTH FINDING WOULD HAVE TO LOOK LIKE: a fixed design arriving from
+    // OUTSIDE this struct, from some helper that hands one back without the tile
+    // naming anything — say a `RecordingPillPreviewTile.someFixedDesign`. That is
+    // a different change in a different type, and no assertion inside this struct
+    // can see it. Said out loud because a clean round is not evidence a set is
+    // closed; the falsification condition is.
     let text = try String(
       contentsOf: RepoRoot.url.appending(path: Self.panel), encoding: .utf8)
     let tile = try #require(
@@ -803,6 +813,40 @@ struct RecordingPillPreviewWiringTests {
       whatever design it is handed and must know none by name — a named one is how a \
       fixed chrome reaches the card while `chrome: design.chrome` still reads correctly.
       """)
+
+    // The TYPE, which is the other half and the one `allCases[0]` walks through.
+    // Exactly one mention is allowed and it is the stored property's annotation,
+    // so this also fails loudly if that property is ever removed or retyped.
+    let type = "\(RecordingPillDesign.self)"
+    let mentions = Self.identifierCount(type, in: tile)
+    #expect(
+      mentions == 1,
+      """
+      RecordingPillPreview mentions \(type) \(mentions) times. One is the stored \
+      property's own type; any other is a way to reach a fixed design without naming \
+      a case — `\(type).allCases[0]` is the one that prompted this row.
+      """)
+  }
+
+  /// How many times one identifier appears as a TOKEN inside a declaration.
+  /// Tokens, so comments and string literals are not counted.
+  private final class IdentifierCounter: SyntaxVisitor {
+    let wanted: String
+    private(set) var count = 0
+    init(_ wanted: String) {
+      self.wanted = wanted
+      super.init(viewMode: .sourceAccurate)
+    }
+    override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+      if node.tokenKind == .identifier(wanted) { count += 1 }
+      return .visitChildren
+    }
+  }
+
+  private static func identifierCount(_ name: String, in decl: StructDeclSyntax) -> Int {
+    let counter = IdentifierCounter(name)
+    counter.walk(decl)
+    return counter.count
   }
 
   /// Every member name accessed anywhere inside a declaration — `a.b` and a bare

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -761,8 +761,14 @@ struct RecordingPillPreviewWiringTests {
     #expect(
       member.declName.baseName.text == "chrome",
       "chrome is \(expr.trimmedDescription), which does not read a design's chrome at all")
+    // **BOTH SPELLINGS OF THE SAME REFERENCE.** `design` and `self.design` are one
+    // thing to the compiler, and rejecting the explicit form would fail a correct
+    // rewrite — a guard that refuses innocent work is how bypasses get trained
+    // (`validation-discipline.md` RULE: false-positives-not-gates-train-evasion).
+    // Spelling axes are finite, so this is normalised in ONE place rather than
+    // matched at each site.
     #expect(
-      member.base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "design",
+      Self.readsTheTilesOwnDesign(member.base),
       """
       chrome is \(expr.trimmedDescription), which is a fixed design's chrome rather than \
       this tile's own. Every card would then draw the same pill and the picker would \
@@ -855,6 +861,20 @@ struct RecordingPillPreviewWiringTests {
     let counter = IdentifierCounter(name)
     counter.walk(decl)
     return counter.count
+  }
+
+  /// Whether an expression is this tile reading its OWN `design` — `design` or
+  /// `self.design`, which the compiler treats as one thing. The two spellings are
+  /// the whole set: an implicit member reference and an explicit `self` one.
+  private static func readsTheTilesOwnDesign(_ expr: ExprSyntax?) -> Bool {
+    if expr?.as(DeclReferenceExprSyntax.self)?.baseName.text == "design" { return true }
+    if let explicit = expr?.as(MemberAccessExprSyntax.self),
+      explicit.declName.baseName.text == "design",
+      explicit.base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "self"
+    {
+      return true
+    }
+    return false
   }
 
   /// Every member name accessed anywhere inside a declaration — `a.b` and a bare

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -733,6 +733,43 @@ struct RecordingPillPreviewWiringTests {
       """)
   }
 
+  /// **Nothing observed which chrome a tile draws.** #2438's row for it named
+  /// `tileHeightTracksTheLeaf`, which was deliberately retired when the founder
+  /// replaced the layout with three identical cards on 2026-08-26. Its successor
+  /// `thePreviewIsTheRealPillScaled` measures HEIGHT, and chrome is paint: with
+  /// `chrome: RecordingPillDesign.classic.chrome` substituted, all sixteen rows
+  /// in `RecordingPillTileTests` still passed. The row was right and only its
+  /// witness was gone.
+  ///
+  /// The user consequence is the whole point of the picker. Chrome carries the
+  /// header, the notice cap and the ink, so a fixed one makes every card draw the
+  /// same pill and there is nothing to choose between.
+  ///
+  /// The property is that the chrome comes from THIS tile's own `design`, not
+  /// that it is spelled a particular way — a concrete design constant is exactly
+  /// what fails here, however it is written.
+  @Test("each tile draws its own design's chrome, not one design's for all three")
+  func theTileDrawsItsOwnChrome() throws {
+    let call = try Self.theConstruction()
+    let expr = try #require(
+      Self.argument("chrome", of: call),
+      "the tile passes no chrome, so it cannot be a picture of any particular design")
+    let member = try #require(
+      expr.as(MemberAccessExprSyntax.self),
+      "chrome is \(expr.trimmedDescription), which this guard cannot judge")
+
+    #expect(
+      member.declName.baseName.text == "chrome",
+      "chrome is \(expr.trimmedDescription), which does not read a design's chrome at all")
+    #expect(
+      member.base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "design",
+      """
+      chrome is \(expr.trimmedDescription), which is a fixed design's chrome rather than \
+      this tile's own. Every card would then draw the same pill and the picker would \
+      offer three pictures of one design.
+      """)
+  }
+
   /// **THE CLOSURE ROW. Every piece of `@State` the poll writes must be seedable,
   /// and this ENUMERATES them from the poll body rather than from a list I wrote.**
   ///

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -814,10 +814,31 @@ struct RecordingPillPreviewWiringTests {
       Self.structDecl(named: "RecordingPillPreview", in: Parser.parse(source: text)),
       "RecordingPillPreview is not in \(Self.panel) — this guard is pointed at the wrong type")
 
-    let caseNames = Set(RecordingPillDesign.allCases.map { String(describing: $0) })
+    // **THE CASE IDENTIFIERS, READ OFF THE ENUM'S OWN DECLARATION.**
+    // `String(describing:)` was used here and is wrong for this: it returns a
+    // type's `CustomStringConvertible` description if one is ever added, and the
+    // panel's source names CASES. The sweep would then look for user-facing
+    // sentences, match nothing, and pass — silently, with the count check still
+    // green. Raw values have the same defect from the other side, since a raw
+    // value may diverge from its case name.
+    //
+    // So this parses the declaration, which is the producing code. `allCases` is
+    // the two-way control: a parse that found a different number than the type
+    // reports is a broken parse, and it says so rather than sweeping for a short
+    // list.
+    let enums = try String(
+      contentsOf: RepoRoot.url.appending(path: Self.designEnum), encoding: .utf8)
+    let design = try #require(
+      Self.enumDecl(named: "\(RecordingPillDesign.self)", in: Parser.parse(source: enums)),
+      "\(RecordingPillDesign.self) is not in \(Self.designEnum) — this guard reads the wrong file")
+    let caseNames = Self.caseNames(of: design)
     #expect(
       caseNames.count == RecordingPillDesign.allCases.count,
-      "two designs describe themselves identically, so the sweep below cannot tell them apart")
+      """
+      parsed \(caseNames.count) case names from \(Self.designEnum) but the type reports \
+      \(RecordingPillDesign.allCases.count). The sweep below would be looking for a \
+      short list and would pass on a design it never checked.
+      """)
 
     let named = Self.memberNames(in: tile).intersection(caseNames).sorted()
     #expect(
@@ -861,6 +882,37 @@ struct RecordingPillPreviewWiringTests {
     let counter = IdentifierCounter(name)
     counter.walk(decl)
     return counter.count
+  }
+
+  static let designEnum = "Sources/EnviousWisprCore/SettingsEnums.swift"
+
+  private final class EnumFinder: SyntaxVisitor {
+    let wanted: String
+    private(set) var found: EnumDeclSyntax?
+    init(_ wanted: String) {
+      self.wanted = wanted
+      super.init(viewMode: .sourceAccurate)
+    }
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+      if node.name.text == wanted { found = node }
+      return .visitChildren
+    }
+  }
+
+  private static func enumDecl(named: String, in tree: SourceFileSyntax) -> EnumDeclSyntax? {
+    let finder = EnumFinder(named)
+    finder.walk(tree)
+    return finder.found
+  }
+
+  /// The case IDENTIFIERS an enum declares, as source writes them.
+  private static func caseNames(of decl: EnumDeclSyntax) -> Set<String> {
+    var names: Set<String> = []
+    for member in decl.memberBlock.members {
+      guard let cases = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
+      for element in cases.elements { names.insert(element.name.text) }
+    }
+    return names
   }
 
   /// Whether an expression is this tile reading its OWN `design` — `design` or

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -775,194 +775,126 @@ struct RecordingPillPreviewWiringTests {
       offer three pictures of one design.
       """)
 
-    // **The row above reads the NAME, so it cannot see what the name binds to.**
-    // A `let design = RecordingPillDesign.classic` ahead of the construction
-    // leaves `chrome: design.chrome` spelled exactly as required while every card
-    // draws one design — the failure this row exists to prevent, passing it.
+    // **THE ROW ABOVE READS A NAME; THIS ONE ANSWERS WHAT THE NAME BINDS TO.**
     //
-    // Chasing the SHAPES a shadow can take is the wrong shape of answer: a local
-    // `let`, a closure parameter, a capture and a `for` binding are four members
-    // of a set with no last member, and three review rounds each returned a new
-    // one — the third being `RecordingPillDesign.allCases[0]`, which names no case
-    // at all. So the two rows below are CLOSED questions instead of a list.
+    // Nine review rounds landed on this guard and every finding was one shape: a
+    // local `design` introduced ahead of the construction, so `chrome:
+    // design.chrome` stays spelled exactly as required while every card draws one
+    // design. The rounds differed only in where the fixed design came from — a
+    // case, a closure capture, `allCases[0]`, `type(of: self.design).allCases[0]`,
+    // and finally `.canonicalWithoutWords`, a static member that already exists in
+    // `PillDefinition.swift` and is neither a case nor a mention of the type.
     //
-    // A closure argument was published here and then FALSIFIED, which is worth
-    // keeping rather than quietly replacing. It claimed that reaching a design
-    // inside this struct requires naming a CASE or naming the TYPE, so refusing
-    // both closes the set. Round four answered `type(of: self.design).allCases[0]`
-    // — a third route, naming neither.
+    // **Two text sweeps stood here and both are gone.** One matched case
+    // spellings, the other the type name, and each was a DESCRIPTION of where a
+    // design can come from. A description always has a next member, which is why
+    // the rounds kept producing one, and the last one walked past both.
     //
-    // **SO THE HONEST STATEMENT IS A SCOPE, NOT A CLOSURE.** Deciding what
-    // `design` BINDS TO is name resolution, and no syntax test can do it; the
-    // reviewer's own repair each round was "resolve the base", which needs a
-    // compiler. Four rounds is the evidence, not a guess.
+    // **THE CLOSED QUESTION IS THE ONE SWIFT ITSELF ASKS: is anything named
+    // `design` in scope at the construction other than the stored property?** If
+    // nothing is, then a bare `design` there IS the stored property, whatever a
+    // hypothetical shadow's right-hand side would have been. That settles every
+    // shape at once, including the two previously declared out of scope, and it
+    // stops caring what a fixed design is spelled like.
     //
-    // COVERED, and these are the shapes an ordinary edit produces — each verified
-    // by mutation: the argument taking a fixed design outright; a local `let`; a
-    // closure capture; a design named anywhere else in the struct; `allCases[0]`.
-    // NOT COVERED: deliberately obfuscated reaches such as `type(of:)`, and a
-    // fixed design handed in from another type. This is a drift guard, so the
-    // threat is an accidental edit, not code written to get past it.
+    // Scoped to the DECLARATION the construction sits in, not to the whole
+    // struct, and the scoping is load-bearing in both directions: a binding
+    // anywhere else cannot reach this expression, and an ordinary
+    // `init(design:)` parameter is named `design` on purpose and must not be
+    // blamed for it. A round already found that false positive in the previous
+    // shape of this guard.
     //
-    // **THE TWO ROWS BELOW SPLIT ONE QUESTION ON THE GRAMMAR'S OWN TWO-STATE
-    // BASE, so this axis is closed rather than described.** A reach with NO base
-    // resolves against the contextual type and is judged by case name; a reach
-    // WITH one names a type and is judged by whether that type is this one.
-    // There is no third state, so the list cannot grow a member.
+    // The binding forms are closed because the GRAMMAR closes them, not because
+    // the list looked complete: a simple name enters scope through a pattern, a
+    // function parameter, a closure parameter in either spelling, or a capture.
+    // `IdentifierPatternSyntax` is `let`, `var`, `guard let`, `if let`, `for` and
+    // `case let` at once, which is why an earlier round's four-member list was
+    // the wrong unit to be counting.
     //
-    // The closure is falsifiable, which is the point of writing it down: a next
-    // finding on this axis would have to be a reach that is neither an implicit
-    // member nor a reference to the type name. Every such reach known to us goes
-    // through `type(of:)` or through another type's stored value, and both are
-    // already declared out of scope above. A finding inside the scope would mean
-    // this paragraph is wrong, not that the list needs extending.
-    //
-    // The two rounds that produced this were FALSE POSITIVES, not evasions —
-    // an explicit initializer, and an unrelated `SomeStyle.classic`. Both were
-    // one unqualified text match reading more than it meant to, in the direction
-    // that accuses innocent work.
-    //
-    // The structural fix that would end the class — the leaf deriving chrome from
-    // the design it is already given, so there is no argument to get wrong at
-    // either call site — is #2520, and it changes shipped source rather than a
-    // test.
-    let text = try String(
-      contentsOf: RepoRoot.url.appending(path: Self.panel), encoding: .utf8)
-    let tile = try #require(
-      Self.structDecl(named: "RecordingPillPreview", in: Parser.parse(source: text)),
-      "RecordingPillPreview is not in \(Self.panel) — this guard is pointed at the wrong type")
-
-    // **THE CASE IDENTIFIERS, READ OFF THE ENUM'S OWN DECLARATION.**
-    // `String(describing:)` was used here and is wrong for this: it returns a
-    // type's `CustomStringConvertible` description if one is ever added, and the
-    // panel's source names CASES. The sweep would then look for user-facing
-    // sentences, match nothing, and pass — silently, with the count check still
-    // green. Raw values have the same defect from the other side, since a raw
-    // value may diverge from its case name.
-    //
-    // So this parses the declaration, which is the producing code. `allCases` is
-    // the two-way control: a parse that found a different number than the type
-    // reports is a broken parse, and it says so rather than sweeping for a short
-    // list.
-    let enums = try String(
-      contentsOf: RepoRoot.url.appending(path: Self.designEnum), encoding: .utf8)
-    let design = try #require(
-      Self.enumDecl(named: "\(RecordingPillDesign.self)", in: Parser.parse(source: enums)),
-      "\(RecordingPillDesign.self) is not in \(Self.designEnum) — this guard reads the wrong file")
-    let caseNames = Self.caseNames(of: design)
+    // NOT COVERED, and stated rather than implied: a design handed in from
+    // another type through a differently-named property. That needs the stored
+    // property to stop being the thing the preview reads, which the row above
+    // already refuses. The structural fix that would end the whole class — the
+    // leaf deriving chrome from the design it is already given, so there is no
+    // argument to get wrong at either call site — is #2520, and it changes
+    // shipped source rather than a test.
+    let scope = try #require(
+      Self.enclosingDeclaration(of: call),
+      "the chrome argument sits in no declaration, so this guard cannot say what is in scope")
+    let shadows = Self.bindings(named: "design", in: scope).sorted()
     #expect(
-      caseNames.count == RecordingPillDesign.allCases.count,
+      shadows.isEmpty,
       """
-      parsed \(caseNames.count) case names from \(Self.designEnum) but the type reports \
-      \(RecordingPillDesign.allCases.count). The sweep below would be looking for a \
-      short list and would pass on a design it never checked.
-      """)
-
-    // **BARE `.classic`, not `Other.classic`** — see `implicitMemberNames`. The
-    // two rows are one question split on the grammar's own two-state base: a
-    // reach with no base is a contextual design, and a reach with one is a named
-    // type, which the row below refuses when that type is this one. Counting
-    // every member name spelled like a case blamed an unrelated `SomeStyle.classic`.
-    let named = Self.implicitMemberNames(in: tile).intersection(caseNames).sorted()
-    #expect(
-      named.isEmpty,
-      """
-      RecordingPillPreview names \(named.joined(separator: ", ")). This tile draws \
-      whatever design it is handed and must know none by name — a named one is how a \
-      fixed chrome reaches the card while `chrome: design.chrome` still reads correctly.
-      """)
-
-    // The TYPE, which is the other half and the one `allCases[0]` walks through.
-    //
-    // **REACHES THROUGH THE TYPE, NOT MENTIONS OF IT.** Counting every token
-    // spelled `RecordingPillDesign` counted the stored property's own
-    // ANNOTATION, so it allowed exactly one — and an ordinary explicit
-    // `init(design: RecordingPillDesign)`, which keeps `chrome: design.chrome`
-    // wired correctly, would have made it two and failed this row. That is the
-    // class the spelling row above already normalises: a guard refusing innocent
-    // work is how bypasses get trained
-    // (`validation-discipline.md` RULE: false-positives-not-gates-train-evasion).
-    //
-    // The grammar separates the two for free, so this needs no list of allowed
-    // annotation sites: an ANNOTATION is a type node, a REACH is an expression
-    // node. `\(RecordingPillDesign.self).allCases[0]` is the second; every
-    // property, parameter and return annotation is the first, however many the
-    // struct grows.
-    //
-    // The old row also claimed to fail loudly if the stored property were
-    // removed or retyped. Dropping that claim costs nothing, because the
-    // COMPILER owns it: `design.chrome` does not build without a `design` that
-    // has chrome.
-    let type = "\(RecordingPillDesign.self)"
-    let reaches = Self.typeReaches(type, in: tile).sorted()
-    #expect(
-      reaches.isEmpty,
-      """
-      RecordingPillPreview reaches through \(type) at \(reaches.joined(separator: ", ")). \
-      This tile draws whatever design it is handed, so any reach through the type is a \
-      way to a fixed design without naming a case — `\(type).allCases[0]` is the one \
-      that prompted this row. Annotations are not counted.
+      \(shadows.joined(separator: ", ")) named `design` where the preview is built, so \
+      `chrome: design.chrome` reads that instead of the design this tile was handed. \
+      Every card would draw the same pill and the picker would offer three pictures \
+      of one design.
       """)
   }
 
-  /// Every place a TYPE NAME is used as an EXPRESSION inside a declaration —
-  /// `RecordingPillDesign.allCases`, never `let design: RecordingPillDesign`.
-  /// `DeclReferenceExprSyntax` is the expression node, so annotations, parameter
-  /// types and return types are invisible here by construction rather than by an
-  /// allow-list that would need extending every time the struct grew one.
-  ///
-  /// Each hit is reported as the expression AROUND it, since the type name alone
-  /// would say nothing about which reach was found.
-  private final class TypeReachFinder: SyntaxVisitor {
-    let wanted: String
-    private(set) var reaches: Set<String> = []
-    init(_ wanted: String) {
-      self.wanted = wanted
-      super.init(viewMode: .sourceAccurate)
-    }
-    override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
-      if node.baseName.text == wanted {
-        reaches.insert(node.parent?.trimmedDescription ?? node.trimmedDescription)
+  /// The declaration an expression sits inside — the property or function whose
+  /// body holds it. Scope for a bare name starts here, so this is what a shadow
+  /// has to be inside to reach that name.
+  private static func enclosingDeclaration(of node: some SyntaxProtocol) -> Syntax? {
+    var current = node.parent
+    while let here = current {
+      if here.is(VariableDeclSyntax.self) || here.is(FunctionDeclSyntax.self)
+        || here.is(InitializerDeclSyntax.self)
+      {
+        return here
       }
-      return .visitChildren
+      current = here.parent
     }
+    return nil
   }
 
-  private static func typeReaches(_ name: String, in decl: StructDeclSyntax) -> Set<String> {
-    let finder = TypeReachFinder(name)
-    finder.walk(decl)
-    return finder.reaches
-  }
-
-  static let designEnum = "Sources/EnviousWisprCore/SettingsEnums.swift"
-
-  private final class EnumFinder: SyntaxVisitor {
+  /// Every site inside a declaration that brings `name` into scope, described in
+  /// the words of the form that does it.
+  ///
+  /// The forms are the grammar's rather than a guess. `IdentifierPatternSyntax`
+  /// covers `let`, `var`, `guard let`, `if let`, `for` and `case let` in one
+  /// node; the other four are the parameter and capture spellings. A name cannot
+  /// enter scope any other way, which is what makes this a closed question
+  /// instead of a list that grows a member every review round.
+  private final class BindingFinder: SyntaxVisitor {
     let wanted: String
-    private(set) var found: EnumDeclSyntax?
+    private(set) var sites: Set<String> = []
+
     init(_ wanted: String) {
       self.wanted = wanted
       super.init(viewMode: .sourceAccurate)
     }
-    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-      if node.name.text == wanted { found = node }
+
+    override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+      note(node.identifier, "a local binding")
       return .visitChildren
     }
-  }
-
-  private static func enumDecl(named: String, in tree: SourceFileSyntax) -> EnumDeclSyntax? {
-    let finder = EnumFinder(named)
-    finder.walk(tree)
-    return finder.found
-  }
-
-  /// The case IDENTIFIERS an enum declares, as source writes them.
-  private static func caseNames(of decl: EnumDeclSyntax) -> Set<String> {
-    var names: Set<String> = []
-    for member in decl.memberBlock.members {
-      guard let cases = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
-      for element in cases.elements { names.insert(element.name.text) }
+    override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+      note(node.secondName ?? node.firstName, "a parameter")
+      return .visitChildren
     }
-    return names
+    override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
+      note(node.secondName ?? node.firstName, "a closure parameter")
+      return .visitChildren
+    }
+    override func visit(_ node: ClosureShorthandParameterSyntax) -> SyntaxVisitorContinueKind {
+      note(node.name, "a closure parameter")
+      return .visitChildren
+    }
+    override func visit(_ node: ClosureCaptureSyntax) -> SyntaxVisitorContinueKind {
+      note(node.name, "a capture")
+      return .visitChildren
+    }
+
+    private func note(_ token: TokenSyntax, _ form: String) {
+      if token.text == wanted { sites.insert(form) }
+    }
+  }
+
+  private static func bindings(named name: String, in decl: Syntax) -> Set<String> {
+    let finder = BindingFinder(name)
+    finder.walk(decl)
+    return finder.sites
   }
 
   /// Whether an expression is this tile reading its OWN `design` — `design` or
@@ -977,34 +909,6 @@ struct RecordingPillPreviewWiringTests {
       return true
     }
     return false
-  }
-
-  /// Member names reached with NO base — a bare `.classic`, never `Other.classic`.
-  ///
-  /// **The base is the whole discriminator, and it has two states, so this axis
-  /// is closed rather than described.** An implicit member resolves against the
-  /// CONTEXTUAL type, and the only contextual type in this struct carrying a
-  /// design's case names is the design type, so a bare `.classic` here is always
-  /// a fixed design. An explicit base names a type, and that type is either the
-  /// design type — which `typeReaches` already refuses — or an unrelated one that
-  /// happens to spell a member the same way, which is innocent and must not be
-  /// blamed.
-  ///
-  /// Counting both is what a review round found: an unrelated `SomeStyle.classic`
-  /// would have failed the row while `chrome: design.chrome` stayed correct.
-  /// Comments and strings are not members, so they cannot trip it either way.
-  private final class ImplicitMemberFinder: SyntaxVisitor {
-    private(set) var names: Set<String> = []
-    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-      if node.base == nil { names.insert(node.declName.baseName.text) }
-      return .visitChildren
-    }
-  }
-
-  private static func implicitMemberNames(in decl: StructDeclSyntax) -> Set<String> {
-    let finder = ImplicitMemberFinder(viewMode: .sourceAccurate)
-    finder.walk(decl)
-    return finder.names
   }
 
   /// **THE CLOSURE ROW. Every piece of `@State` the poll writes must be seedable,

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -780,20 +780,28 @@ struct RecordingPillPreviewWiringTests {
     // one — the third being `RecordingPillDesign.allCases[0]`, which names no case
     // at all. So the two rows below are CLOSED questions instead of a list.
     //
-    // THE CLOSURE ARGUMENT, stated so it can be held to: to bind a fixed design
-    // inside this struct you must obtain a value of that type, and within one
-    // struct there are exactly two ways to reach one — name a CASE, or name the
-    // TYPE. The first row refuses every case name, enumerated from `allCases` so a
-    // design added later is covered with no edit here. The second refuses every
-    // mention of the type beyond the stored property's own annotation, which is
-    // what `allCases`, a static, an initialiser and a type alias all need.
+    // A closure argument was published here and then FALSIFIED, which is worth
+    // keeping rather than quietly replacing. It claimed that reaching a design
+    // inside this struct requires naming a CASE or naming the TYPE, so refusing
+    // both closes the set. Round four answered `type(of: self.design).allCases[0]`
+    // — a third route, naming neither.
     //
-    // WHAT A FOURTH FINDING WOULD HAVE TO LOOK LIKE: a fixed design arriving from
-    // OUTSIDE this struct, from some helper that hands one back without the tile
-    // naming anything — say a `RecordingPillPreviewTile.someFixedDesign`. That is
-    // a different change in a different type, and no assertion inside this struct
-    // can see it. Said out loud because a clean round is not evidence a set is
-    // closed; the falsification condition is.
+    // **SO THE HONEST STATEMENT IS A SCOPE, NOT A CLOSURE.** Deciding what
+    // `design` BINDS TO is name resolution, and no syntax test can do it; the
+    // reviewer's own repair each round was "resolve the base", which needs a
+    // compiler. Four rounds is the evidence, not a guess.
+    //
+    // COVERED, and these are the shapes an ordinary edit produces — each verified
+    // by mutation: the argument taking a fixed design outright; a local `let`; a
+    // closure capture; a design named anywhere else in the struct; `allCases[0]`.
+    // NOT COVERED: deliberately obfuscated reaches such as `type(of:)`, and a
+    // fixed design handed in from another type. This is a drift guard, so the
+    // threat is an accidental edit, not code written to get past it.
+    //
+    // The structural fix that would end the class — the leaf deriving chrome from
+    // the design it is already given, so there is no argument to get wrong at
+    // either call site — is #2520, and it changes shipped source rather than a
+    // test.
     let text = try String(
       contentsOf: RepoRoot.url.appending(path: Self.panel), encoding: .utf8)
     let tile = try #require(

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingPillTileTests.swift
@@ -768,6 +768,50 @@ struct RecordingPillPreviewWiringTests {
       this tile's own. Every card would then draw the same pill and the picker would \
       offer three pictures of one design.
       """)
+
+    // **The row above reads the NAME, so it cannot see what the name binds to.**
+    // A `let design = RecordingPillDesign.classic` introduced before the
+    // construction leaves `chrome: design.chrome` spelled exactly as required
+    // while every card draws one design — the same failure the row exists to
+    // prevent, passing it. So the binding is checked separately: the tile
+    // declares `design` once, as its own stored property, and nothing inside it
+    // shadows that name.
+    let text = try String(
+      contentsOf: RepoRoot.url.appending(path: Self.panel), encoding: .utf8)
+    let tile = try #require(
+      Self.structDecl(named: "RecordingPillPreview", in: Parser.parse(source: text)),
+      "RecordingPillPreview is not in \(Self.panel) — this guard is pointed at the wrong type")
+    let bindings = Self.bindingsNamed("design", in: tile)
+
+    #expect(
+      bindings == 1,
+      """
+      RecordingPillPreview declares `design` \(bindings) times. One is the stored \
+      property every row above assumes; a second SHADOWS it, so `chrome: design.chrome` \
+      can read a fixed design while still being spelled correctly.
+      """)
+  }
+
+  /// Every `let`/`var` binding of one name anywhere inside a declaration, the
+  /// stored property included. Used as a count rather than a lookup: the answer
+  /// that matters is whether the name is declared more than once.
+  private final class BindingCounter: SyntaxVisitor {
+    let wanted: String
+    private(set) var count = 0
+    init(_ wanted: String) {
+      self.wanted = wanted
+      super.init(viewMode: .sourceAccurate)
+    }
+    override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+      if node.identifier.text == wanted { count += 1 }
+      return .visitChildren
+    }
+  }
+
+  private static func bindingsNamed(_ name: String, in decl: StructDeclSyntax) -> Int {
+    let counter = BindingCounter(name)
+    counter.walk(decl)
+    return counter.count
   }
 
   /// **THE CLOSURE ROW. Every piece of `@State` the poll writes must be seedable,


### PR DESCRIPTION
One guard, for a gap #2438's battery found while trying to run a row it could not run.

## The gap

#2438's row "every tile draws the CAPSULE's chrome" names `tileHeightTracksTheLeaf`, a test that was deliberately retired when the founder replaced the picker layout with three identical cards on 2026-08-26. Its own replacement says so in a comment.

Re-aimed at the successor, `thePreviewIsTheRealPillScaled`, the mutation still survived — that test measures HEIGHT, and chrome is paint. With `chrome: RecordingPillDesign.classic.chrome` substituted, **all sixteen rows of `RecordingPillTileTests` passed.** The row was right about the behaviour; only its witness was gone.

Chrome carries the header, the notice cap and the ink. A fixed one makes every card draw the same pill, so the appearance picker would offer three pictures of one design and there would be nothing to choose between.

## The guard

`theTileDrawsItsOwnChrome()` reads the one `RecordingOverlayView` construction in the panel and requires the `chrome:` argument's base to be a plain reference to the tile's own `design`. Any concrete design constant fails it however spelled; a missing argument fails the `#require` above it. It sits beside the cadence, glow and seed rows and uses the same helpers.

## Evidence

Two mutants, a different substituted design in each, run against this tree:

```
[ EXP  ] row 1: every tile draws the capsule's chrome
[ EXP  ] row 2: every tile draws the reading well's chrome
```

2/2 matched, two named silent controls unchanged, baseline green before and after. Suite green at 7/7.

Classified REPRODUCIBLE: demonstrable by editing one line of shipped source and observing the whole suite stay green.

## The rest of #2438, reported there rather than here

Six runnable rows, all six caught. The other two unrunnable rows are not defects: one names a silent control that lives in a different test target and so can never run under the row's own filter, and one targets code that no longer exists anywhere in the app.

Frozen recipe for the new case: #2518.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprAppKit`
`Lane: Code`

Part of #2438.
