### PR TITLE
test(settings): freeze the three chip sentences, because a word list cannot decide English

### DIFF
--- a/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewStatusBarPresentationTests.swift
@@ -361,6 +361,15 @@ struct LivePreviewStatusBarPresentationTests {
       (.paused, .universal, nil, true),
       (.buildCannotRun, .universal, nil, false),
     ]
+    // **What this list is now FOR, after #2441's evasion pass.** The three
+    // provenance sentences are frozen literal-for-literal in
+    // `LivePreviewSettingsCopyTests.provenanceSentencesAreFrozen`, because a
+    // vocabulary check demonstrably cannot decide whether a sentence promises
+    // output — "picking up your voice" holds none of these words and walked past.
+    // So this list no longer carries the provenance; what it still covers is the
+    // COMPOSED text, which includes the language NAME the catalogue supplies and
+    // which no copy test pins. Kept as a tripwire on that, not as the guard.
+    //
     // **"detect" is here because its absence is what let a real defect through.**
     // `languageProvenanceDetected` said "detected as you speak", which the chip
     // rendered while the preview was off, paused, downloading or failed. The guard

--- a/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
+++ b/Tests/EnviousWisprTests/Settings/LivePreviewSettingsCopyTests.swift
@@ -242,7 +242,8 @@ struct LivePreviewSettingsCopyTests {
     // Asserting its ABSENCE is the half that would have caught the shared-string defect.
     let universal = LivePreviewSettingsCopy.pickerUniversalCaveat.lowercased()
     #expect(
-      !["uses your mac", "follows your mac", "goes by your mac"].contains(where: universal.contains),
+      !["uses your mac", "follows your mac", "goes by your mac"].contains(
+        where: universal.contains),
       "Universal's caveat claims Apple's Mac fallback, which is false for that engine")
     #expect(universal.contains("auto"), "Universal's caveat stopped naming the mode")
 
@@ -255,19 +256,39 @@ struct LivePreviewSettingsCopyTests {
   /// The status bar's provenance describes CONFIGURATION, never activity: the chip
   /// renders in every state, including off and failed, so any word implying live
   /// detection is a claim the bar cannot keep.
-  @Test("Language provenance never claims the preview is doing something")
-  func provenanceIsConfigurationOnly() {
-    let strings = [
+  ///
+  /// **This test used to be a list of banned words, and #2441's independent evasion
+  /// pass walked past it — measured, not argued.** Replacing
+  /// `languageProvenanceDetected` with `"picking up your voice"` is a promise the bar
+  /// cannot keep, holds none of the banned words, and left the whole suite green. The
+  /// paired control, `"listening now"`, fired. So the list caught the words somebody
+  /// thought of and nothing else, which is what a vocabulary guard can do.
+  ///
+  /// **Whether a sentence promises output is a judgement about English, and no list
+  /// of substrings decides it.** What a test CAN hold is that the set of sentences is
+  /// closed and each one is the sentence a human approved, so any rewording is red
+  /// exactly once, here, on the copy surface where a reviewer is already reading the
+  /// words. That is the whole mechanism, and it is stated rather than implied.
+  ///
+  /// **Deliberately literals, and only in THIS file.** The presentation suite compares
+  /// against the symbols on purpose — its subject is which sentence is chosen, not
+  /// what it says, and pinning words there would fail on every honest correction.
+  /// Here the words ARE the subject.
+  @Test("Each provenance sentence is the one that was approved")
+  func provenanceSentencesAreFrozen() {
+    #expect(LivePreviewSettingsCopy.languageProvenanceFromMac == "from your Mac")
+    #expect(LivePreviewSettingsCopy.languageProvenanceUserPicked == "you picked this")
+    #expect(LivePreviewSettingsCopy.languageProvenanceDetected == "no language pinned")
+
+    // Distinctness, which no single constant can satisfy on its own: three sentences
+    // that had drifted into one would still pass every equality above only if all
+    // three were edited, and would pass nothing here.
+    let all = [
       LivePreviewSettingsCopy.languageProvenanceFromMac,
       LivePreviewSettingsCopy.languageProvenanceUserPicked,
       LivePreviewSettingsCopy.languageProvenanceDetected,
     ]
-    for s in strings {
-      let t = s.lowercased()
-      for claim in ["detect", "appear", "show", "ready", "working", "active", "hearing"] {
-        #expect(!t.contains(claim), "provenance claims activity: \(s)")
-      }
-    }
+    #expect(Set(all).count == 3, "two provenances say the same thing")
   }
 
   @Test("The description says the preview is not the pasted text")
@@ -322,7 +343,9 @@ struct LivePreviewSettingsCopyTests {
       LivePreviewSettingsCopy.pausedForFasterTranscription,
       LivePreviewSettingsCopy.statusPausedDetail,
     ]
-    #expect(LivePreviewSettingsCopy.pausedForFasterTranscription == "Paused while Faster Transcription is on")
+    #expect(
+      LivePreviewSettingsCopy.pausedForFasterTranscription
+        == "Paused while Faster Transcription is on")
     #expect(
       LivePreviewSettingsCopy.statusPausedDetail
         == "Your dictation keeps its full speed. Turn Faster Transcription off to see the preview.")


### PR DESCRIPTION
#2441 asks for an **independent evasion attempt** against `chipNeverPromisesOutput`, and names the verdict in advance: *if any shape walks past, the answer is not a fourth word — it is that the guard should assert the OUTCOME rather than the vocabulary.*

It walked past. This is that verdict.

## The measurement

Two tests guarded one claim — the language chip states configuration, never readiness — with lists of banned words, in two files, with **different members**. `scripts/mutation-battery.py`, source restored byte-exact:

```
languageProvenanceDetected = "picking up your voice"   SURVIVED, whole suite green
languageProvenanceDetected = "listening now"           CAUGHT
```

The first is a promise the bar cannot keep. The chip renders while the preview is **off, paused, downloading and failed**, so that sentence is false in four states a user can actually be in. It holds none of the banned words in either list, and nothing went red.

The control is the half that makes it a measurement rather than an anecdote: the list works exactly when the word is on it.

## Why a fourth word is not the fix

Whether a sentence promises output is a judgement about English. No set of substrings decides it, and every list is one synonym from being wrong again — which is how this guard already got here, since "detect" was added after its absence let a real defect through.

## What is held instead

The set of sentences the chip can utter is **closed and small**: three constants, one file. So they are frozen literal-for-literal, plus distinctness. Any rewording is red exactly once, on the copy surface, where a reviewer is already reading the words rather than inferring them from a symbol.

```
[ EXP ] the evasion that walked past the word list    must_fire matched
[ EXP ] two provenances drifting into one sentence    must_fire matched
baseline 9 green before and after
```

**Literals here and nowhere else, which honours a recorded objection rather than overruling it.** `universalLanguageIsIndependentOfApple` compares against the symbols on purpose and says why: the wording changed twice during review, and a presentation test pinning words fails on every honest correction while catching none of the wrong ones. That is right about the presentation suite and silent about the copy suite, where the words ARE the subject.

The presentation-side list is kept and relabelled. It no longer carries the provenance; what it still covers is the **composed** text, including the language name the catalogue supplies, which no copy test pins. A tripwire on that, not the guard.

Full Debug lane: **PASS, 7205 tests.**

## Not in this PR

#2441 also asks for the C1 branch battery re-run, the filed recipe rows, and an evasion pass on the caveat pairs. Those stay open; this is the finding that changed a guard.

Part of #2441.
