### PR TITLE
test(onboarding): reach the reopen decision, which lived where no test could

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -687,6 +687,24 @@ final class OnboardingV2ViewModel {
     return stamp == current
   }
 
+  /// **The reopen DECISION, hoisted so a test can drive it** (#2371 row 20).
+  ///
+  /// It lived only inside `PracticeScreen.onAppear`, which no unit test can
+  /// reach. `reopeningClearsTheBox` calls `beginPractice()` directly, so it
+  /// exercises the RESET and never the decision that triggers it — and making
+  /// `practiceBelongsToCurrentVisit` always answer true left every test green
+  /// while a reopened window kept the previous visit's words and an already-lit
+  /// FINISH SETUP.
+  ///
+  /// That is the covered site and its uncovered twin
+  /// (`workflow-process.md` RULE: fix-the-path-that-runs-first-not-the-one-you-were-reading),
+  /// and #2371 asked for coverage rather than a corrected string. The view now
+  /// calls this and nothing else, so the decision has one home and a test names it.
+  func beginPracticeIfNewVisit() {
+    guard !practiceBelongsToCurrentVisit else { return }
+    beginPractice()
+  }
+
   func beginPractice() {
     practiceVisitStamp = sessionStartFloor?()
     practiceText = ""

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -265,9 +265,7 @@ struct PracticeScreenV2: View {
       // screen. Without this, someone who closed the window here and came back
       // would find a previous visit's words already in the box and FINISH SETUP
       // already lit (cloud review). Same class as the warm gate's reopen guard.
-      if !viewModel.practiceBelongsToCurrentVisit {
-        viewModel.beginPractice()
-      }
+      viewModel.beginPracticeIfNewVisit()
       boxFocused = true
       // A take can ALREADY be running when this view mounts — press the
       // shortcut during the warming transition and `isDictationActive` is true

--- a/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
+++ b/Tests/EnviousWisprTests/App/OnboardingWarmingGateTests.swift
@@ -703,6 +703,51 @@ import Testing
         #expect(vm.practiceSucceeded == false, "the box opened already believing it had succeeded")
       }
 
+      /// **The reopen DECISION, which no test could reach** (#2371 row 20).
+      ///
+      /// `reopeningClearsTheBox` above calls `beginPractice()` directly, so it
+      /// proves the RESET works and says nothing about whether the screen decides
+      /// to run it. That decision lived in `PracticeScreen.onAppear` — unreachable
+      /// from a unit test — so making `practiceBelongsToCurrentVisit` always answer
+      /// true left the whole suite green while a reopened window kept the previous
+      /// visit's words and an already-lit FINISH SETUP.
+      ///
+      /// All three states, because any single one is satisfiable by a constant: a
+      /// decision stuck on "always reset" passes the two reopen cases and destroys
+      /// work mid-visit; one stuck on "never reset" passes the mid-visit case and
+      /// is the shipped defect.
+      @Test("reopening in a NEW visit clears the box; staying in the same one does not")
+      func theScreenDecidesWhetherToClearTheBox() {
+        let vm = makePracticeViewModel()
+
+        // Never visited: there is no stamp, so the box must open fresh.
+        var floor = Date(timeIntervalSince1970: 1_000)
+        vm.sessionStartFloor = { floor }
+        vm.beginPracticeIfNewVisit()
+        #expect(vm.currentScreen == .tryItOut, "a first visit never opened the box")
+
+        // SAME visit: the user's words must survive a re-appear. This is the half
+        // a decision stuck on "always reset" would destroy.
+        vm.setPracticeText("hey Mike pick up Emma from school today")
+        #expect(vm.practiceSucceeded)
+        vm.beginPracticeIfNewVisit()
+        #expect(
+          vm.practiceText == "hey Mike pick up Emma from school today",
+          "re-appearing inside one visit wiped the words the user had just dictated")
+        #expect(vm.practiceSucceeded, "re-appearing inside one visit undid a success the user earned")
+
+        // NEW visit: the floor moves, so the previous visit's words and its lit
+        // FINISH SETUP must not survive. This is the shipped defect's half.
+        floor = Date(timeIntervalSince1970: 2_000)
+        vm.beginPracticeIfNewVisit()
+        #expect(
+          vm.practiceText.isEmpty,
+          "a reopened window kept the previous visit's words")
+        #expect(
+          vm.practiceSucceeded == false,
+          "a reopened window offered FINISH SETUP to someone who has not dictated in it")
+      }
+
       /// The gate's ready exit opens the box; it no longer ends setup. If this
       /// regresses, the warm gate silently becomes the last screen again and the
       /// entire feature is absent while every other test still passes.


### PR DESCRIPTION
`Part of #2371.` Row 20, filed by that issue as a known REAL GAP with the explicit instruction to fix it with **coverage, not a corrected string**.

## What was uncovered

Onboarding's practice step must open a fresh box when someone closes the window and comes back — not the previous visit's words with FINISH SETUP already lit.

`reopeningClearsTheBox` proves the RESET works. Nothing proved the screen **decides** to run it. That decision lived inside `PracticeScreen.onAppear`:

```swift
if !viewModel.practiceBelongsToCurrentVisit {
  viewModel.beginPractice()
}
```

which no unit test can reach. Making `practiceBelongsToCurrentVisit` always answer true left the whole suite green while a returning user saw stale words and a lit FINISH SETUP they had not earned.

That is the covered site and its uncovered twin — `workflow-process.md` RULE: fix-the-path-that-runs-first-not-the-one-you-were-reading — and it is the **third instance of this exact shape found tonight**, after crash recovery's Discard wiring (#2356) and the pill preview's chrome binding (#2438). In all three the tests were green and the thing that mattered was untouched.

## The fix

`beginPracticeIfNewVisit()` hoists the decision onto the view model, and the view calls that and nothing else — one home, and a test can name it.

`theScreenDecidesWhetherToClearTheBox` drives **all three states**, because any single one is satisfiable by a constant:

- a decision stuck on "always reset" passes both reopen cases and destroys work mid-visit;
- one stuck on "never reset" passes the mid-visit case and IS the shipped defect.

## Proof

Four-way, exact `must_fire` matched with the new case the only firing test, baseline green before and after:

```
the visit check always answers TRUE      RED   (stale words on reopen)
the visit check always answers FALSE     RED   (words wiped mid-visit)
the stamp is never recorded              RED
the decision stops guarding entirely     RED
```

Suite: `OnboardingPracticeStepSuite` 44 → 45.

`scripts/xcode-test.sh`: Debug lane **PASS**, 7205 tests. Dev app **BUILD SUCCEEDED** (this touches shipped source).

`Tier: SMALL | Test: required | Modules: EnviousWisprAppKit`
`Lane: Code`
