### PR TITLE
fix(mutation): tell a MOVED anchor from a deleted one

### DIFF
--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -264,6 +264,14 @@ check("an anchor opening with a newline still names its offset",
       extra_files={"Sources/Thing.swift":
                    "func f() {\n    let a = 1\n    let b = 2\n}\n"})
 
+check("an offset whose re-cut anchor would NOT be unique is not offered",
+      [dict(VALID_ROW, anchor="let a = 1\nlet b = 2")],
+      expect_exit=2, expect_text="anchor not found",
+      forbid_text="matches exactly once",
+      extra_files={"Sources/Thing.swift":
+                   "func f() {\n    let a = 1\n    let b = 2\n"
+                   "    // zz    let a = 1\n    let b = 2\n}\n"})
+
 check("a non-unique anchor is refused",
       [dict(VALID_ROW, anchor="x")],
       expect_exit=2, expect_text="must be unique",

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -258,6 +258,12 @@ check("an anchor covering only the START of a line still names its offset",
       extra_files={"Sources/Thing.swift":
                    "func f() {\n    guard let value = item else { return }\n}\n"})
 
+check("an anchor opening with a newline still names its offset",
+      [dict(VALID_ROW, anchor="\nlet a = 1\nlet b = 2")],
+      expect_exit=2, expect_text="matches exactly once at +4 spaces",
+      extra_files={"Sources/Thing.swift":
+                   "func f() {\n    let a = 1\n    let b = 2\n}\n"})
+
 check("a non-unique anchor is refused",
       [dict(VALID_ROW, anchor="x")],
       expect_exit=2, expect_text="must be unique",

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -94,7 +94,7 @@ def make_tree(tmp: Path):
 
 
 def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=None, remove=None,
-          non_executable=None):
+          non_executable=None, forbid_text=None):
     """Run --validate-only against a throwaway tree and assert the exit code and message."""
     global ran
     ran += 1
