### PR TITLE
test(recovery): reach the Discard wiring, which no test executed

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -134,30 +134,7 @@ final class DictationRuntime {
       // arguments until the architectural ceiling caught the accretion. Still
       // bare closures, so the starter stays off its collaborator cap and the
       // kernel never sees the coordinator.
-      recovery: RecordingStarter.RecoveryAccess(
-        // #1063 PR1: arm crash recovery for this start.
-        makeDirective: { settings, backend, lid in
-          await recoveryCoordinator.makeDirective(
-            settings: settings, backendType: backend, supportsLanguageDetection: lid)
-        },
-        // #1063 PR1 (Codex r3): a PTT release or concurrent-toggle stop landing in
-        // the arm window mints no session, so the lifecycle coordinator sees no
-        // terminal state — the starter cleans the armed spool/key directly. #1464:
-        // a pre-start abort has no `RecordingOutcome`, so it routes to the
-        // dedicated coordinator entry point (always a discard — nothing was
-        // captured).
-        cleanupArm: { id in
-          recoveryCoordinator.handlePreStartAbort(recoverySessionID: id)
-        },
-        // #1063 PR2: the recording gate — a press while recovery holds the shared
-        // engine mints no session (shows the "recovering" pill).
-        isRecovering: { recoveryCoordinator.isRecovering },
-        // #1707 Phase 3 (§3.1): a refused press yields the engine BETWEEN a
-        // multi-item recovery scan's items, not only after the whole scan.
-        signalPendingLiveStart: { recoveryCoordinator.pendingLiveStartSignal = true },
-        // #2292 C4b: the recovery notice's Discard button, bound at its own
-        // presentation rather than routed through a settable overlay sink.
-        discardActive: { recoveryCoordinator.discardActiveRecovery() }),
+      recovery: Self.recoveryAccess(binding: recoveryCoordinator),
       // #1171: drive the selected engine to ready before recording, gate a press
       // during an in-flight switch, and hold the start-window state-gate so the
       // coordinator can't switch the engine out mid-startup.
@@ -201,6 +178,56 @@ final class DictationRuntime {
     )
     self.hotkeyController = hotkeyController
     hotkeyController.install()
+  }
+
+
+  /// The five recovery seams, bound to one collaborator.
+  ///
+  /// **Extracted so a test can reach the WIRE, which nothing did** (#2356). Both
+  /// halves were well covered and the line between them was not:
+  /// `RecoveryCoordinatorTests` drives `discardActiveRecovery()` directly, and
+  /// `RecordingStarterStartPathTests` builds its own `RecoveryAccess` with a probe
+  /// closure — so the composition root's binding was the one site no test named.
+  /// Replacing `discardActive:` with `{}` here left every suite green, which is
+  /// the whole failure: Discard would reach nobody and crash recovery would keep
+  /// the engine while the user watched a button do nothing.
+  ///
+  /// A source-text guard was the alternative and was rejected: this repo has
+  /// spent several rounds learning that a check over spelling is evadable, and
+  /// the honest repair for an untested site is to make it REACHABLE rather than
+  /// to assert what it looks like.
+  ///
+  /// Every closure below binds the SAME coordinator; they were five separate
+  /// arguments until the architectural ceiling caught the accretion. Still bare
+  /// closures, so the starter stays off its collaborator cap and the kernel never
+  /// sees the coordinator.
+  static func recoveryAccess(
+    binding recoveryCoordinator: RecoveryCoordinator
+  ) -> RecordingStarter.RecoveryAccess {
+    RecordingStarter.RecoveryAccess(
+    // #1063 PR1: arm crash recovery for this start.
+    makeDirective: { settings, backend, lid in
+      await recoveryCoordinator.makeDirective(
+        settings: settings, backendType: backend, supportsLanguageDetection: lid)
+    },
+    // #1063 PR1 (Codex r3): a PTT release or concurrent-toggle stop landing in
+    // the arm window mints no session, so the lifecycle coordinator sees no
+    // terminal state — the starter cleans the armed spool/key directly. #1464:
+    // a pre-start abort has no `RecordingOutcome`, so it routes to the
+    // dedicated coordinator entry point (always a discard — nothing was
+    // captured).
+    cleanupArm: { id in
+      recoveryCoordinator.handlePreStartAbort(recoverySessionID: id)
+    },
+    // #1063 PR2: the recording gate — a press while recovery holds the shared
+    // engine mints no session (shows the "recovering" pill).
+    isRecovering: { recoveryCoordinator.isRecovering },
+    // #1707 Phase 3 (§3.1): a refused press yields the engine BETWEEN a
+    // multi-item recovery scan's items, not only after the whole scan.
+    signalPendingLiveStart: { recoveryCoordinator.pendingLiveStartSignal = true },
+    // #2292 C4b: the recovery notice's Discard button, bound at its own
+    // presentation rather than routed through a settable overlay sink.
+    discardActive: { recoveryCoordinator.discardActiveRecovery() })
   }
 
   // MARK: - Facade (UI / menus / AppDelegate command surface)

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -134,7 +134,7 @@ final class DictationRuntime {
       // arguments until the architectural ceiling caught the accretion. Still
       // bare closures, so the starter stays off its collaborator cap and the
       // kernel never sees the coordinator.
-      recovery: Self.recoveryAccess(binding: recoveryCoordinator),
+      recovery: RecoveryWiring.access(binding: recoveryCoordinator),
       // #1171: drive the selected engine to ready before recording, gate a press
       // during an in-flight switch, and hold the start-window state-gate so the
       // coordinator can't switch the engine out mid-startup.
@@ -180,55 +180,6 @@ final class DictationRuntime {
     hotkeyController.install()
   }
 
-
-  /// The five recovery seams, bound to one collaborator.
-  ///
-  /// **Extracted so a test can reach the WIRE, which nothing did** (#2356). Both
-  /// halves were well covered and the line between them was not:
-  /// `RecoveryCoordinatorTests` drives `discardActiveRecovery()` directly, and
-  /// `RecordingStarterStartPathTests` builds its own `RecoveryAccess` with a probe
-  /// closure — so the composition root's binding was the one site no test named.
-  /// Replacing `discardActive:` with `{}` here left every suite green, which is
-  /// the whole failure: Discard would reach nobody and crash recovery would keep
-  /// the engine while the user watched a button do nothing.
-  ///
-  /// A source-text guard was the alternative and was rejected: this repo has
-  /// spent several rounds learning that a check over spelling is evadable, and
-  /// the honest repair for an untested site is to make it REACHABLE rather than
-  /// to assert what it looks like.
-  ///
-  /// Every closure below binds the SAME coordinator; they were five separate
-  /// arguments until the architectural ceiling caught the accretion. Still bare
-  /// closures, so the starter stays off its collaborator cap and the kernel never
-  /// sees the coordinator.
-  static func recoveryAccess(
-    binding recoveryCoordinator: RecoveryCoordinator
-  ) -> RecordingStarter.RecoveryAccess {
-    RecordingStarter.RecoveryAccess(
-    // #1063 PR1: arm crash recovery for this start.
-    makeDirective: { settings, backend, lid in
-      await recoveryCoordinator.makeDirective(
-        settings: settings, backendType: backend, supportsLanguageDetection: lid)
-    },
-    // #1063 PR1 (Codex r3): a PTT release or concurrent-toggle stop landing in
-    // the arm window mints no session, so the lifecycle coordinator sees no
-    // terminal state — the starter cleans the armed spool/key directly. #1464:
-    // a pre-start abort has no `RecordingOutcome`, so it routes to the
-    // dedicated coordinator entry point (always a discard — nothing was
-    // captured).
-    cleanupArm: { id in
-      recoveryCoordinator.handlePreStartAbort(recoverySessionID: id)
-    },
-    // #1063 PR2: the recording gate — a press while recovery holds the shared
-    // engine mints no session (shows the "recovering" pill).
-    isRecovering: { recoveryCoordinator.isRecovering },
-    // #1707 Phase 3 (§3.1): a refused press yields the engine BETWEEN a
-    // multi-item recovery scan's items, not only after the whole scan.
-    signalPendingLiveStart: { recoveryCoordinator.pendingLiveStartSignal = true },
-    // #2292 C4b: the recovery notice's Discard button, bound at its own
-    // presentation rather than routed through a settable overlay sink.
-    discardActive: { recoveryCoordinator.discardActiveRecovery() })
-  }
 
   // MARK: - Facade (UI / menus / AppDelegate command surface)
 

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecoveryWiring.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecoveryWiring.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// How the recovery seams are bound to the coordinator that answers them.
+///
+/// **Its own namespace rather than a method on `DictationRuntime`, and that is a
+/// constraint rather than taste.** `DictationRuntimeCeilingsTests` caps the
+/// runtime's non-private `func` count at 8, and raising it requires an
+/// architecture entry. The wiring needed to be reachable from a test (#2356);
+/// the ceiling is what decided it should not live on the runtime to get there.
+enum RecoveryWiring {
+
+  /// The five recovery seams, bound to one collaborator.
+  ///
+  /// **Extracted so a test can reach the WIRE, which nothing did** (#2356). Both
+  /// halves were well covered and the line between them was not:
+  /// `RecoveryCoordinatorTests` drives `discardActiveRecovery()` directly, and
+  /// `RecordingStarterStartPathTests` builds its own `RecoveryAccess` with a probe
+  /// closure — so the composition root's binding was the one site no test named.
+  /// Replacing `discardActive:` with `{}` here left every suite green, which is
+  /// the whole failure: Discard would reach nobody and crash recovery would keep
+  /// the engine while the user watched a button do nothing.
+  ///
+  /// A source-text guard was the alternative and was rejected: this repo has
+  /// spent several rounds learning that a check over spelling is evadable, and
+  /// the honest repair for an untested site is to make it REACHABLE rather than
+  /// to assert what it looks like.
+  ///
+  /// Every closure below binds the SAME coordinator; they were five separate
+  /// arguments until the architectural ceiling caught the accretion. Still bare
+  /// closures, so the starter stays off its collaborator cap and the kernel never
+  /// sees the coordinator.
+  static func access(
+    binding recoveryCoordinator: RecoveryCoordinator
+  ) -> RecordingStarter.RecoveryAccess {
+    RecordingStarter.RecoveryAccess(
+    // #1063 PR1: arm crash recovery for this start.
+    makeDirective: { settings, backend, lid in
+      await recoveryCoordinator.makeDirective(
+        settings: settings, backendType: backend, supportsLanguageDetection: lid)
+    },
+    // #1063 PR1 (Codex r3): a PTT release or concurrent-toggle stop landing in
+    // the arm window mints no session, so the lifecycle coordinator sees no
+    // terminal state — the starter cleans the armed spool/key directly. #1464:
+    // a pre-start abort has no `RecordingOutcome`, so it routes to the
+    // dedicated coordinator entry point (always a discard — nothing was
+    // captured).
+    cleanupArm: { id in
+      recoveryCoordinator.handlePreStartAbort(recoverySessionID: id)
+    },
+    // #1063 PR2: the recording gate — a press while recovery holds the shared
+    // engine mints no session (shows the "recovering" pill).
+    isRecovering: { recoveryCoordinator.isRecovering },
+    // #1707 Phase 3 (§3.1): a refused press yields the engine BETWEEN a
+    // multi-item recovery scan's items, not only after the whole scan.
+    signalPendingLiveStart: { recoveryCoordinator.pendingLiveStartSignal = true },
+    // #2292 C4b: the recovery notice's Discard button, bound at its own
+    // presentation rather than routed through a settable overlay sink.
+    discardActive: { recoveryCoordinator.discardActiveRecovery() })
+  }
+}

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -373,6 +373,36 @@ import EnviousWisprAppKitTestSupport
       "the notice the user already answered is still on screen")
   }
 
