### PR TITLE
test(services): replace a tautological assertion that could not fail

### DIFF
--- a/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
+++ b/Tests/EnviousWisprTests/Services/SelectionReaderTests.swift
@@ -424,7 +424,21 @@ struct SelectionReaderTests {
     let coordinatorOwned = SelectionReader.Refusal.allCases.filter { !readerOwned.contains($0) }
     // The subtraction is only meaningful if it left something, and only honest if it left the
     // members this test was written about.
-    #expect(coordinatorOwned.count == SelectionReader.Refusal.allCases.count - readerOwned.count)
+    //
+    // **The count identity that stood here was a TAUTOLOGY, and it read as the check that made the
+    // subtraction safe.** `coordinatorOwned.count == allCases.count - readerOwned.count` is true for
+    // ANY `readerOwned` whose members are all in `allCases` and which holds no duplicate — and both
+    // are guaranteed, one by the type and the other by `Set`. So it could not fail. Measured on
+    // #2469: moving `.copyRefused` into `readerOwned` — a member the reader does not own — left that
+    // line green and was caught two lines down instead, because a wrongly-CLASSIFIED member moves
+    // both sides of the subtraction by one.
+    //
+    // What the comment above actually asks for is that the subtraction left something, so that is
+    // what is asserted. It fails on a `readerOwned` that has swallowed the whole enum, which is the
+    // one way this row could go quietly vacuous while every `contains` below still passed.
+    #expect(
+      !coordinatorOwned.isEmpty,
+      "readerOwned covers the whole enum, so this row is asserting nothing about a boundary")
     #expect(coordinatorOwned.contains(.wordsUnavailable))
     #expect(coordinatorOwned.contains(.nothingSelected))
     #expect(coordinatorOwned.contains(.copyRefused))


### PR DESCRIPTION
`Part of #2469.` The battery ran **28 mutants across five suites**. Every guard fired. One assertion could not, and that is the whole diff.

## The finding

`noReadOutcomeIsCoordinatorOwned` splits `SelectionReader.Refusal` into the members the reader mints and the members the coordinator mints, by subtracting the first set from `allCases`. It then asserted:

```swift
coordinatorOwned.count == SelectionReader.Refusal.allCases.count - readerOwned.count
```

That is TRUE for any `readerOwned` whose members are all in `allCases` and which holds no duplicate. Both are guaranteed — one by the type, one by `Set`. **The line could not fail**, while reading as the check that made the subtraction safe.

Measured rather than argued, following the issue's own instruction to mutate the SUBTRACTION. Moving `.copyRefused` into `readerOwned` — a member the reader does not own — left that line GREEN and failed two lines down on `contains(.copyRefused)` instead, because a wrongly-CLASSIFIED member moves both sides of the subtraction by one.

The comment above it already said what it wanted: *"the subtraction is only meaningful if it left something"*. That is now what is asserted, and it can fail.

```
as shipped                                    35 tests PASS
readerOwned replaced by the whole enum        new row RED at !coordinatorOwned.isEmpty
```

The old identity stays green in that second run.

## The battery, for the record

Baseline green before and after every run; every mutated file restored byte-exact.

**`SelectionAcquisitionTests` — 17 mutants, all caught.** Every `mayAttempt` refusal, both halves of the secure-input guard separately, the wrong-refusal case, the keystroke-forwarding half, prefix-vs-membership on the forwarding list, **all four precedence boundaries swapped one at a time**, both eligibility directions, a second `NSWorkspace` sample, and a second restore site.

**The source-reading rows carry their own control, and it was exercised.** Pointing `sourceRoot` at a directory that does not exist failed all three loudly with the missing path named — they throw rather than passing on an empty file list.

**`ClipboardCleanupTests` — 4 mutants, all caught.** Baseline from the wrong moment, the takeover no longer consuming a stale pending cleanup, cancellation moved ahead of the budget refusal, and a budget that counts only the plain-text representation.

**Menu bar and refusal copy — 6 mutants, all caught.** The row ignoring the fallback setting in both directions, the whitespace-only guard, naming terminals again, dropping the way forward, and the click carrying an empty acquisition context instead of the sampled one.

**`SelectionReaderTests` — 1 mutant, caught.** The reader minting a coordinator-owned refusal.

## Three recipe rows could not be built as written, and each says something

- **"drop the context from `representedObject`"** — impossible. `QuickAddMenuSelection.context` is non-optional, so the property is held by the TYPE rather than by a test, which is stronger. Re-aimed at an EMPTY context, which is the mistake a person could actually make; caught.
- **"return `snapshot.changeCount` as the baseline"** — a NO-OP. In the branch that test drives, `intendedPayload` returns `boundedSaveClipboard`, whose `changeCount` IS the board's, and the loop only accepts when the board has not moved. The two values are provably equal, so the edit was invisible. Re-aimed at the PENDING operation's moment; caught. Same shape as #2393 r3 on #2508: **read a replacement as the compiler will, not as its label describes it.**
- **"make `isFallbackEligible` return `true` for `.text`"** — caught by `everythingElseIsTerminal()`, not by `theThreeEligibleOutcomes(result:)`, which is parameterised over outcomes that are already eligible. Binding that row needs the opposite mutation, making one of the three terminal; both now run.

Four rows' declared fire sets were mine and were too narrow — the guards bind harder than I declared, never softer. Corrected and re-run to exact matches; no assertion anywhere was loosened.

`theQuickAddItemFollowsTheSelection` is covered transitively rather than by its own row: the rendered menu calls the same `quickAddItem`, and it fired on the context mutant. Stated rather than counted as a separate proof.

`scripts/xcode-test.sh`: Debug lane **PASS**, 7201 tests.

`Tier: SMALL | Test: n/a (hardening) | Modules: EnviousWisprServices`
`Lane: Code`
`council-skip: zero-blast-radius (one test assertion, no shipped source touched)`
