### PR TITLE
test(overlay): make the hover/slot-revision case reach the code it names

### DIFF
--- a/Tests/EnviousWisprTests/App/Overlay/RecordingTransactionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingTransactionTests.swift
@@ -258,18 +258,44 @@ struct RecordingTransactionTests {
 
   /// **The narrowing, at the level the loop reads it.** A hover must not move the
   /// slot revision, or every hover would invalidate a prepared recording.
+  ///
+  /// **THE FIXTURE IS A HOVER-PAUSABLE PILL, and that is the whole test.** This
+  /// case used `reducerWithLiveRecording()`, whose expiry is not
+  /// `.after(_, pausesOnHover: true)`, so `reduceHover` returned `.noChange` at
+  /// its guard and `state.set` was never reached. It was asserting that a
+  /// revision does not move across an event that does nothing — true of any
+  /// implementation, including one that advances the revision on every hover
+  /// it does accept.
+  ///
+  /// Measured on #2402 row 5, which makes `slotRevision &+= 1` unconditional:
+  /// this case stayed GREEN while three siblings failed. Same trap
+  /// `incumbentHoverDoesNotInvalidate` above already carries a comment about —
+  /// there it was a non-pausable incumbent, here a non-pausable current — so the
+  /// accepted-hover assertions come first and the revision claim rests on them.
   @Test("a hover does not move the slot revision")
   func hoverDoesNotMoveTheSlotRevision() throws {
-    var r = Self.reducerWithLiveRecording()
-    let id = try #require(r.state.current?.id)
+    var r = OverlayReducer()
+    let pill = try #require(
+      r.reduce(.pipeline(.escapeRecovery(transcriptID: UUID()))).presentation)
     let before = r.recordingReconciliationSnapshot.revision
 
-    _ = r.reduce(.hoverChanged(id, true))
+    let entered = r.reduce(.hoverChanged(pill.id, true))
+    #expect(r.state.isHovered, "the fixture never entered the hovered state")
+    #expect(entered.expiryCommand == .cancel, "the hover event was not accepted")
     #expect(
       r.recordingReconciliationSnapshot.revision == before,
       "a hover advanced the slot revision, which would discard prepared recordings")
 
-    _ = r.reduce(.hoverChanged(id, false))
-    #expect(r.recordingReconciliationSnapshot.revision == before)
+    // Leaving RE-ARMS from full, so the accepted answer is an `arm` rather than
+    // merely "not unchanged" — `.unchanged` is what a dropped stale event returns
+    // and is exactly the reading this precondition exists to refuse.
+    let left = r.reduce(.hoverChanged(pill.id, false))
+    var rearmed = false
+    if case .arm = left.expiryCommand { rearmed = true }
+    #expect(!r.state.isHovered, "the fixture never left the hovered state")
+    #expect(rearmed, "the hover-exit event did not re-arm: \(left.expiryCommand)")
+    #expect(
+      r.recordingReconciliationSnapshot.revision == before,
+      "leaving a hover advanced the slot revision")
   }
 }


### PR DESCRIPTION
One test that could not fail, found by running #2402's frozen mutation battery.

## The gap

#2402 row 5 makes `slotRevision &+= 1` unconditional in `OverlayReducer`. It names `hoverDoesNotMoveTheSlotRevision()` — and **that case stayed GREEN** while three siblings failed. The runner reported CAUGHT-ELSEWHERE: something else caught the mutation, which says nothing about the named guard.

The cause is the fixture. `reducerWithLiveRecording()` has an expiry that is not `.after(_, pausesOnHover: true)`, so `reduceHover` returns `.noChange` at its guard and `state.set` is never reached.

**The case was asserting that a revision does not move across an event that does nothing.** That is true of any implementation, including one that advances the revision on every hover it does accept — which is exactly the failure its own comment describes: *"A hover must not move the slot revision, or every hover would invalidate a prepared recording."*

`incumbentHoverDoesNotInvalidate` twenty lines above already carries a comment about this exact trap from a previous encounter — *"this case passed with hover handling entirely broken"* — where the non-pausable pill was the INCUMBENT rather than the CURRENT.

## The fix

That case's own pattern: an Escape Recovery pill, which pauses on hover, with the accepted-hover assertions first so the revision claim rests on them.

Hover-exit asserts an `arm` rather than "not unchanged", because `.unchanged` is precisely what a dropped stale event returns and is the reading this precondition exists to refuse.

## Evidence

With #2402 row 5 applied verbatim, the case now fails at **both** assertion sites:

```
✘ "a hover does not move the slot revision" — revision 1 -> 2 on hover-enter
✘ "a hover does not move the slot revision" — revision 1 -> 3 on hover-exit
```

1/1 matched, baseline green before and after. Classified REPRODUCIBLE: demonstrated by running the row and reading which tests changed status, not inferred.

## The rest of the batteries this covers

Reported on their own issues, nothing else to ship:

- **#2402** — 13 of 16 rows runnable; 12 caught outright, row 5 fixed here. Three rows have stale anchors in `PillDefinition.swift`.
- **#2369** — all four rows accounted for; two were stale by LOCATION only (`fire()` moved file, `isFresh` reflowed) and one of those caught immediately once re-aimed. One legitimate redundant-protection survivor.
- **#2351** — both runnable rows caught.
- **#2356** — its one runnable row survives, and that is a real coverage gap: `discardActiveRecovery()` has one production call site and zero test references, so nothing binds the composition root's wiring.

## Validation

`scripts/xcode-test.sh`: **6984 tests in 614 suites passed**.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprAppKit`
`Lane: Code`

Part of #2402.