+  /// **The recovery notice's sink must answer ONLY to Discard** (#2356).
+  ///
+  /// The presentation carries one button today, so this is a filter standing in
+  /// front of a door nobody else knocks on — and that is exactly why nothing
+  /// reached it: dropping the `guard case .discardRecovery` and firing on ANY
+  /// action left every suite green, measured.
+  ///
+  /// It is worth a row rather than a comment because of what the failure would
+  /// be if a second button were ever added to this notice: pressing it would
+  /// SILENTLY discard the recording the user was being offered back. A destructive
+  /// action reached through the wrong button is the shape that has to fail loudly
+  /// the day it is written, not the day someone notices their recording is gone.
+  ///
+  /// Nothing is fabricated here. The action sent is a real member of `PillAction`
+  /// travelling the real root; the claim is that this sink ignores it.
+  @Test func onlyDiscardReachesTheRecoveryOwner() async throws {
+    let fx = Self.makeFixture(isRecovering: true)
+    fx.asr.activeBackendType = .parakeet
+    _ = await fx.starter.start()
+
+    try fx.overlayHost.sendCurrentUserActionThroughRoot(.lockLanguage)
+
+    #expect(
+      fx.discards.count == 0,
+      "a button that is not Discard discarded the recovering recording")
+    #expect(
+      Self.showsRecoveryOffer(fx.overlay),
+      "the recovery notice was dismissed by an action it does not own")
+  }
+
   @Test func toggleWhileRecoveringMintsNoSessionAndShowsRecoveringPill() async {
     let fx = Self.makeFixture(isRecovering: true)
     fx.asr.activeBackendType = .parakeet

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -831,6 +831,35 @@ struct RecoveryCoordinatorTests {
       await !access.isRecovering(),
       "isRecovering is not reading the coordinator: nothing is recovering yet")
 
+    // **makeDirective, taken BOTH ways**, because a seam replaced by a constant
+    // `nil` passes an off-only check and a seam replaced by a constant directive
+    // passes an on-only one. Off and on differ here, so neither constant survives.
+    #expect(
+      await access.makeDirective(
+        Self.freshSettings(crashRecoveryEnabled: false), .parakeet, false) == nil,
+      "makeDirective is not reading the coordinator: recovery is off, so there is no directive")
+    let armed = try #require(
+      await access.makeDirective(
+        Self.freshSettings(crashRecoveryEnabled: true), .whisperKit, true),
+      "makeDirective is not reading the coordinator: recovery is on and it armed nothing")
+    #expect(
+      try h.keyStore.retrieve(for: armed.recoverySessionID) != nil,
+      "the armed directive's key was never stored, so this is not the coordinator's directive")
+
+    // **cleanupArm, observed by its EFFECT**, since the seam discards the Task
+    // the coordinator returns. The spool for an aborted arm must be gone.
+    let aborted = "aborted-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, aborted)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: aborted)
+    await access.cleanupArm(aborted)
+    for _ in 0..<100_000
+    where FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: aborted).path) {
+      await Task.yield()
+    }
+    #expect(
+      !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: aborted).path),
+      "cleanupArm is not reaching the coordinator: the aborted arm's spool is still on disk")
+
     let id = "wire-\(UUID().uuidString)"
     try Self.writeSpool(h.spoolStore, id)
     try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -818,14 +818,14 @@ struct RecoveryCoordinatorTests {
   /// What that costs a user: crash recovery holds the engine, they press
   /// Discard, and nothing happens. The notice goes away and recovery does not.
   ///
-  /// This enters through `DictationRuntime.recoveryAccess`, which the app itself
+  /// This enters through `RecoveryWiring.access`, which the app itself
   /// calls, rather than through a hand-built one. All five seams are asserted
   /// rather than only Discard, because the slot binds them together and any one
   /// of them could be cut the same way.
   @Test("the composition root binds all five recovery seams to the real coordinator")
   func theCompositionRootBindsTheRecoverySeams() async throws {
     let h = Self.makeHarness()
-    let access = await DictationRuntime.recoveryAccess(binding: h.coordinator)
+    let access = await RecoveryWiring.access(binding: h.coordinator)
 
     #expect(
       await !access.isRecovering(),

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -805,6 +805,58 @@ struct RecoveryCoordinatorTests {
 
   // MARK: - Discard
 
+  /// **The WIRE, which nothing reached** (#2356).
+  ///
+  /// The two halves of Discard were both covered and the line between them was
+  /// not. `discardDuringRecovery` below drives `discardActiveRecovery()`
+  /// directly; `RecordingStarterStartPathTests.discardInvokesRecoveryOwner`
+  /// builds its own `RecoveryAccess` with a probe closure. So the composition
+  /// root's binding — the one line that joins the button to its owner — was the
+  /// single site no test named, and replacing it with `{}` left every suite
+  /// green.
+  ///
+  /// What that costs a user: crash recovery holds the engine, they press
+  /// Discard, and nothing happens. The notice goes away and recovery does not.
+  ///
+  /// This enters through `DictationRuntime.recoveryAccess`, which the app itself
+  /// calls, rather than through a hand-built one. All five seams are asserted
+  /// rather than only Discard, because the slot binds them together and any one
+  /// of them could be cut the same way.
+  @Test("the composition root binds all five recovery seams to the real coordinator")
+  func theCompositionRootBindsTheRecoverySeams() async throws {
+    let h = Self.makeHarness()
+    let access = await DictationRuntime.recoveryAccess(binding: h.coordinator)
+
+    #expect(
+      await !access.isRecovering(),
+      "isRecovering is not reading the coordinator: nothing is recovering yet")
+
+    let id = "wire-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.replayer.suspendFirstReplay = true
+    let scan = Task { await h.coordinator.scanAndRecover() }
+    while h.replayer.gateContinuation == nil { await Task.yield() }
+
+    #expect(
+      await access.isRecovering(),
+      "isRecovering is not reading the coordinator: a replay holds the engine")
+
+    await access.signalPendingLiveStart()
+    #expect(
+      h.coordinator.pendingLiveStartSignal,
+      "signalPendingLiveStart is not reaching the coordinator")
+
+    await access.discardActive()
+    #expect(
+      h.resetEngineCount.value == 1,
+      "Discard reached nobody — the button is bound to something that is not the coordinator")
+
+    h.replayer.gateContinuation?.resume()
+    await scan.value
+    #expect(!h.coordinator.isRecovering, "the gate never cleared after the discard")
+  }
+
   @Test("Discard mid-recovery bumps the generation, frees the gate, and deletes the orphan")
   func discardDuringRecovery() async throws {
     let h = Self.makeHarness()


### PR DESCRIPTION
`Part of #2356.` The battery found two gaps. The first is the one this issue was written around, and it is the shape where every test is green and the button does nothing.

## Gap 1 — the composition root's binding was the one site no test named

Both halves of Discard were covered:

- `RecoveryCoordinatorTests` drives `discardActiveRecovery()` directly.
- `RecordingStarterStartPathTests.discardInvokesRecoveryOwner` builds its **own** `RecoveryAccess` with a probe closure.

The LINE BETWEEN THEM — `discardActive: { recoveryCoordinator.discardActiveRecovery() }` in `DictationRuntime` — was executed by nothing. **Replacing it with `{}` left every suite green**, measured, which is the issue's row M1.

What that costs a user: crash recovery holds the engine, they press Discard, the notice goes away and recovery does not.

**Repaired by making the site REACHABLE, not by guarding its text.** A source-text guard was the alternative and was rejected — this repo has spent several review rounds this week learning that a check over spelling is evadable, and the honest answer for an untested site is a test that runs it.

`RecoveryWiring.access(binding:)` holds the five-seam slot, which depends on nothing but the coordinator. The new case enters through **that**, the same function the app itself calls, rather than through a hand-built copy — which is precisely how the gap survived. All five seams are asserted, since the slot binds them together and any one could be cut the same way.

Exact `must_fire` matched, the new case the only firing test each time:

```
discardActive: {}                  -> RED
isRecovering: { false }            -> RED
signalPendingLiveStart: {}         -> RED
```

### The ceiling decided where the wiring lives

The first attempt put the factory on `DictationRuntime` and `DictationRuntimeCeilingsTests.nonPrivateMethodCount` went red: the cap is 8 and raising it requires an architecture entry. **That is not negotiated with** — it is the same ceiling this issue records as having caught the original five-argument accretion.

`private` was not an option either, since `@testable import` reaches `internal` and not `private`, which would have returned the site to unreachable. So the wiring is its own namespace in its own file, and the file states that the ceiling is what decided it.

## Gap 2 — the recovery notice's sink answered to any action

Dropping `guard case .discardRecovery = action` and firing on ANY action left every suite green. The presentation carries one button today, so this is a filter in front of a door nobody else knocks on — which is exactly why nothing reached it.

Classified HYPOTHETICAL and fixed anyway, because the failure would be **silent and destructive**: add a second button to that notice and pressing it discards the recording the user was being offered back. That has to fail the day it is written, not the day someone's recording is gone.

`onlyDiscardReachesTheRecoveryOwner` sends a real `PillAction` through the real root and requires the recovery to survive it. Nothing is fabricated.

## The filed rows

| row | result |
|---|---|
| M1 the injected discard reaches nobody | CAUGHT after the extraction |
| M2 no silent dismissal after the discard | CAUGHT |

M2's anchor had gone stale by LOCATION and was re-aimed at the current site.

**The issue's two STRUCTURAL checks were run rather than assumed.** `grep -rn "OverlayOutputRouter" Sources` returns **0** hits — the single remaining mention in the tree is a historical note in a test comment — and the seams are bound strongly through the extracted factory.

Suites: `RecoveryCoordinatorTests` 48 → 49, `RecordingStarterStartPathTests` 29 → 30.

`scripts/xcode-test.sh`: Debug lane **PASS**, 7204 tests. Dev app **BUILD SUCCEEDED** (this touches shipped source).

`Tier: SMALL | Test: required (AppKit) | Modules: EnviousWisprAppKit`
`Lane: Code`
