### PR TITLE
test(settings): make the compiler own the list of states the sweeps read

### DIFF
--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -24,12 +24,41 @@ struct LivePreviewStatusBarPresentationTests {
 
   /// Every kind the mapping can return, so the sweeps below are over the real
   /// closed set rather than the ones a test author happened to think of.
+  ///
+  /// **THAT SENTENCE WAS A CLAIM THE CODE DID NOT IMPLEMENT.** This is a
+  /// hand-written array, and an array literal is not exhaustive over an enum — the
+  /// compiler sees an omission from a `switch`, never from a list. A twelfth `Kind`
+  /// would have escaped this sweep and the four others that read `allKinds`, while
+  /// the sentence above told the next reader the set was closed.
+  ///
+  /// `allKindsCoversEveryKind` now holds it, with `caseName` as the compiler's half.
+  /// Raised by #2441, which asked whether a new case falls through safely. It does
+  /// not fall through: it is never swept at all.
   private static let allKinds: [LivePreviewStatusMapping.Kind] = [
     .active, .off, .needsMacOS26, .checking,
     .needsLanguage(name: "German"),
     .unsupportedLanguage, .needsDownload, .gettingReady,
     .downloadFailed, .buildCannotRun, .paused,
   ]
+
+  /// The case's own identifier, from an EXHAUSTIVE switch. A case added to `Kind`
+  /// stops this compiling until it is handled, which is why it is a switch rather
+  /// than a read of `"\(kind)"`.
+  private static func caseName(_ kind: LivePreviewStatusMapping.Kind) -> String {
+    switch kind {
+    case .active: return "active"
+    case .off: return "off"
+    case .needsMacOS26: return "needsMacOS26"
+    case .checking: return "checking"
+    case .needsLanguage: return "needsLanguage"
+    case .unsupportedLanguage: return "unsupportedLanguage"
+    case .needsDownload: return "needsDownload"
+    case .gettingReady: return "gettingReady"
+    case .downloadFailed: return "downloadFailed"
+    case .buildCannotRun: return "buildCannotRun"
+    case .paused: return "paused"
+    }
+  }
 
   private func summary(
     _ kind: LivePreviewStatusMapping.Kind,
@@ -117,6 +146,50 @@ struct LivePreviewStatusBarPresentationTests {
         }
       }
     }
+  }
+
+  /// **THE SWEEP LIST IS NOT ALLOWED TO FALL BEHIND THE ENUM.**
+  ///
+  /// Five tests in this file read `allKinds`, and it is a hand-written array, so a
+  /// twelfth `Kind` escapes all five at once — not falling through to a safe
+  /// default, simply never reached. The row above says the next kind added "has to
+  /// be classified"; that was only true once this existed.
+  ///
+  /// `Kind` carries an associated value, so `CaseIterable` cannot be synthesised.
+  /// `caseName` is the substitute the compiler CAN enforce, and both halves are
+  /// needed: the switch alone would let someone add a case without sweeping it,
+  /// and this row alone could be satisfied by editing one list to match the other.
+  @Test("every kind the mapping can return is in the list the sweeps read")
+  func allKindsCoversEveryKind() {
+    let swept = Set(Self.allKinds.map(Self.caseName))
+
+    // Every name `caseName` can produce. The compiler has already forced that
+    // switch to be complete, so a case added to `Kind` fails to BUILD there first;
+    // adding it there and not here then fails this row.
+    let declared: Set<String> = [
+      "active", "off", "needsMacOS26", "checking", "needsLanguage",
+      "unsupportedLanguage", "needsDownload", "gettingReady",
+      "downloadFailed", "buildCannotRun", "paused",
+    ]
+
+    let missing = declared.subtracting(swept).sorted()
+    let extra = swept.subtracting(declared).sorted()
+
+    #expect(
+      missing.isEmpty,
+      """
+      \(missing.joined(separator: ", ")) is a Kind the mapping can return and no \
+      sweep in this file reaches it.
+      """)
+    #expect(
+      extra.isEmpty,
+      """
+      allKinds carries \(extra.joined(separator: ", ")), which caseName cannot \
+      produce — the list and the enum have diverged.
+      """)
+    #expect(
+      Self.allKinds.count == swept.count,
+      "allKinds lists \(Self.allKinds.count) entries for \(swept.count) distinct kinds")
   }
 
   /// The locked language is NAMED when Apple cannot preview it, rather than the row


### PR DESCRIPTION
Answers the open question on #2441, and the answer is worse than the question assumed.

## The question

> A new `Kind` case is classified by FALLING THROUGH to "must show a language". That is the safe direction, but confirm it: add a case to `Kind` and check the test fails rather than silently passing.

**It does not fall through. It is never swept at all.**

`allKinds` is a hand-written array literal over an enum, and an array literal is not exhaustive: the compiler sees an omission from a `switch`, never from a list. **Five tests in this file read it**, so a twelfth `Kind` escapes all five at once — including `languageControlSurvivesTheStatesThatNeedIt`, whose own comment promises the next kind "has to be classified".

The list's own doc comment said the opposite of the truth:

> Every kind the mapping can return, so the sweeps below are over the real closed set rather than the ones a test author happened to think of.

It is precisely the set a test author happened to think of. That is a comment asserting a mechanism the code does not implement, sitting exactly where a reader looking for the enforcement would stop.

## The fix

`Kind` carries an associated value on `.needsLanguage`, so `CaseIterable` cannot be synthesised. `caseName` is the substitute the compiler CAN enforce — an exhaustive `switch`, so a case added to `Kind` stops it compiling. `allKindsCoversEveryKind` then requires the swept list and the declared set to agree in **both** directions, and that the list has no duplicates.

**Both halves are needed and neither is sufficient.** The switch alone lets someone add a case without sweeping it; the row alone could be satisfied by editing one list to match the other.

## Evidence

| | run | result |
|---|---|---|
| 1 | clean | 11/11 green |
| 2 | `.paused` removed from `allKinds` by hand | **FAILS**: `Expectation failed: (missing → ["paused"]).isEmpty → false` |

File restored byte-exact afterwards (`cmp` clean). The mutation runner refuses to mutate anything under `Tests/` — correctly, since a mutant there proves only that breaking a test breaks it — so the negative control is a hand run and is recorded as one.

Classified REPRODUCIBLE: a case added to the enum is silently unswept, with nothing anywhere failing to say so.

## What this does NOT do

It does not touch `mayHide`, the other half of #2441's question. That set is still three hardcoded strings, and whether it should exist at all is a separate call — this change only guarantees a new kind reaches the loop that would classify it.

## Validation

`scripts/xcode-test.sh`: Debug lane **PASS**. `LivePreviewStatusBarPresentationTests` 11/11.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprAppKit`
`Lane: Code`

Part of #2441.
