### PR TITLE
test(settings): bind the observation registration the picker depends on

### DIFF
--- a/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AppearancePillPickerTests.swift
@@ -37,6 +37,63 @@ struct AppearancePillPickerTests {
     return (settings, PillAppearanceModel(settings: settings, capability: { capability }))
   }
 
+  /// **A capability change INVALIDATES a page that read the capability.**
+  ///
+  /// `wordsCapability` opens with a bare `_ = capabilityGeneration`, and that
+  /// discard is the whole mechanism: the closure behind `capability` reaches a
+  /// class that is not `@Observable`, so a page reading only its RESULT would
+  /// never be told when removal suppression begins or ends. Reading the stored
+  /// property is what puts the page in this object's dependency graph.
+  ///
+  /// **Nothing bound it.** #2421 row 3 deletes that line and names
+  /// `aCapabilityReaderIsInvalidated()`, which does not exist in this suite or
+  /// anywhere else, and `capabilityGeneration` had ZERO test references — so the
+  /// line could be deleted as dead code with every suite green.
+  ///
+  /// What a user would meet: begin removing the model with the appearance page
+  /// open, and the greyed-out cards and their reason stay exactly as they were.
+  ///
+  /// The oracle is `withObservationTracking`, which is the same registration
+  /// SwiftUI performs — not a stand-in for it. A change that stops reading the
+  /// generation fails here because `onChange` never fires.
+  @Test("a page that read the capability is invalidated when the capability changes")
+  func aCapabilityReaderIsInvalidated() async {
+    let model = Self.model(.available)
+    let fired = Invalidation()
+
+    withObservationTracking {
+      _ = model.wordsCapability
+    } onChange: {
+      fired.mark()
+    }
+
+    model.capabilityDidChange()
+    await Task.yield()
+
+    #expect(
+      fired.happened,
+      """
+      reading wordsCapability registered no dependency, so a settings page showing \
+      the greyed cards is never invalidated when removal suppression begins or ends.
+      """)
+  }
+
+  /// A box `withObservationTracking`'s escaping handler can write to.
+  private final class Invalidation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+    func mark() {
+      lock.lock()
+      value = true
+      lock.unlock()
+    }
+    var happened: Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return value
+    }
+  }
+
   /// **The tick marks what the NEXT RECORDING will use, not what is stored.**
   ///
   /// The recording director puts both stored slots through
@@ -103,7 +160,8 @@ struct AppearancePillPickerTests {
   @Test("the two groups between them offer every design")
   func groupsCoverEveryDesign() {
     let m = Self.model(.available)
-    let all = Set(PillCatalog.designs(holdingWords: true) + PillCatalog.designs(holdingWords: false))
+    let all = Set(
+      PillCatalog.designs(holdingWords: true) + PillCatalog.designs(holdingWords: false))
     #expect(
       all == Set(RecordingPillDesign.allCases),
       "the picker lays out \(all.count) of \(RecordingPillDesign.allCases.count) designs")
@@ -131,8 +189,9 @@ struct AppearancePillPickerTests {
   /// Both directions asserted, so a future change that greys a card without
   /// explaining it fails here, and so does one that leaves an orphaned sentence
   /// under a row where everything is selectable.
-  @Test("a state explains itself exactly when it greys something",
-        arguments: PillWordsCapability.allCases)
+  @Test(
+    "a state explains itself exactly when it greys something",
+    arguments: PillWordsCapability.allCases)
   func reasonAppearsExactlyWhenSomethingIsGreyed(capability: PillWordsCapability) throws {
     let reason = RecordingPillAppearancePanel.reason(for: capability)
     let switchCanFixIt = capability == .available || capability == .previewOff
@@ -190,8 +249,9 @@ struct AppearancePillPickerTests {
   /// remaining bar is whether the machine can produce words at all — something no
   /// tap can change. Asserted per state so the two cases the switch cannot fix
   /// stay closed.
-  @Test("a tap can reach any design the machine can actually run",
-        arguments: PillWordsCapability.allCases)
+  @Test(
+    "a tap can reach any design the machine can actually run",
+    arguments: PillWordsCapability.allCases)
   func couplingOpensEverythingTheMachineCanDo(capability: PillWordsCapability) {
     let model = Self.model(capability)
 


### PR DESCRIPTION
One line in shipped source that nothing tested, found by running #2421's frozen mutation battery.

## The gap

Row 3 deletes `_ = capabilityGeneration` from `PillAppearanceModel.wordsCapability` and names `AppearancePillPickerTests/aCapabilityReaderIsInvalidated()`. **That test did not exist** — not in that suite, not anywhere.

And `capabilityGeneration` had **zero test references**; source hits only. So the line could have been deleted as dead tidying with every suite green.

The discard is the whole mechanism, and the property's own comment already says so:

> Reading `capabilityGeneration` is what registers the dependency; the closure behind `capability` reaches a class that is not `@Observable`, so a page that read only its result would never be invalidated when removal suppression begins or ends.

A bare `_ =` of a stored property is exactly the shape a tidy-up removes. It looks like a no-op and it is load-bearing.

**What a user meets without it:** begin removing the model with the appearance page open, and the greyed-out cards and their reason stay exactly as they were. A design can then be picked that the pill is about to stop being able to draw — the same class rows 1 and 2 protect against, one layer up, and it was the unguarded one.

## The test

`withObservationTracking` performs the same registration SwiftUI does rather than standing in for it, so removing the read means `onChange` never fires. The name matches the one the recipe asked for, so row 3 is runnable from now on rather than needing a re-file.

## Evidence

With row 3 applied verbatim: **CAUGHT**, baseline green before and after. Classified REPRODUCIBLE — one deleted line of shipped source, and its absence is silent.

Rows 1 and 2 of #2421 both CAUGHT unchanged; reported on the issue.

## Validation

`scripts/xcode-test.sh` in this worktree: Debug lane **PASS**. `AppearancePillPickerTests` 7/7.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprAppKit`
`Lane: Code`

Part of #2421.
