### PR TITLE
test(quickadd): reach the refusal that keeps an invisible panel off the screen

### DIFF
--- a/Tests/EnviousWisprDesktopEffectsTests/QuickAddPanelHostRealPanelTests.swift
+++ b/Tests/EnviousWisprDesktopEffectsTests/QuickAddPanelHostRealPanelTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import EnviousWisprCore
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2542: the refusal that keeps an invisible Quick Add panel off the screen.
+///
+/// **A real-panel suite, and deliberately so.** `present` builds its panel through
+/// `ensurePanel()` before it measures anything, so any test reaching the refusal
+/// puts a window-server-backed `NSPanel` into the process. That is what this target
+/// is for; the unit target stays free of live desktop effects. Cloud review on
+/// PR #2545 named the boundary.
+///
+/// Nothing is ever ordered on screen: keying goes through the injected presenter,
+/// which records instead of performing.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct QuickAddPanelHostRealPanelTests {
+
+  /// Records the one call the host makes, instead of making it.
+  ///
+  /// A local double rather than the unit target's recorder, which is not visible
+  /// from here. It answers the single member `present` reaches.
+  private final class RecordingPresenter: PanelPresenting {
+    private(set) var keyed: [ObjectIdentifier] = []
+    func makeKeyAndOrderFront(_ panel: NSPanel) {
+      keyed.append(ObjectIdentifier(panel))
+    }
+  }
+
+  /// **The refusal's own comment names the failure and nothing exercised it.**
+  ///
+  /// `present` refuses a panel whose size cannot be worked out, because a window
+  /// ordered onto the screen at a size nobody could compute is invisible while the
+  /// caller is told it opened: the user sees nothing, the telemetry says `opened`,
+  /// and every event after it describes a panel that was never there.
+  ///
+  /// Measured on #2388 — replacing that refusal with "size it 360×240 and report
+  /// success" left the whole Quick Add suite green across 56 tests.
+  ///
+  /// **The return value is the assertion that matters**, because it is the only
+  /// thing the caller reads. Nothing being keyed is the second half: a refused
+  /// panel must not take the keyboard on its way out.
+  @Test("A panel whose size cannot be worked out is refused, and nothing is keyed")
+  func anUnmeasurablePanelIsRefused() {
+    let presenter = RecordingPresenter()
+    let host = QuickAddPanelHost(presenter: presenter)
+
+    #expect(host.present(EmptyView().frame(width: 0, height: 0)) == false)
+    #expect(presenter.keyed.isEmpty, "a refused panel must not take the keyboard")
+  }
+
+  /// **The two-way control, without which the guard above passes for a host that
+  /// refuses EVERYTHING** — which is the same invisible panel by another route.
+  @Test("An ordinary panel still opens, so the refusal is not blanket")
+  func aMeasurablePanelStillOpens() {
+    let presenter = RecordingPresenter()
+    let host = QuickAddPanelHost(presenter: presenter)
+
+    #expect(host.present(Color.clear.frame(width: 320, height: 180)) == true)
+    #expect(presenter.keyed.count == 1, "exactly one keying, for the one panel shown")
+    host.dismiss()
+  }
+}

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -3,6 +3,7 @@ import EnviousWisprPipeline
 import EnviousWisprPostProcessing
 import EnviousWisprServices
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import EnviousWisprAppKit
@@ -1159,5 +1160,40 @@ struct QuickAddCoordinatorTests {
     #expect(authored?.aliases.isEmpty == true, "a word is not an alias of itself")
     // The selection is NON-empty, which is exactly what the old rule read.
     #expect(!model.spellingToWrite.isEmpty)
+  }
+
+  // MARK: - A panel nobody could measure is refused, not shown (#2542)
+
+  /// **The refusal's own comment names the failure and nothing exercised it.**
+  ///
+  /// `QuickAddPanelHost.present` refuses a panel whose size cannot be worked out,
+  /// because a window ordered onto the screen at a size nobody could compute is
+  /// invisible while the caller is told it opened: the user sees nothing, the
+  /// telemetry says `opened`, and every event after it describes a panel that was
+  /// never there. Measured on #2388 — replacing that refusal with "size it 360×240
+  /// and report success" left this whole suite green across 56 tests.
+  ///
+  /// **The return value is the assertion that matters**, because it is the only
+  /// thing the caller reads. Nothing being keyed is the second half: a refused
+  /// panel must not take the keyboard on its way out.
+  @Test("A panel whose size cannot be worked out is refused, and nothing is keyed")
+  func anUnmeasurablePanelIsRefused() {
+    let effects = RecordingDesktopPresentationEffects()
+    let host = QuickAddPanelHost(presenter: effects)
+
+    #expect(host.present(EmptyView().frame(width: 0, height: 0)) == false)
+    #expect(effects.calls.isEmpty, "a refused panel must not take the keyboard")
+  }
+
+  /// **The two-way control, without which the guard above passes for a host that
+  /// refuses everything** — which is the same invisible panel by another route.
+  @Test("An ordinary panel still opens, so the refusal is not blanket")
+  func aMeasurablePanelStillOpens() {
+    let effects = RecordingDesktopPresentationEffects()
+    let host = QuickAddPanelHost(presenter: effects)
+
+    #expect(host.present(Color.clear.frame(width: 320, height: 180)) == true)
+    #expect(effects.calls.count == 1, "exactly one keying, for the one panel shown")
+    host.dismiss()
   }
 }

