### PR TITLE
test(overlay): bind the mirror direction of the substitution flag

### DIFF
--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogRecordingParityTests.swift
@@ -151,6 +151,26 @@ struct PillCatalogRecordingParityTests {
     let withoutWords = bad.resolve(capabilityHasWords: false)
     #expect(withoutWords.design == .classic)
     #expect(withoutWords.substituted == false, "an unnecessary substitution was reported")
+
+    // **THE MIRROR, which this case did not stage** (#2402). A with-words design
+    // sitting in the WITHOUT-words slot substitutes the other way, and only that
+    // half of the flag was bound: setting the mirror's `substituted` to a
+    // constant `false` left the whole suite green, measured, while the same lie
+    // on the branch above is caught here.
+    //
+    // The flag is not decoration. `PillCatalog` reads `.substituted == false` to
+    // decide whether a design is offerable, so a substitution that reports itself
+    // as "no substitution" makes the Appearance picker offer a design the pill
+    // will not actually use — the exact drift the fail-closed resolve exists to
+    // prevent, arriving through the flag instead of through the design.
+    let mirrored = PillDesignSelections(withoutWords: .readingWell, withWords: .readingWell)
+    let substitutedDown = mirrored.resolve(capabilityHasWords: false)
+    #expect(
+      substitutedDown.design == .classic,
+      "a words-holding design was accepted for a pill that will show no words")
+    #expect(
+      substitutedDown.substituted,
+      "the mirror substitution was silent, so the picker would offer a design the pill will not use")
   }
 
   /// The shipped pair never substitutes, in either state. If it ever does, the


### PR DESCRIPTION
`Part of #2402.` **16 filed rows, all CAUGHT.** The one finding came from the mutant this issue's floor-not-ceiling rule asks the night session to add itself.

## The finding — a substitution flag bound in one direction only

`PillDesignSelections.resolve` substitutes in BOTH directions and reports it with `substituted`. Only one direction's flag was bound:

```
with-words substitution reports `substituted: false`      CAUGHT
without-words substitution reports `substituted: false`   SURVIVED — nothing saw it
```

`resolveIsFailClosed` staged a pair that substitutes upward and, for the other capability, a pair that needs NO substitution — so the mirror case, a words-holding design sitting in the without-words slot, was never resolved at all.

**The flag is not decoration.** `PillCatalog.swift:98` reads `.substituted == false` to decide whether a design is offerable, so a substitution that reports itself as no substitution makes the Appearance picker offer a design the pill will not use. That is the drift the fail-closed resolve exists to prevent, arriving through the flag instead of through the design — and #2376 C4's own comment records that the mirror direction *"was NOT hypothetical"*.

After the fix, both directions fire `resolveIsFailClosed()`, exact set matched, baseline green before and after.

## The battery

| group | result |
|---|---|
| 13 rows runnable as filed | all CAUGHT |
| 3 rows whose anchors had gone stale by LOCATION | re-aimed at the current `PillDefinition.swift`, all fire |
| 2 mutants of the night session's own choosing | 1 CAUGHT, 1 SURVIVED — the finding above |

Every guard in the four suites holds: the reading well's width, the classic pill's reserved box, the word capability that gates the provider, the fail-closed resolve, the slot-revision narrowing, COMMIT's token check and lock application, PREPARE mutating nothing, morph design preservation, the effect routed before the capability read, the reconciliation bound, the coalescing flag, the two designs' geometries, morphs re-reading selections, a discarded recording inheriting a receipt, and the synchronous pass clearing a flag it did not set.

**Four declared fire sets were mine and too narrow** — the guards bind harder than declared, never softer. Corrected and re-run to exact matches. No assertion was loosened anywhere.

**Two runs were REFUSED rather than run**, both correctly: once for an anchor that no longer matched after a reindent, once for a test name that does not exist in the named suite. A row that never applied is not a row that passed.

`scripts/xcode-test.sh`: Debug lane **PASS**, 7202 tests.

`Tier: SMALL | Test: required | Modules: EnviousWisprAppKit`
`Lane: Code`
`council-skip: zero-blast-radius (one added assertion, no shipped source touched)`
