### PR TITLE
test(onboarding): a focused box that words missed is not a missed box

### DIFF
--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -13,7 +13,7 @@ import Testing
   /// under contention the guess can expire before the subject has run, so a
   /// negative assertion passes having exercised nothing.
   @MainActor
-  fileprivate final class EntrySignal {
+  private final class EntrySignal {
     private var waiters: [(UUID, CheckedContinuation<Bool, Never>)] = []
     private var fired = false
 
@@ -633,7 +633,6 @@ import Testing
       }
     }
 
-
     /// #2196 chunk 2 — the box.
     ///
     /// When these fail a new person reaches the end of setup without ever
@@ -762,7 +761,8 @@ import Testing
         vm.practiceTakeStarted()
         vm.practiceTakeEnded()
 
-        #expect(vm.practiceState == .saidNothing, "a silent take inherited the previous take's words")
+        #expect(
+          vm.practiceState == .saidNothing, "a silent take inherited the previous take's words")
       }
 
       /// FOUNDER-FOUND IN LIVE UAT, 2026-08-24, and the most valuable finding
@@ -785,6 +785,39 @@ import Testing
         #expect(
           vm.practiceState != .saidNothing,
           "the screen told someone it heard nothing when it heard them fine")
+      }
+
+      /// **The twin of the case above, with the focus flag the other way — and
+      /// the flag is the ONLY thing keeping the wrong advice off this screen.**
+      ///
+      /// Words existed and the box did not grow, exactly as above. The
+      /// difference is that the box WAS focused, so "you missed the box" is
+      /// advice that cannot be right: they were typing into it. The code falls
+      /// through to `saidNothing` for precisely that reason.
+      ///
+      /// **Nothing bound it.** #2371 row 16 replaces
+      /// `boxWasFocusedAtTakeStart = boxFocused` with `= false`, which turns
+      /// this case into `missedTheBox`, and the whole suite stayed green. The
+      /// row named three silence cases, and no silence case can ever see it:
+      /// silence means `producedWords` is false, which short-circuits the flag
+      /// before it is read. Only a take that PRODUCED words can observe it, and
+      /// this is the only such take with the box focused.
+      @Test("a focused box that words missed is not called a missed box")
+      func focusedBoxIsNeverBlamedForMissing() {
+        let vm = makePracticeViewModel()
+        vm.practiceTakeStarted(boxFocused: true, transcriptCount: 3)
+
+        // The same shape as `missedBoxIsNotSilence`: a transcript appeared, so
+        // words genuinely existed, and none of them reached this box.
+        vm.practiceTakeEnded(transcriptCount: 4)
+
+        #expect(
+          vm.practiceState != .missedTheBox,
+          """
+          the screen told someone they missed a box they were focused on, which sends \
+          them to click somewhere they already were.
+          """)
+        #expect(vm.practiceState == .saidNothing)
       }
 
       /// Cloud review, and it is the founder's own defect pointed the other way,
@@ -890,7 +923,8 @@ import Testing
         let vm = makePracticeViewModel()
         vm.applyPracticePosture(micGranted: true, accessibilityGranted: false)
         #expect(
-          vm.practiceState == .cannotHear(reason: "accessibility_denied", permission: "accessibility"))
+          vm.practiceState
+            == .cannotHear(reason: "accessibility_denied", permission: "accessibility"))
       }
 
       @Test("granting the permission afterwards clears the blocked state")

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -817,7 +817,21 @@ import Testing
           the screen told someone they missed a box they were focused on, which sends \
           them to click somewhere they already were.
           """)
-        #expect(vm.practiceState == .saidNothing)
+
+        // **THE `saidNothing` THIS CURRENTLY FALLS THROUGH TO IS NOT ASSERTED,
+        // DELIBERATELY.** Its screen says "We just did not hear anything"
+        // (`PracticeScreen.swift:138-142`), and this setup has just proved the
+        // opposite by growing the transcript. Pinning it would cement a second
+        // piece of wrong advice as the expected answer, and a later change that
+        // gave this state an honest message would fail a test for improving it.
+        //
+        // The property this row exists for is the one above: a focused box is
+        // never blamed for missing. That alone kills #2371 row 16, which turns
+        // this case into `missedTheBox`.
+        //
+        // What the screen SHOULD say for a focused take whose words went
+        // elsewhere is a product question, open as #2527. Cloud review raised it
+        // on this PR.
       }
 
       /// Cloud review, and it is the founder's own defect pointed the other way,


### PR DESCRIPTION
One onboarding case that did not exist, found by running #2371's frozen mutation battery.

## The gap

Row 16 replaces `boxWasFocusedAtTakeStart = boxFocused` with `= false` in `OnboardingV2View`. **The whole 44-test suite stayed green.**

The branch it feeds:

```swift
} else if !boxWasFocusedAtTakeStart && producedWords {
  practiceState = .missedTheBox
```

The row named three SILENCE cases, and **none of them can ever observe it** — silence means `producedWords` is false, which short-circuits before the flag is read. `focusedSilenceIsStillSilence` starts with `boxFocused: true`, ends with no words, and reaches `saidNothing` by the same branch either way.

Only a take that PRODUCED words can see the flag, and there was exactly one: `missedBoxIsNotSilence`, with the box NOT focused, which the mutation leaves unchanged and which the row correctly lists as a silent control.

**Its twin, with the box FOCUSED, did not exist — and that twin is the case the flag exists for.**

## What a person would meet

They click into the practice box, speak, and the words land somewhere other than that box. The screen tells them they missed the box, so they go and click into the box they were already typing in. The `boxWasFocusedAtTakeStart` read is the only thing keeping that advice off the screen, and it could have been changed with every test green.

## The test

`focusedBoxIsNeverBlamedForMissing()` — the same shape as `missedBoxIsNotSilence` with the flag flipped: a transcript appears so words genuinely existed, the box does not grow, and the box WAS focused.

## Evidence

With row 16 applied verbatim: **CAUGHT**, both named silent controls (`missedBoxIsNotSilence`, `wordsBeatTheFocusFlag`) unchanged, baseline green before and after. Classified REPRODUCIBLE.

## The rest of the battery

Reported on #2371, nothing else to ship. Two findings worth the issue rather than the PR:

- **`validate-mutation-recipe.py` reported ALL 23 rows unrunnable. 22 of them run.** It cannot see a nested `@Suite`, and the nesting here is deliberate — `.serialized` does not order sibling suites, so a sibling's telemetry was landing in this one's capture. Filed as **#2525**, with two smaller faults in the same tool: every unrunnable row is labelled `row 1 anchor not found`, and the replacement is never compiled, which cost a baseline twice tonight.
- 20 rows matched; row 11 caught its guard and a neighbour too; row 15 is the one genuinely stale anchor.

## Validation

`scripts/xcode-test.sh`: Debug lane **PASS**. `OnboardingPracticeStepSuite` 44/44.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprAppKit`
`Lane: Code`

Part of #2371.
