### PR TITLE
test(delivery): enter the Resume door's second kill-switch read, which nothing did

### DIFF
--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -590,8 +590,17 @@ struct ModelDeliveryHomeTests {
 
     suite.set(false, forKey: "modelDelivery.parakeet.enabled")
 
-    // Signal, not clock: the re-read increments this from inside the door's Task.
-    for _ in 0..<400 where home.parakeetResumeRefusalsForTests == 0 { await Task.yield() }
+    // **A HANG GUARD, not a settle budget** — the convention this file already
+    // records at `baselineAfterLaunchProbe`. A small count is a bet on how many
+    // yields a contended runner needs before an unstructured task gets to run,
+    // and losing that bet fails correct production code. This bound can only be
+    // reached when the door never reports at all, and then it SAYS so rather
+    // than letting the expectation below read a silence as a verdict.
+    for _ in 0..<100_000 where home.parakeetResumeRefusalsForTests == 0 { await Task.yield() }
+    if home.parakeetResumeRefusalsForTests == 0 {
+      Issue.record(
+        "the Resume door's task never reported, so it is not known whether the re-read ran")
+    }
 
     #expect(
       home.parakeetResumeRefusalsForTests == 1,

--- a/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
+++ b/Tests/EnviousWisprTests/App/ModelDeliveryHomeTests.swift
@@ -486,6 +486,15 @@ struct ModelDeliveryHomeTests {
   ///
   /// The flag store is injected. Reading the real one would mean writing an
   /// operational delivery kill switch onto a developer's machine.
+  ///
+  /// **KNOWN SURVIVOR, and it is structural rather than an oversight (#2389).**
+  /// Deleting the `_ = await handle.ensureAvailable()` line inside the claim
+  /// leaves every row here green, confirmed by mutation. It cannot be otherwise:
+  /// `tryBegin` returns false, so `withClaim` refuses and never runs its
+  /// operation, which is exactly the property the paragraph above relies on to
+  /// keep real Parakeet delivery off the developer's cache and the network.
+  /// Binding "the download was actually asked for" needs a seam this file does
+  /// not have, and buying it by letting delivery run would be the worse trade.
   @Test("the Parakeet Resume door honours the parakeet kill switch, both ways")
   func parakeetResumeHonoursTheKillSwitch() async throws {
     final class Box: @unchecked Sendable {
@@ -529,6 +538,68 @@ struct ModelDeliveryHomeTests {
     #expect(
       onBox.refusedSites == ["parakeetResumeDownload"],
       "with the flag ON the door must still reach delivery; a welded-shut door would pass the assertions above"
+    )
+  }
+
+  /// The Resume door's SECOND kill-switch read — the one inside the Task (#2389).
+  ///
+  /// **Nothing bound it, and the case beside this one cannot.** Deleting that
+  /// guard left every row of `parakeetResumeHonoursTheKillSwitch()` green, found
+  /// by a mutation of the night session's own choosing rather than by the filed
+  /// recipe. The reason is structural: that case's flag-off arm returns at the
+  /// SYNCHRONOUS guard, so the re-read is never reached, and its flag-on arm
+  /// never turns the switch off. The second door was live code with no test
+  /// entering it at all.
+  ///
+  /// **The window is real, not contrived.** The flag is set remotely, so it can
+  /// go off between the user pressing Resume and the download starting. The
+  /// re-read exists for exactly that, and it must refuse BEFORE the mutation
+  /// claim: a download that is not going to happen must not serialise against a
+  /// dictation's engine switch.
+  ///
+  /// **Staged, never raced.** `resumeParakeetDownload()` is synchronous and
+  /// returns before its unstructured `Task` can run, so writing the flag on the
+  /// next line puts the store in the off state for the re-read and only for the
+  /// re-read. The first expectation is the precondition: if the synchronous
+  /// guard had already refused, this case would be testing the first door again
+  /// and would prove nothing about the second.
+  @Test("the Resume door re-reads the kill switch after the button, not only before")
+  func parakeetResumeRereadsTheKillSwitch() async throws {
+    final class Box: @unchecked Sendable {
+      var refusedSites: [String] = []
+    }
+
+    let box = Box()
+    let suite = try #require(UserDefaults(suiteName: "ew-2389-reread-\(UUID().uuidString)"))
+    suite.set(true, forKey: "modelDelivery.parakeet.enabled")
+    let home = ModelDeliveryHome(
+      engineMutationScope: .live(
+        tryBegin: { false },
+        end: { false },
+        wake: {},
+        onRefused: { box.refusedSites.append($0) }),
+      manifestBundle: try Self.manifestBundle(),
+      appSupportOverride: try Self.tempAppSupport(),
+      deliveryFlagDefaults: suite)
+
+    home.resumeParakeetDownload()
+    #expect(
+      home.parakeetResumeRefusalsForTests == 0,
+      "the switch was ON at the button, so the synchronous guard must let this through — a refusal here means this case never reaches the door it exists for"
+    )
+
+    suite.set(false, forKey: "modelDelivery.parakeet.enabled")
+
+    // Signal, not clock: the re-read increments this from inside the door's Task.
+    for _ in 0..<400 where home.parakeetResumeRefusalsForTests == 0 { await Task.yield() }
+
+    #expect(
+      home.parakeetResumeRefusalsForTests == 1,
+      "the switch went off between the button and the download starting and the door carried on anyway"
+    )
+    #expect(
+      box.refusedSites.isEmpty,
+      "the re-read refused, so it must have refused BEFORE taking the mutation claim"
     )
   }
 


