### PR TITLE
fix(pipeline): stop alerting Sentry on a denied microphone

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -1027,12 +1027,14 @@ final class KernelLifecycleTelemetrySink {
         asrFailedExtra,
         snapshot: recordingSnapshot())
     case .permissionDenied:
+      // #2550: microphone permission denial is a user/OS condition. Keep it
+      // countable in PostHog and available as Sentry context without filing
+      // an alerting handled-error event.
       let error =
         telemetryState.captureFailureError
         ?? KernelFallbackSentryError.permissionDenied
-      emitCaptureError(
-        error,
-        .audioCaptureFailed, "recording",
+      breadcrumb(
+        "recording", "Microphone permission denied",
         captureFailureExtra(error: error, failureMode: "permission_denied"))
     case .prepareFailed:
       let error =

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -84,6 +84,10 @@ import Testing
     }
 
     var breadcrumbs: [BreadcrumbCall] = []
+    /// #2550: the raw data dict alongside `breadcrumbs`, whose `dataKeys` only
+    /// carries sorted key names (`Any`-typed values aren't `Equatable`). Needed
+    /// to assert a specific data VALUE, e.g. `capture.failure_mode`.
+    var breadcrumbData: [[String: Any]] = []
     var vadGateNoSpeechCalls: [VADGateNoSpeechCall] = []
     var recordingStates: [RecordingStateCall] = []
     var audioRoutes: [String] = []
@@ -132,6 +136,7 @@ import Testing
           Recorder.BreadcrumbCall(
             stage: stage, message: message,
             dataKeys: (data?.keys.map { $0 } ?? []).sorted()))
+        recorder.breadcrumbData.append(data ?? [:])
       },
       updateRecordingState: { active, backend, isStreaming in
         recorder.recordingStates.append(
@@ -1216,14 +1221,22 @@ import Testing
     #expect(capturedIdentity == "boundary.unexpected_transcription_failure")
   }
 
-  @Test(".failed(.permissionDenied) emits .audioCaptureFailed captureError")
-  func failedPermissionDeniedEmission() {
+  @Test(
+    ".failed(.permissionDenied) downgrades to a breadcrumb, emits NO captureError (#2550)",
+    .bug(
+      "https://github.com/saurabhav88/EnviousWispr/issues/2550", "permission-denied Sentry noise"))
+  func failedPermissionDeniedEmission() throws {
     let recorder = Recorder()
     let sink = makeSink(recorder: recorder)
     sink.emit(.failed(.permissionDenied))
-    #expect(recorder.captureErrors.count == 1)
-    #expect(recorder.captureErrors.first?.category == .audioCaptureFailed)
-    #expect(recorder.captureErrors.first?.stage == "recording")
+    // #2550: a denied microphone is a user/OS permission state, not our
+    // defect — no alerting Sentry error, only a non-alerting breadcrumb.
+    #expect(recorder.captureErrors.isEmpty)
+    let crumb = try #require(recorder.breadcrumbs.first)
+    #expect(crumb.stage == "recording")
+    #expect(crumb.message == "Microphone permission denied")
+    #expect(
+      recorder.breadcrumbData.first?["capture.failure_mode"] as? String == "permission_denied")
   }
 
   @Test(".failed(.prepareFailed) emits .audioCaptureFailed captureError")


### PR DESCRIPTION
## Summary
- A denied microphone was filing an alerting Sentry error (`audio_capture_failed`), the same path a real capture crash uses, instead of being treated as the user/OS permission state it actually is. This is what fired the two Discord alerts during #2549's Live UAT, where mic access was deliberately toggled to test that fix.
- Routes `.permissionDenied` through the same non-alerting breadcrumb mechanism `.asrEmpty` already uses (#979), keeping the diagnostic context available on Sentry without opening a new issue for it. PostHog's `pipeline.failed.error_code=permission_denied` is unaffected — it already fires generically per terminal reason, independent of this Sentry sink.

## Test plan
- [x] Rewritten `failedPermissionDeniedEmission` confirmed to fail against the pre-fix code before this commit, then pass after
- [x] `scripts/xcode-test.sh` — 7,220 tests, all green
- [x] Local Codex code-diff review: clean, no actionable findings
- [x] `test-hardening` issue filed with a mutation recipe for the rewritten test: #2559

Not run in this pass, both requiring a Sentry OAuth login declined earlier this session: confirming historical Sentry issue `7703059828`'s exact failure reason, and a live dev-build telemetry check. Shipping on the unit-test proof, per that explicit call.

Part of #2550.
