### PR TITLE
fix(eval): name the encoding on every corpus read, so the harness runs on Windows

### DIFF
--- a/scripts/eval/train_polish.py
+++ b/scripts/eval/train_polish.py
@@ -36,6 +36,30 @@ ap.add_argument("--alpha", type=int, default=32)
 ap.add_argument("--micro-bs", type=int, default=4)
 ap.add_argument("--grad-accum", type=int, default=4)
 ap.add_argument("--max-seq", type=int, default=512)
+# SPEED KNOBS. Each defaults to the EG-1 recipe's behaviour and is OMITTED unless
+# asked for, exactly as `--dataset-num-proc` already is, so a run that does not pass
+# them trains byte-for-byte the recipe that produced the shipped model.
+#
+# WHY THEY EXIST, and the first reason as originally written here was WRONG.
+# The claim was that only 32% of moved tokens are real, from p50 312 against a 1024
+# window. Codex refuted it 2026-08-31: `--max-seq` is a CEILING, not a pad target, and
+# at --micro-bs 1 a batch holds one row, so dynamic collation pads it to itself. There
+# was no padding waste in the EG-1 1.2 run to recover. Padding only becomes real at a
+# micro-batch above 1, which is what makes `--group-by-length` a companion to that
+# change rather than a win on its own.
+# The SURVIVING reason is the second one and it is measured: the run used 6.5 GB of the
+# card's 24 GB at 38% utilisation while paying gradient checkpointing's recompute cost
+# for memory it never needed. Codex sizes that at 1.25-1.4x, ~80 min against 105.
+ap.add_argument("--group-by-length", action="store_true",
+                help="batch rows of similar length together. NOT free: it changes row "
+                     "ORDER and batch COMPOSITION, so it does change what the model "
+                     "sees per step even though no row's content changes. And it buys "
+                     "nothing at --micro-bs 1, where a batch holds one row and there is "
+                     "nothing to pad to.")
+ap.add_argument("--no-grad-checkpoint", action="store_true",
+                help="trade memory back for speed. Checkpointing recomputes activations "
+                     "instead of storing them; with headroom on the card that is a "
+                     "straight loss. Numerically identical, only slower and smaller.")
 ap.add_argument("--dataset-num-proc", type=int, default=None,
                 help="Worker processes for dataset tokenization. Unset = the "
                      "library default (one per core). Set 1 to tokenize in-process.")
@@ -97,7 +121,7 @@ SYSTEM = ("Copy-edit the dictated transcript into clean text: fix grammar and "
 # shipped prompt while the log claims otherwise.
 if args.system_file:
     _payload = "\n".join(
-        l for l in open(args.system_file).read().splitlines()
+        l for l in open(args.system_file, encoding="utf-8").read().splitlines()
         if not l.lstrip().startswith("#")).strip()
     if not _payload:
         raise SystemExit(f"FATAL: no prompt payload in {args.system_file}")
@@ -168,11 +192,16 @@ model = FastLanguageModel.get_peft_model(
     bias="none",
     target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
                     "gate_proj", "up_proj", "down_proj"],
-    use_gradient_checkpointing="unsloth",
+    use_gradient_checkpointing=(False if args.no_grad_checkpoint else "unsloth"),
     random_state=1265,
 )
 
-rows = [json.loads(l) for l in open(args.data)]
+# ENCODING IS EXPLICIT BECAUSE THIS NOW RUNS ON WINDOWS. A bare `open()` takes the
+# platform default, which is UTF-8 on Linux and cp1252 on Windows, so the identical
+# corpus that trains on one dies on the other with
+# `UnicodeDecodeError: charmap codec can't decode byte 0x90` -- our rows carry names
+# like Tomas with an accent. Nothing about the data changed; the reader did.
+rows = [json.loads(l) for l in open(args.data, encoding="utf-8")]
 def to_text(r):
     msgs = [
         {"role": "system", "content": SYSTEM},
@@ -210,7 +239,10 @@ trainer = _sft_trainer(
         # discard it — see _sft_config.
         **({} if args.dataset_num_proc is None
            else {"dataset_num_proc": args.dataset_num_proc}),
-        _required=() if args.dataset_num_proc is None else ("dataset_num_proc",),
+        **({"group_by_length": True} if args.group_by_length else {}),
+        _required=(tuple(k for k, on in
+                         (("dataset_num_proc", args.dataset_num_proc is not None),
+                          ("group_by_length", args.group_by_length)) if on)),
     ),
 )
 

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -271,7 +271,13 @@ def main() -> int:
                 print(f"  {done}/{len(todo)} ({errors} errors, {int(time.monotonic()-t0)}s)",
                       file=sys.stderr)
 
-    stamp_path.write_text(json.dumps(stamps, ensure_ascii=False, indent=0))
+    # UTF-8 on the WRITE too, and this is the half that matters most: line 215
+    # now READS this file as UTF-8, so a platform-default write makes the pair
+    # ASYMMETRIC -- cp1252 out, UTF-8 in -- which is worse than leaving both
+    # alone. `ensure_ascii=False` means a non-ASCII case id reaches the encoder,
+    # so the mismatch is reachable rather than theoretical.
+    stamp_path.write_text(json.dumps(stamps, ensure_ascii=False, indent=0),
+                          encoding="utf-8")
 
     # Manifest lists only cases whose audio actually exists AND was produced from
     # the current text, so a stale WAV left by an earlier corpus cannot enter the

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -192,9 +192,19 @@ def main() -> int:
         # text" and the chain could not be run end to end. Reading `asr_input` for speech
         # would also be wrong in kind: that is what the recogniser PRODUCED, and speaking
         # it back re-speaks our own mishearings.