### PR DESCRIPTION
The Resume button on the Parakeet delivery row checks its kill switch twice: once when you press it, and once again inside the download's own task, just before the download starts. Only the first check had a test entering it.

`Part of #2389.` Both filed rows CAUGHT. The value is in the two mutants the issue asked the night session to add itself — both survived, and they mean different things.

## Survivor 1 — structural, reported and not fixed

Deleting `_ = await handle.ensureAvailable()` inside the claim leaves every row of `parakeetResumeHonoursTheKillSwitch()` green, and cannot do otherwise: the case sets `tryBegin: { false }`, so `withClaim` refuses and never runs its operation.

That is the same property the case relies on to keep real Parakeet delivery off the developer's model cache and the network, since Parakeet's install directory is deliberately not rerouted by `appSupportOverride`. Binding "the download was actually asked for" needs a seam this file does not have, and buying it by letting delivery run would be the worse trade.

Recorded as a KNOWN SURVIVOR in the test's own doc comment so the next reader does not mistake it for an oversight.

## Survivor 2 — a real hole, closed here

Deleting the ASYNC re-read guard left the whole suite green. The reason is structural: the existing case's flag-off arm returns at the SYNCHRONOUS guard and never reaches the second door, while its flag-on arm never turns the switch off.

The window is real rather than contrived — the flag is set remotely, so it can go off between the button and the download starting, which is exactly what the re-read is for, and it must refuse BEFORE the mutation claim so a download that will not happen does not serialise against a dictation's engine switch.

`parakeetResumeRereadsTheKillSwitch()` STAGES that window rather than racing it: `resumeParakeetDownload()` is synchronous and returns before its unstructured `Task` can run, so writing the flag on the next line puts the store in the off state for the re-read and only for the re-read. The first expectation is the precondition, so a case that silently refused at the first door fails rather than passing vacuously.

## Receipts

`scripts/mutation-battery.py`, baseline green before and after every run:

| row | result |
|---|---|
| filed 1 — delete the synchronous guard | `ok` |
| filed 2 — un-inject the flag store | `ok` |
| night A — delete `ensureAvailable()` | `EXP` survivor |
| night B — delete the async re-read guard | `EXP` survivor — the hole |
| after the fix — delete the async re-read guard | exact `must_fire` matched: `parakeetResumeRereadsTheKillSwitch()`; silent control `parakeetResumeHonoursTheKillSwitch()` unchanged |
| move the claim ahead of the re-read | exact `must_fire` matched: `parakeetResumeRereadsTheKillSwitch()`, `parakeetResumeHonoursTheKillSwitch()`, `aGateRefusedResumeReportsTheSiteAndNeverReleasesOrWakes()` |

The last row is worth reading for what it does NOT say: the ORDERING was already bound by two cases that predate this change, so the new case is not what protects it. The missing entry into the second door was the only real gap.

`scripts/xcode-test.sh`: Debug lane **PASS**, 7200 tests.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprAppKit`
`Lane: Code`
`council-skip: zero-blast-radius (test-only, no shipped source touched)`
