### PR TITLE
test(uat): make two first-render rows observe what their names claim

### DIFF
--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -174,8 +174,16 @@ def test_unknown_schema_or_malformed_line_blocks():
     expect_verdict("a line with a missing field blocks",
                    text() + f"{m.SCHEMA}\trun={RUN}\tpid={PID}\n",
                    m.BLOCKED_MALFORMED_MARKER)
+    # **Substituted, never truncated.** This row used to build its input by
+    # cutting the text at the last `\twindow=` and appending `\twindow=0`, which
+    # also DROPPED the `\tintent=` field that follows it. The line was then
+    # malformed by field count, so the missing-field check answered and the
+    # window rule was never reached: with `if window_id <= 0:` disabled, this row
+    # stayed GREEN. Measured on #2434 — a row named for the window value that was
+    # testing the field count instead. The neighbouring rows already substitute;
+    # this one is now the same shape as they are.
     expect_verdict("a host marker naming window 0 blocks",
-                   text()[: text().rindex("\twindow=")] + "\twindow=0\n",
+                   text().replace(f"window={HOST_WINDOW}", "window=0"),
                    m.BLOCKED_MALFORMED_MARKER)
     expect_verdict("a non-numeric window id blocks",
                    text().replace(f"window={HOST_WINDOW}", "window=main"),
@@ -803,6 +811,22 @@ def test_p95_uses_nearest_rank():
     # Order of the input must not matter.
     expect("p95 is order-independent",
            m.nearest_rank(list(reversed(values)), 95), 19.0)
+    # **The row that binds the INTEGER arithmetic, and it has to be taken at a
+    # percentile this harness does not use.** `nearest_rank`'s doc warns that
+    # `math.ceil(p / 100 * n)` lands one rank high where the true product is a
+    # whole number, and the rows above cannot see that: measured on #2434 by
+    # brute force over every n to 20000, the float form NEVER differs from the
+    # exact one at p95 or p50, so swapping the implementation left all five rows
+    # above green. The hazard is real at twelve other percentiles — 7, 14, 17,
+    # 27, 28, 34, 54, 55, 56, 67, 68 and 81 — and p14 over 50 values is the
+    # cheapest of them: exact rank 7, float rank 8.
+    #
+    # So this row is not about a percentile anyone reports. It is the only thing
+    # standing between the integer expression and a "simplification" to
+    # `math.ceil`, which would be silently correct for every number this harness
+    # prints and wrong for the next one it is asked to print.
+    expect("p14 of 1..50 is the 7th value, not the 8th",
+           m.nearest_rank([float(i) for i in range(1, 51)], 14), 7.0)
 
 
 # ------------------------------------------- 12. the OTHER implementation


### PR DESCRIPTION
`Part of #2434.` **32 mutants** against the Phase 6 first-render harness, every one restored byte-exact with the baseline re-run after. Two rows were not binding, and both were invisible from a green run.

## Finding 1 — a row named for a window value was testing the field count

`test_unknown_schema_or_malformed_line_blocks` carries a row called *"a host marker naming window 0 blocks"*. It built its input as:

```python
text()[: text().rindex("\twindow=")] + "\twindow=0\n"
```

The marker format is `… \twindow={window}\tintent={intent}`, so cutting at the last `\twindow=` also DROPPED the `intent` field. The line was malformed by FIELD COUNT, the missing-field check answered first, and the window rule was never reached.

Measured: with `if window_id <= 0:` replaced by `if False:`, the row stayed **GREEN**. Substituting the value instead of truncating the line — what the rows on either side already do — makes it **CAUGHT**.

The property nothing was testing: the app must name a real window when it puts the recording pill on screen.

## Finding 2 — the percentile row could not see the defect its own subject warns about

`nearest_rank`'s doc records that `math.ceil(p / 100 * n)` lands one rank high where the true product is a whole number, which is why the rank is integer arithmetic. #2434 predicted this row would SURVIVE the substitution and **required a brute force over n before any edit**.

Brute forced, as instructed: at **p95 and p50 the float form never differs from the exact one, for every n to 20000.** So the row could not be made to fire by choosing n, and all five existing expectations stayed green under the mutant.

The class is real at twelve other percentiles — 7, 14, 17, 27, 28, 34, 54, 55, 56, 67, 68, 81 — and p14 over 50 values is the cheapest: exact rank 7, float rank 8. Added as its own row.

It deliberately tests a percentile nobody reports. Its whole job is to stand between the integer expression and a "simplification" to `math.ceil` that is silently correct for every number this harness prints and wrong for the next one it is asked to print.

Per this issue's governing rule, **both survivors were resolved by making the test observe its subject more tightly. No assertion was loosened.**

## The battery

Baseline 48 green before and after every run.

| group | result |
|---|---|
| launch adjudicator, marker parser, benchmark budgets, schedule, AX endpoint | **26 CAUGHT** |
| the two rows above | CAUGHT only after the fixes |
| rows 19, 20 | ANCHOR NOT FOUND — correct, see below |
| rows 23, 24, 26 re-aimed at their successors, plus 2 of my own | **5 CAUGHT** |

**Rows 19 and 20 reporting a missing anchor is the right answer, not drift.** They named a candidate-counting adjudicator that round 2 deliberately retired, because counting candidates cannot tell an unrelated window from the pill — only that there are two of them. Rows 23, 24 and 26 named the same retired design; their successors in `adjudicate_ax_overlay` are re-aimed here and all fire.

**Two mutants of the night session's own choosing**, both CAUGHT: more than one window matching at the moment of first appearance must be refused rather than picked from, and an unreadable AX tree must be its own refusal rather than a silent OK.

Twelve rows' anchors had gone stale by LOCATION rather than by design — the harness has been rewritten since filing. Re-aimed against the current source; all fire.

`Tests/RuntimeUAT/measure_overlay_first_render_test.py`: **48 tests, 0 failures.** `scripts/xcode-test.sh`: Debug lane **PASS**, 7202 tests.

`Tier: SMALL | Test: n/a (hardening) | Modules: RuntimeUAT`
`Lane: Code`
`council-skip: zero-blast-radius (two test rows, no shipped source touched)`