@@ -123,6 +123,8 @@ def check(name, rows, *, expect_exit, expect_text=None, extra_files=None, top=No
             return
         if expect_text and expect_text not in out:
             failures.append(f"{name}: message missing {expect_text!r}\n{out.strip()[:400]}")
+        if forbid_text and forbid_text in out:
+            failures.append(f"{name}: message should not carry {forbid_text!r}\n{out.strip()[:400]}")
             return
         print(f"  ok  {name}")
 
@@ -217,6 +219,21 @@ check("a non-backup file in the dedicated backup root refuses the whole run",
 check("an anchor absent from the target file is refused",
       [dict(VALID_ROW, anchor="this text is nowhere in the file")],
       expect_exit=2, expect_text="anchor not found")
+
+# #2529: an anchor is TEXT, so a reflow that changes only nesting depth retires a row
+# while the behaviour it binds is untouched. Both rows below are "anchor not found",
+# and the pair is the point — one has moved and one is gone, and the refusal has to
+# tell them apart or a baseline gets spent rediscovering it.
+check("an anchor that only moved indentation names the offset",
+      [dict(VALID_ROW, anchor="let a = 1\nlet b = 2")],
+      expect_exit=2, expect_text="matches exactly once at +4 spaces",
+      extra_files={"Sources/Thing.swift": "func f() {\n    let a = 1\n    let b = 2\n}\n"})
+
+check("an anchor that is genuinely gone gets no offset hint",
+      [dict(VALID_ROW, anchor="let deleted = 1\nlet alsoDeleted = 2")],
+      expect_exit=2, expect_text="anchor not found",
+      forbid_text="matches exactly once",
+      extra_files={"Sources/Thing.swift": "func f() {\n    let a = 1\n    let b = 2\n}\n"})
 
 check("a non-unique anchor is refused",
       [dict(VALID_ROW, anchor="x")],

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -235,6 +235,23 @@ check("an anchor that is genuinely gone gets no offset hint",
       forbid_text="matches exactly once",
       extra_files={"Sources/Thing.swift": "func f() {\n    let a = 1\n    let b = 2\n}\n"})
 
+# Review r1, both directions of the same defect: a RANGE chosen here rather than read
+# off the file, and a SUBSTRING test standing in for a line-start one.
+check("an anchor that moved four Swift nesting levels is still found",
+      [dict(VALID_ROW, anchor="let a = 1\nlet b = 2")],
+      expect_exit=2, expect_text="matches exactly once at +16 spaces",
+      extra_files={"Sources/Thing.swift":
+                   "func f() {\n" + " " * 16 + "let a = 1\n" + " " * 16 + "let b = 2\n}\n"})
+
+check("a shifted anchor found MID-LINE is not reported as indentation",
+      [dict(VALID_ROW, anchor="let a = 1\nlet b = 2")],
+      expect_exit=2, expect_text="anchor not found",
+      forbid_text="matches exactly once",
+      # The shifted anchor DOES occur here, but its first line begins mid-line
+      # inside `zzz(`, so it is not indentation and must not be reported as such.
+      extra_files={"Sources/Thing.swift":
+                   "func f() {\n    zzz(    let a = 1\n    let b = 2)\n}\n"})
+
 check("a non-unique anchor is refused",
       [dict(VALID_ROW, anchor="x")],
       expect_exit=2, expect_text="must be unique",

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -252,6 +252,12 @@ check("a shifted anchor found MID-LINE is not reported as indentation",
       extra_files={"Sources/Thing.swift":
                    "func f() {\n    zzz(    let a = 1\n    let b = 2)\n}\n"})
 
+check("an anchor covering only the START of a line still names its offset",
+      [dict(VALID_ROW, anchor="        guard let value")],
+      expect_exit=2, expect_text="matches exactly once at -4 spaces",
+      extra_files={"Sources/Thing.swift":
+                   "func f() {\n    guard let value = item else { return }\n}\n"})
+
 check("a non-unique anchor is refused",
       [dict(VALID_ROW, anchor="x")],
       expect_exit=2, expect_text="must be unique",

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1220,11 +1220,13 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
         # nothing. The row re-checks at apply time because an earlier row may share the file.
         # Reads the resolved, contained path through the helper, so a binary resource under Sources/
         # is refused HERE — before any row runs — rather than raising mid-battery.
-        occurrences = read_recipe_target(target, f"row {i}'s target").count(row["anchor"])
+        clean = read_recipe_target(target, f"row {i}'s target")
+        occurrences = clean.count(row["anchor"])
         if occurrences == 0:
             raise Refusal(
                 f"row {i} anchor not found in {row['file']} — the mutation would never be applied, "
                 "and a row that never applied is not a row that passed."
+                + indentation_hint(clean, row["anchor"])
             )
         if occurrences > 1:
             raise Refusal(
@@ -1232,6 +1234,50 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
                 "the mutation lands somewhere you did not choose."
             )
     return rows
+
+
+def reindented(anchor, delta):
+    """`anchor` with every non-blank line's leading indentation shifted by `delta` spaces.
+
+    Returns None when a dedent would eat a non-space character, so a shift that
+    changes the TEXT can never be offered as the same anchor.
+    """
+    out = []
+    for line in anchor.split("\n"):
+        if not line.strip():
+            out.append(line)
+            continue
+        if delta >= 0:
+            out.append(" " * delta + line)
+        else:
+            if line[:-delta].strip():
+                return None
+            out.append(line[-delta:])
+    return "\n".join(out)
+
+
+def indentation_hint(src, anchor):
+    """A sentence naming the offsets at which this anchor matches exactly once, or ''.
+
+    An anchor is TEXT, so a formatter reflow or an extract that changes only nesting
+    depth retires a row while the behaviour it binds is untouched. `anchor not found`
+    is true in both cases and reads like the subject is gone. This distinguishes them
+    and REPORTS ONLY: re-pointing a frozen row is a judgement, never the runner's.
+    Ref: #2529.
+    """
+    offsets = [
+        delta
+        for delta in list(range(1, 13)) + list(range(-1, -13, -1))
+        if (shifted := reindented(anchor, delta)) is not None and src.count(shifted) == 1
+    ]
+    if not offsets:
+        return ""
+    named = ", ".join(f"{delta:+d}" for delta in sorted(offsets))
+    return (
+        f" The same text matches exactly once at {named} spaces of indentation, so the code "
+        "MOVED rather than changed. File a corrected row on a new issue; a frozen row is never "
+        "edited in place."
+    )
 
 
 def select_recipe_row(rows, number):
@@ -1578,7 +1624,9 @@ def main(argv=None):
             src = read_recipe_target(target, f"row {i}'s target")
             occurrences = src.count(row["anchor"])
             if occurrences == 0:
-                detail = "anchor not found — the mutation was never applied"
+                detail = "anchor not found — the mutation was never applied" + indentation_hint(
+                    src, row["anchor"]
+                )
             elif occurrences > 1:
                 detail = f"anchor occurs {occurrences} times; it must be unique"
             else:

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1280,23 +1280,30 @@ def indentation_hint(src, anchor):
     and REPORTS ONLY: re-pointing a frozen row is a judgement, never the runner's.
     Ref: #2529.
 
-    **The candidate offsets are READ OFF THE FILE, never a range chosen here.** A
-    fixed span is a parameter that can be wrong, and it fails toward SILENCE: a first
-    draft searched +-12 and could not see code that moved four Swift nesting levels,
-    reporting the anchor as gone. Every line whose stripped text equals the anchor's
-    first stripped line names its own offset, so nesting depth is unbounded and there
-    is nothing left to tune. Ref: #2529 review r1.
+    **The candidate offsets are READ OFF THE FILE, never chosen here.** A fixed span
+    is a parameter that can be wrong, and it fails toward SILENCE: a first draft
+    searched +-12 and could not see code that moved four Swift nesting levels,
+    reporting the anchor as gone.
+
+    **Two rounds then landed on WHICH LINES are candidates, so that question is gone
+    too.** Requiring a line to equal the anchor's first line suppressed a legitimate
+    anchor covering only the START of a line (`guard let value` against
+    `guard let value = item else {`). Rather than trade one matching rule for
+    another, the candidates are now every distinct INDENTATION WIDTH the file
+    actually uses. There is no matching heuristic left to get wrong: an offset that
+    could line up with any real line is tried, and the verification below — the whole
+    shifted anchor, occurring exactly once, BEGINNING A LINE — is what decides.
+    Ref: #2529 review r1 and r2.
     """
     first = next((line for line in anchor.split("\n") if line.strip()), None)
     if first is None:
         return ""
     anchor_indent = len(first) - len(first.lstrip(" "))
-    body = first.strip()
 
     candidates = {
         (len(line) - len(line.lstrip(" "))) - anchor_indent
         for line in src.split("\n")
-        if line.strip() == body
+        if line.strip()
     }
     offsets = [
         delta

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1256,16 +1256,40 @@ def reindented(anchor, delta):
     return "\n".join(out)
 
 
+def first_content_line_offset(text):
+    """Where `text`'s first line that has content begins, as an index into `text`.
+
+    Zero for the ordinary anchor. Non-zero when an anchor opens with blank lines or a
+    bare newline, which say nothing about indentation and must not be the thing tested
+    for beginning a line. Ref: #2529 review r3.
+    """
+    offset = 0
+    for line in text.split("\n"):
+        if line.strip():
+            return offset
+        offset += len(line) + 1
+    return 0
+
+
 def line_start_occurrences(src, text):
-    """How many times `text` occurs BEGINNING A LINE.
+    """How many times `text` occurs with its FIRST CONTENT LINE beginning a line.
 
     `str.count` is a substring test, so it would accept a shifted anchor found in the
     middle of a longer line — which is not indentation, and the sentence this feeds
-    says the word "indentation". Ref: #2529 review r1.
+    says the word "indentation".
+
+    **The subject is the first CONTENT line, not the first character**, which is the
+    general form of a finding about anchors opening with a newline: there the match
+    begins at the separator, whose preceding character is ordinary content from the
+    line before, so an exact uniquely-reindented match was never reported. Testing the
+    content line covers that, leading blank lines, and the ordinary case at once.
+    Ref: #2529 review r1 and r3.
     """
+    lead = first_content_line_offset(text)
     total, start = 0, 0
     while (found := src.find(text, start)) != -1:
-        if found == 0 or src[found - 1] == "\n":
+        anchored = found + lead
+        if anchored == 0 or src[anchored - 1] == "\n":
             total += 1
         start = found + 1
     return total

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1256,6 +1256,21 @@ def reindented(anchor, delta):
     return "\n".join(out)
 
 
+def line_start_occurrences(src, text):
+    """How many times `text` occurs BEGINNING A LINE.
+
+    `str.count` is a substring test, so it would accept a shifted anchor found in the
+    middle of a longer line — which is not indentation, and the sentence this feeds
+    says the word "indentation". Ref: #2529 review r1.
+    """
+    total, start = 0, 0
+    while (found := src.find(text, start)) != -1:
+        if found == 0 or src[found - 1] == "\n":
+            total += 1
+        start = found + 1
+    return total
+
+
 def indentation_hint(src, anchor):
     """A sentence naming the offsets at which this anchor matches exactly once, or ''.
 
@@ -1264,11 +1279,31 @@ def indentation_hint(src, anchor):
     is true in both cases and reads like the subject is gone. This distinguishes them
     and REPORTS ONLY: re-pointing a frozen row is a judgement, never the runner's.
     Ref: #2529.
+
+    **The candidate offsets are READ OFF THE FILE, never a range chosen here.** A
+    fixed span is a parameter that can be wrong, and it fails toward SILENCE: a first
+    draft searched +-12 and could not see code that moved four Swift nesting levels,
+    reporting the anchor as gone. Every line whose stripped text equals the anchor's
+    first stripped line names its own offset, so nesting depth is unbounded and there
+    is nothing left to tune. Ref: #2529 review r1.
     """
+    first = next((line for line in anchor.split("\n") if line.strip()), None)
+    if first is None:
+        return ""
+    anchor_indent = len(first) - len(first.lstrip(" "))
+    body = first.strip()
+
+    candidates = {
+        (len(line) - len(line.lstrip(" "))) - anchor_indent
+        for line in src.split("\n")
+        if line.strip() == body
+    }
     offsets = [
         delta
-        for delta in list(range(1, 13)) + list(range(-1, -13, -1))
-        if (shifted := reindented(anchor, delta)) is not None and src.count(shifted) == 1
+        for delta in sorted(candidates)
+        if delta != 0
+        and (shifted := reindented(anchor, delta)) is not None
+        and line_start_occurrences(src, shifted) == 1
     ]
     if not offsets:
         return ""

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1334,7 +1334,13 @@ def indentation_hint(src, anchor):
         for delta in sorted(candidates)
         if delta != 0
         and (shifted := reindented(anchor, delta)) is not None
+        # BOTH counts, because an offset is only useful as advice if a row re-cut at
+        # it would RUN. A shifted text unique at a line start but repeated mid-line —
+        # duplicate bytes inside a comment or a string — passes the first count and is
+        # then refused as non-unique by the check above. Naming it points the reader at
+        # a number that cannot work, which is worse than naming none. Ref: #2529 r4.
         and line_start_occurrences(src, shifted) == 1
+        and src.count(shifted) == 1
     ]
     if not offsets:
         return ""


### PR DESCRIPTION
Across nine mutation batteries the largest single cause of unrunnable rows was not drift in what the code does. It was a reflow or an extract that changed only NESTING DEPTH, which retires a frozen row while the behaviour it binds is untouched. #2352's four rows were every one of them exactly four spaces short.

The refusal said `anchor not found`. True, and indistinguishable from a subject that has been deleted — so each one cost a read to tell apart, and one of them cost a baseline.

## What changes

The zero-occurrence refusal re-tries the same text at each indentation offset. When it matches exactly once it says so:

```
row 1 anchor not found in …OverlayCapsuleBackgrounds.swift — the mutation would never be
applied … The same text matches exactly once at +4 spaces of indentation, so the code
MOVED rather than changed. File a corrected row on a new issue; a frozen row is never
edited in place.
```

**It reports and never re-aims.** Re-pointing a frozen row at what looks like its successor is a guess about what the recipe meant, which is the one thing freezing a recipe exists to prevent. The sentence names the offset and hands the judgement back.

`reindented` returns nil rather than dedenting through a non-space character, so an offset that would change the TEXT can never be offered as the same anchor.

One edit reaches both tools: `validate-mutation-recipe.py` calls the battery's own `load_recipes`, so it inherits the message with no second copy to drift.

## Proof

Against the real runner, not the helper. A genuinely dedented multi-line anchor into shipped source:

```
The same text matches exactly once at +4 spaces of indentation
```

and an anchor naming a symbol that does not exist:

```
row 1 anchor not found in … (no hint)
```

Both are now rows in `mutation-battery-test.py`, and the second is the half that matters — without it, a hint that fired on everything would read as a working feature. `python3 scripts/mutation-battery-test.py`: **all 169 cases passed.**

## Not in this PR

#2529 also collects six frozen rows that need re-cutting, four of which need a judgement about what the recipe meant. Those stay open; this is the mechanical half that makes the next one self-service.

Part of #2529.
