### PR TITLE
fix(permissions): correctly detect and recover from denied microphone access

### DIFF
--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -369,6 +369,14 @@ final class AppLifecycleCoordinator {
       keychainManager: keychainManager
     )
 
+    // #2549: a permission revoked in System Settings while the app was
+    // backgrounded is otherwise invisible until the next poll tick.
+    // `accessibilityGranted` is a CACHED property (unlike mic, which reads
+    // live), so it must be refreshed before the restart decision reads it.
+    permissions.refreshAccessibilityStatus()
+    permissions.restartMonitoringIfNeeded()
+    menuBarController.updateIcon()
+
     setup.applicationDidBecomeActive()
   }
 

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -72,7 +72,7 @@ final class MenuBarController: NSObject {
     // from `AppDelegate.applicationDidFinishLaunching`. `AppDelegate.swift:228`
     // was the sole assigner of this single-slot closure — a verified 1:1
     // transfer. The owner of the icon owns the trigger.
-    permissions.onAccessibilityChange = { [weak self] in self?.updateIcon() }
+    permissions.onPermissionChange = { [weak self] in self?.updateIcon() }
 
     // #1019: flip the icon to / from the "update waiting" gold-wave cue the
     // moment availability changes, even with no window or menu open. The
@@ -97,7 +97,11 @@ final class MenuBarController: NSObject {
   /// Pure icon-state mapping. Logic byte-identical to the pre-PR-B.3
   /// `AppDelegate.updateIcon()`.
   static func iconState(_ state: MenuBarViewState) -> MenuBarIconAnimator.IconState {
-    let needsAccessWarning = state.pipelineState == .idle && state.showAccessibilityWarning
+    // #2549: the microphone warning forces the same error icon state as
+    // Accessibility's, since either one means dictation is currently broken.
+    let needsAccessWarning =
+      state.pipelineState == .idle
+      && (state.showAccessibilityWarning || state.showMicrophoneWarning)
     let onboardingIncomplete = !state.onboardingComplete
 
     if needsAccessWarning || (onboardingIncomplete && state.pipelineState == .idle) {
@@ -247,7 +251,8 @@ final class MenuBarController: NSObject {
     let quickAdd = ShortcutBinding.keyboard(keyCode: keyCode, modifiers: modifiers)
     let record = ShortcutBinding.keyboard(keyCode: recordKeyCode, modifiers: recordModifiers)
     let cancel = ShortcutBinding.keyboard(keyCode: cancelKeyCode, modifiers: cancelModifiers)
-    guard ShortcutMatcher.quickAddOwnsItsBinding(quickAdd: quickAdd, record: record, cancel: cancel) else {
+    guard ShortcutMatcher.quickAddOwnsItsBinding(quickAdd: quickAdd, record: record, cancel: cancel)
+    else {
       return nil
     }
 
@@ -424,6 +429,22 @@ final class MenuBarController: NSObject {
       menu.addItem(warningItem)
     }
 
+    // #2549: microphone warning — always shown while denied (no dismiss,
+    // unlike Accessibility's, since a denied mic means zero dictation output
+    // at all rather than a clipboard-only fallback).
+    if state.showMicrophoneWarning {
+      let micWarningItem = NSMenuItem(
+        title: "Dictation disabled — Microphone access required",
+        action: #selector(openPermissionsAction),
+        keyEquivalent: ""
+      )
+      micWarningItem.image = NSImage(
+        systemSymbolName: "exclamationmark.shield.fill",
+        accessibilityDescription: "Microphone access required")
+      micWarningItem.target = self
+      menu.addItem(micWarningItem)
+    }
+
     menu.addItem(.separator())
 
     // Settings (opens unified window to Speech Engine tab)
@@ -535,6 +556,7 @@ final class MenuBarController: NSObject {
       vadAutoStop: settings.vadAutoStop,
       vadSilenceTimeout: settings.vadSilenceTimeout,
       showAccessibilityWarning: permissions.shouldShowAccessibilityWarning,
+      showMicrophoneWarning: permissions.microphonePermissionIsDenied,
       hasUpdater: sparkleUpdateController.hasUpdater,
       updateAvailable: pending != nil,
       updateDisplayVersion: pending?.displayVersion,
@@ -682,8 +704,9 @@ struct MenuBarActions: Sendable {
   /// Open Quick Add on the text the menu read while the user's own app was still frontmost (#2412).
   /// Takes the CONTEXT as well as the result (#2465): the click path may fall back to a synthetic
   /// Copy, and that chord must be aimed at the process the render-time read sampled.
-  let addSelectedWord: @MainActor (SelectionReader.Result, SelectionReader.AcquisitionContext) ->
-    Void
+  let addSelectedWord:
+    @MainActor (SelectionReader.Result, SelectionReader.AcquisitionContext) ->
+      Void
   let continueOnboarding: @MainActor () -> Void
   let openSettings: @MainActor () -> Void
   let openPermissions: @MainActor () -> Void
@@ -775,6 +798,11 @@ struct MenuBarViewState: Equatable {
   let vadAutoStop: Bool
   let vadSilenceTimeout: Double
   let showAccessibilityWarning: Bool
+  /// #2549: no separate `PermissionsService` property — populated directly
+  /// from `permissions.microphonePermissionIsDenied`, mirroring how
+  /// `showAccessibilityWarning` above is populated from its own live/cached
+  /// property.
+  let showMicrophoneWarning: Bool
   let hasUpdater: Bool
   /// #1019: a non-critical update is waiting to install.
   var updateAvailable: Bool = false

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -301,6 +301,12 @@ final class OverlayDirector {
   /// which is the failure this whole phase exists to make unspellable.
   private let grantAccessibility: () -> Void
 
+  /// #2549: the "Open Settings" button on the microphone-permission-denied
+  /// notice pill. Same reasoning as `grantAccessibility` immediately above —
+  /// no default, so a composition-root caller that forgets to wire it fails to
+  /// compile rather than shipping a button that reaches nobody.
+  private let openMicrophoneSettings: () -> Void
+
   init(
     host: any OverlayWindowHosting,
     position: @escaping () -> OverlayPillPosition = { .top },
@@ -315,6 +321,8 @@ final class OverlayDirector {
     // about neither; choosing one is now visible in the source.
     livePreview: LivePreviewBridge,
     grantAccessibility: @escaping () -> Void,
+    // #2549: same no-default reasoning as `grantAccessibility` above.
+    openMicrophoneSettings: @escaping () -> Void,
     // **No default either, for the reason directly above** (#2375 C3a). This is
     // the seam Phase 4 replaces: a settings-backed snapshot at this same
     // construction point, changing this closure's BODY and nothing else. A
@@ -341,6 +349,7 @@ final class OverlayDirector {
     self.accessibilityEligibility = accessibilityEligibility
     self.livePreview = livePreview
     self.grantAccessibility = grantAccessibility
+    self.openMicrophoneSettings = openMicrophoneSettings
     self.position = position
     self.model = model
     self.expiryClock = PillExpiryClock(
@@ -1380,7 +1389,23 @@ extension OverlayDirector: OverlayPresenting {
     case .warning(let reason):
       handle(.pipeline(.warning(reason: reason)), binding: .none, relay: relay)
     case .error(let reason):
-      handle(.pipeline(.error(reason: reason)), binding: .none, relay: relay)
+      // #2549: only `.permissionDenied` carries a button (the "Open Settings"
+      // pill PillCatalog attaches for that one reason) — every other `.error`
+      // reason is unchanged and installs no action binding.
+      if reason == .permissionDenied {
+        handle(
+          .pipeline(.error(reason: reason)),
+          binding: .install(
+            deliver: { [weak self] action in
+              guard case .openMicrophoneSettings = action else { return }
+              self?.openMicrophoneSettings()
+              self?.dismissSilently()
+            },
+            onExpire: nil),
+          relay: relay)
+      } else {
+        handle(.pipeline(.error(reason: reason)), binding: .none, relay: relay)
+      }
     case .advisory(let reason):
       handle(.pipeline(.advisory(reason: reason)), binding: .none, relay: relay)
     case .interruption(let reason):

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -230,8 +230,15 @@ struct OverlayRootView: View {
     case .notification:
       NotificationOverlayView(
         message: notice.text, style: Self.style(for: notice.severity),
-        isMultiline: notice.isMultiline, action: notice.action,
-        onAction: notice.action == nil ? nil : { dispatch(notice.action, on: presentation) })
+        isMultiline: notice.isMultiline, secondaryText: notice.secondaryText,
+        action: notice.action,
+        onAction: notice.action == nil ? nil : { dispatch(notice.action, on: presentation) }
+      )
+      // Same shape `.recovery` already ships: `.contain` (not `.combine`) so
+      // the action button below stays its own reachable VoiceOver element
+      // instead of being flattened into one non-interactive label.
+      .accessibilityElement(children: .contain)
+      .accessibilityLabel(notice.accessibilityLabel ?? notice.text)
     case .importStatus:
       ImportStatusOverlayView(message: notice.text)
     case .recovery:

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayRootView.swift
@@ -56,8 +56,7 @@ struct OverlayRootView: View {
   ///
   /// It reports the values PASSED to the leaf, never the values present on the
   /// definition, because those two agreeing is the thing being tested.
-  @MainActor static var leafObserverForTesting:
-    ((PresentationID, Bool, String?) -> Void)?
+  @MainActor static var leafObserverForTesting: ((PresentationID, Bool, String?) -> Void)?
 
   var body: some View {
     // **ONE snapshot read, at the top, used by everything below** (#2377 Phase 5
@@ -231,7 +230,8 @@ struct OverlayRootView: View {
     case .notification:
       NotificationOverlayView(
         message: notice.text, style: Self.style(for: notice.severity),
-        isMultiline: notice.isMultiline)
+        isMultiline: notice.isMultiline, action: notice.action,
+        onAction: notice.action == nil ? nil : { dispatch(notice.action, on: presentation) })
     case .importStatus:
       ImportStatusOverlayView(message: notice.text)
     case .recovery:

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -136,7 +136,6 @@ enum PillCatalog {
     return announcement(for: intent)
   }
 
-
   /// The spoken announcement for a pipeline intent, and its priority.
   ///
   /// **Both halves come from the shipped `apply(intent:)` switch, read one arm
@@ -207,6 +206,20 @@ enum PillCatalog {
         expiry: .after(seconds: 2.5), severity: .warning)  // NotificationStyle 2.5
 
     case .error(let reason):
+      // #2549: `.permissionDenied` gets a wider, content-sized box (no
+      // `fixedHeight` — see `notice`'s doc comment: omitting it is what makes
+      // `showPanel` call `fitToContent: true`) plus a button to the
+      // Microphone settings pane, because the fixed 280×44 single-line box
+      // truncated "Microphone access is off." mid-word. Every other `.error`
+      // reason keeps the original fixed box unchanged — those sentences are
+      // short and this is the one that was actually broken.
+      if reason == .permissionDenied {
+        return notice(
+          id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
+          width: .fixed(320),
+          expiry: .after(seconds: 6), severity: .error, isMultiline: true,
+          action: NoticeAction(label: "Open Settings", action: .openMicrophoneSettings))
+      }
       return notice(
         id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
         width: .fixed(280), fixedHeight: 44,
@@ -354,7 +367,6 @@ enum PillCatalog {
 
     }
   }
-
 
   // MARK: - Shared shape
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -206,17 +206,17 @@ enum PillCatalog {
         expiry: .after(seconds: 2.5), severity: .warning)  // NotificationStyle 2.5
 
     case .error(let reason):
-      // #2549: `.permissionDenied` gets a wider, content-sized box (no
-      // `fixedHeight` — see `notice`'s doc comment: omitting it is what makes
-      // `showPanel` call `fitToContent: true`) plus a button to the
-      // Microphone settings pane, because the fixed 280×44 single-line box
+      // #2549: `.permissionDenied` gets the same wider box the accessibility
+      // toast and recovery pills already use for a notice that carries a
+      // button (`width: .fixed(300..340), fixedHeight: 56`), plus a button to
+      // the Microphone settings pane. The fixed 280×44 single-line box
       // truncated "Microphone access is off." mid-word. Every other `.error`
       // reason keeps the original fixed box unchanged — those sentences are
       // short and this is the one that was actually broken.
       if reason == .permissionDenied {
         return notice(
           id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
-          width: .fixed(320),
+          width: .fixed(340), fixedHeight: 56,
           expiry: .after(seconds: 6), severity: .error, isMultiline: true,
           action: NoticeAction(label: "Open Settings", action: .openMicrophoneSettings))
       }

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -206,17 +206,19 @@ enum PillCatalog {
         expiry: .after(seconds: 2.5), severity: .warning)  // NotificationStyle 2.5
 
     case .error(let reason):
-      // #2549: `.permissionDenied` gets the same wider box the accessibility
-      // toast and recovery pills already use for a notice that carries a
-      // button (`width: .fixed(300..340), fixedHeight: 56`), plus a button to
-      // the Microphone settings pane. The fixed 280×44 single-line box
-      // truncated "Microphone access is off." mid-word. Every other `.error`
-      // reason keeps the original fixed box unchanged — those sentences are
-      // short and this is the one that was actually broken.
+      // #2549: `.permissionDenied` gets the richer badge+title+subtitle+button
+      // shape (founder-directed visual, matching the mockup he supplied) in a
+      // wider, taller box than the other `.error` reasons' 280×44 single line —
+      // the badge alone is 40pt tall. `accessibilityLabel` restates
+      // `DictationNarrator.copy(for: reason)` so VoiceOver keeps saying the
+      // shared, narrator-owned sentence even though the two on-screen lines
+      // are this pill's own copy, not the narrator's.
       if reason == .permissionDenied {
         return notice(
-          id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
-          width: .fixed(340), fixedHeight: 56,
+          id: id, kind: .notification, text: "Microphone access needed",
+          secondary: "Turn it on to start dictating.",
+          accessibilityLabel: DictationNarrator.copy(for: reason),
+          width: .fixed(400), fixedHeight: 64,
           expiry: .after(seconds: 6), severity: .error, isMultiline: true,
           action: NoticeAction(label: "Open Settings", action: .openMicrophoneSettings))
       }

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillRequest.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillRequest.swift
@@ -36,6 +36,11 @@ import Foundation
 enum PillAction: Equatable, Sendable {
   /// grantHandler.
   case grantAccessibility
+  /// #2549: the "Open Settings" button on the microphone-permission-denied
+  /// notice pill. Named for what it does (open the Microphone privacy pane, or
+  /// re-request access if not yet asked — `PermissionsService.requestMicrophoneAccessOrOpenSettings()`
+  /// decides which), not for the handler field, matching every other case here.
+  case openMicrophoneSettings
   /// discardRecoveryHandler.
   case discardRecovery
   /// onEscapeRecoveryPaste, which takes the `CancelUndoPayload`.

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/NotificationOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/NotificationOverlayView.swift
@@ -55,6 +55,12 @@ struct NotificationOverlayView: View {
   /// row, so one pill's wrapping was stated twice and the model's copy was
   /// ignored. The style's copy is deleted; this is the survivor.
   let isMultiline: Bool
+  /// #2549: the one button a notification may carry (mirrors
+  /// `AccessibilityToastView`'s "Grant"). `nil` for every notice that carries
+  /// none today, so this is additive to the existing single-line and advisory
+  /// shapes.
+  var action: NoticeAction?
+  var onAction: (() -> Void)?
 
   var body: some View {
     HStack(spacing: 8) {
@@ -75,6 +81,21 @@ struct NotificationOverlayView: View {
         .lineLimit(isMultiline ? nil : 1)
         .fixedSize(horizontal: false, vertical: isMultiline)
         .multilineTextAlignment(.leading)
+
+      if let action, let onAction {
+        Spacer(minLength: 8)
+        Button(action: onAction) {
+          Text(action.label)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .background(Capsule().fill(style.iconColor.opacity(0.85)))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(action.spokenLabel)
+      }
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/NotificationOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/NotificationOverlayView.swift
@@ -55,43 +55,76 @@ struct NotificationOverlayView: View {
   /// row, so one pill's wrapping was stated twice and the model's copy was
   /// ignored. The style's copy is deleted; this is the survivor.
   let isMultiline: Bool
+  /// #2549: a second line under `message`, shown only in the "carries a
+  /// button" shape below. `nil` for every existing single-string notice.
+  var secondaryText: String?
   /// #2549: the one button a notification may carry (mirrors
   /// `AccessibilityToastView`'s "Grant"). `nil` for every notice that carries
-  /// none today, so this is additive to the existing single-line and advisory
-  /// shapes.
+  /// none today, so everything below is additive to the existing single-line
+  /// and advisory shapes.
   var action: NoticeAction?
   var onAction: (() -> Void)?
 
+  /// #2549: only a notice with a button gets the richer badge/stripe
+  /// treatment. Every other `.notification` row (the compact 280x44 single
+  /// line, the borderless advisory) renders exactly as it did before this
+  /// case existed.
+  private var isRich: Bool { action != nil }
+
   var body: some View {
-    HStack(spacing: 8) {
+    HStack(spacing: isRich ? 10 : 8) {
       if style.usesDistressLips {
         RainbowLipsIcon(size: 24, audioLevel: 0, isDistress: true)
+      } else if isRich {
+        Image(systemName: style.iconName)
+          .foregroundStyle(.white)
+          .font(.system(size: 18, weight: .semibold))
+          .frame(width: 40, height: 40)
+          .background(Circle().fill(style.iconColor.opacity(0.22)))
+          .overlay(Circle().strokeBorder(style.iconColor.opacity(0.45), lineWidth: 1.5))
       } else {
         Image(systemName: style.iconName)
           .foregroundStyle(style.iconColor)
           .font(.system(size: 16))
       }
 
-      Text(message)
-        .font(.system(size: 13, weight: .medium))
-        .foregroundStyle(style.usesDistressLips ? Color.orange : .white)
-        // #1891: `.lineLimit(1)` in a 280pt box truncates the advisory sentence
-        // to a fragment. Only the advisory wraps; every other notice keeps its
-        // single-line shape exactly as before.
-        .lineLimit(isMultiline ? nil : 1)
-        .fixedSize(horizontal: false, vertical: isMultiline)
-        .multilineTextAlignment(.leading)
+      if isRich {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(message)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.white)
+          if let secondaryText {
+            Text(secondaryText)
+              .font(.system(size: 12))
+              .foregroundStyle(.white.opacity(0.65))
+          }
+        }
+      } else {
+        Text(message)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(style.usesDistressLips ? Color.orange : .white)
+          // #1891: `.lineLimit(1)` in a 280pt box truncates the advisory sentence
+          // to a fragment. Only the advisory wraps; every other notice keeps its
+          // single-line shape exactly as before.
+          .lineLimit(isMultiline ? nil : 1)
+          .fixedSize(horizontal: false, vertical: isMultiline)
+          .multilineTextAlignment(.leading)
+      }
 
       if let action, let onAction {
         Spacer(minLength: 8)
         Button(action: onAction) {
-          Text(action.label)
-            .font(.system(size: 12, weight: .semibold))
-            .foregroundStyle(.white)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 4)
-            .contentShape(Rectangle())
-            .background(Capsule().fill(style.iconColor.opacity(0.85)))
+          HStack(spacing: 4) {
+            Text(action.label)
+            Image(systemName: "arrow.up.right")
+              .font(.system(size: 10, weight: .bold))
+          }
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.white)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 6)
+          .contentShape(Rectangle())
+          .background(Capsule().fill(Color.white.opacity(0.18)))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(action.spokenLabel)
@@ -99,8 +132,24 @@ struct NotificationOverlayView: View {
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
+    .padding(.leading, isRich ? 6 : 0)
     .background(
       style.usesDistressLips
-        ? AnyView(DistressCapsuleBackground()) : AnyView(OverlayCapsuleBackground()))
+        ? AnyView(DistressCapsuleBackground()) : AnyView(OverlayCapsuleBackground())
+    )
+    .overlay(alignment: .leading) {
+      if isRich {
+        RoundedRectangle(cornerRadius: 3, style: .continuous)
+          .fill(
+            LinearGradient(
+              colors: OverlayCapsuleBackground.rainbowColors, startPoint: .top,
+              endPoint: .bottom)
+          )
+          .frame(width: 4)
+          .padding(.vertical, 8)
+          .padding(.leading, 8)
+          .accessibilityHidden(true)
+      }
+    }
   }
 }

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
@@ -62,6 +62,22 @@ struct OverlayCapsuleBackground: View {
   /// ships OFF by default and is macOS 26+.
   private var isPreview: Bool { cornerStyle == .rounded }
 
+  /// The nine brand spectrum colors, shared with anything else that draws the
+  /// rainbow gradient (#2549: the mic-permission notice's left accent bar) so
+  /// there is one list to keep in sync with `brand-guide`'s `--rainbow-full`,
+  /// not a second hand-copied one.
+  static let rainbowColors: [Color] = [
+    Color(red: 1.0, green: 0.165, blue: 0.251),  // #ff2a40 red
+    Color(red: 1.0, green: 0.549, blue: 0.0),  // #ff8c00 orange
+    Color(red: 1.0, green: 0.843, blue: 0.0),  // #ffd700 yellow
+    Color(red: 0.678, green: 1.0, blue: 0.184),  // #adff2f yellow-green
+    Color(red: 0.0, green: 0.98, blue: 0.604),  // #00fa9a mint
+    Color(red: 0.0, green: 1.0, blue: 1.0),  // #00ffff cyan
+    Color(red: 0.118, green: 0.565, blue: 1.0),  // #1e90ff dodger blue
+    Color(red: 0.255, green: 0.412, blue: 0.882),  // #4169e1 royal blue
+    Color(red: 0.541, green: 0.169, blue: 0.886),  // #8a2be2 purple
+  ]
+
   var body: some View {
     shape
       .fill(
@@ -86,19 +102,7 @@ struct OverlayCapsuleBackground: View {
       )
       .overlay(alignment: .bottom) {
         LinearGradient(
-          colors: [
-            .clear,
-            Color(red: 1.0, green: 0.165, blue: 0.251),  // #ff2a40 red
-            Color(red: 1.0, green: 0.549, blue: 0.0),  // #ff8c00 orange
-            Color(red: 1.0, green: 0.843, blue: 0.0),  // #ffd700 yellow
-            Color(red: 0.678, green: 1.0, blue: 0.184),  // #adff2f yellow-green
-            Color(red: 0.0, green: 0.98, blue: 0.604),  // #00fa9a mint
-            Color(red: 0.0, green: 1.0, blue: 1.0),  // #00ffff cyan
-            Color(red: 0.118, green: 0.565, blue: 1.0),  // #1e90ff dodger blue
-            Color(red: 0.255, green: 0.412, blue: 0.882),  // #4169e1 royal blue
-            Color(red: 0.541, green: 0.169, blue: 0.886),  // #8a2be2 purple
-            .clear,
-          ],
+          colors: [.clear] + Self.rainbowColors + [.clear],
           startPoint: .leading,
           endPoint: .trailing
         )
@@ -107,7 +111,8 @@ struct OverlayCapsuleBackground: View {
         // else — the reading well, and any capsule asked to hold still — takes
         // the chosen steady one.
         .opacity(
-          animatesGlow && cornerStyle == .capsule ? glowOpacity : Self.steadyGlowOpacity)
+          animatesGlow && cornerStyle == .capsule ? glowOpacity : Self.steadyGlowOpacity
+        )
         .padding(.horizontal, 20)
         .offset(y: -1)
       }

--- a/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
+++ b/Sources/EnviousWisprAppKit/App/StandingSnapshotBuilder.swift
@@ -47,10 +47,10 @@ struct StandingSnapshotBuilder {
       fillerRemoval: s.fillerRemovalEnabled,
       customWordsCount: customWordsCoordinator.customWords.count,
       hasApiKeys: hasKeys,
-      // Phase 3 (#1172): point-in-time microphone / Accessibility posture. A mic
-      // change is only observable across launches (macOS hides an out-of-process
-      // mic toggle from a running app), so the launch snapshot is the one place
-      // it surfaces.
+      // Phase 3 (#1172): point-in-time microphone / Accessibility posture. #2549
+      // keeps `microphoneStatus` refreshed periodically via the shared permission
+      // monitor (not just at launch), so this snapshot is now more likely to
+      // reflect an out-of-process mic toggle made while the app kept running.
       microphoneStatus: permissions.microphoneStatusString,
       accessibilityStatus: permissions.accessibilityGranted ? "granted" : "denied",
       accessibilityWarningDismissed: permissions.accessibilityWarningDismissed,

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -398,6 +398,7 @@ package final class WisprBootstrapper {
         engineMutationScope: engineMutationScope,
         outputClassifierHolder: outputClassifierHolder,
         dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
+        microphonePermissionIsDenied: { permissions.microphonePermissionIsDenied },
         egOneRuntime: egOneRuntime,
         parakeetDelivery: modelDelivery.parakeetHandle,
         batchDecodeFaultController: batchDecodeFaultController,
@@ -450,6 +451,7 @@ package final class WisprBootstrapper {
         engineMutationScope: engineMutationScope,
         outputClassifierHolder: outputClassifierHolder,
         dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
+        microphonePermissionIsDenied: { permissions.microphonePermissionIsDenied },
         egOneRuntime: egOneRuntime,
         batchDecodeFaultController: batchDecodeFaultController,
         escapeRecovery: EscapeRecoveryWiring.wire(transcriptCoordinator)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -565,6 +565,11 @@ package final class WisprBootstrapper {
       // and that captures weakly. `WisprBootstrapper` owns the service for the
       // app's lifetime regardless.
       grantAccessibility: { _ = permissions.requestAccessibilityAccess() },
+      // #2549: the notice pill's "Open Settings" button, on the SAME shared
+      // owner Part 2 of #2549 already gave the Settings page and onboarding.
+      openMicrophoneSettings: {
+        Task { await permissions.requestMicrophoneAccessOrOpenSettings() }
+      },
       // **THE SEAM PHASE 3 LEFT, NOW SPENT** (#2376 Phase 4, C6). It is a closure
       // so that it can be: the director lives for the app's lifetime, so a stored
       // pair would freeze the user's choice at launch — a picker would appear to

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -589,7 +589,8 @@ final class OnboardingV2ViewModel {
       practiceState = .somethingBroke
       return
     }
-    let grew = practiceText != practiceTextAtTakeStart
+    let grew =
+      practiceText != practiceTextAtTakeStart
       && !practiceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     // A transcript that did not reach the box IS the missed-box case, and it
     // is the only evidence that words existed at all. Requiring BOTH — the box
@@ -1633,9 +1634,10 @@ private struct PermissionsPhaseView: View {
       // within one poll cycle. Mic stays one-way below — its source is cached.
       viewModel.accessibilityGranted = axNow
 
-      // Mic stays one-way: hasMicrophonePermission reads cached microphoneStatus
-      // (PermissionsService.swift:49-50), not a live check, so mirroring it both
-      // ways could flip a true flag false from stale cache.
+      // Mic stays one-way: hasMicrophonePermission reads cached microphoneStatus,
+      // not a live check — #2549 keeps it refreshed periodically via the shared
+      // permission monitor (never on every access), so mirroring it both ways
+      // could still flip a true flag false between poll ticks.
       if permissions.hasMicrophonePermission && !viewModel.micGranted {
         viewModel.micGranted = true
         viewModel.completeStep("mic_permission", result: "granted")

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/PracticeScreen.swift
@@ -75,19 +75,14 @@ struct PracticeScreenV2: View {
 
   private func grantPermission(reason: String) async {
     if reason == "mic_denied" {
-      // `AVCaptureDevice.requestAccess` only presents the prompt from the
-      // UNDETERMINED state. After a prior denial it returns false immediately
-      // and nothing appears, so the button did nothing at all and the recovery
-      // path read as broken (cloud review). Send them where the switch is.
-      if permissions.microphonePermissionIsDenied {
-        if let url = URL(
-          string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
-        {
-          NSWorkspace.shared.open(url)
-        }
-      } else {
-        _ = await permissions.requestMicrophoneAccess()
-      }
+      // #2549: consolidated into `PermissionsService.requestMicrophoneAccessOrOpenSettings()`,
+      // the same shared owner Settings → Permissions now calls — this used to
+      // carry its own copy of the same branch. `AVCaptureDevice.requestAccess`
+      // only presents the prompt from the UNDETERMINED state; after a prior
+      // denial it returns false immediately and nothing appears, so the
+      // button did nothing at all and the recovery path read as broken
+      // (cloud review). Send them where the switch is.
+      await permissions.requestMicrophoneAccessOrOpenSettings()
     } else {
       _ = permissions.requestAccessibilityAccess()
     }
@@ -113,7 +108,9 @@ struct PracticeScreenV2: View {
     case .missedTheBox: return "Click the box first"
     case .saidNothing: return "All quiet"
     case .worked: return "That is it. You are set."
-    case .waiting: return viewModel.practiceSucceeded ? "That is it. You are set." : "Time for your first dictation!"
+    case .waiting:
+      return viewModel.practiceSucceeded
+        ? "That is it. You are set." : "Time for your first dictation!"
     }
   }
 
@@ -129,17 +126,20 @@ struct PracticeScreenV2: View {
       // Takes the blame explicitly. Someone told "we did not hear anything"
       // tries harder at a thing that is broken; someone told it was us tries
       // once more and then moves on, which is the honest ask.
-      return "Something went wrong on our side, not yours.\nTry once more, or skip ahead and dictate anywhere."
+      return
+        "Something went wrong on our side, not yours.\nTry once more, or skip ahead and dictate anywhere."
     case .missedTheBox:
       // Says what happened and what to do, and takes the blame off them. The
       // words are genuinely on the clipboard, so telling them that is useful
       // rather than a consolation.
-      return "We heard you. The box was not selected, so your words went to the clipboard.\nClick inside the box, then hold \(shortcutName) again."
+      return
+        "We heard you. The box was not selected, so your words went to the clipboard.\nClick inside the box, then hold \(shortcutName) again."
     case .saidNothing:
       // Not an error, and never worded as one: the microphone worked, there
       // was simply nothing to hear. The prompt is drawn from the persona banks
       // so it sounds like something a person would actually say.
-      return "Your microphone is working. We just did not hear anything.\nTry holding \(shortcutName) and saying: tell grandma I will call Sunday."
+      return
+        "Your microphone is working. We just did not hear anything.\nTry holding \(shortcutName) and saying: tell grandma I will call Sunday."
     case .worked:
       return "Those are your words, typed for you.\nIn any other app, click into a text box first."
     case .waiting:
@@ -168,11 +168,11 @@ struct PracticeScreenV2: View {
         .padding(.bottom, 6)
 
       Text(subhead)
-      .font(.obBody)
-      .foregroundStyle(Color.obTextSecondary)
-      .multilineTextAlignment(.center)
-      .fixedSize(horizontal: false, vertical: true)
-      .padding(.bottom, 18)
+        .font(.obBody)
+        .foregroundStyle(Color.obTextSecondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.bottom, 18)
 
       // The target. Focused on appear, because an unfocused box is exactly the
       // state this whole feature exists to remove.
@@ -185,7 +185,8 @@ struct PracticeScreenV2: View {
         .overlay(
           RoundedRectangle(cornerRadius: 12)
             .strokeBorder(
-              viewModel.practiceSucceeded ? Color.obSuccess.opacity(0.55) : Color.obAccent.opacity(0.35),
+              viewModel.practiceSucceeded
+                ? Color.obSuccess.opacity(0.55) : Color.obAccent.opacity(0.35),
               lineWidth: boxFocused ? 2 : 1)
         )
         .focused($boxFocused)

--- a/Sources/EnviousWisprAppKit/Views/Settings/PermissionsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/PermissionsSettingsView.swift
@@ -16,7 +16,11 @@ struct PermissionsSettingsView: View {
             actionLabel: "Request Access",
             action: {
               Task {
-                _ = await permissions.requestMicrophoneAccess()
+                // #2549: `requestMicrophoneAccess()` is a guaranteed no-op once
+                // already denied — Apple never re-shows the system dialog after
+                // an explicit deny. This shared method sends the user to System
+                // Settings instead when that is the case.
+                await permissions.requestMicrophoneAccessOrOpenSettings()
               }
             }
           )

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -97,6 +97,10 @@ public enum KernelDictationDriverFactory {
     /// frozen value, so an off-flip stops archiving on the very next
     /// dictation (cloud review, PR #1250).
     package let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
+    /// #2549: live mic-permission read, forwarded into the kernel's own
+    /// `microphonePermissionIsDenied` init parameter. See that property's
+    /// doc comment on `RecordingSessionKernel`.
+    package let microphonePermissionIsDenied: @MainActor () -> Bool
     /// #1271: EG-1 runtime handle for `LLMPolishStep` — same
     /// composition-root threading as `keychainManager`. Nil (tests,
     /// pre-wiring) means every `.egOne` polish silently skips.
@@ -136,6 +140,7 @@ public enum KernelDictationDriverFactory {
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
       dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+      microphonePermissionIsDenied: @escaping @MainActor () -> Bool = { false },
       egOneRuntime: (any EGOneEndpointProviding)? = nil,
       parakeetDelivery: ParakeetDeliveryHandle? = nil,
       batchDecodeFaultController: BatchDecodeFaultController? = nil,
@@ -152,6 +157,7 @@ public enum KernelDictationDriverFactory {
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
+      self.microphonePermissionIsDenied = microphonePermissionIsDenied
       self.egOneRuntime = egOneRuntime
       self.parakeetDelivery = parakeetDelivery
       self.batchDecodeFaultController = batchDecodeFaultController
@@ -181,6 +187,8 @@ public enum KernelDictationDriverFactory {
     /// dictation-audio archive (#1230). See
     /// `ParakeetInputs.dictationAudioArchiveOptInProvider`.
     package let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
+    /// #2549: live mic-permission read. See `ParakeetInputs.microphonePermissionIsDenied`.
+    package let microphonePermissionIsDenied: @MainActor () -> Bool
     /// #1271: EG-1 runtime handle. See `ParakeetInputs.egOneRuntime`.
     package let egOneRuntime: (any EGOneEndpointProviding)?
     /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1/§3.2a-i) — nil in
@@ -217,6 +225,7 @@ public enum KernelDictationDriverFactory {
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
       dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+      microphonePermissionIsDenied: @escaping @MainActor () -> Bool = { false },
       egOneRuntime: (any EGOneEndpointProviding)? = nil,
       batchDecodeFaultController: BatchDecodeFaultController? = nil,
       escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false }
@@ -233,6 +242,7 @@ public enum KernelDictationDriverFactory {
       self.captureErrorSink = captureErrorSink
       self.outputClassifierHolder = outputClassifierHolder
       self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
+      self.microphonePermissionIsDenied = microphonePermissionIsDenied
       self.egOneRuntime = egOneRuntime
       self.batchDecodeFaultController = batchDecodeFaultController
       self.escapeRecovery = escapeRecovery
@@ -309,6 +319,7 @@ public enum KernelDictationDriverFactory {
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
       dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
+      microphonePermissionIsDenied: inputs.microphonePermissionIsDenied,
       egOneRuntime: inputs.egOneRuntime,
       batchDecodeFaultController: inputs.batchDecodeFaultController,
       escapeRecovery: inputs.escapeRecovery)
@@ -344,6 +355,7 @@ public enum KernelDictationDriverFactory {
       captureErrorSink: inputs.captureErrorSink,
       outputClassifierHolder: inputs.outputClassifierHolder,
       dictationAudioArchiveOptInProvider: inputs.dictationAudioArchiveOptInProvider,
+      microphonePermissionIsDenied: inputs.microphonePermissionIsDenied,
       egOneRuntime: inputs.egOneRuntime,
       batchDecodeFaultController: inputs.batchDecodeFaultController,
       escapeRecovery: inputs.escapeRecovery)
@@ -366,6 +378,7 @@ public enum KernelDictationDriverFactory {
     captureErrorSink: @escaping HeartPathCaptureErrorSink,
     outputClassifierHolder: OutputClassifierHolder? = nil,
     dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+    microphonePermissionIsDenied: @escaping @MainActor () -> Bool = { false },
     egOneRuntime: (any EGOneEndpointProviding)? = nil,
     batchDecodeFaultController: BatchDecodeFaultController? = nil,
     escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false }
@@ -583,6 +596,7 @@ public enum KernelDictationDriverFactory {
       },
       telemetryState: telemetryState,
       dictationAudioArchiveOptInProvider: dictationAudioArchiveOptInProvider,
+      microphonePermissionIsDenied: microphonePermissionIsDenied,
       batchDecodeFaultController: batchDecodeFaultController
     )
     telemetryRelay.kernel = kernel

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -443,6 +443,15 @@ final class RecordingSessionKernel {
   /// ORs with the `EW_KEEP_DICTATION_AUDIO` env var at the archive call site.
   private let dictationAudioArchiveOptInProvider: @MainActor () -> Bool
 
+  /// #2549: live, uncached mic-permission read consulted immediately before
+  /// each capture-start attempt. macOS does not reliably throw from the
+  /// engine on a TCC-denied mic — it can start and deliver real, well-formed
+  /// zero-value buffers — so a denied take would otherwise fall through to
+  /// the zero-signal/VAD classifiers and show the muted-mic advisory instead
+  /// of "Microphone access is off." Defaults to `{ false }` so every existing
+  /// test construction site is unaffected.
+  private let microphonePermissionIsDenied: @MainActor () -> Bool
+
   // MARK: Observable surface
 
   /// The current FSM state. Callers observe; they never mutate it.
@@ -955,6 +964,8 @@ final class RecordingSessionKernel {
     markASRTimingEnd: @escaping @MainActor () -> Void = {},
     telemetryState: KernelTelemetryState = KernelTelemetryState(),
     dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
+    // #2549: see the stored property's doc comment.
+    microphonePermissionIsDenied: @escaping @MainActor () -> Bool = { false },
     // #1707 Phase 2: oracle for the shared-backend overlap Live UAT
     // (§3.2a-i). Defaulted `nil` so every existing test construction site is
     // unaffected. `BatchDecodeFaultController` is always compiled (a plain
@@ -1025,6 +1036,7 @@ final class RecordingSessionKernel {
     self.markASRTimingEnd = markASRTimingEnd
     self.telemetryState = telemetryState
     self.dictationAudioArchiveOptInProvider = dictationAudioArchiveOptInProvider
+    self.microphonePermissionIsDenied = microphonePermissionIsDenied
     self.batchDecodeFaultController = batchDecodeFaultController
   }
 
@@ -1487,6 +1499,24 @@ final class RecordingSessionKernel {
       }
     }
 
+    // #2549: check the LIVE mic permission before the first capture attempt.
+    // Re-check stopLatched/cancelRequested here too, so a stop/cancel the
+    // user already requested during warm-up cannot be preempted by a
+    // permission-denied terminal firing after it.
+    guard isCurrent(sid) else { return }
+    if stopLatched {
+      finishTerminal(.discarded(.releasedBeforeRecording), sid: sid)
+      return
+    }
+    if cancelRequested {
+      finishTerminal(.cancelled, sid: sid)
+      return
+    }
+    if microphonePermissionIsDenied() {
+      finishTerminal(.failed(.permissionDenied), sid: sid)
+      return
+    }
+
     // Capture start.
     do {
       try await audioCapture.startEnginePhase()
@@ -1532,6 +1562,23 @@ final class RecordingSessionKernel {
     captureRebuiltForFormatThisSession = !stabilized
     if !stabilized {
       audioCapture.rebuildEngine()
+      // #2549: identical check before the rebuild-retry attempt — see the
+      // first attempt's comment above for why both the user-command
+      // priority and the permission read are re-checked here rather than
+      // reused from before the rebuild.
+      guard isCurrent(sid) else { return }
+      if stopLatched {
+        finishTerminal(.discarded(.releasedBeforeRecording), sid: sid)
+        return
+      }
+      if cancelRequested {
+        finishTerminal(.cancelled, sid: sid)
+        return
+      }
+      if microphonePermissionIsDenied() {
+        finishTerminal(.failed(.permissionDenied), sid: sid)
+        return
+      }
       do {
         try await audioCapture.startEnginePhase()
       } catch {

--- a/Sources/EnviousWisprServices/PermissionsService.swift
+++ b/Sources/EnviousWisprServices/PermissionsService.swift
@@ -48,16 +48,24 @@ public final class PermissionsService {
   /// `NSWorkspace` call.
   private let openMicrophoneSettings: @MainActor (URL) -> Void
 
+  /// #2549: injected so tests can drive the monitor loop through several real
+  /// ticks in milliseconds instead of `TimingConstants.accessibilityPollIntervalSec`;
+  /// defaults to that same production value.
+  private let permissionPollIntervalNanoseconds: UInt64
+
   public init(
     accessibilityReader: @escaping () -> Bool = { AXIsProcessTrusted() },
     microphoneReader: @escaping () -> AVAuthorizationStatus = {
       AVCaptureDevice.authorizationStatus(for: .audio)
     },
-    openMicrophoneSettings: @escaping @MainActor (URL) -> Void = { NSWorkspace.shared.open($0) }
+    openMicrophoneSettings: @escaping @MainActor (URL) -> Void = { NSWorkspace.shared.open($0) },
+    permissionPollIntervalNanoseconds: UInt64 = UInt64(
+      TimingConstants.accessibilityPollIntervalSec * 1_000_000_000)
   ) {
     self.accessibilityReader = accessibilityReader
     self.microphoneReader = microphoneReader
     self.openMicrophoneSettings = openMicrophoneSettings
+    self.permissionPollIntervalNanoseconds = permissionPollIntervalNanoseconds
     microphoneStatus = microphoneReader()
     accessibilityGranted = accessibilityReader()
   }
@@ -206,8 +214,8 @@ public final class PermissionsService {
 
   /// Start smart polling for Accessibility AND Microphone permission (#2549:
   /// generalized from Accessibility-only).
-  /// Polls every TimingConstants.accessibilityPollIntervalSec seconds, but ONLY
-  /// while at least one permission is outstanding. Exits once BOTH are granted.
+  /// Polls every `permissionPollIntervalNanoseconds` (production: `TimingConstants.accessibilityPollIntervalSec`),
+  /// but ONLY while at least one permission is outstanding. Exits once BOTH are granted.
   public func startMonitoring() {
     guard permissionMonitorTask == nil || permissionMonitorTask?.isCancelled == true else {
       return
@@ -216,11 +224,11 @@ public final class PermissionsService {
 
     var lastAccessibilityGranted = accessibilityGranted
     var lastMicrophoneStatus = microphoneReader()
+    let pollInterval = permissionPollIntervalNanoseconds
 
     permissionMonitorTask = Task { [weak self] in
       while true {
-        try? await Task.sleep(
-          nanoseconds: UInt64(TimingConstants.accessibilityPollIntervalSec * 1_000_000_000))
+        try? await Task.sleep(nanoseconds: pollInterval)
         guard let self, !Task.isCancelled else { return }
         self.refreshAccessibilityStatus()
         // #2549: read the mic status ONCE this tick and reuse the single

--- a/Sources/EnviousWisprServices/PermissionsService.swift
+++ b/Sources/EnviousWisprServices/PermissionsService.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import AppKit
 import ApplicationServices
 import EnviousWisprCore
 
@@ -9,10 +10,12 @@ public final class PermissionsService {
   public private(set) var microphoneStatus: AVAuthorizationStatus = .notDetermined
   public private(set) var accessibilityGranted: Bool = false
 
-  /// Called when accessibility permission status changes — set by AppDelegate for icon updates.
-  public var onAccessibilityChange: (() -> Void)?
+  /// Called when either permission's status changes — set by AppDelegate/MenuBarController for
+  /// icon and menu updates. #2549: renamed from `onAccessibilityChange`; the monitor below now
+  /// observes both permissions, so a single accessibility-only name would be misleading.
+  public var onPermissionChange: (() -> Void)?
 
-  private var accessibilityMonitorTask: Task<Void, Never>?
+  private var permissionMonitorTask: Task<Void, Never>?
 
   /// Whether the user has explicitly dismissed the accessibility warning banner.
   /// Stored property so @Observable tracks changes and SwiftUI re-renders.
@@ -40,14 +43,21 @@ public final class PermissionsService {
   /// no-prompt system check.
   private let microphoneReader: () -> AVAuthorizationStatus
 
+  /// #2549: injected so tests can observe/intercept the System Settings
+  /// deep-link without a real window opening; defaults to the real
+  /// `NSWorkspace` call.
+  private let openMicrophoneSettings: @MainActor (URL) -> Void
+
   public init(
     accessibilityReader: @escaping () -> Bool = { AXIsProcessTrusted() },
     microphoneReader: @escaping () -> AVAuthorizationStatus = {
       AVCaptureDevice.authorizationStatus(for: .audio)
-    }
+    },
+    openMicrophoneSettings: @escaping @MainActor (URL) -> Void = { NSWorkspace.shared.open($0) }
   ) {
     self.accessibilityReader = accessibilityReader
     self.microphoneReader = microphoneReader
+    self.openMicrophoneSettings = openMicrophoneSettings
     microphoneStatus = microphoneReader()
     accessibilityGranted = accessibilityReader()
   }
@@ -70,6 +80,24 @@ public final class PermissionsService {
     TelemetryService.shared.permissionStatus(
       permission: "microphone", status: granted ? "granted" : "denied", context: "request")
     return granted
+  }
+
+  /// #2549: request microphone access when not yet asked, or send the user to
+  /// System Settings when access is already denied. Apple's `requestAccess`
+  /// API only ever shows the system dialog once, from the "not yet asked"
+  /// state — after an explicit deny it returns `false` immediately with no
+  /// dialog, every time. Single shared owner for both Settings → Permissions
+  /// and onboarding, so the branch is not copied at each call site.
+  public func requestMicrophoneAccessOrOpenSettings() async {
+    if microphonePermissionIsDenied {
+      if let url = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+      {
+        openMicrophoneSettings(url)
+      }
+    } else {
+      _ = await requestMicrophoneAccess()
+    }
   }
 
   /// Whether microphone permission has been granted.
@@ -161,34 +189,62 @@ public final class PermissionsService {
     }
   }
 
-  /// Start smart polling for Accessibility permission.
+  /// #2549: true while EITHER permission still needs the monitor watching it.
+  /// Shared by `startMonitoring()` and `restartMonitoringIfNeeded()` so they
+  /// can never disagree about when the monitor is needed.
+  private var permissionMonitoringStillNeeded: Bool {
+    !accessibilityGranted || microphonePermissionIsDenied
+  }
+
+  /// Start smart polling for Accessibility AND Microphone permission (#2549:
+  /// generalized from Accessibility-only).
   /// Polls every TimingConstants.accessibilityPollIntervalSec seconds, but ONLY
-  /// while accessibilityGranted == false. Once granted, loop exits.
+  /// while at least one permission is outstanding. Exits once BOTH are granted.
   public func startMonitoring() {
-    guard accessibilityMonitorTask == nil || accessibilityMonitorTask?.isCancelled == true else {
+    guard permissionMonitorTask == nil || permissionMonitorTask?.isCancelled == true else {
       return
     }
-    guard !accessibilityGranted else { return }
+    guard permissionMonitoringStillNeeded else { return }
 
-    accessibilityMonitorTask = Task { [weak self] in
+    var lastAccessibilityGranted = accessibilityGranted
+    var lastMicrophoneDenied = microphonePermissionIsDenied
+
+    permissionMonitorTask = Task { [weak self] in
       while true {
         try? await Task.sleep(
           nanoseconds: UInt64(TimingConstants.accessibilityPollIntervalSec * 1_000_000_000))
         guard let self, !Task.isCancelled else { return }
         self.refreshAccessibilityStatus()
-        if self.accessibilityGranted {
-          self.onAccessibilityChange?()
-          self.accessibilityMonitorTask = nil
+        // #2549: read the mic status ONCE this tick and reuse the single
+        // snapshot for the assignment, the denied-state comparison, and the
+        // exit decision — never a second, independent
+        // `microphonePermissionIsDenied` read in the same tick, which would
+        // be a separate OS call that could in principle disagree.
+        let microphoneStatusNow = self.microphoneReader()
+        self.microphoneStatus = microphoneStatusNow
+        let microphoneDeniedNow =
+          microphoneStatusNow == .denied || microphoneStatusNow == .restricted
+
+        if self.accessibilityGranted != lastAccessibilityGranted
+          || microphoneDeniedNow != lastMicrophoneDenied
+        {
+          lastAccessibilityGranted = self.accessibilityGranted
+          lastMicrophoneDenied = microphoneDeniedNow
+          self.onPermissionChange?()
+        }
+
+        if self.accessibilityGranted && !microphoneDeniedNow {
+          self.permissionMonitorTask = nil
           return
         }
       }
     }
   }
 
-  /// Restart monitoring if not running and permission is missing.
+  /// Restart monitoring if not running and either permission is still missing.
   public func restartMonitoringIfNeeded() {
-    let taskDone = accessibilityMonitorTask == nil || accessibilityMonitorTask?.isCancelled == true
-    guard taskDone && !accessibilityGranted else { return }
+    let taskDone = permissionMonitorTask == nil || permissionMonitorTask?.isCancelled == true
+    guard taskDone && permissionMonitoringStillNeeded else { return }
     startMonitoring()
   }
 }

--- a/Sources/EnviousWisprServices/PermissionsService.swift
+++ b/Sources/EnviousWisprServices/PermissionsService.swift
@@ -192,8 +192,16 @@ public final class PermissionsService {
   /// #2549: true while EITHER permission still needs the monitor watching it.
   /// Shared by `startMonitoring()` and `restartMonitoringIfNeeded()` so they
   /// can never disagree about when the monitor is needed.
+  ///
+  /// **Round-1 cloud-review finding: this must read "not yet AUTHORIZED", not
+  /// "denied".** `.notDetermined` — the ordinary state before the user has
+  /// ever been asked — is neither granted nor denied, so a denied-only check
+  /// never starts the monitor for it. A user whose very first system prompt
+  /// is a DENY is then watched by nothing: the monitor never ran, so nothing
+  /// notices the transition into denied, and nothing notices a later grant
+  /// via Open Settings either.
   private var permissionMonitoringStillNeeded: Bool {
-    !accessibilityGranted || microphonePermissionIsDenied
+    !accessibilityGranted || microphoneReader() != .authorized
   }
 
   /// Start smart polling for Accessibility AND Microphone permission (#2549:
@@ -207,7 +215,7 @@ public final class PermissionsService {
     guard permissionMonitoringStillNeeded else { return }
 
     var lastAccessibilityGranted = accessibilityGranted
-    var lastMicrophoneDenied = microphonePermissionIsDenied
+    var lastMicrophoneAuthorized = microphoneReader() == .authorized
 
     permissionMonitorTask = Task { [weak self] in
       while true {
@@ -216,24 +224,29 @@ public final class PermissionsService {
         guard let self, !Task.isCancelled else { return }
         self.refreshAccessibilityStatus()
         // #2549: read the mic status ONCE this tick and reuse the single
-        // snapshot for the assignment, the denied-state comparison, and the
-        // exit decision — never a second, independent
-        // `microphonePermissionIsDenied` read in the same tick, which would
-        // be a separate OS call that could in principle disagree.
+        // snapshot for the assignment, the authorized-state comparison, and
+        // the exit decision — never a second, independent
+        // `microphoneReader()` read in the same tick, which would be a
+        // separate OS call that could in principle disagree.
+        //
+        // Round-1 cloud-review finding: track AUTHORIZED, not denied. Denied
+        // is what the WARNING shows (`microphonePermissionIsDenied`), but the
+        // MONITOR must also keep running through `.notDetermined` — the
+        // ordinary pre-prompt state — so a first-prompt deny is still caught,
+        // and a later grant via Open Settings is still caught too.
         let microphoneStatusNow = self.microphoneReader()
         self.microphoneStatus = microphoneStatusNow
-        let microphoneDeniedNow =
-          microphoneStatusNow == .denied || microphoneStatusNow == .restricted
+        let microphoneAuthorizedNow = microphoneStatusNow == .authorized
 
         if self.accessibilityGranted != lastAccessibilityGranted
-          || microphoneDeniedNow != lastMicrophoneDenied
+          || microphoneAuthorizedNow != lastMicrophoneAuthorized
         {
           lastAccessibilityGranted = self.accessibilityGranted
-          lastMicrophoneDenied = microphoneDeniedNow
+          lastMicrophoneAuthorized = microphoneAuthorizedNow
           self.onPermissionChange?()
         }
 
-        if self.accessibilityGranted && !microphoneDeniedNow {
+        if self.accessibilityGranted && microphoneAuthorizedNow {
           self.permissionMonitorTask = nil
           return
         }

--- a/Sources/EnviousWisprServices/PermissionsService.swift
+++ b/Sources/EnviousWisprServices/PermissionsService.swift
@@ -215,7 +215,7 @@ public final class PermissionsService {
     guard permissionMonitoringStillNeeded else { return }
 
     var lastAccessibilityGranted = accessibilityGranted
-    var lastMicrophoneAuthorized = microphoneReader() == .authorized
+    var lastMicrophoneStatus = microphoneReader()
 
     permissionMonitorTask = Task { [weak self] in
       while true {
@@ -224,25 +224,30 @@ public final class PermissionsService {
         guard let self, !Task.isCancelled else { return }
         self.refreshAccessibilityStatus()
         // #2549: read the mic status ONCE this tick and reuse the single
-        // snapshot for the assignment, the authorized-state comparison, and
-        // the exit decision — never a second, independent
+        // snapshot for the assignment, the change-notification comparison,
+        // and the exit decision — never a second, independent
         // `microphoneReader()` read in the same tick, which would be a
         // separate OS call that could in principle disagree.
         //
-        // Round-1 cloud-review finding: track AUTHORIZED, not denied. Denied
-        // is what the WARNING shows (`microphonePermissionIsDenied`), but the
-        // MONITOR must also keep running through `.notDetermined` — the
-        // ordinary pre-prompt state — so a first-prompt deny is still caught,
-        // and a later grant via Open Settings is still caught too.
+        // Round-2 cloud-review finding: change-notification must compare the
+        // FULL STATUS VALUE, not a collapsed boolean. Round 1 fixed the
+        // LIFECYCLE question (keep running through `.notDetermined`) by
+        // tracking "authorized or not" — but that same boolean, reused for
+        // NOTIFICATION, is blind to a `.notDetermined` → `.denied` transition:
+        // both sides read `false`, so nothing looked like it changed, even
+        // though `microphonePermissionIsDenied` (what the warning reads) flips
+        // from false to true right there. Comparing the raw status closes the
+        // whole class at once — any transition between any two of the four
+        // states is caught, not just the ones that cross the authorized line.
         let microphoneStatusNow = self.microphoneReader()
         self.microphoneStatus = microphoneStatusNow
         let microphoneAuthorizedNow = microphoneStatusNow == .authorized
 
         if self.accessibilityGranted != lastAccessibilityGranted
-          || microphoneAuthorizedNow != lastMicrophoneAuthorized
+          || microphoneStatusNow != lastMicrophoneStatus
         {
           lastAccessibilityGranted = self.accessibilityGranted
-          lastMicrophoneAuthorized = microphoneAuthorizedNow
+          lastMicrophoneStatus = microphoneStatusNow
           self.onPermissionChange?()
         }
 

--- a/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
+++ b/Sources/EnviousWisprServices/UpdateAvailabilityService.swift
@@ -62,7 +62,7 @@ public final class UpdateAvailabilityService {
   /// #1019: AppKit-facing change hook (the `@Observable` macro only notifies
   /// SwiftUI dependency tracking; AppKit consumers — the menu-bar icon, the
   /// once-per-version notification — get no callback from it). Mirrors the
-  /// `SettingsManager.onChange` / `PermissionsService.onAccessibilityChange`
+  /// `SettingsManager.onChange` / `PermissionsService.onPermissionChange`
   /// single-slot pattern. Fired from every `state` mutation.
   @ObservationIgnored public var onAvailabilityChange: (() -> Void)?
 

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -69,6 +69,20 @@ struct MenuBarControllerTests {
     #expect(MenuBarController.iconState(s) == .recording)
   }
 
+  @Test("iconState: idle + microphone warning → error")
+  func iconStateMicrophoneWarning() {
+    // #2549
+    let s = fixture(pipelineState: .idle, showMicrophoneWarning: true)
+    #expect(MenuBarController.iconState(s) == .error)
+  }
+
+  @Test("iconState: microphone warning ignored while recording")
+  func iconStateMicrophoneWarningIgnoredWhileRecording() {
+    // #2549 — mirrors iconStateWarningIgnoredWhileRecording for Accessibility.
+    let s = fixture(pipelineState: .recording, showMicrophoneWarning: true)
+    #expect(MenuBarController.iconState(s) == .recording)
+  }
+
   @Test("iconState: idle + onboarding incomplete → error")
   func iconStateOnboardingIncomplete() {
     let s = fixture(pipelineState: .idle, onboardingComplete: false)
@@ -457,6 +471,33 @@ struct MenuBarControllerTests {
     #expect(warning?.target as AnyObject? === controller)
   }
 
+  @Test("renderMenu (d2): microphone warning → Dictation disabled item")
+  func renderMenuMicrophoneWarning() {
+    // #2549
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, showMicrophoneWarning: true))
+
+    let warning = item(menu, "Dictation disabled — Microphone access required")
+    #expect(warning != nil)
+    #expect(warning?.target as AnyObject? === controller)
+  }
+
+  @Test("renderMenu (d3): both Accessibility and microphone warnings can show together")
+  func renderMenuBothWarnings() {
+    // #2549 — no special-cased interaction; each row renders independently.
+    let controller = makeController()
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu,
+      state: fixture(
+        pipelineState: .idle, showAccessibilityWarning: true, showMicrophoneWarning: true))
+
+    #expect(item(menu, "Paste disabled — Accessibility required") != nil)
+    #expect(item(menu, "Dictation disabled — Microphone access required") != nil)
+  }
+
   @Test("renderMenu (e): hasUpdater → Check for Updates targets SparkleUpdateController")
   func renderMenuCheckForUpdates() {
     let controller = makeController()
@@ -560,6 +601,18 @@ struct MenuBarControllerTests {
     #expect(spy.fired == ["openPermissions"])
   }
 
+  @Test("microphone-warning item dispatches openPermissions")
+  func microphoneWarningItemDispatchesPermissions() {
+    // #2549
+    let spy = ActionSpy()
+    let controller = makeController(spy: spy)
+    let menu = NSMenu()
+    controller.renderMenu(
+      into: menu, state: fixture(pipelineState: .idle, showMicrophoneWarning: true))
+    perform(item(menu, "Dictation disabled — Microphone access required"))
+    #expect(spy.fired == ["openPermissions"])
+  }
+
   // MARK: - Fixtures
 
   private func fixture(
@@ -567,6 +620,7 @@ struct MenuBarControllerTests {
     onboardingComplete: Bool = true,
     vadAutoStop: Bool = false,
     showAccessibilityWarning: Bool = false,
+    showMicrophoneWarning: Bool = false,
     hasUpdater: Bool = false,
     updateAvailable: Bool = false,
     updateDisplayVersion: String? = nil,
@@ -590,6 +644,7 @@ struct MenuBarControllerTests {
       vadAutoStop: vadAutoStop,
       vadSilenceTimeout: 2.0,
       showAccessibilityWarning: showAccessibilityWarning,
+      showMicrophoneWarning: showMicrophoneWarning,
       hasUpdater: hasUpdater,
       updateAvailable: updateAvailable,
       updateDisplayVersion: updateDisplayVersion,
@@ -729,7 +784,9 @@ struct QuickAddMenuItemTests {
   /// boundary is the ordinary case, not an edge one.
   @Test("Surrounding whitespace does not reach the title")
   func whitespaceIsTrimmed() {
-    #expect(MenuBarController.quickAddItem(.ready("  clawwed \n"), fallbackEnabled: true).title == "Add \u{201C}clawwed\u{201D}")
+    #expect(
+      MenuBarController.quickAddItem(.ready("  clawwed \n"), fallbackEnabled: true).title
+        == "Add \u{201C}clawwed\u{201D}")
   }
 
   /// **A selection spanning two lines carries a newline, and a newline in a native menu title
@@ -750,7 +807,8 @@ struct QuickAddMenuItemTests {
   /// tells them nothing. Enabled, so the panel opens and states the reason.
   @Test("A refused read stays clickable so the panel can say why")
   func aRefusedReadIsNotAnEmptySelection() {
-    let blocked = MenuBarController.quickAddItem(.blocked(.accessibilityNotTrusted), fallbackEnabled: true)
+    let blocked = MenuBarController.quickAddItem(
+      .blocked(.accessibilityNotTrusted), fallbackEnabled: true)
     #expect(blocked.enabled, "the door that must be reliable cannot fail silently")
     #expect(blocked.title == "Add Selected Word")
 
@@ -758,7 +816,9 @@ struct QuickAddMenuItemTests {
     // display is deliberately uniform — the panel states the reason, not the menu — but dropping the
     // reason here is what forced the click path to re-read without the menu's cap (PR #2427).
     for why in SelectionReader.Refusal.allCases where why != .accessibilityNotTrusted {
-      #expect(MenuBarController.quickAddItem(.blocked(why), fallbackEnabled: true) == blocked, "one row for every refusal")
+      #expect(
+        MenuBarController.quickAddItem(.blocked(why), fallbackEnabled: true) == blocked,
+        "one row for every refusal")
       #expect(
         QuickAddMenuState.blocked(why).selectionResult == .refused(why),
         "and the panel is handed the refusal we measured, not a fresh guess")

--- a/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
@@ -1,9 +1,9 @@
 import AppKit
+import EnviousWisprAppKitTestSupport
 import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit
-import EnviousWisprAppKitTestSupport
 
 /// The language chip's dismissal belongs to the director, and the leaf owns no
 /// clock (#2377 Phase 5, C3).
@@ -62,14 +62,15 @@ struct LanguageChipExpiryOwnershipTests {
   func theDirectorOwnsTheChipsDismissal() throws {
     let counts = Counts()
     let armed = Armed()
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } }, effects: .recording())
+    let host = OverlayWindowHost(
+      screens: { OverlayScreenResolver { Self.screen } }, effects: .recording())
     defer { host.hide() }
     let d = OverlayDirector(
       host: host,
       scheduler: .manual { armed.work = $0 },
       announce: { _ in },
       livePreview: .disabled,
-      grantAccessibility: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
       firstRenderSchedule: { $0() })
 
     d.present(

--- a/Tests/EnviousWisprTests/App/Overlay/MicrophoneNoticeGeometryTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/MicrophoneNoticeGeometryTests.swift
@@ -17,22 +17,28 @@ import Testing
 @Suite(.tags(.productOutcome))
 struct MicrophoneNoticeGeometryTests {
 
-  @Test("permissionDenied reserves the same fixed box the other button-carrying notices use")
+  @Test("permissionDenied gets the wider badge+title+subtitle+button box")
   func permissionDeniedGeometry() throws {
     let entry = PillCatalog.entry(
       for: .error(reason: .permissionDenied), id: PresentationID())
     let definition = try #require(entry.definition)
 
-    #expect(definition.requestedWidth == .fixed(340))
+    #expect(definition.requestedWidth == .fixed(400))
     #expect(
-      definition.reservesFixedHeight == 56,
-      "matches the accessibility-toast/recovery box for a notice that carries a button")
+      definition.reservesFixedHeight == 64,
+      "the 40pt circular badge needs a taller box than the other button-carrying notices")
 
     guard case .notice(let model) = definition.content else {
       Issue.record("expected a notice, got \(definition.content)")
       return
     }
     #expect(model.isMultiline == true)
+    #expect(model.text == "Microphone access needed")
+    #expect(model.secondaryText == "Turn it on to start dictating.")
+    #expect(
+      model.accessibilityLabel == DictationNarrator.copy(for: .permissionDenied),
+      "VoiceOver keeps reading the narrator's shared sentence even though the on-screen copy is this pill's own"
+    )
     #expect(model.action?.action == .openMicrophoneSettings)
     #expect(model.action?.label == "Open Settings")
   }

--- a/Tests/EnviousWisprTests/App/Overlay/MicrophoneNoticeGeometryTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/MicrophoneNoticeGeometryTests.swift
@@ -17,16 +17,16 @@ import Testing
 @Suite(.tags(.productOutcome))
 struct MicrophoneNoticeGeometryTests {
 
-  @Test("permissionDenied is content-sized, capped at 320, with the Open Settings action")
+  @Test("permissionDenied reserves the same fixed box the other button-carrying notices use")
   func permissionDeniedGeometry() throws {
     let entry = PillCatalog.entry(
       for: .error(reason: .permissionDenied), id: PresentationID())
     let definition = try #require(entry.definition)
 
-    #expect(definition.requestedWidth == .fixed(320))
+    #expect(definition.requestedWidth == .fixed(340))
     #expect(
-      definition.reservesFixedHeight == nil,
-      "omitting fixedHeight is what makes showPanel content-size the box")
+      definition.reservesFixedHeight == 56,
+      "matches the accessibility-toast/recovery box for a notice that carries a button")
 
     guard case .notice(let model) = definition.content else {
       Issue.record("expected a notice, got \(definition.content)")

--- a/Tests/EnviousWisprTests/App/Overlay/MicrophoneNoticeGeometryTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/MicrophoneNoticeGeometryTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprCore
+
+// MARK: - MicrophoneNoticeGeometryTests (#2549)
+//
+// The founder caught the shipped `.error` notice pill truncating "Microphone
+// access is off." mid-word — a fixed 280×44, single-line box with no room to
+// grow. These assert PillCatalog's fix directly, isolated from
+// `PillCatalogParityTests`' frozen sixteen-row fixture (which this change
+// deliberately does not touch, since only ONE `.error` reason's geometry
+// changes and the fixture's own "every row covered" test already proves the
+// other fifteen rows are untouched).
+
+@Suite(.tags(.productOutcome))
+struct MicrophoneNoticeGeometryTests {
+
+  @Test("permissionDenied is content-sized, capped at 320, with the Open Settings action")
+  func permissionDeniedGeometry() throws {
+    let entry = PillCatalog.entry(
+      for: .error(reason: .permissionDenied), id: PresentationID())
+    let definition = try #require(entry.definition)
+
+    #expect(definition.requestedWidth == .fixed(320))
+    #expect(
+      definition.reservesFixedHeight == nil,
+      "omitting fixedHeight is what makes showPanel content-size the box")
+
+    guard case .notice(let model) = definition.content else {
+      Issue.record("expected a notice, got \(definition.content)")
+      return
+    }
+    #expect(model.isMultiline == true)
+    #expect(model.action?.action == .openMicrophoneSettings)
+    #expect(model.action?.label == "Open Settings")
+  }
+
+  @Test("every other error reason keeps the original fixed 280x44 box, no action")
+  func otherReasonsUnchanged() throws {
+    // A representative sample, not exhaustive — TerminalNoticeReason's full
+    // enumeration against the frozen fixture is PillCatalogParityTests' job.
+    for reason: TerminalNoticeReason in [.asrFailed, .zeroSignal, .noMicrophoneFound] {
+      let entry = PillCatalog.entry(for: .error(reason: reason), id: PresentationID())
+      let definition = try #require(entry.definition)
+
+      #expect(definition.requestedWidth == .fixed(280), "\(reason) width regressed")
+      #expect(definition.reservesFixedHeight == 44, "\(reason) height regressed")
+
+      guard case .notice(let model) = definition.content else {
+        Issue.record("expected a notice, got \(definition.content)")
+        continue
+      }
+      #expect(model.isMultiline == false, "\(reason) should not have gone multiline")
+      #expect(model.action == nil, "\(reason) should not have gained a button")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
@@ -1,8 +1,8 @@
+import EnviousWisprAppKitTestSupport
 import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
-import EnviousWisprAppKitTestSupport
 
 /// A director for tests that need one only as a DEPENDENCY (#2292, C4c).
 ///
@@ -35,7 +35,8 @@ enum OverlayTestDouble {
       host: WindowlessOverlayHost(),
       // Announcements go nowhere: a test that has not asked for a screen has not
       // asked for VoiceOver either, and the real post reaches the system.
-      announce: { _ in }, livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
+      announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      openMicrophoneSettings: {}, selections: { .shipped },
       firstRenderSchedule: { $0() })
   }
 
@@ -46,7 +47,8 @@ enum OverlayTestDouble {
     return (
       OverlayDirector(
         host: host, announce: { _ in },
-        livePreview: .disabled, grantAccessibility: {}, selections: { .shipped }, firstRenderSchedule: { $0() }),
+        livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+        selections: { .shipped }, firstRenderSchedule: { $0() }),
       host
     )
   }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -7,13 +7,13 @@
 // for, all of which are production surface. 39 cases moved into the Release lane
 // with this line.
 import AppKit
+import EnviousWisprAppKitTestSupport
 import EnviousWisprCore
 import EnviousWisprPipeline
 import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
-import EnviousWisprAppKitTestSupport
 
 /// #2292 chunk C4b. The presentation transaction.
 ///
@@ -116,6 +116,7 @@ struct OverlayDirectorTests {
         wordsCapability: { preview.isEnabled ? .available : .previewOff },
         display: { preview.display() }),
       grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+      openMicrophoneSettings: { sink.appActions.append(.openMicrophoneSettings) },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     return (d, host, sink)
@@ -188,7 +189,7 @@ struct OverlayDirectorTests {
       scheduler: .manual { _ in },
       announce: { _ in },
       livePreview: .disabled,
-      grantAccessibility: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
   }
 
@@ -256,7 +257,8 @@ struct OverlayDirectorTests {
     // Real HOST, inert panel driver (#2455 C4): the director renders through the
     // production host, whose panel is a recorder rather than a window. Held so the
     // caller can hide the host and release its content when the test ends.
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { screen } }, effects: .recording())
+    let host = OverlayWindowHost(
+      screens: { OverlayScreenResolver { screen } }, effects: .recording())
     let d = OverlayDirector(
       host: host,
       position: position,
@@ -282,6 +284,7 @@ struct OverlayDirectorTests {
         wordsCapability: { preview.isEnabled ? .available : .previewOff },
         display: { preview.display() }),
       grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+      openMicrophoneSettings: { sink.appActions.append(.openMicrophoneSettings) },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     hosts.append(host)
@@ -313,7 +316,7 @@ struct OverlayDirectorTests {
       scheduler: .manual { armed.work = $0 },
       announce: { _ in },
       livePreview: .disabled,
-      grantAccessibility: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
 
     d.present(.warning(reason: .polishFailed))
@@ -940,7 +943,8 @@ struct OverlayDirectorTests {
   @Test("a recording's effect is delivered before its geometry is resolved")
   func recordingEffectsPrecedeGeometry() {
     var recordingStarted = false
-    let host = OverlayWindowHost(screens: { OverlayScreenResolver { Self.screen } }, effects: .recording())
+    let host = OverlayWindowHost(
+      screens: { OverlayScreenResolver { Self.screen } }, effects: .recording())
     // **Both halves ride on the SAME bridge now** (#2292 C2), which states the
     // ordering this case is about more directly than the old pair did: the
     // recording signal and the geometry answer arrive together, so "did the
@@ -953,7 +957,8 @@ struct OverlayDirectorTests {
         isEnabledForGeometry: { recordingStarted },
         wordsCapability: { recordingStarted ? .available : .previewOff },
         display: { .off }),
-      grantAccessibility: {}, selections: { .shipped }, firstRenderSchedule: { $0() })
+      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
+      firstRenderSchedule: { $0() })
     Self.hosts.append(host)
     defer { Self.closeAllWindows() }
 
@@ -1424,7 +1429,7 @@ struct OverlayDirectorTests {
     let deferral = Deferral()
     let d = OverlayDirector(
       host: host, scheduler: .manual { _ in }, announce: { _ in }, livePreview: .disabled,
-      grantAccessibility: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
     defer { recorder.panel?.orderOut() }
 
@@ -1454,7 +1459,8 @@ struct OverlayDirectorTests {
     var announcements: [OverlayAnnouncement] = []
     let d = OverlayDirector(
       host: host, scheduler: .manual { _ in }, announce: { announcements.append($0) },
-      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
+      livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
 
     Self.record(d, level: 0.2)
@@ -1482,7 +1488,8 @@ struct OverlayDirectorTests {
     let deferral = Deferral()
     let d = OverlayDirector(
       host: host, scheduler: .manual { _ in }, announce: { _ in },
-      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped },
+      livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
 
     Self.record(d, level: 0.2)
@@ -1689,7 +1696,8 @@ struct OverlayDirectorTests {
     // The production `firstRenderSchedule` — the default — is the subject here.
     let d = OverlayDirector(
       host: host, announce: { _ in },
-      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
+      livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      selections: { .shipped })
 
     d.present(.warning(reason: .polishFailed))
     #expect(
@@ -1715,7 +1723,8 @@ struct OverlayDirectorTests {
     let host = WindowlessOverlayHost()
     let d = OverlayDirector(
       host: host, announce: { _ in },
-      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
+      livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      selections: { .shipped })
 
     // First request, deferred. A second replaces it before the run loop turns,
     // so the first drops on its identity gate and builds nothing.
@@ -1739,7 +1748,8 @@ struct OverlayDirectorTests {
     let host = WindowlessOverlayHost()
     let d = OverlayDirector(
       host: host, announce: { _ in },
-      livePreview: .disabled, grantAccessibility: {}, selections: { .shipped })
+      livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      selections: { .shipped })
     d.present(.warning(reason: .polishFailed))
     await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
 
@@ -1918,6 +1928,7 @@ struct OverlayDirectorTests {
       announce: { sink.announcements.append($0) },
       livePreview: .disabled,
       grantAccessibility: { sink.appActions.append(.grantAccessibility) },
+      openMicrophoneSettings: { sink.appActions.append(.openMicrophoneSettings) },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     hosts.append(host)

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
@@ -1,10 +1,10 @@
 import AppKit
 import CoreGraphics
+import EnviousWisprAppKitTestSupport
 import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit
-import EnviousWisprAppKitTestSupport
 
 /// The contract BOTH `OverlayWindowHosting` implementations must satisfy
 /// (#2292, C7).
@@ -50,6 +50,7 @@ struct OverlayHostingContractTests {
     let host = WindowlessOverlayHost()
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      openMicrophoneSettings: {},
       selections: { .shipped },
       firstRenderSchedule: { $0() })
 

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingParityTests.swift
@@ -1,8 +1,9 @@
 import AppKit
-@testable import EnviousWisprAppKit
 import EnviousWisprAppKitTestSupport
 import EnviousWisprCore
 import Testing
+
+@testable import EnviousWisprAppKit
 
 // #2455 C4 (#2461): STAYS in the unit target, and the chunk plan expected it to
 // move.
@@ -35,7 +36,8 @@ struct OverlayHostingParityTests {
   /// twice. A per-host copy is how the two definitions drift apart without
   /// anything failing.
   private static func hosts() -> [(name: String, host: any OverlayWindowHosting)] {
-    let real = OverlayWindowHost(screens: { OverlayScreenResolver { screen } }, effects: .recording())
+    let real = OverlayWindowHost(
+      screens: { OverlayScreenResolver { screen } }, effects: .recording())
     realHosts.append(real)
     return [("real", real), ("windowless", WindowlessOverlayHost())]
   }
@@ -48,6 +50,7 @@ struct OverlayHostingParityTests {
   private static func director(on host: any OverlayWindowHosting) -> OverlayDirector {
     OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      openMicrophoneSettings: {},
       selections: { .shipped },
       firstRenderSchedule: { $0() })
   }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
@@ -233,6 +233,7 @@ struct OverlayRetainedWindowBehaviourTests {
     let host = OverlayWindowHost(effects: recorder.makeEffects())
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      openMicrophoneSettings: {},
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     defer { recorder.panel?.orderOut() }
@@ -264,6 +265,7 @@ struct OverlayRetainedWindowBehaviourTests {
     let host = OverlayWindowHost(effects: recorder.makeEffects())
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
+      openMicrophoneSettings: {},
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     defer { recorder.panel?.orderOut() }

--- a/Tests/EnviousWisprTests/App/Overlay/PillCatalogParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillCatalogParityTests.swift
@@ -91,6 +91,7 @@ struct PillCatalogParityTests {
   private static func name(_ action: PillAction) -> String {
     switch action {
     case .grantAccessibility: return "grantAccessibility"
+    case .openMicrophoneSettings: return "openMicrophoneSettings"
     case .discardRecovery: return "discardRecovery"
     case .pasteEscapeRecovery: return "pasteEscapeRecovery"
     case .lockLanguage: return "lockLanguage"

--- a/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
@@ -1,11 +1,11 @@
 import CoreGraphics
+import EnviousWisprAppKitTestSupport
 import EnviousWisprCore
 import EnviousWisprPipeline
 import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
-import EnviousWisprAppKitTestSupport
 
 /// What the typed pill boundary DOES, asserted on outputs an observer outside
 /// the director can see (#2292 Phase 1).
@@ -68,6 +68,9 @@ struct PillRequestParityTests {
     /// "granted, then dismissed" from "dismissed, then granted".
     var grantSawPresentation: Bool?
     var discardSawPresentation: Bool?
+    /// #2549: same reasoning as `grantSawPresentation` above, for the
+    /// microphone notice's "Open Settings" button.
+    var openMicrophoneSettingsSawPresentation: Bool?
 
     @MainActor
     init(manualClock: Bool = false) {
@@ -85,6 +88,10 @@ struct PillRequestParityTests {
         grantAccessibility: { [self] in
           appActions.append(.grantAccessibility)
           grantSawPresentation = director.renderModel.state.presentation != nil
+        },
+        openMicrophoneSettings: { [self] in
+          appActions.append(.openMicrophoneSettings)
+          openMicrophoneSettingsSawPresentation = director.renderModel.state.presentation != nil
         },
         selections: { .shipped },
         firstRenderSchedule: { $0() })
@@ -127,8 +134,9 @@ struct PillRequestParityTests {
       lang: "es", displayName: "Spanish", state: .askToLock, generation: 1)
     let rig = Rig()
 
-    let receipt = rig.director.present(.languageChip(
-      payload: payload, onLock: {}, onDismiss: {}, onExpire: {}))
+    let receipt = rig.director.present(
+      .languageChip(
+        payload: payload, onLock: {}, onDismiss: {}, onExpire: {}))
 
     #expect(receipt != nil, "the chip was refused on an empty slot")
     // **The pipeline-intent half moved to `OverlayReducerTests`**
@@ -173,9 +181,12 @@ struct PillRequestParityTests {
     var hiddenWhenPasted: Bool?
     // Hoisted out of `#require`: the macro cannot expand a call whose argument
     // closure captures the rig, and fails with an internal diagnostic error.
-    let presented = rig.director.present(.escapeRecovery(payload: payload, onPaste: { [rig] _ in
-      hiddenWhenPasted = rig.host.isShowing == false
-    }))
+    let presented = rig.director.present(
+      .escapeRecovery(
+        payload: payload,
+        onPaste: { [rig] _ in
+          hiddenWhenPasted = rig.host.isShowing == false
+        }))
     let receipt = try #require(presented)
     try rig.host.sendUserActionThroughRoot(
       .pasteEscapeRecovery(transcriptID: payload.transcriptID), for: receipt)
@@ -226,12 +237,15 @@ struct PillRequestParityTests {
   /// presentation it does not own — which `dismissIfCurrent` would then dismiss.
   @Test("a refused feature request returns nil and leaves the incumbent") func refusalReturnsNil() {
     let rig = Rig()
-    let recording = rig.director.present(.recording(RecordingPillInput(
-      audioLevel: 0.3, audioLevelProvider: { 0.3 },
-      recordingElapsedProvider: { nil }, isLocked: false)))
+    let recording = rig.director.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0.3, audioLevelProvider: { 0.3 },
+          recordingElapsedProvider: { nil }, isLocked: false)))
     #expect(recording != nil)
-    let refused = rig.director.present(.bluetoothAwareness(
-      onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
+    let refused = rig.director.present(
+      .bluetoothAwareness(
+        onAcknowledge: {}, onClose: {}, onOpenSettings: {}))
     #expect(refused == nil, "a recording holds the slot, so the card is refused")
     #expect(rig.director.isCurrent(recording!), "the recording still owns the slot")
   }
@@ -253,14 +267,18 @@ struct PillRequestParityTests {
   @Test("a language chip is refused while a recording owns the slot")
   func refusedLanguageRequestDoesNotReplaceRecording() throws {
     let rig = Rig()
-    let recording = try #require(rig.director.present(.recording(RecordingPillInput(
-      audioLevel: 0.3, audioLevelProvider: { 0.3 },
-      recordingElapsedProvider: { nil }, isLocked: false))))
+    let recording = try #require(
+      rig.director.present(
+        .recording(
+          RecordingPillInput(
+            audioLevel: 0.3, audioLevelProvider: { 0.3 },
+            recordingElapsedProvider: { nil }, isLocked: false))))
 
-    let refused = rig.director.present(.languageChip(
-      payload: LanguageChipPayload(
-        lang: "es", displayName: "Spanish", state: .askToLock, generation: 1),
-      onLock: {}, onDismiss: {}, onExpire: {}))
+    let refused = rig.director.present(
+      .languageChip(
+        payload: LanguageChipPayload(
+          lang: "es", displayName: "Spanish", state: .askToLock, generation: 1),
+        onLock: {}, onDismiss: {}, onExpire: {}))
 
     #expect(refused == nil, "the chip was admitted over a live recording")
     #expect(
@@ -272,12 +290,16 @@ struct PillRequestParityTests {
   /// id is an ACCEPTED continuation rather than a refusal.
   @Test("a recording morph still returns a receipt") func morphReturnsReceipt() {
     let rig = Rig()
-    let first = rig.director.present(.recording(RecordingPillInput(
-      audioLevel: 0.1, audioLevelProvider: { 0.1 },
-      recordingElapsedProvider: { nil }, isLocked: false)))
-    let morph = rig.director.present(.recording(RecordingPillInput(
-      audioLevel: 0.8, audioLevelProvider: { 0.8 },
-      recordingElapsedProvider: { nil }, isLocked: false)))
+    let first = rig.director.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0.1, audioLevelProvider: { 0.1 },
+          recordingElapsedProvider: { nil }, isLocked: false)))
+    let morph = rig.director.present(
+      .recording(
+        RecordingPillInput(
+          audioLevel: 0.8, audioLevelProvider: { 0.8 },
+          recordingElapsedProvider: { nil }, isLocked: false)))
     #expect(first != nil)
     #expect(morph != nil, "a morph is accepted, not refused")
   }
@@ -290,17 +312,23 @@ struct PillRequestParityTests {
   func everyActionIsBound() throws {
     var fired: [String] = []
     let chipRig = Rig()
-    let chipReceipt = try #require(chipRig.director.present(.languageChip(
-      payload: LanguageChipPayload(lang: "es", displayName: "Spanish", state: .askToLock, generation: 1),
-      onLock: { fired.append("lock") },
-      onDismiss: { fired.append("dismiss") },
-      onExpire: { fired.append("expire") })))
+    let chipReceipt = try #require(
+      chipRig.director.present(
+        .languageChip(
+          payload: LanguageChipPayload(
+            lang: "es", displayName: "Spanish", state: .askToLock, generation: 1),
+          onLock: { fired.append("lock") },
+          onDismiss: { fired.append("dismiss") },
+          onExpire: { fired.append("expire") })))
     try chipRig.host.sendUserActionThroughRoot(.lockLanguage, for: chipReceipt)
 
     let dismissRig = Rig()
-    let dismissReceipt = try #require(dismissRig.director.present(.languageChip(
-      payload: LanguageChipPayload(lang: "es", displayName: "Spanish", state: .askToLock, generation: 1),
-      onLock: {}, onDismiss: { fired.append("dismiss") }, onExpire: {})))
+    let dismissReceipt = try #require(
+      dismissRig.director.present(
+        .languageChip(
+          payload: LanguageChipPayload(
+            lang: "es", displayName: "Spanish", state: .askToLock, generation: 1),
+          onLock: {}, onDismiss: { fired.append("dismiss") }, onExpire: {})))
     try dismissRig.host.sendUserActionThroughRoot(.dismissChip, for: dismissReceipt)
 
     for (action, label) in [
@@ -309,10 +337,12 @@ struct PillRequestParityTests {
       (PillAction.openBluetoothSettings, "settings"),
     ] {
       let rig = Rig()
-      let receipt = try #require(rig.director.present(.bluetoothAwareness(
-        onAcknowledge: { fired.append("gotIt") },
-        onClose: { fired.append("close") },
-        onOpenSettings: { fired.append("settings") })))
+      let receipt = try #require(
+        rig.director.present(
+          .bluetoothAwareness(
+            onAcknowledge: { fired.append("gotIt") },
+            onClose: { fired.append("close") },
+            onOpenSettings: { fired.append("settings") })))
       try rig.host.sendUserActionThroughRoot(action, for: receipt)
       #expect(fired.last == label, "\(label) must reach its own callback")
     }
@@ -370,6 +400,36 @@ struct PillRequestParityTests {
       "the notice the user already answered is still on screen")
   }
 
+  /// #2549: same REPRODUCIBLE shape as the Grant test above, for the
+  /// microphone-permission-denied notice's "Open Settings" button — a user
+  /// with mic access denied sees the notice and clicks the button. If it
+  /// reaches nobody, the button does nothing and the user is never sent to
+  /// the Microphone privacy pane.
+  @Test("Open Settings reaches the app action sink") func openMicrophoneSettingsIsBound() throws {
+    let rig = Rig()
+    let receipt = try #require(rig.director.present(.error(reason: .permissionDenied)))
+    try rig.host.sendUserActionThroughRoot(.openMicrophoneSettings, for: receipt)
+    #expect(rig.appActions == [.openMicrophoneSettings])
+  }
+
+  /// Same ordering guarantee as `grantRunsBeforeDismissal` above: the action
+  /// must run WHILE the notice is still showing, and the notice must be gone
+  /// by the time the button's own handler returns — never the reverse.
+  @Test("Open Settings runs before the notice is dismissed, and the notice then goes")
+  func openMicrophoneSettingsRunsBeforeDismissal() throws {
+    let rig = Rig()
+    let receipt = try #require(rig.director.present(.error(reason: .permissionDenied)))
+
+    try rig.host.sendUserActionThroughRoot(.openMicrophoneSettings, for: receipt)
+
+    #expect(
+      rig.openMicrophoneSettingsSawPresentation == true,
+      "the notice was dismissed before Open Settings ran")
+    #expect(
+      rig.director.renderModel.state.presentation == nil,
+      "the notice the user already answered is still on screen")
+  }
+
   /// **Preserves the temporary recovery transaction: notify the owner, then
   /// dismiss.** The owner still lives outside the director until C4, so only the
   /// DISMISSAL moved here; C4 replaces this split with the request-owned
@@ -412,10 +472,11 @@ struct PillRequestParityTests {
   func expiryReachesItsCallback() {
     let rig = Rig(manualClock: true)
     var expiries = 0
-    rig.director.present(.languageChip(
-      payload: LanguageChipPayload(
-        lang: "fr", displayName: "French", state: .askToLock, generation: 7),
-      onLock: {}, onDismiss: {}, onExpire: { expiries += 1 }))
+    rig.director.present(
+      .languageChip(
+        payload: LanguageChipPayload(
+          lang: "fr", displayName: "French", state: .askToLock, generation: 7),
+        onLock: {}, onDismiss: {}, onExpire: { expiries += 1 }))
 
     let armed = try! #require(rig.armedExpiry)
     armed.fire()

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
@@ -1,9 +1,9 @@
 import CoreGraphics
+import EnviousWisprAppKitTestSupport
 import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
-import EnviousWisprAppKitTestSupport
 @testable import EnviousWisprCore
 @testable import EnviousWisprPipeline
 
@@ -64,6 +64,7 @@ struct RecordingDirectorCaptureTests {
           return .off
         }),
       grantAccessibility: {},
+      openMicrophoneSettings: {},
       selections: {
         counts.selections += 1
         return selections
@@ -325,6 +326,7 @@ struct RecordingDirectorCaptureTests {
         wordsCapability: { .available },
         display: { .off }),
       grantAccessibility: {},
+      openMicrophoneSettings: {},
       selections: { .shipped },
       firstRenderSchedule: { $0() })
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
@@ -1,9 +1,9 @@
 import CoreGraphics
+import EnviousWisprAppKitTestSupport
 import Foundation
 import Testing
 
 @testable import EnviousWisprAppKit
-import EnviousWisprAppKitTestSupport
 @testable import EnviousWisprCore
 @testable import EnviousWisprPipeline
 
@@ -77,6 +77,7 @@ struct RecordingReconciliationTests {
         wordsCapability: { capability() ? .available : .previewOff },
         display: { .off }),
       grantAccessibility: {},
+      openMicrophoneSettings: {},
       selections: selections,
       firstRenderSchedule: { $0() },
       scheduleReconciliation: { queue.schedule($0) })
@@ -277,7 +278,8 @@ struct RecordingReconciliationTests {
       "expected the initial effect plus two synchronous attempts, saw \(routes) routes")
     #expect(
       queue.enqueued == 1,
-      "expected exactly one queued continuation, saw \(queue.enqueued) — an unbounded loop would have run them all synchronously and queued none")
+      "expected exactly one queued continuation, saw \(queue.enqueued) — an unbounded loop would have run them all synchronously and queued none"
+    )
     #expect(queue.pending.count == 1, "a duplicate continuation was enqueued")
 
     // **The FIRST drain must leave another continuation queued**, which is what
@@ -412,7 +414,8 @@ struct RecordingReconciliationTests {
 
     #expect(
       queue.enqueued > afterFirst,
-      "a second reconciliation could not enqueue — the coalescing flag was never cleared, so it is a permanent mute rather than coalescing")
+      "a second reconciliation could not enqueue — the coalescing flag was never cleared, so it is a permanent mute rather than coalescing"
+    )
 
     turns = 0
     while !queue.pending.isEmpty, turns < 8 {
@@ -473,17 +476,20 @@ struct RecordingReconciliationTests {
     // about the wrong scenario without it.
     guard case .notice? = d.renderModel.state.presentation?.content else {
       Issue.record(
-        "the winner did not take the slot, so the recording was never discarded: \(String(describing: d.renderModel.state.presentation?.content))")
+        "the winner did not take the slot, so the recording was never discarded: \(String(describing: d.renderModel.state.presentation?.content))"
+      )
       return
     }
-    let winner = try #require(winnerReceipt, "the winner was itself refused, so it owns no receipt to inherit")
+    let winner = try #require(
+      winnerReceipt, "the winner was itself refused, so it owns no receipt to inherit")
     #expect(
       d.renderModel.state.presentation?.id == winner.presentationID,
       "the pill on screen is not the winner, so this fixture is staging something else")
 
     #expect(
       recordingReceipt == nil,
-      "the discarded recording was handed a receipt naming \(String(describing: recordingReceipt?.presentationID))")
+      "the discarded recording was handed a receipt naming \(String(describing: recordingReceipt?.presentationID))"
+    )
     #expect(results == [.notPresented], "the discarded recording was told it was presented")
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/MicrophonePermissionPreflightTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/MicrophonePermissionPreflightTests.swift
@@ -1,0 +1,60 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// MARK: - MicrophonePermissionPreflightTests (#2549)
+//
+// Before this fix, a denied-mic take reached the zero-signal/VAD terminals
+// instead of `.permissionDenied`, because the engine-start step had no live
+// permission check of its own — only a thrown-error text match that a denied
+// mic does not reliably trigger. These tests drive the REAL
+// `RecordingSessionKernel` through the simulator fakes and assert the new
+// preflight fires before the capture engine is ever asked to start.
+
+@MainActor
+@Suite("RecordingSessionKernel — microphone-permission preflight (#2549)", .tags(.productOutcome))
+struct MicrophonePermissionPreflightTests {
+
+  private func makeSession(microphonePermissionIsDenied: @escaping @MainActor () -> Bool) -> (
+    wrapper: KernelRecordingSession, capture: FakeAudioCapture
+  ) {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste,
+      microphonePermissionIsDenied: microphonePermissionIsDenied)
+    return (wrapper, capture)
+  }
+
+  @Test("denied mic ends .failed(.permissionDenied) without ever starting the engine")
+  func deniedMicSkipsEngineStart() async {
+    let (wrapper, capture) = makeSession(microphonePermissionIsDenied: { true })
+    await wrapper.apply(.start)
+    await wrapper.drainUntilConcluded()
+
+    let kernel = wrapper.testKernel
+    #expect(kernel.recordingOutcome == .failed(.permissionDenied))
+    #expect(
+      capture.startEnginePhaseCallCount == 0,
+      "a denied-mic take must never reach the capture engine at all")
+  }
+
+  @Test("granted mic is unaffected — defaulted behavior is byte-identical to before #2549")
+  func grantedMicUnaffected() async {
+    let (wrapper, capture) = makeSession(microphonePermissionIsDenied: { false })
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+    capture.deliverBuffer(frameCount: 48000, amplitude: 0.25)
+    await wrapper.drainReadyWork()
+    await wrapper.apply(.stop)
+    await wrapper.drainUntilConcluded()
+
+    #expect(capture.startEnginePhaseCallCount == 1)
+    #expect(wrapper.testKernel.recordingOutcome == .completed)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -273,7 +273,12 @@ final class KernelRecordingSession: RecordingSessionDriving {
     /// at the kernel's construction site survived every test — the sink and the
     /// event were covered, and the step that FILLS the field was not. Defaulted
     /// so every existing scenario is unchanged.
-    onTerminalSnapshot: @escaping @MainActor (KernelTerminalTelemetrySnapshot) -> Void = { _ in }
+    onTerminalSnapshot: @escaping @MainActor (KernelTerminalTelemetrySnapshot) -> Void = { _ in },
+    /// #2549: defaults to `{ false }` (permission granted), matching the
+    /// kernel's own production default, so every existing scenario in the
+    /// 37-scenario inventory is unchanged. A scenario that wants to exercise
+    /// the denied-mic preflight passes `{ true }` explicitly.
+    microphonePermissionIsDenied: @escaping @MainActor () -> Bool = { false }
   ) {
     self.vad = vad
     let limb = self.limb
@@ -344,7 +349,8 @@ final class KernelRecordingSession: RecordingSessionDriving {
       zeroSignalRefusalSink: zeroSignalRefusalSink,
       sessionTerminalTelemetry: onTerminalSnapshot,
       markASRTimingEnd: { [asrTimingLog] in asrTimingLog.count += 1 },
-      telemetryState: telemetryState)
+      telemetryState: telemetryState,
+      microphonePermissionIsDenied: microphonePermissionIsDenied)
   }
 
   // MARK: RecordingSessionDriving — observation

--- a/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
@@ -1,3 +1,4 @@
+@preconcurrency import AVFoundation
 import EnviousWisprServices
 import Foundation
 import Testing
@@ -131,6 +132,66 @@ import Testing
       #expect(
         box.opened?.absoluteString
           == "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+    }
+
+    // #2549: runs the monitor loop for real (fast injected interval, no
+    // mocked comparison logic) through the exact transition class two
+    // cloud-review rounds found broken: a not-yet-authorized mic status
+    // changing to a DIFFERENT not-yet-authorized status. Round 1's bug and
+    // round 2's bug both collapsed the four real statuses to a yes/no
+    // "authorized" flag somewhere in this loop, so a not-determined-to-denied
+    // change looked like no change at all under either buggy version. This
+    // test fails against both prior versions and only passes once the loop
+    // compares the real status value, closing the class rather than the one
+    // reported instance of it. Uses `CountWaiters` (Pipeline/TestSupport) to
+    // park on the callback firing instead of polling real time.
+    @MainActor
+    @Test("permission monitor notices a change between two not-yet-authorized mic states")
+    func monitorNoticesNotDeterminedToDeniedTransition() async {
+      final class MicStatusBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: AVAuthorizationStatus = .notDetermined
+        func set(_ status: AVAuthorizationStatus) { lock.withLock { stored = status } }
+        var current: AVAuthorizationStatus { lock.withLock { stored } }
+      }
+
+      let micStatus = MicStatusBox()
+      var observed: [AVAuthorizationStatus] = []
+      var waiters = CountWaiters("permission-monitor-changes")
+      let svc = PermissionsService(
+        accessibilityReader: { true },
+        microphoneReader: { micStatus.current },
+        permissionPollIntervalNanoseconds: 5_000_000  // 5ms: fast, deterministic ticks
+      )
+      svc.onPermissionChange = {
+        observed.append(svc.microphoneStatus)
+        waiters.notify(reached: observed.count)
+      }
+
+      func waitForChange(count: Int) async {
+        if observed.count >= count { return }
+        let id = UUID()
+        let timeoutTask = Task {
+          try? await Task.sleep(for: .seconds(5))  // deadline-fallback: fail fast if the monitor tick never fires
+          waiters.resume(id: id)
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+          waiters.install(id: id, target: count, continuation)
+        }
+        timeoutTask.cancel()
+      }
+
+      svc.startMonitoring()
+      micStatus.set(.denied)
+      await waitForChange(count: 1)
+
+      #expect(observed == [.denied])
+      #expect(svc.microphoneStatus == .denied)
+
+      micStatus.set(.authorized)
+      await waitForChange(count: 2)
+
+      #expect(observed == [.denied, .authorized])
     }
   }
 

--- a/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
+++ b/Tests/EnviousWisprTests/Services/PermissionsServiceTests.swift
@@ -105,6 +105,33 @@ import Testing
       #expect(svc.accessibilityGranted == false)  // pure read did NOT mutate the cache
       #expect(box.events.isEmpty)  // and did NOT emit a flip event
     }
+
+    // #2549: `requestMicrophoneAccessOrOpenSettings()` — the denied branch is
+    // fully injectable and testable. The not-denied branch calls the real,
+    // un-injectable `AVCaptureDevice.requestAccess` (a pre-existing limit of
+    // `requestMicrophoneAccess()` this change does not alter), so it is not
+    // exercised here — matches the existing untested shape of that call.
+    @MainActor
+    @Test("requestMicrophoneAccessOrOpenSettings opens System Settings when already denied")
+    func deniedOpensSystemSettings() async {
+      final class OpenedURLBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: URL?
+        func set(_ url: URL) { lock.withLock { stored = url } }
+        var opened: URL? { lock.withLock { stored } }
+      }
+      let box = OpenedURLBox()
+      let svc = PermissionsService(
+        microphoneReader: { .denied },
+        openMicrophoneSettings: { box.set($0) }
+      )
+
+      await svc.requestMicrophoneAccessOrOpenSettings()
+
+      #expect(
+        box.opened?.absoluteString
+          == "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+    }
   }
 
 #endif


### PR DESCRIPTION
## Summary
- A denied microphone showed the generic "muted mic" notice instead of a permission-specific one, and the Settings "Request Access" button did nothing on a repeat denial (Apple's system prompt only ever shows once). Fixes both by checking the live permission immediately before capture starts and sending a repeat denial to System Settings instead of a silent no-op re-request.
- Extends the existing Accessibility-only background permission monitor to also watch the microphone, so the Settings row and menu bar warning update live instead of only on next launch — this needed two follow-up fixes after cloud review found the monitor's own state-change comparison collapsing the real four-value permission status into a yes/no flag in two different spots (entry/exit condition, then separately the change-notification), each hiding a real transition. Closed by comparing the raw status value everywhere a transition must be detected, and backed by a new test that runs the real monitor through the exact transition class both bugs broke.
- Redesigns the mic-denied notice pill per founder direction after Live UAT: a circular icon badge, title + subtitle copy, a vertical rainbow accent bar, and a real "Open Settings" button (the button was wired into the data model but never actually rendered in the first pass — the leaf view had no button support at all). Scoped to notices that carry a button so the four existing single-line/advisory pills are pixel-identical to before (`RenderedPillFreezeTests` pins this).

## Test plan
- [x] `scripts/xcode-test.sh` — 7,220 tests, all green (Debug lane)
- [x] New regression test drives the real permission monitor through a live not-determined → denied → authorized sequence, verified to fail against both prior buggy versions and pass only against the fix
- [x] Cloud/local Codex review: clean on the final diff (no actionable findings)
- [x] Live UAT: founder toggled mic access off/on in System Settings, confirmed the notice text, the live-updating Settings row, the redesigned pill, and the Open Settings button opening the correct pane and completing a real dictation afterward

Part of #2549.