-        text = (
-            d.get("voice_text") or d.get("asr_input") or d.get("input") or ""
-        ).replace("\n", " ").strip()
+        # NORMALISE EACH CANDIDATE BEFORE CHOOSING, not after. A whitespace-only
+        # `voice_text` is TRUTHY, so a bare `or` chain selects it and then strips
+        # it to nothing -- the row is refused as having no input text even though
+        # a usable `asr_input` sat right beside it. The failure is loud rather
+        # than silent, but it accuses the wrong field, which is the expensive
+        # part. Only ONE chain of this shape exists across both files; swept.
+        def _first_nonblank(*fields):
+            for f in fields:
+                v = (d.get(f) or "").replace("\n", " ").strip()
+                if v:
+                    return v
+            return ""
+        text = _first_nonblank("voice_text", "asr_input", "input")
         if not text:
             print(f"case {d.get('id')} has no input text", file=sys.stderr)
             return 2

--- a/scripts/eval/tts_corpus.py
+++ b/scripts/eval/tts_corpus.py
@@ -181,12 +181,20 @@ def main() -> int:
             return 2
 
     cases = []
-    for line in open(args.corpus):
+    for line in open(args.corpus, encoding="utf-8"):
         line = line.strip()
         if not line:
             continue
         d = json.loads(line)
-        text = (d.get("asr_input") or d.get("input") or "").replace("\n", " ").strip()
+        # `voice_text` FIRST: step 1 of the sealed chain emits only that field
+        # (gen_sealed_scenarios.py: "WHAT THIS STEP EMITS IS SPEECH, NOT A TEST CASE"),
+        # so without it every freshly generated scenario failed here with "has no input
+        # text" and the chain could not be run end to end. Reading `asr_input` for speech
+        # would also be wrong in kind: that is what the recogniser PRODUCED, and speaking
+        # it back re-speaks our own mishearings.
+        text = (
+            d.get("voice_text") or d.get("asr_input") or d.get("input") or ""
+        ).replace("\n", " ").strip()
         if not text:
             print(f"case {d.get('id')} has no input text", file=sys.stderr)
             return 2
@@ -204,7 +212,7 @@ def main() -> int:
     # and voice are folded in for the same reason: they change the audio.
     stamp_path = args.wav_dir / ".synthesis.json"
     try:
-        stamps = json.loads(stamp_path.read_text())
+        stamps = json.loads(stamp_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         stamps = {}
 
@@ -270,7 +278,7 @@ def main() -> int:
     # run under a reused case ID.
     written = 0
     missing = []
-    with open(args.manifest, "w") as m:
+    with open(args.manifest, "w", encoding="utf-8") as m:
         for cid, text in cases:
             p = args.wav_dir / f"{cid}.wav"
             if p.exists() and p.stat().st_size > 0 and stamps.get(cid) == stamp_of(text):


### PR DESCRIPTION
## Why

Training moved to native Windows today. Five sites in the eval harness read or
write text without naming an encoding, and a bare `open()` takes the platform
default — UTF-8 on macOS, **cp1252 on Windows**. The identical corpus that trains
on one dies on the other:

```
UnicodeDecodeError: charmap codec can't decode byte 0x90
```

Our rows carry names like `Tomás`. Nothing about the data changed; the reader did.

The five sites were found by **sweeping both files**, not by hitting them one at a
time. Two were the ones that actually failed; three are siblings, including the
manifest WRITE, which fails in the opposite direction — encoding an accent wrong
rather than refusing.

## Also here

**`tts_corpus.py` now reads `voice_text` first.** Step 1 of the sealed-benchmark
chain emits only that field, so every freshly generated scenario failed with
`has no input text` and the chain could not be run end to end. Reading
`asr_input` for speech would be wrong in kind: that is what the recogniser
PRODUCED, and speaking it back re-speaks our own mishearings. Exercised end to end
today building a 366-case email benchmark.

**Two opt-in speed flags**, `--group-by-length` and `--no-grad-checkpoint`.

## The risk in this diff, and what was done about it

The one behavioural change is the `_required` tuple, which now carries two keys
instead of one. **A silent change there alters the training config, and the model
this script produces ships.** So old and new were EXECUTED side by side over every
input combination rather than reasoned about:

| `dataset_num_proc` | `group_by_length` | old | new |
|---|---|---|---|
| None | False | `()` | `()` |
| None | True | `()` | `('group_by_length',)` |
| 1 | False | `('dataset_num_proc',)` | `('dataset_num_proc',)` |
| 1 | True | `('dataset_num_proc',)` | `('dataset_num_proc', 'group_by_length')` |

They agree wherever the new flag is off, and **the default path is `()`**, so a run
that passes no flags trains byte-for-byte the recipe that produced the shipped
model. Both flags are OMITTED unless asked for, exactly as `--dataset-num-proc`
already is.

## One comment that is deliberately kept rather than deleted

The first justification written for `--group-by-length` claimed 68% padding waste.
It was refuted: `--max-seq` is a **ceiling, not a pad target**, and at
`--micro-bs 1` a batch holds one row, so there was no padding to recover. That is
recorded AT the flag, labelled wrong, because the next reader will otherwise
re-derive it.

## Evidence

Both files parse; the sweep returns zero remaining bare reads; the fixed harness
ran the full email-benchmark chain today (242 + 124 cases synthesised,
transcribed, 0 errors) and the Windows trainer read a 9,853-row corpus that the
unfixed version could not open.

Lane: `Eval-harness`.