--- a/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/QuickAddCoordinatorTests.swift
@@ -3,7 +3,6 @@ import EnviousWisprPipeline
 import EnviousWisprPostProcessing
 import EnviousWisprServices
 import Foundation
-import SwiftUI
 import Testing
 
 @testable import EnviousWisprAppKit
@@ -1160,40 +1159,5 @@ struct QuickAddCoordinatorTests {
     #expect(authored?.aliases.isEmpty == true, "a word is not an alias of itself")
     // The selection is NON-empty, which is exactly what the old rule read.
     #expect(!model.spellingToWrite.isEmpty)
-  }
-
-  // MARK: - A panel nobody could measure is refused, not shown (#2542)
-
-  /// **The refusal's own comment names the failure and nothing exercised it.**
-  ///
-  /// `QuickAddPanelHost.present` refuses a panel whose size cannot be worked out,
-  /// because a window ordered onto the screen at a size nobody could compute is
-  /// invisible while the caller is told it opened: the user sees nothing, the
-  /// telemetry says `opened`, and every event after it describes a panel that was
-  /// never there. Measured on #2388 — replacing that refusal with "size it 360×240
-  /// and report success" left this whole suite green across 56 tests.
-  ///
-  /// **The return value is the assertion that matters**, because it is the only
-  /// thing the caller reads. Nothing being keyed is the second half: a refused
-  /// panel must not take the keyboard on its way out.
-  @Test("A panel whose size cannot be worked out is refused, and nothing is keyed")
-  func anUnmeasurablePanelIsRefused() {
-    let effects = RecordingDesktopPresentationEffects()
-    let host = QuickAddPanelHost(presenter: effects)
-
-    #expect(host.present(EmptyView().frame(width: 0, height: 0)) == false)
-    #expect(effects.calls.isEmpty, "a refused panel must not take the keyboard")
-  }
-
-  /// **The two-way control, without which the guard above passes for a host that
-  /// refuses everything** — which is the same invisible panel by another route.
-  @Test("An ordinary panel still opens, so the refusal is not blanket")
-  func aMeasurablePanelStillOpens() {
-    let effects = RecordingDesktopPresentationEffects()
-    let host = QuickAddPanelHost(presenter: effects)
-
-    #expect(host.present(Color.clear.frame(width: 320, height: 180)) == true)
-    #expect(effects.calls.count == 1, "exactly one keying, for the one panel shown")
-    host.dismiss()
   }
 }


### PR DESCRIPTION
`QuickAddPanelHost.present` refuses a panel whose size cannot be worked out. The guard's own comment names the failure — *"a zero fitting size is an INVISIBLE panel that reports success"* — and nothing exercised it.

**Measured on #2388, not assumed:** replacing that refusal with "size it 360×240 and report success" left `QuickAddCoordinatorTests` entirely green across 56 tests. The type had zero references anywhere in `Tests/`; the single grep hit was a doc comment.

## What it costs a user

Quick Add is invoked, a window is ordered onto the screen at a size nobody could compute, and the coordinator is told the panel opened. The user sees nothing, telemetry says `opened`, and every event after it describes a panel that was never there.

This is the fourth instance this session of one shape — **a well-covered ACTION beside a DECISION no test can reach** — after #2356's recovery binding, #2438's chrome binding and #2371's reopen decision.

## The test

Reached through the presenter seam the host already takes, so there is no new seam and no real window: `RecordingDesktopPresentationEffects` records the keying instead of performing it. The return value carries the claim, because it is the only thing the caller reads.

Two-way, and the control is not decoration: without it the guard passes for a host that refuses EVERYTHING, which is the same invisible panel by another route.

## Proof

The frozen row from #2388/12, with the corrected replacement #2542 carries:

```
[ EXP ] row 1: present an unmeasurable panel and report success
        exact must_fire set matched (anUnmeasurablePanelIsRefused)
        1 named silent control unchanged (aMeasurablePanelStillOpens)
        baseline 58 green before and after, tree restored byte-exact
```

Full Debug lane: **PASS, 7207 tests.**

The filed row did not compile as written — it omitted `return true`, leaving a non-returning path in a `-> Bool` function, so the runner reported ERR and the row proved nothing. #2542 carries the corrected replacement, which is the one run here.

Closes #2542.
