### PR TITLE
ci: measure whether wispr_eyes imports on the hosted runner (#2426)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -758,6 +758,20 @@ jobs:
           python3 Tests/RuntimeUAT/ptt_binding.py --self-test
           python3 Tests/RuntimeUAT/faultInjection.py --self-test
 
+      # THROWAWAY MEASUREMENT, REMOVED BEFORE THIS PR MERGES (#2426).
+      # `wispr_eyes.py --self-test` exists, has six two-way rows, and no gate
+      # invokes it. It was left out because it imports Quartz transitively via
+      # `ui_helpers`, and whether PyObjC resolves on the hosted runner was never
+      # measured — the step above says outright "Neither module imports Quartz,
+      # so both run here."
+      #
+      # `continue-on-error` is the whole point: learn the answer without
+      # reddening `build-check`, which is the REQUIRED check, on a guess.
+      - name: does wispr_eyes import on the runner (#2426 probe)
+        continue-on-error: true
+        run: |
+          python3 -c "import sys; sys.path.insert(0,'Tests/RuntimeUAT'); import wispr_eyes; print('WISPR_EYES_IMPORT_OK')"
+
       - name: Judge receipt + billing contracts (#2007/#2008)
         run: |
           set -euo pipefail


### PR DESCRIPTION
**A measurement PR. The probe step is removed before this merges; only the answer is kept.**

#2426 states its own closing condition: *"One measurement, not a design decision. Does `import wispr_eyes` succeed on the hosted macOS runner?"*

## Why it was never measured

`wispr_eyes.py --self-test` has six rows, two-way by construction — four must refuse, two must pass — and **no CI job invokes it**. It was left out because it imports Quartz transitively through `ui_helpers`, while the step that runs its two siblings says outright:

> Neither module imports Quartz, so both run here.

The asymmetry is what kept it out: a wrong guess reddens `build-check`, the **required** check, for everybody, while leaving it out costs only that this control is run by hand.

## The probe

One step, `continue-on-error: true`, printing a sentinel. That flag is the whole design — it learns the answer without reddening the required check to do so.

## What happens next in this same PR

- **If it imports** — add `python3 Tests/RuntimeUAT/wispr_eyes.py --self-test` to the existing step, and correct that step's comment, which asserts a property of the SET that stops holding the moment a third line is added.
- **If it does not** — split `running_enviouswispr_instances` and `_require_single_instance` into a module importing nothing heavy, leave a re-export in `wispr_eyes.py`, and wire the new module's `--self-test` instead. That guard is pure `subprocess` plus string handling.

Either way the probe step comes out.

`Tier: SMALL | Test: n/a | Modules: CI`
`Lane: CI/workflow`

Part of #2426.
