### PR TITLE
feat(eval): give every EG-1 model a permanent id, and one place that says which won

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,13 @@ scripts/eval/apple_runner/Package.resolved
 # numbers was gitignored, got deleted, and cost a session rediscovering that
 # those scores had been measured through the wrong prompt. Tooling that produces
 # a number we later cite must survive in git.
+# EG-1 artifact registry (#2547, 2026-08-31) — the authority for which model won.
+# Tracked for the reason stated above and then some: an untracked registry is a
+# record of which artifact shipped that cannot survive a fresh clone, which is the
+# exact confusion it exists to remove.
+!scripts/eval/model-registry.json
+!scripts/eval/model_registry.py
+!scripts/eval/rebuild-model-registry.py
 !scripts/eval/classify_redundant.py
 !scripts/eval/run_cloud_type_b.py
 !scripts/eval/tts_corpus.py

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -595,6 +595,40 @@ def _rubric_identity() -> str:
         return "unreadable"
 
 
+# The floor may only ever move DOWN. Founder decision 2026-08-31: the old
+# `full_corpus_no_s4` demanded zero absolute S4, a bar NOTHING we have ever
+# shipped has cleared — EG-1 1.0 shipped at 73 and EG-1 1.1 at 65 — so it fired
+# BLOCK on every release and taught everyone to waive it. A gate that is always
+# waived is not a gate. The bar is now "never worse than the best we have on
+# record", which is passable, gets strictly harder every time we ship, and makes
+# an improvement visible instead of reporting it as a failure.
+#
+# The floor is NOT a number kept here or in a file of its own. It is derived from
+# `model-registry.json`, which already has to know which artifact won and what it
+# scored. A second home for the same fact is how the two come to disagree.
+
+
+def _s4_floor(corpus: str | None, rubric: str | None) -> tuple[int | None, str]:
+    """The floor for this corpus and rubric, or a reason there is none.
+
+    Fails toward NO FLOOR with a stated reason, never toward a permissive default:
+    a ratchet that cannot find its bar must refuse, and refusing is what makes the
+    missing-registry case loud rather than silently disarming the gate.
+    """
+    if not corpus or not rubric:
+        return None, ("this run has no corpus or rubric identity, so its count "
+                      "cannot be compared to any recorded one")
+    try:
+        sys.path.insert(0, str(Path(__file__).parent))
+        from model_registry import floor as registry_floor, RegistryError
+    except ImportError as exc:
+        return None, f"cannot load the model registry ({exc})"
+    try:
+        return registry_floor(corpus, rubric)
+    except RegistryError as exc:
+        return None, str(exc)
+
+
 def judge_identity(model: str) -> str:
     """What actually graded, as one string safe to hash into a resume stamp.
 
@@ -1467,7 +1501,8 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
               adjudicate_pct: float = DEFAULT_ADJUDICATE_PCT,
               adjudicate_min: int = DEFAULT_ADJUDICATE_MIN,
               adjudicate: bool = True,
-              blind: bool = False) -> dict:
+              blind: bool = False,
+              corpus_name: str | None = None) -> dict:
     """Run (or ingest) the behavior-aware judge and aggregate. Returns the full
     report dict. Cases with no candidate or an engine error are recorded as
     infra-skips (NOT scored as fails — an engine error is not a grading signal).
@@ -1596,7 +1631,18 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
                            # Same distinction `cacheable` already draws: an ABSENT
                            # answer and a FALSE answer are different situations,
                            # and collapsing them shipped a wrong claim twice.
-                           blind=None if external_verdicts is not None else blind)
+                           blind=None if external_verdicts is not None else blind,
+                           # Same distinction again: this file's sha IS the rubric, so
+                           # it identifies the grading only when this file did the
+                           # grading. Borrowed verdicts get None, and the ratchet then
+                           # refuses to compare rather than assuming.
+                           rubric_identity=(None if external_verdicts is not None
+                                            else _rubric_identity()),
+                           # Joined exactly as `meta.corpus_files` is, because the
+                           # registry's recorded corpus strings were read from that
+                           # field. Two spellings of one corpus would make every
+                           # comparison silently unmatchable.
+                           corpus_name=corpus_name)
     report["skipped"] = skipped
     report["missing_scores"] = missing
     report["per_case"] = per_case
@@ -1634,7 +1680,9 @@ def _is_pass(verdict: str) -> bool:
 def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list[str],
                   has_production: bool, missing_count: int = 0, skipped_count: int = 0,
                   adjudication_missing_count: int = 0,
-                  blind: bool | None = False) -> dict:
+                  blind: bool | None = False,
+                  rubric_identity: str | None = None,
+                  corpus_name: str | None = None) -> dict:
     total = len(per_case)
 
     def rate(items, pred):
@@ -1751,9 +1799,14 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
         wobble = {"status": "single replication (no wobble check)"}
 
     # Release gate — apply the conditions for which we have data.
+    # Resolved OUTSIDE the gate so a registry failure is one value the gate must
+    # handle, not an exception raised from inside a check — a guard that raises
+    # returns no verdict at all, which the caller reads as no objection.
+    s4_floor, s4_floor_source = _s4_floor(corpus_name, rubric_identity)
     gate = evaluate_new_gate(overall, smoke_metrics, trap_metrics, wobble, pairwise,
                              has_production, missing_count, skipped_count,
-                             adjudication_missing_count)
+                             adjudication_missing_count,
+                             s4_floor=s4_floor, s4_floor_source=s4_floor_source)
 
     return {
         "system": "new",
@@ -1784,9 +1837,37 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
     }
 
 
+def _add_s4_ratchet(add, overall, floor, floor_source) -> None:
+    """Never worse than the best on record, and say by how much.
+
+    `floor` is None when the comparison cannot be made — no registry, no recorded
+    winner on this corpus and rubric, or a run with no rubric of its own. Each of
+    those FAILS rather than passing, because "I could not compare" recorded as a
+    pass is how a ratchet quietly stops ratcheting. None of them is a quality
+    failure, so the message says what to fix instead of blaming the model.
+    """
+    count = overall["critical_fail_count"]
+    if floor is None:
+        add("full_corpus_s4_ratchet", False, f"{count} S4, but there is no floor to "
+            f"compare against: {floor_source}")
+        return
+    delta = floor - count
+    if count > floor:
+        add("full_corpus_s4_ratchet", False,
+            f"{count} S4, WORSE than the {floor} on record from {floor_source} "
+            f"(+{-delta}). The floor only ever moves down.")
+    else:
+        moved = (f"Accepting this lowers the floor to {count}." if delta
+                 else "Level with the floor, which therefore does not move.")
+        add("full_corpus_s4_ratchet", True,
+            f"{count} S4 against a floor of {floor} from {floor_source} "
+            f"({'-' + str(delta) if delta else 'level'}). {moved}")
+
+
 def evaluate_new_gate(overall, smoke, traps, wobble, pairwise, has_production,
                       missing_count=0, skipped_count=0,
-                      adjudication_missing_count=0) -> dict:
+                      adjudication_missing_count=0,
+                      s4_floor=None, s4_floor_source="not resolved") -> dict:
     """Apply the proposed release gate. Three-valued verdict:
       BLOCK      — a quality check FAILED (S4 / wobble / pairwise).
       INCOMPLETE — quality clean but the run did not cover every case (engine
@@ -1800,10 +1881,18 @@ def evaluate_new_gate(overall, smoke, traps, wobble, pairwise, has_production,
     def add(name, ok, detail):
         quality_checks.append({"check": name, "status": "PASS" if ok else "FAIL", "detail": detail})
 
-    add("critical_smoke_no_s4", smoke["s4_count"] == 0,
-        f"{smoke['s4_count']} S4 in {smoke['n']} critical-smoke cases (limit 0)")
-    add("full_corpus_no_s4", overall["critical_fail_count"] == 0,
-        f"{overall['critical_fail_count']} S4 across full corpus (limit 0; waiver needs founder sign-off)")
+    # A check over ZERO cases is not a pass, it is an absent measurement. Reporting
+    # PASS for `0 S4 in 0 cases` put a green row in front of the reader for a
+    # question nobody asked. N/A is the same treatment `pairwise_vs_production`
+    # already gives a missing baseline.
+    if smoke["n"] == 0:
+        quality_checks.append({"check": "critical_smoke_no_s4", "status": "N/A",
+                               "detail": "no critical-smoke cases in this run"})
+    else:
+        add("critical_smoke_no_s4", smoke["s4_count"] == 0,
+            f"{smoke['s4_count']} S4 in {smoke['n']} critical-smoke cases (limit 0)")
+
+    _add_s4_ratchet(add, overall, s4_floor, s4_floor_source)
     if wobble.get("unreliable") is not None:
         add("judge_stable", not wobble["unreliable"],
             f"rep pass-rate delta {wobble.get('delta_pp')}pp (limit {REP_PASSRATE_DELTA_MAX}pp)")
@@ -2277,7 +2366,8 @@ def main() -> int:
     if args.system == "new":
         report = score_new(norm_cases, cands, prod, args.judge, args.chunk_size,
                            external_verdicts, args.adjudicate_pct, args.adjudicate_min,
-                           adjudicate=not args.no_adjudicate, blind=args.blind)
+                           adjudicate=not args.no_adjudicate, blind=args.blind,
+                           corpus_name=",".join(p.name for p in corpus_paths))
     else:
         report = score_old(norm_cases, cands, args.judge, args.reps, args.chunk_size)
 

--- a/scripts/eval/behavior_judge.py
+++ b/scripts/eval/behavior_judge.py
@@ -595,40 +595,6 @@ def _rubric_identity() -> str:
         return "unreadable"
 
 
-# The floor may only ever move DOWN. Founder decision 2026-08-31: the old
-# `full_corpus_no_s4` demanded zero absolute S4, a bar NOTHING we have ever
-# shipped has cleared — EG-1 1.0 shipped at 73 and EG-1 1.1 at 65 — so it fired
-# BLOCK on every release and taught everyone to waive it. A gate that is always
-# waived is not a gate. The bar is now "never worse than the best we have on
-# record", which is passable, gets strictly harder every time we ship, and makes
-# an improvement visible instead of reporting it as a failure.
-#
-# The floor is NOT a number kept here or in a file of its own. It is derived from
-# `model-registry.json`, which already has to know which artifact won and what it
-# scored. A second home for the same fact is how the two come to disagree.
-
-
-def _s4_floor(corpus: str | None, rubric: str | None) -> tuple[int | None, str]:
-    """The floor for this corpus and rubric, or a reason there is none.
-
-    Fails toward NO FLOOR with a stated reason, never toward a permissive default:
-    a ratchet that cannot find its bar must refuse, and refusing is what makes the
-    missing-registry case loud rather than silently disarming the gate.
-    """
-    if not corpus or not rubric:
-        return None, ("this run has no corpus or rubric identity, so its count "
-                      "cannot be compared to any recorded one")
-    try:
-        sys.path.insert(0, str(Path(__file__).parent))
-        from model_registry import floor as registry_floor, RegistryError
-    except ImportError as exc:
-        return None, f"cannot load the model registry ({exc})"
-    try:
-        return registry_floor(corpus, rubric)
-    except RegistryError as exc:
-        return None, str(exc)
-
-
 def judge_identity(model: str) -> str:
     """What actually graded, as one string safe to hash into a resume stamp.
 
@@ -1501,8 +1467,7 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
               adjudicate_pct: float = DEFAULT_ADJUDICATE_PCT,
               adjudicate_min: int = DEFAULT_ADJUDICATE_MIN,
               adjudicate: bool = True,
-              blind: bool = False,
-              corpus_name: str | None = None) -> dict:
+              blind: bool = False) -> dict:
     """Run (or ingest) the behavior-aware judge and aggregate. Returns the full
     report dict. Cases with no candidate or an engine error are recorded as
     infra-skips (NOT scored as fails — an engine error is not a grading signal).
@@ -1631,18 +1596,7 @@ def score_new(norm_cases: dict, cands: dict, prod: dict | None,
                            # Same distinction `cacheable` already draws: an ABSENT
                            # answer and a FALSE answer are different situations,
                            # and collapsing them shipped a wrong claim twice.
-                           blind=None if external_verdicts is not None else blind,
-                           # Same distinction again: this file's sha IS the rubric, so
-                           # it identifies the grading only when this file did the
-                           # grading. Borrowed verdicts get None, and the ratchet then
-                           # refuses to compare rather than assuming.
-                           rubric_identity=(None if external_verdicts is not None
-                                            else _rubric_identity()),
-                           # Joined exactly as `meta.corpus_files` is, because the
-                           # registry's recorded corpus strings were read from that
-                           # field. Two spellings of one corpus would make every
-                           # comparison silently unmatchable.
-                           corpus_name=corpus_name)
+                           blind=None if external_verdicts is not None else blind)
     report["skipped"] = skipped
     report["missing_scores"] = missing
     report["per_case"] = per_case
@@ -1680,9 +1634,7 @@ def _is_pass(verdict: str) -> bool:
 def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list[str],
                   has_production: bool, missing_count: int = 0, skipped_count: int = 0,
                   adjudication_missing_count: int = 0,
-                  blind: bool | None = False,
-                  rubric_identity: str | None = None,
-                  corpus_name: str | None = None) -> dict:
+                  blind: bool | None = False) -> dict:
     total = len(per_case)
 
     def rate(items, pred):
@@ -1799,14 +1751,9 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
         wobble = {"status": "single replication (no wobble check)"}
 
     # Release gate — apply the conditions for which we have data.
-    # Resolved OUTSIDE the gate so a registry failure is one value the gate must
-    # handle, not an exception raised from inside a check — a guard that raises
-    # returns no verdict at all, which the caller reads as no objection.
-    s4_floor, s4_floor_source = _s4_floor(corpus_name, rubric_identity)
     gate = evaluate_new_gate(overall, smoke_metrics, trap_metrics, wobble, pairwise,
                              has_production, missing_count, skipped_count,
-                             adjudication_missing_count,
-                             s4_floor=s4_floor, s4_floor_source=s4_floor_source)
+                             adjudication_missing_count)
 
     return {
         "system": "new",
@@ -1837,37 +1784,9 @@ def aggregate_new(per_case: list[dict], rep_scores: list[dict], judged_ids: list
     }
 
 
-def _add_s4_ratchet(add, overall, floor, floor_source) -> None:
-    """Never worse than the best on record, and say by how much.
-
-    `floor` is None when the comparison cannot be made — no registry, no recorded
-    winner on this corpus and rubric, or a run with no rubric of its own. Each of
-    those FAILS rather than passing, because "I could not compare" recorded as a
-    pass is how a ratchet quietly stops ratcheting. None of them is a quality
-    failure, so the message says what to fix instead of blaming the model.
-    """
-    count = overall["critical_fail_count"]
-    if floor is None:
-        add("full_corpus_s4_ratchet", False, f"{count} S4, but there is no floor to "
-            f"compare against: {floor_source}")
-        return
-    delta = floor - count
-    if count > floor:
-        add("full_corpus_s4_ratchet", False,
-            f"{count} S4, WORSE than the {floor} on record from {floor_source} "
-            f"(+{-delta}). The floor only ever moves down.")
-    else:
-        moved = (f"Accepting this lowers the floor to {count}." if delta
-                 else "Level with the floor, which therefore does not move.")
-        add("full_corpus_s4_ratchet", True,
-            f"{count} S4 against a floor of {floor} from {floor_source} "
-            f"({'-' + str(delta) if delta else 'level'}). {moved}")
-
-
 def evaluate_new_gate(overall, smoke, traps, wobble, pairwise, has_production,
                       missing_count=0, skipped_count=0,
-                      adjudication_missing_count=0,
-                      s4_floor=None, s4_floor_source="not resolved") -> dict:
+                      adjudication_missing_count=0) -> dict:
     """Apply the proposed release gate. Three-valued verdict:
       BLOCK      — a quality check FAILED (S4 / wobble / pairwise).
       INCOMPLETE — quality clean but the run did not cover every case (engine
@@ -1881,18 +1800,10 @@ def evaluate_new_gate(overall, smoke, traps, wobble, pairwise, has_production,
     def add(name, ok, detail):
         quality_checks.append({"check": name, "status": "PASS" if ok else "FAIL", "detail": detail})
 
-    # A check over ZERO cases is not a pass, it is an absent measurement. Reporting
-    # PASS for `0 S4 in 0 cases` put a green row in front of the reader for a
-    # question nobody asked. N/A is the same treatment `pairwise_vs_production`
-    # already gives a missing baseline.
-    if smoke["n"] == 0:
-        quality_checks.append({"check": "critical_smoke_no_s4", "status": "N/A",
-                               "detail": "no critical-smoke cases in this run"})
-    else:
-        add("critical_smoke_no_s4", smoke["s4_count"] == 0,
-            f"{smoke['s4_count']} S4 in {smoke['n']} critical-smoke cases (limit 0)")
-
-    _add_s4_ratchet(add, overall, s4_floor, s4_floor_source)
+    add("critical_smoke_no_s4", smoke["s4_count"] == 0,
+        f"{smoke['s4_count']} S4 in {smoke['n']} critical-smoke cases (limit 0)")
+    add("full_corpus_no_s4", overall["critical_fail_count"] == 0,
+        f"{overall['critical_fail_count']} S4 across full corpus (limit 0; waiver needs founder sign-off)")
     if wobble.get("unreliable") is not None:
         add("judge_stable", not wobble["unreliable"],
             f"rep pass-rate delta {wobble.get('delta_pp')}pp (limit {REP_PASSRATE_DELTA_MAX}pp)")
@@ -2366,8 +2277,7 @@ def main() -> int:
     if args.system == "new":
         report = score_new(norm_cases, cands, prod, args.judge, args.chunk_size,
                            external_verdicts, args.adjudicate_pct, args.adjudicate_min,
-                           adjudicate=not args.no_adjudicate, blind=args.blind,
-                           corpus_name=",".join(p.name for p in corpus_paths))
+                           adjudicate=not args.no_adjudicate, blind=args.blind)
     else:
         report = score_old(norm_cases, cands, args.judge, args.reps, args.chunk_size)
 

--- a/scripts/eval/model-registry.json
+++ b/scripts/eval/model-registry.json
@@ -1,0 +1,1070 @@
+{
+  "_comment": "Every EG-1 model we have trained, under the artifact-ID convention. The authority for candidate status and evaluation provenance. Numbers are read from score receipts, never typed.",
+  "_idFormat": "eg1-<release>-c<NNN>. The release is what the candidate was AIMED at; the candidate number resets when the release changes. A candidate is never renamed, including when it wins.",
+  "_candidateOrder": "For rows carrying legacyExemption, the candidate number is position in the historical arm ledger (arm version order), NOT a measured training timestamp. Do not read c007 as 'trained seventh by date'.",
+  "_comparability": "An evaluation is comparable to another ONLY when corpus, rubricIdentity and judgeIdentity all match. Nine rubrics and 38 corpora appear across this history; ranking across them is the mistake this file exists to prevent.",
+  "artifacts": [
+    {
+      "artifactId": "eg1-1.0-c001",
+      "release": "1.0",
+      "status": "superseded",
+      "statusReason": "Replaced by 1.1. The monolith is retired and deleted on upgrade.",
+      "legacyNames": [
+        "eg1-v1-monolith",
+        "eg1_sealed.jsonl",
+        "eg1_shipped.jsonl",
+        "arm_eg1_candidates.jsonl",
+        "eg1_gold150_candidates.jsonl",
+        "candidates_eg1_native_1890.jsonl",
+        "eg1_shipped_holdout900.jsonl",
+        "eg1_shipped_trained1690.jsonl",
+        "eg1_promptprobe_sealed.jsonl",
+        "eg1_probe_v3_sealed.jsonl",
+        "arm_eg1_candidates_v3.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 81.8,
+          "s4Count": 73,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/s1mini-2026-08-26/scores_eg1_v1_archived/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 81.6,
+          "s4Count": 75,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_eg1/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 82.6,
+          "s4Count": 85,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_eg1_probe_v3/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 81.2,
+          "s4Count": 87,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_eg1_promptprobe/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 89.7,
+          "s4Count": 72,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/scores_eg1_sealed/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "401bcf0b2929",
+          "runComplete": true,
+          "passRatePct": 75.9,
+          "s4Count": 66,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-2026-08-15/scores_arm_eg1/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "14e84d338924",
+          "runComplete": true,
+          "passRatePct": 69.4,
+          "s4Count": 52,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "531e6c619736",
+          "runComplete": true,
+          "passRatePct": 68.7,
+          "s4Count": 67,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v2/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "1f7313cb4f29",
+          "runComplete": false,
+          "passRatePct": 73.2,
+          "s4Count": 50,
+          "casesScored": 1837,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v3/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "b2b8274414f0",
+          "runComplete": false,
+          "passRatePct": 72.6,
+          "s4Count": 53,
+          "casesScored": 1860,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v4/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861_v2.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 76.5,
+          "s4Count": 53,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-2026-08-15/scores_v2_eg1/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861_v3.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 76.8,
+          "s4Count": 50,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/goldset-2026-08-15/scores_v3_eg1/summary.json"
+        },
+        {
+          "corpus": "speechpath_gold150.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 78.7,
+          "s4Count": 2,
+          "casesScored": 150,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-v8-2026-08-15/scores_gold150_eg1/summary.json"
+        },
+        {
+          "corpus": "type_b_approved_1890.jsonl",
+          "judgeIdentity": "claude-sonnet-5",
+          "rubricIdentity": null,
+          "runComplete": null,
+          "passRatePct": 93.7,
+          "s4Count": 8,
+          "casesScored": 1890,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/type-b-1199/eg1_native_shipped_1890/scores/summary.json"
+        },
+        {
+          "corpus": "type_b_parakeet.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": null,
+          "runComplete": true,
+          "passRatePct": 81.1,
+          "s4Count": 42,
+          "casesScored": 1690,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/typeb-holdout-parakeet-2026-08-12/scores_eg1_trained/summary.json"
+        },
+        {
+          "corpus": "type_b_parakeet_holdout900.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": null,
+          "runComplete": true,
+          "passRatePct": 76.0,
+          "s4Count": 18,
+          "casesScored": 900,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/typeb-holdout-parakeet-2026-08-12/scores_eg1_shipped/summary.json"
+        },
+        {
+          "corpus": "type_b_v2_2559.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": null,
+          "runComplete": true,
+          "passRatePct": 61.7,
+          "s4Count": 207,
+          "casesScored": 2559,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/typeb-v2-2026-08-13/scores_eg1/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c001",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "No-op rate trimmed. +0.1pp, p=0.90 — null.",
+      "legacyNames": [
+        "v6capped",
+        "arm_v6capped_candidates.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "401bcf0b2929",
+          "runComplete": true,
+          "passRatePct": 76.0,
+          "s4Count": 51,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-2026-08-15/scores_arm_v6capped/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c002",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "All non-production inputs reshaped. -2.0pp, p=0.015 — WORSE.",
+      "legacyNames": [
+        "v6prod",
+        "arm_v6prod_candidates.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "401bcf0b2929",
+          "runComplete": true,
+          "passRatePct": 73.9,
+          "s4Count": 71,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-2026-08-15/scores_arm_v6prod/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c003",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "Drills reshaped to production shape. +0.5pp, p=0.55 — null.",
+      "legacyNames": [
+        "v7drills",
+        "arm_v7drills_candidates.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "speechpath_1861.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "401bcf0b2929",
+          "runComplete": true,
+          "passRatePct": 76.4,
+          "s4Count": 57,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-2026-08-15/scores_arm_v7drills/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c004",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "+3,437 synthetic SFT drills. -2.0pp, p=0.021 — WORSE.",
+      "legacyNames": [
+        "v8",
+        "arm_v8_candidates.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "speechpath_1861_v3.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 74.4,
+          "s4Count": 78,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-v8-2026-08-15/scores_v8/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c005",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "Preference pairs at 5e-6 x1. 99% of outputs byte-identical to the base — null.",
+      "legacyNames": [
+        "dpo1",
+        "dpo1_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 89.7,
+          "s4Count": 69,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/scores_dpo1_sealed/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c006",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "Preference pairs at 3e-5 x2. Over-optimised: formatted 100% of wanted cases AND 39.9% of flat ones, restraint 85% -> 49%. Killed before a sealed run, so it has no evaluation receipt.",
+      "legacyNames": [
+        "dpo2"
+      ],
+      "legacyExemption": true,
+      "evaluations": []
+    },
+    {
+      "artifactId": "eg1-1.1-c007",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "Preference pairs at 1.2e-5 x1. Beaten by dpo4 on the same corpus.",
+      "legacyNames": [
+        "dpo3",
+        "dpo3_sealed.jsonl",
+        "dpo3_speechpath.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 83.7,
+          "s4Count": 72,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_dpo3/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 89.9,
+          "s4Count": 64,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/scores_dpo3_sealed/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861_v3.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 75.9,
+          "s4Count": 56,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-v8-2026-08-15/scores_dpo3_speechpath/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c008",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "Meaning-weighted pairs, 30% structure. The only arm of its line to improve every dimension at once, and still not the arm that shipped.",
+      "legacyNames": [
+        "dpo4",
+        "dpo4_sealed.jsonl",
+        "dpo4_speechpath.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 83.4,
+          "s4Count": 71,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_dpo4/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": true,
+          "passRatePct": 90.6,
+          "s4Count": 59,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/scores_dpo4_sealed/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861_v3.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "c9cf6ca83fc4",
+          "runComplete": false,
+          "passRatePct": 76.5,
+          "s4Count": 43,
+          "casesScored": 1765,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/eg2-v8-2026-08-15/scores_dpo4_speechpath/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c009",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "SFT list drills. Lists solved, self_correction fell 71.2 -> 65.3.",
+      "legacyNames": [
+        "v13",
+        "v13_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 84.7,
+          "s4Count": 65,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v13/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c010",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "SFT hinge gate. Superseded within the same line.",
+      "legacyNames": [
+        "v14",
+        "v14_sealed.jsonl",
+        "v14_promptprobe_sealed.jsonl",
+        "v14_fluidprompt_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 87.8,
+          "s4Count": 65,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v14/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 86.9,
+          "s4Count": 61,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v14_fluidprompt/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 89.1,
+          "s4Count": 67,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v14_promptprobe/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c011",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "SFT marker classes. Superseded within the same line.",
+      "legacyNames": [
+        "v15",
+        "v15_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 87.2,
+          "s4Count": 69,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v15/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c012",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "v15 corpus trained ON a fuller prompt. p=1.00 — in SFT the system prompt is a constant prefix and carries no gradient.",
+      "legacyNames": [
+        "v15align",
+        "v15align_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 87.8,
+          "s4Count": 75,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v15align/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c013",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "Marker prior rebalanced. First arm ever to beat EG-1 1.0 on self_correction.",
+      "legacyNames": [
+        "v17",
+        "v17_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 88.7,
+          "s4Count": 66,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v17/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c014",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "+ list-trigger prior rebalanced. Beat cloud +120/-89, p=0.038.",
+      "legacyNames": [
+        "v18",
+        "v18_sealed.jsonl",
+        "v18_speechpath.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 89.7,
+          "s4Count": 67,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v18/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861_v3.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 71.3,
+          "s4Count": 99,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v18/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c015",
+      "release": "1.1",
+      "status": "rejected",
+      "statusReason": "Superseded by v20 within the same line.",
+      "legacyNames": [
+        "v19",
+        "v19_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 88.9,
+          "s4Count": 69,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v19/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.1-c016",
+      "release": "1.1",
+      "status": "shipped",
+      "statusReason": "SHIPPED as EG-1 1.1, delivery revision v3-eg2, shards eg-1-v2-*. Lineage evidence: branch feat/eg2-v20-model, docs/eg2-campaign/build_v20_manifest.py and shard_v20.sh, and the commit 'point the shipped manifests at model revision v3-eg2' on that branch.",
+      "legacyNames": [
+        "v20",
+        "v20_sealed.jsonl",
+        "v20_speechpath.jsonl",
+        "eg1_v2_installed_sealed.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "ce234dcb8cac",
+          "runComplete": true,
+          "passRatePct": 89.9,
+          "s4Count": 65,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/ratchet-seed-2026-08-31/eg1_11/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 90.3,
+          "s4Count": 66,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/s1mini-2026-08-26/scores_eg1_v2_installed/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 90.6,
+          "s4Count": 65,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v20/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 90.4,
+          "s4Count": 63,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v20_confirm/summary.json"
+        },
+        {
+          "corpus": "speechpath_1861_v3.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 72.6,
+          "s4Count": 98,
+          "casesScored": 1861,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v20/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.2-c001",
+      "release": "1.2",
+      "status": "rejected",
+      "statusReason": "Round 1. 4 genuine stable critical regressions against shipped 1.1.",
+      "legacyNames": [
+        "v21email",
+        "sealed_v21.jsonl",
+        "typeb_v21.jsonl",
+        "tail_v21.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 91.6,
+          "s4Count": 36,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/scores_sealed/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": false,
+          "passRatePct": 92.1,
+          "s4Count": 28,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/scores_sealed_incomplete_commute/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 64.1,
+          "s4Count": 9,
+          "casesScored": 117,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read1/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 60.7,
+          "s4Count": 13,
+          "casesScored": 117,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read2/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 65.0,
+          "s4Count": 10,
+          "casesScored": 117,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read3/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 59.0,
+          "s4Count": 16,
+          "casesScored": 117,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read4/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 63.2,
+          "s4Count": 10,
+          "casesScored": 117,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read5/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 68.3,
+          "s4Count": 8,
+          "casesScored": 249,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read1/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 65.9,
+          "s4Count": 8,
+          "casesScored": 249,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read2/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 69.1,
+          "s4Count": 8,
+          "casesScored": 249,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read3/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 66.3,
+          "s4Count": 8,
+          "casesScored": 249,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read4/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 69.1,
+          "s4Count": 10,
+          "casesScored": 249,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read5/summary.json"
+        },
+        {
+          "corpus": "type_b_parakeet.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 86.7,
+          "s4Count": 22,
+          "casesScored": 1690,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/v21email-2026-08-31/scores_typeb/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.2-c002",
+      "release": "1.2",
+      "status": "rejected",
+      "statusReason": "Round 2. Made meaning WORSE (5 genuine regressions): a drill gate forced every one of 263 rows shorter, so the model learned to delete.",
+      "legacyNames": [
+        "v22round2",
+        "sealed_v22.jsonl",
+        "email_v22.jsonl",
+        "tail_v22.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "email_bench_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 76.4,
+          "s4Count": 16,
+          "casesScored": 356,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/email-bench-2026-08-31/scores_email_v22/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 91.9,
+          "s4Count": 32,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round2-2026-08-31/scores_sealed_v22/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 63.3,
+          "s4Count": 9,
+          "casesScored": 139,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read1/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 64.0,
+          "s4Count": 9,
+          "casesScored": 139,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read2/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 62.6,
+          "s4Count": 12,
+          "casesScored": 139,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read3/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 64.0,
+          "s4Count": 4,
+          "casesScored": 139,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read4/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 64.0,
+          "s4Count": 12,
+          "casesScored": 139,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read5/summary.json"
+        }
+      ]
+    },
+    {
+      "artifactId": "eg1-1.2-c003",
+      "release": "1.2",
+      "status": "selected",
+      "statusReason": "Round 3. Zero genuine stable critical regressions, email held at +75. Won but NOT yet shipped: the shards are not uploaded, and two founder decisions are open (the absolute S4 waiver, and two verbatim_passthrough refusals).",
+      "legacyNames": [
+        "v23round3",
+        "sealed_v23.jsonl",
+        "email_v23.jsonl",
+        "typeb_v23.jsonl",
+        "tail_v23.jsonl"
+      ],
+      "legacyExemption": true,
+      "evaluations": [
+        {
+          "corpus": "email_bench_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 75.8,
+          "s4Count": 11,
+          "casesScored": 356,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/scores_email_v23/summary.json"
+        },
+        {
+          "corpus": "sealed_v1.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 92.4,
+          "s4Count": 31,
+          "casesScored": 1462,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/scores_sealed_v23/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 73.5,
+          "s4Count": 12,
+          "casesScored": 132,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read1/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 75.8,
+          "s4Count": 7,
+          "casesScored": 132,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read2/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 70.5,
+          "s4Count": 9,
+          "casesScored": 132,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read3/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 68.9,
+          "s4Count": 10,
+          "casesScored": 132,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read4/summary.json"
+        },
+        {
+          "corpus": "tail_corpus.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 74.2,
+          "s4Count": 7,
+          "casesScored": 132,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read5/summary.json"
+        },
+        {
+          "corpus": "type_b_parakeet.jsonl",
+          "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
+          "rubricIdentity": "626d3a1c5219",
+          "runComplete": true,
+          "passRatePct": 87.0,
+          "s4Count": 30,
+          "casesScored": 1690,
+          "verdict": "BLOCK",
+          "summaryPath": "scripts/eval/runs/round3-2026-08-31/scores_typeb_v23/summary.json"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/eval/model-registry.json
+++ b/scripts/eval/model-registry.json
@@ -25,6 +25,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -36,6 +37,7 @@
           "summaryPath": "scripts/eval/runs/s1mini-2026-08-26/scores_eg1_v1_archived/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -47,6 +49,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_eg1/summary.json"
         },
         {
+          "promptVariant": "probe_v3",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -58,6 +61,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_eg1_probe_v3/summary.json"
         },
         {
+          "promptVariant": "promptprobe",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -69,6 +73,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_eg1_promptprobe/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -80,6 +85,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/scores_eg1_sealed/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "401bcf0b2929",
@@ -91,6 +97,7 @@
           "summaryPath": "scripts/eval/runs/eg2-2026-08-15/scores_arm_eg1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "14e84d338924",
@@ -102,6 +109,7 @@
           "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "531e6c619736",
@@ -113,6 +121,7 @@
           "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v2/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "1f7313cb4f29",
@@ -124,6 +133,7 @@
           "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v3/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "b2b8274414f0",
@@ -135,6 +145,7 @@
           "summaryPath": "scripts/eval/runs/speechpath-2026-08-13-r2/scores_v4/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861_v2.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -146,6 +157,7 @@
           "summaryPath": "scripts/eval/runs/eg2-2026-08-15/scores_v2_eg1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861_v3.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -157,6 +169,7 @@
           "summaryPath": "scripts/eval/runs/goldset-2026-08-15/scores_v3_eg1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_gold150.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -168,6 +181,7 @@
           "summaryPath": "scripts/eval/runs/eg2-v8-2026-08-15/scores_gold150_eg1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "type_b_approved_1890.jsonl",
           "judgeIdentity": "name-only:claude-sonnet-5",
           "rubricIdentity": null,
@@ -179,6 +193,7 @@
           "summaryPath": "scripts/eval/runs/type-b-1199/eg1_native_shipped_1890/scores/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "type_b_parakeet.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": null,
@@ -190,6 +205,7 @@
           "summaryPath": "scripts/eval/runs/typeb-holdout-parakeet-2026-08-12/scores_eg1_trained/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "type_b_parakeet_holdout900.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": null,
@@ -201,6 +217,7 @@
           "summaryPath": "scripts/eval/runs/typeb-holdout-parakeet-2026-08-12/scores_eg1_shipped/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "type_b_v2_2559.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": null,
@@ -225,6 +242,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "401bcf0b2929",
@@ -249,6 +267,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "401bcf0b2929",
@@ -273,6 +292,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "401bcf0b2929",
@@ -297,6 +317,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861_v3.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -321,6 +342,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -357,6 +379,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -368,6 +391,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_dpo3/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -379,6 +403,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/scores_dpo3_sealed/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861_v3.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -404,6 +429,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -415,6 +441,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_dpo4/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -426,6 +453,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/scores_dpo4_sealed/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861_v3.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "c9cf6ca83fc4",
@@ -450,6 +478,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -476,6 +505,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -487,6 +517,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v14/summary.json"
         },
         {
+          "promptVariant": "fluidprompt",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -498,6 +529,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v14_fluidprompt/summary.json"
         },
         {
+          "promptVariant": "promptprobe",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -522,6 +554,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -546,6 +579,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -570,6 +604,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -595,6 +630,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -606,6 +642,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v18/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861_v3.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -630,6 +667,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -656,6 +694,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "ce234dcb8cac",
@@ -667,6 +706,7 @@
           "summaryPath": "scripts/eval/runs/ratchet-seed-2026-08-31/eg1_11/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -678,6 +718,7 @@
           "summaryPath": "scripts/eval/runs/s1mini-2026-08-26/scores_eg1_v2_installed/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -689,6 +730,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v20/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -700,6 +742,7 @@
           "summaryPath": "scripts/eval/runs/sealed-2026-08-15/regrade_v20_confirm/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "speechpath_1861_v3.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -726,6 +769,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -737,6 +781,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/scores_sealed/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -748,6 +793,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/scores_sealed_incomplete_commute/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -759,6 +805,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -770,6 +817,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read2/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -781,6 +829,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read3/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -792,6 +841,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read4/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -803,6 +853,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/sealed_tail_five/read5/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -814,6 +865,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -825,6 +877,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read2/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -836,6 +889,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read3/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -847,6 +901,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read4/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -858,6 +913,7 @@
           "summaryPath": "scripts/eval/runs/v21email-2026-08-31/tail_read5/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "type_b_parakeet.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -884,6 +940,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "email_bench_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -895,6 +952,7 @@
           "summaryPath": "scripts/eval/runs/email-bench-2026-08-31/scores_email_v22/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -906,6 +964,7 @@
           "summaryPath": "scripts/eval/runs/round2-2026-08-31/scores_sealed_v22/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -917,6 +976,7 @@
           "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -928,6 +988,7 @@
           "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read2/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -939,6 +1000,7 @@
           "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read3/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -950,6 +1012,7 @@
           "summaryPath": "scripts/eval/runs/round2-2026-08-31/tail_read4/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -977,6 +1040,7 @@
       "legacyExemption": true,
       "evaluations": [
         {
+          "promptVariant": "own",
           "corpus": "email_bench_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -988,6 +1052,7 @@
           "summaryPath": "scripts/eval/runs/round3-2026-08-31/scores_email_v23/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "sealed_v1.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -999,6 +1064,7 @@
           "summaryPath": "scripts/eval/runs/round3-2026-08-31/scores_sealed_v23/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -1010,6 +1076,7 @@
           "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read1/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -1021,6 +1088,7 @@
           "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read2/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -1032,6 +1100,7 @@
           "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read3/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -1043,6 +1112,7 @@
           "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read4/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "tail_corpus.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",
@@ -1054,6 +1124,7 @@
           "summaryPath": "scripts/eval/runs/round3-2026-08-31/tail_read5/summary.json"
         },
         {
+          "promptVariant": "own",
           "corpus": "type_b_parakeet.jsonl",
           "judgeIdentity": "azure/gpt-5-6-luna@d9697a344ff6",
           "rubricIdentity": "626d3a1c5219",

--- a/scripts/eval/model-registry.json
+++ b/scripts/eval/model-registry.json
@@ -169,7 +169,7 @@
         },
         {
           "corpus": "type_b_approved_1890.jsonl",
-          "judgeIdentity": "claude-sonnet-5",
+          "judgeIdentity": "name-only:claude-sonnet-5",
           "rubricIdentity": null,
           "runComplete": null,
           "passRatePct": 93.7,

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -110,6 +110,20 @@ def load(path: Path = REGISTRY_PATH) -> dict:
                         f"{want if isinstance(want, type) else 'a number'}. A value of "
                         f"the right name and the wrong type passes every comparison "
                         f"floor() makes, by failing all of them.")
+
+            # RANGE, after type. A number can be well-typed and impossible, and an
+            # impossible one is not caught by any comparison either: a negative
+            # s4Count would set a floor nothing can ever beat, and a count larger
+            # than the corpus describes an exam that did not happen.
+            n, s4, pct = e["casesScored"], e["s4Count"], e["passRatePct"]
+            if n <= 0:
+                raise RegistryError(f"{aid}: casesScored {n} — an exam with no cases")
+            if not 0 <= s4 <= n:
+                raise RegistryError(
+                    f"{aid}: s4Count {s4} outside 0..{n}. A negative floor can never "
+                    f"be beaten; one above the corpus size describes a different exam.")
+            if not 0 <= pct <= 100:
+                raise RegistryError(f"{aid}: passRatePct {pct} outside 0..100")
             # `rubricIdentity` may be NULL and the key must still be present. A run
             # scored from borrowed verdicts genuinely has no rubric of its own —
             # 197 of our 329 historical receipts are that shape. Deleting them

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -86,7 +86,7 @@ def load(path: Path = REGISTRY_PATH) -> dict:
             # row without it raises KeyError from inside `floor()` — a validator that
             # passed such a row would be certifying data that crashes its own reader.
             for field in ("corpus", "passRatePct", "s4Count", "casesScored",
-                          "summaryPath", "judgeIdentity"):
+                          "summaryPath", "judgeIdentity", "promptVariant"):
                 if e.get(field) is None:
                     raise RegistryError(
                         f"{aid}: an evaluation is missing {field}; a score with no "
@@ -111,13 +111,17 @@ def load(path: Path = REGISTRY_PATH) -> dict:
 
 
 def comparable(evaluation: dict, corpus: str, rubric: str, judge: str) -> bool:
-    """All three, because the module docstring says all three and a predicate that
-    checked two would have quietly contradicted it. An Azure deployment can be
-    repointed in place, so the same corpus and rubric graded through a different
-    deployment are two different graders wearing one name."""
+    """Corpus, rubric, judge — and the run must have used the artifact's OWN prompt.
+
+    An Azure deployment can be repointed in place, so the same corpus and rubric
+    graded through a different deployment are two graders wearing one name. And a
+    prompt PROBE attaches to the artifact it experimented on while describing a
+    configuration that was never selected or shipped, so letting one set the floor
+    would gate releases on a prompt we do not serve."""
     return (evaluation["corpus"] == corpus
             and evaluation["rubricIdentity"] == rubric
-            and evaluation["judgeIdentity"] == judge)
+            and evaluation["judgeIdentity"] == judge
+            and evaluation["promptVariant"] == "own")
 
 
 def floor(corpus: str, rubric: str, judge: str,
@@ -188,14 +192,16 @@ def cmd_list(args) -> int:
             complete = [e for e in sealed if e.get("runComplete") is True]
             groups: dict[tuple, dict] = {}
             for e in complete:
-                key = (e["corpus"], e["rubricIdentity"], e["judgeIdentity"])
+                key = (e["corpus"], e["rubricIdentity"], e["judgeIdentity"],
+                       e["promptVariant"])
                 if key not in groups or e["s4Count"] < groups[key]["s4Count"]:
                     groups[key] = e
-            for (_c, rubric, judge), e in sorted(
+            for (_c, rubric, judge, variant), e in sorted(
                     groups.items(), key=lambda kv: -kv[1]["passRatePct"]):
+                tag = "" if variant == "own" else f", PROMPT PROBE: {variant}"
                 print(f"      {e['passRatePct']}% pass, {e['s4Count']} serious "
                       f"({e['casesScored']} cases, rubric "
-                      f"{(rubric or 'external')[:8]}, judge {judge})")
+                      f"{(rubric or 'external')[:8]}, judge {judge}{tag})")
             if not groups:
                 why = (f"{len(sealed)} sealed_v1 run(s) on record, all INCOMPLETE"
                        if sealed else "no sealed_v1 score on record")

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -16,7 +16,7 @@ CLI:
     model_registry.py list                 every artifact, newest release first
     model_registry.py list --release 1.2   one release
     model_registry.py validate             schema + convention + one-winner rules
-    model_registry.py floor --corpus sealed_v1.jsonl --rubric <id>
+    model_registry.py floor --corpus sealed_v1.jsonl --rubric <id> --judge <id>
 """
 import argparse
 import json
@@ -69,7 +69,11 @@ def load(path: Path = REGISTRY_PATH) -> dict:
         if not aid.startswith(f"eg1-{a.get('release')}-"):
             raise RegistryError(f"{aid}: id does not match release {a.get('release')!r}")
         if a["status"] in EXCLUSIVE:
-            winners.setdefault((a["release"], a["status"]), []).append(aid)
+            # Keyed by RELEASE ALONE, not by (release, status). Both statuses set
+            # the floor, so a release holding one `selected` and a different
+            # `shipped` artifact has two winners and the floor would depend on
+            # which. Grouping by status would have let that pass.
+            winners.setdefault(a["release"], []).append(f"{aid} ({a['status']})")
         for e in a.get("evaluations") or []:
             for field in ("corpus", "passRatePct", "s4Count", "casesScored",
                           "summaryPath"):
@@ -88,19 +92,26 @@ def load(path: Path = REGISTRY_PATH) -> dict:
                     f"{aid}: an evaluation omits the rubricIdentity key. Write null "
                     f"for a run scored from external verdicts; do not leave it out.")
 
-    for (release, status), ids in winners.items():
+    for release, ids in winners.items():
         if len(ids) > 1:
             raise RegistryError(
-                f"release {release} has {len(ids)} artifacts marked {status}: "
-                f"{', '.join(ids)}. Exactly one may win.")
+                f"release {release} has {len(ids)} winning artifacts: "
+                f"{', '.join(ids)}. Exactly one may be selected or shipped.")
     return doc
 
 
-def comparable(evaluation: dict, corpus: str, rubric: str) -> bool:
-    return evaluation["corpus"] == corpus and evaluation["rubricIdentity"] == rubric
+def comparable(evaluation: dict, corpus: str, rubric: str, judge: str) -> bool:
+    """All three, because the module docstring says all three and a predicate that
+    checked two would have quietly contradicted it. An Azure deployment can be
+    repointed in place, so the same corpus and rubric graded through a different
+    deployment are two different graders wearing one name."""
+    return (evaluation["corpus"] == corpus
+            and evaluation["rubricIdentity"] == rubric
+            and evaluation["judgeIdentity"] == judge)
 
 
-def floor(corpus: str, rubric: str, doc: dict | None = None) -> tuple[int | None, str]:
+def floor(corpus: str, rubric: str, judge: str,
+          doc: dict | None = None) -> tuple[int | None, str]:
     """The best S4 count on record for this corpus and rubric, and where it came from.
 
     Only `shipped` and `selected` artifacts set the floor. A `candidate` has not
@@ -121,13 +132,14 @@ def floor(corpus: str, rubric: str, doc: dict | None = None) -> tuple[int | None
         if a["status"] not in EXCLUSIVE:
             continue
         for e in a.get("evaluations") or []:
-            if not comparable(e, corpus, rubric) or e.get("runComplete") is not True:
+            if (not comparable(e, corpus, rubric, judge)
+                    or e.get("runComplete") is not True):
                 continue
             if best is None or e["s4Count"] < best[0]:
                 best = (e["s4Count"], a["artifactId"], e["summaryPath"])
     if best is None:
         return None, (f"no complete evaluation of a shipped or selected artifact on "
-                      f"corpus {corpus} under rubric {rubric}")
+                      f"corpus {corpus} under rubric {rubric} judged by {judge}")
     return best[0], f"{best[1]} ({best[2]})"
 
 
@@ -174,7 +186,7 @@ def cmd_validate(_args) -> int:
 
 
 def cmd_floor(args) -> int:
-    count, where = floor(args.corpus, args.rubric)
+    count, where = floor(args.corpus, args.rubric, args.judge)
     if count is None:
         print(f"NO FLOOR: {where}", file=sys.stderr)
         return 1
@@ -189,6 +201,7 @@ def main() -> int:
     p = sub.add_parser("validate"); p.set_defaults(fn=cmd_validate)
     p = sub.add_parser("floor")
     p.add_argument("--corpus", required=True); p.add_argument("--rubric", required=True)
+    p.add_argument("--judge", required=True, help="judge identity, exactly as recorded")
     p.set_defaults(fn=cmd_floor)
     args = ap.parse_args()
     try:

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""The authority for "which EG-1 model is this, and which one won".
+
+Reads `model-registry.json`. Every EG-1 model we have trained has exactly one
+immutable artifact ID here, `eg1-<release>-c<NNN>`, and every score we have on it
+is attached with the corpus, rubric and judge that produced it.
+
+WHY THE PROVENANCE FIELDS ARE NOT OPTIONAL. Across our history the receipts carry
+nine different rubric identities and thirty-eight different corpora. Two numbers
+from different rubrics are not two measurements of the same thing, they are two
+different questions, and putting them in one column is exactly the confusion this
+file exists to prevent. So nothing here ever ranks across a rubric or a corpus
+boundary; it groups by them and refuses when asked to cross one.
+
+CLI:
+    model_registry.py list                 every artifact, newest release first
+    model_registry.py list --release 1.2   one release
+    model_registry.py validate             schema + convention + one-winner rules
+    model_registry.py floor --corpus sealed_v1.jsonl --rubric <id>
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REGISTRY_PATH = Path(__file__).parent / "model-registry.json"
+ID_RE = re.compile(r"^eg1-[0-9]+\.[0-9]+-c[0-9]{3}$")
+STATUSES = ("candidate", "rejected", "selected", "shipped", "superseded")
+# At most one of each per release: two winners is the ambiguity, not a tidiness rule.
+EXCLUSIVE = ("selected", "shipped")
+
+
+class RegistryError(Exception):
+    """Anything that would make the registry answer confidently and wrongly."""
+
+
+def load(path: Path = REGISTRY_PATH) -> dict:
+    """Read and validate. Every failure raises; none returns a default.
+
+    A registry that cannot be read must stop its caller, not hand back an empty
+    one — an empty registry answers "no artifact has ever won", which is a
+    confident wrong answer to the only question this file exists to answer.
+    """
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RegistryError(f"cannot read {path.name} ({exc})") from exc
+    except ValueError as exc:
+        raise RegistryError(f"{path.name} is not valid JSON ({exc})") from exc
+
+    artifacts = doc.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise RegistryError(f"{path.name} carries no artifacts")
+
+    seen = set()
+    winners: dict[tuple[str, str], list[str]] = {}
+    for a in artifacts:
+        aid = a.get("artifactId")
+        if not isinstance(aid, str) or not ID_RE.match(aid):
+            raise RegistryError(f"bad artifact id {aid!r}: expected eg1-<release>-c<NNN>")
+        if aid in seen:
+            raise RegistryError(f"duplicate artifact id {aid}")
+        seen.add(aid)
+        if a.get("status") not in STATUSES:
+            raise RegistryError(f"{aid}: status {a.get('status')!r} not in {STATUSES}")
+        if not a.get("statusReason"):
+            raise RegistryError(f"{aid}: status {a['status']} with no reason")
+        if not aid.startswith(f"eg1-{a.get('release')}-"):
+            raise RegistryError(f"{aid}: id does not match release {a.get('release')!r}")
+        if a["status"] in EXCLUSIVE:
+            winners.setdefault((a["release"], a["status"]), []).append(aid)
+        for e in a.get("evaluations") or []:
+            for field in ("corpus", "passRatePct", "s4Count", "casesScored",
+                          "summaryPath"):
+                if e.get(field) is None:
+                    raise RegistryError(
+                        f"{aid}: an evaluation is missing {field}; a score with no "
+                        f"provenance cannot be compared to anything")
+            # `rubricIdentity` may be NULL and the key must still be present. A run
+            # scored from borrowed verdicts genuinely has no rubric of its own —
+            # 197 of our 329 historical receipts are that shape. Deleting them
+            # would destroy real history; the honest record is the number WITH the
+            # fact that nothing produced by us graded it. `floor()` requires an
+            # exact rubric match, so a null can never set a bar.
+            if "rubricIdentity" not in e:
+                raise RegistryError(
+                    f"{aid}: an evaluation omits the rubricIdentity key. Write null "
+                    f"for a run scored from external verdicts; do not leave it out.")
+
+    for (release, status), ids in winners.items():
+        if len(ids) > 1:
+            raise RegistryError(
+                f"release {release} has {len(ids)} artifacts marked {status}: "
+                f"{', '.join(ids)}. Exactly one may win.")
+    return doc
+
+
+def comparable(evaluation: dict, corpus: str, rubric: str) -> bool:
+    return evaluation["corpus"] == corpus and evaluation["rubricIdentity"] == rubric
+
+
+def floor(corpus: str, rubric: str, doc: dict | None = None) -> tuple[int | None, str]:
+    """The best S4 count on record for this corpus and rubric, and where it came from.
+
+    Only `shipped` and `selected` artifacts set the floor. A `candidate` has not
+    been accepted by anyone, and letting an unreviewed run move the bar would mean
+    a single lucky grading could raise a wall nothing can clear afterwards.
+
+    Where one artifact has SEVERAL runs on the same corpus and rubric — the shipped
+    1.1 has three, reading 66, 65 and 63 — the LOWEST is taken. "The best we have
+    on record" is what the founder asked for, and it is the reading that makes the
+    bar hardest rather than easiest.
+
+    Returns (count, description); count is None when nothing qualifies, and the
+    description then says why.
+    """
+    doc = doc if doc is not None else load()
+    best = None
+    for a in doc["artifacts"]:
+        if a["status"] not in EXCLUSIVE:
+            continue
+        for e in a.get("evaluations") or []:
+            if not comparable(e, corpus, rubric) or e.get("runComplete") is not True:
+                continue
+            if best is None or e["s4Count"] < best[0]:
+                best = (e["s4Count"], a["artifactId"], e["summaryPath"])
+    if best is None:
+        return None, (f"no complete evaluation of a shipped or selected artifact on "
+                      f"corpus {corpus} under rubric {rubric}")
+    return best[0], f"{best[1]} ({best[2]})"
+
+
+def cmd_list(args) -> int:
+    doc = load()
+    rows = [a for a in doc["artifacts"]
+            if args.release is None or a["release"] == args.release]
+    for release in sorted({a["release"] for a in rows}, reverse=True):
+        print(f"\n=== EG-1 {release} " + "=" * 46)
+        for a in [r for r in rows if r["release"] == release]:
+            mark = {"shipped": "SHIPPED", "selected": "WON, not shipped",
+                    "superseded": "superseded", "rejected": "", "candidate": "untested"}
+            print(f"  {a['artifactId']:16s} {mark[a['status']]:17s} "
+                  f"was: {a['legacyNames'][0]}")
+            # COMPLETE runs only. An incomplete run's numbers are better than the
+            # truth by exactly the cases nobody scored, so showing one as an
+            # artifact's headline is how a loser comes to look like a winner.
+            # Measured here: round 1 carried an incomplete run reading 92.1% / 28
+            # serious beside its real 91.6% / 36, and the first version of this
+            # display printed the incomplete one — which made round 1 look better
+            # than the round that actually won.
+            sealed = [e for e in a.get("evaluations") or []
+                      if e["corpus"] == "sealed_v1.jsonl"]
+            complete = [e for e in sealed if e.get("runComplete") is True]
+            best = sorted(complete, key=lambda e: -(e["passRatePct"] or 0))
+            for e in best[:1]:
+                rubric = (e["rubricIdentity"] or "external")[:8]
+                print(f"      {e['passRatePct']}% pass, {e['s4Count']} serious "
+                      f"({e['casesScored']} cases, rubric {rubric})")
+            if not best:
+                why = (f"{len(sealed)} sealed_v1 run(s) on record, all INCOMPLETE"
+                       if sealed else "no sealed_v1 score on record")
+                print(f"      {why}")
+            print(f"      {a['statusReason']}")
+    return 0
+
+
+def cmd_validate(_args) -> int:
+    doc = load()
+    n = sum(len(a.get("evaluations") or []) for a in doc["artifacts"])
+    print(f"OK: {len(doc['artifacts'])} artifacts, {n} evaluations, "
+          f"ids and one-winner-per-release rules hold")
+    return 0
+
+
+def cmd_floor(args) -> int:
+    count, where = floor(args.corpus, args.rubric)
+    if count is None:
+        print(f"NO FLOOR: {where}", file=sys.stderr)
+        return 1
+    print(f"{count} S4 — {where}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("list"); p.add_argument("--release"); p.set_defaults(fn=cmd_list)
+    p = sub.add_parser("validate"); p.set_defaults(fn=cmd_validate)
+    p = sub.add_parser("floor")
+    p.add_argument("--corpus", required=True); p.add_argument("--rubric", required=True)
+    p.set_defaults(fn=cmd_floor)
+    args = ap.parse_args()
+    try:
+        return args.fn(args)
+    except RegistryError as exc:
+        print(f"REGISTRY ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -157,7 +157,12 @@ def cmd_list(args) -> int:
     doc = load()
     rows = [a for a in doc["artifacts"]
             if args.release is None or a["release"] == args.release]
-    for release in sorted({a["release"] for a in rows}, reverse=True):
+    # NUMERIC, not string: at 1.10 a string sort puts 1.9 above it and the CLI's
+    # promise of "newest release first" would point a reader at an older winner.
+    # Same axis as the pinned ids — an ordering derived from the wrong property.
+    for release in sorted({a["release"] for a in rows},
+                          key=lambda v: tuple(int(part) for part in v.split(".")),
+                          reverse=True):
         print(f"\n=== EG-1 {release} " + "=" * 46)
         for a in [r for r in rows if r["release"] == release]:
             mark = {"shipped": "SHIPPED", "selected": "WON, not shipped",

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -85,12 +85,31 @@ def load(path: Path = REGISTRY_PATH) -> dict:
             # `judgeIdentity` is REQUIRED, not optional: `comparable()` reads it, so a
             # row without it raises KeyError from inside `floor()` — a validator that
             # passed such a row would be certifying data that crashes its own reader.
-            for field in ("corpus", "passRatePct", "s4Count", "casesScored",
-                          "summaryPath", "judgeIdentity", "promptVariant"):
-                if e.get(field) is None:
+            # TYPE, not just presence. `floor()` compares with `is not True` and with
+            # `==`, so a value of the right NAME and the wrong type — `run_complete:
+            # "true"`, or a case count as a string — passes validation and then makes
+            # `floor()` silently skip a winning row. Checking every field's type here
+            # closes that axis rather than the one field a reviewer happened to name.
+            # `bool` is excluded from the numeric checks deliberately: in Python
+            # `isinstance(True, int)` is True, so a boolean would sneak through as a
+            # count.
+            required = {
+                "corpus": str, "summaryPath": str, "judgeIdentity": str,
+                "promptVariant": str, "s4Count": int, "casesScored": int,
+                "passRatePct": (int, float),
+            }
+            for field, want in required.items():
+                value = e.get(field)
+                if value is None:
                     raise RegistryError(
                         f"{aid}: an evaluation is missing {field}; a score with no "
                         f"provenance cannot be compared to anything")
+                if isinstance(value, bool) or not isinstance(value, want):
+                    raise RegistryError(
+                        f"{aid}: {field} is {type(value).__name__} {value!r}, expected "
+                        f"{want if isinstance(want, type) else 'a number'}. A value of "
+                        f"the right name and the wrong type passes every comparison "
+                        f"floor() makes, by failing all of them.")
             # `rubricIdentity` may be NULL and the key must still be present. A run
             # scored from borrowed verdicts genuinely has no rubric of its own —
             # 197 of our 329 historical receipts are that shape. Deleting them
@@ -103,11 +122,16 @@ def load(path: Path = REGISTRY_PATH) -> dict:
             # is real history. What must not happen is the key going MISSING, because
             # `floor()` reads both and a dropped key would silently skip the row while
             # `validate` reported success.
-            for optional in ("rubricIdentity", "runComplete"):
+            for optional, want in (("rubricIdentity", str), ("runComplete", bool)):
                 if optional not in e:
                     raise RegistryError(
                         f"{aid}: an evaluation omits the {optional} key. Write null "
                         f"when the receipt does not record it; do not leave it out.")
+                value = e[optional]
+                if value is not None and not isinstance(value, want):
+                    raise RegistryError(
+                        f"{aid}: {optional} is {type(value).__name__} {value!r}; "
+                        f"expected {want.__name__} or null.")
 
     for release, ids in winners.items():
         if len(ids) > 1:

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -74,7 +74,14 @@ def load(path: Path = REGISTRY_PATH) -> dict:
             # `shipped` artifact has two winners and the floor would depend on
             # which. Grouping by status would have let that pass.
             winners.setdefault(a["release"], []).append(f"{aid} ({a['status']})")
-        for e in a.get("evaluations") or []:
+        # The KEY must exist. `a.get("evaluations") or []` reads a typo'd or dropped
+        # key as "this artifact was never scored", which is a claim, not an absence.
+        # The three other reads of this field all run on a doc that came through here,
+        # so guarding it once is enough.
+        if not isinstance(a.get("evaluations"), list):
+            raise RegistryError(f"{aid}: no evaluations list. Write [] for an artifact "
+                                f"with no receipt; do not omit the key.")
+        for e in a["evaluations"]:
             # `judgeIdentity` is REQUIRED, not optional: `comparable()` reads it, so a
             # row without it raises KeyError from inside `floor()` — a validator that
             # passed such a row would be certifying data that crashes its own reader.
@@ -180,7 +187,7 @@ def cmd_list(args) -> int:
                 if key not in groups or e["s4Count"] < groups[key]["s4Count"]:
                     groups[key] = e
             for (_c, rubric, judge), e in sorted(
-                    groups.items(), key=lambda kv: -(kv[1]["passRatePct"] or 0)):
+                    groups.items(), key=lambda kv: -kv[1]["passRatePct"]):
                 print(f"      {e['passRatePct']}% pass, {e['s4Count']} serious "
                       f"({e['casesScored']} cases, rubric "
                       f"{(rubric or 'external')[:8]}, judge {judge})")

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -16,7 +16,7 @@ CLI:
     model_registry.py list                 every artifact, newest release first
     model_registry.py list --release 1.2   one release
     model_registry.py validate             schema + convention + one-winner rules
-    model_registry.py floor --corpus sealed_v1.jsonl --rubric <id> --judge <id>
+    model_registry.py floor --corpus sealed_v1.jsonl --cases 1462 --rubric <id> --judge <id>
 """
 import argparse
 import json
@@ -97,10 +97,17 @@ def load(path: Path = REGISTRY_PATH) -> dict:
             # would destroy real history; the honest record is the number WITH the
             # fact that nothing produced by us graded it. `floor()` requires an
             # exact rubric match, so a null can never set a bar.
-            if "rubricIdentity" not in e:
-                raise RegistryError(
-                    f"{aid}: an evaluation omits the rubricIdentity key. Write null "
-                    f"for a run scored from external verdicts; do not leave it out.")
+            # These two may be NULL and the key must still be PRESENT. A receipt can
+            # genuinely lack them — a run scored from borrowed verdicts has no rubric
+            # of its own, and an older summary may not record completeness — so null
+            # is real history. What must not happen is the key going MISSING, because
+            # `floor()` reads both and a dropped key would silently skip the row while
+            # `validate` reported success.
+            for optional in ("rubricIdentity", "runComplete"):
+                if optional not in e:
+                    raise RegistryError(
+                        f"{aid}: an evaluation omits the {optional} key. Write null "
+                        f"when the receipt does not record it; do not leave it out.")
 
     for release, ids in winners.items():
         if len(ids) > 1:
@@ -110,21 +117,38 @@ def load(path: Path = REGISTRY_PATH) -> dict:
     return doc
 
 
-def comparable(evaluation: dict, corpus: str, rubric: str, judge: str) -> bool:
-    """Corpus, rubric, judge — and the run must have used the artifact's OWN prompt.
+def corpus_identity(evaluation: dict) -> tuple[str, int]:
+    """A corpus NAME is a proxy, and in our own receipts it is a WRONG one.
+
+    Measured in the checked-in registry: `tail_corpus.jsonl` names four different
+    case sets (117, 132, 139, 249 cases), `speechpath_1861.jsonl` three, and
+    `speechpath_1861_v3.jsonl` two — files edited in place while keeping the name.
+    Comparing by name alone therefore merges genuinely different exams.
+
+    The case COUNT is the strongest identity recoverable from a receipt, since the
+    receipts never recorded a content digest. It is still a proxy — two edits that
+    keep the size would collide — so a future harness should record a digest and
+    this should use it. Stated rather than left implied.
+    """
+    return (evaluation["corpus"], evaluation["casesScored"])
+
+
+def comparable(evaluation: dict, corpus: str, rubric: str, judge: str,
+               cases: int) -> bool:
+    """Corpus AND its case count, rubric, judge — and the artifact's OWN prompt.
 
     An Azure deployment can be repointed in place, so the same corpus and rubric
     graded through a different deployment are two graders wearing one name. And a
     prompt PROBE attaches to the artifact it experimented on while describing a
     configuration that was never selected or shipped, so letting one set the floor
     would gate releases on a prompt we do not serve."""
-    return (evaluation["corpus"] == corpus
+    return (corpus_identity(evaluation) == (corpus, cases)
             and evaluation["rubricIdentity"] == rubric
             and evaluation["judgeIdentity"] == judge
             and evaluation["promptVariant"] == "own")
 
 
-def floor(corpus: str, rubric: str, judge: str,
+def floor(corpus: str, rubric: str, judge: str, cases: int,
           doc: dict | None = None) -> tuple[int | None, str]:
     """The best S4 count on record for this corpus and rubric, and where it came from.
 
@@ -146,14 +170,15 @@ def floor(corpus: str, rubric: str, judge: str,
         if a["status"] not in EXCLUSIVE:
             continue
         for e in a.get("evaluations") or []:
-            if (not comparable(e, corpus, rubric, judge)
+            if (not comparable(e, corpus, rubric, judge, cases)
                     or e.get("runComplete") is not True):
                 continue
             if best is None or e["s4Count"] < best[0]:
                 best = (e["s4Count"], a["artifactId"], e["summaryPath"])
     if best is None:
         return None, (f"no complete evaluation of a shipped or selected artifact on "
-                      f"corpus {corpus} under rubric {rubric} judged by {judge}")
+                      f"corpus {corpus} ({cases} cases) under rubric {rubric} "
+                      f"judged by {judge}")
     return best[0], f"{best[1]} ({best[2]})"
 
 
@@ -192,11 +217,11 @@ def cmd_list(args) -> int:
             complete = [e for e in sealed if e.get("runComplete") is True]
             groups: dict[tuple, dict] = {}
             for e in complete:
-                key = (e["corpus"], e["rubricIdentity"], e["judgeIdentity"],
+                key = (corpus_identity(e), e["rubricIdentity"], e["judgeIdentity"],
                        e["promptVariant"])
                 if key not in groups or e["s4Count"] < groups[key]["s4Count"]:
                     groups[key] = e
-            for (_c, rubric, judge, variant), e in sorted(
+            for (_cid, rubric, judge, variant), e in sorted(
                     groups.items(), key=lambda kv: -kv[1]["passRatePct"]):
                 tag = "" if variant == "own" else f", PROMPT PROBE: {variant}"
                 print(f"      {e['passRatePct']}% pass, {e['s4Count']} serious "
@@ -219,7 +244,7 @@ def cmd_validate(_args) -> int:
 
 
 def cmd_floor(args) -> int:
-    count, where = floor(args.corpus, args.rubric, args.judge)
+    count, where = floor(args.corpus, args.rubric, args.judge, args.cases)
     if count is None:
         print(f"NO FLOOR: {where}", file=sys.stderr)
         return 1
@@ -235,6 +260,8 @@ def main() -> int:
     p = sub.add_parser("floor")
     p.add_argument("--corpus", required=True); p.add_argument("--rubric", required=True)
     p.add_argument("--judge", required=True, help="judge identity, exactly as recorded")
+    p.add_argument("--cases", required=True, type=int,
+                   help="cases scored; a corpus FILENAME is reused for different sets")
     p.set_defaults(fn=cmd_floor)
     args = ap.parse_args()
     try:

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -75,8 +75,11 @@ def load(path: Path = REGISTRY_PATH) -> dict:
             # which. Grouping by status would have let that pass.
             winners.setdefault(a["release"], []).append(f"{aid} ({a['status']})")
         for e in a.get("evaluations") or []:
+            # `judgeIdentity` is REQUIRED, not optional: `comparable()` reads it, so a
+            # row without it raises KeyError from inside `floor()` — a validator that
+            # passed such a row would be certifying data that crashes its own reader.
             for field in ("corpus", "passRatePct", "s4Count", "casesScored",
-                          "summaryPath"):
+                          "summaryPath", "judgeIdentity"):
                 if e.get(field) is None:
                     raise RegistryError(
                         f"{aid}: an evaluation is missing {field}; a score with no "
@@ -161,15 +164,27 @@ def cmd_list(args) -> int:
             # serious beside its real 91.6% / 36, and the first version of this
             # display printed the incomplete one — which made round 1 look better
             # than the round that actually won.
+            #
+            # And ONE ROW PER PROVENANCE GROUP, never a best-of across them. Sorting
+            # every sealed run together by pass rate silently crosses the rubric and
+            # judge boundary this module refuses to cross everywhere else: it printed
+            # 1.0's 89.7% from an older rubric, and 1.1's S4 65 when its comparable
+            # floor is 63. Within a group the LOWEST s4Count is shown, matching what
+            # `floor()` takes.
             sealed = [e for e in a.get("evaluations") or []
                       if e["corpus"] == "sealed_v1.jsonl"]
             complete = [e for e in sealed if e.get("runComplete") is True]
-            best = sorted(complete, key=lambda e: -(e["passRatePct"] or 0))
-            for e in best[:1]:
-                rubric = (e["rubricIdentity"] or "external")[:8]
+            groups: dict[tuple, dict] = {}
+            for e in complete:
+                key = (e["corpus"], e["rubricIdentity"], e["judgeIdentity"])
+                if key not in groups or e["s4Count"] < groups[key]["s4Count"]:
+                    groups[key] = e
+            for (_c, rubric, judge), e in sorted(
+                    groups.items(), key=lambda kv: -(kv[1]["passRatePct"] or 0)):
                 print(f"      {e['passRatePct']}% pass, {e['s4Count']} serious "
-                      f"({e['casesScored']} cases, rubric {rubric})")
-            if not best:
+                      f"({e['casesScored']} cases, rubric "
+                      f"{(rubric or 'external')[:8]}, judge {judge})")
+            if not groups:
                 why = (f"{len(sealed)} sealed_v1 run(s) on record, all INCOMPLETE"
                        if sealed else "no sealed_v1 score on record")
                 print(f"      {why}")

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -23,12 +23,15 @@ RUNS = Path(os.environ.get("EW_EVAL_RUNS")
             or "/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/scripts/eval/runs")
 OUT = Path(__file__).parent / "model-registry.json"
 
-# release -> ordered arms. The candidate number is position in this list, which is
-# the ledger's own order (arm version numbers), NOT measured timestamps. Said out
-# loud in the file so nobody reads c007 as "trained seventh on the calendar".
+# Each row carries its OWN immutable id. The candidate numbers were originally
+# assigned from the ledger's order (arm version numbers, NOT measured timestamps —
+# do not read c007 as "trained seventh on the calendar"), but they are PINNED here
+# rather than recomputed: deriving an immutable identifier from list POSITION means
+# inserting a forgotten arm silently renames every later candidate in that release,
+# including the shipped winner, which is exactly what the convention forbids.
 ARMS = [
     # --- 1.0: the original EG-1, the only artifact of its line that we still have
-    ("1.0", "eg1-v1-monolith", ["eg1_sealed.jsonl", "eg1_shipped.jsonl",
+    ("eg1-1.0-c001", "1.0", "eg1-v1-monolith", ["eg1_sealed.jsonl", "eg1_shipped.jsonl",
                                 "arm_eg1_candidates.jsonl", "eg1_gold150_candidates.jsonl",
                                 "candidates_eg1_native_1890.jsonl",
                                 "eg1_shipped_holdout900.jsonl",
@@ -39,54 +42,54 @@ ARMS = [
      "superseded", "Replaced by 1.1. The monolith is retired and deleted on upgrade."),
 
     # --- 1.1: the campaign that produced the shipped model
-    ("1.1", "v6capped", ["arm_v6capped_candidates.jsonl"], "rejected",
+    ("eg1-1.1-c001", "1.1", "v6capped", ["arm_v6capped_candidates.jsonl"], "rejected",
      "No-op rate trimmed. +0.1pp, p=0.90 — null."),
-    ("1.1", "v6prod", ["arm_v6prod_candidates.jsonl"], "rejected",
+    ("eg1-1.1-c002", "1.1", "v6prod", ["arm_v6prod_candidates.jsonl"], "rejected",
      "All non-production inputs reshaped. -2.0pp, p=0.015 — WORSE."),
-    ("1.1", "v7drills", ["arm_v7drills_candidates.jsonl"], "rejected",
+    ("eg1-1.1-c003", "1.1", "v7drills", ["arm_v7drills_candidates.jsonl"], "rejected",
      "Drills reshaped to production shape. +0.5pp, p=0.55 — null."),
-    ("1.1", "v8", ["arm_v8_candidates.jsonl"], "rejected",
+    ("eg1-1.1-c004", "1.1", "v8", ["arm_v8_candidates.jsonl"], "rejected",
      "+3,437 synthetic SFT drills. -2.0pp, p=0.021 — WORSE."),
-    ("1.1", "dpo1", ["dpo1_sealed.jsonl"], "rejected",
+    ("eg1-1.1-c005", "1.1", "dpo1", ["dpo1_sealed.jsonl"], "rejected",
      "Preference pairs at 5e-6 x1. 99% of outputs byte-identical to the base — null."),
-    ("1.1", "dpo2", [], "rejected",
+    ("eg1-1.1-c006", "1.1", "dpo2", [], "rejected",
      "Preference pairs at 3e-5 x2. Over-optimised: formatted 100% of wanted cases AND "
      "39.9% of flat ones, restraint 85% -> 49%. Killed before a sealed run, so it has "
      "no evaluation receipt."),
-    ("1.1", "dpo3", ["dpo3_sealed.jsonl", "dpo3_speechpath.jsonl"], "rejected",
+    ("eg1-1.1-c007", "1.1", "dpo3", ["dpo3_sealed.jsonl", "dpo3_speechpath.jsonl"], "rejected",
      "Preference pairs at 1.2e-5 x1. Beaten by dpo4 on the same corpus."),
-    ("1.1", "dpo4", ["dpo4_sealed.jsonl", "dpo4_speechpath.jsonl"], "rejected",
+    ("eg1-1.1-c008", "1.1", "dpo4", ["dpo4_sealed.jsonl", "dpo4_speechpath.jsonl"], "rejected",
      "Meaning-weighted pairs, 30% structure. The only arm of its line to improve every "
      "dimension at once, and still not the arm that shipped."),
-    ("1.1", "v13", ["v13_sealed.jsonl"], "rejected",
+    ("eg1-1.1-c009", "1.1", "v13", ["v13_sealed.jsonl"], "rejected",
      "SFT list drills. Lists solved, self_correction fell 71.2 -> 65.3."),
-    ("1.1", "v14", ["v14_sealed.jsonl", "v14_promptprobe_sealed.jsonl",
+    ("eg1-1.1-c010", "1.1", "v14", ["v14_sealed.jsonl", "v14_promptprobe_sealed.jsonl",
                     "v14_fluidprompt_sealed.jsonl"], "rejected",
      "SFT hinge gate. Superseded within the same line."),
-    ("1.1", "v15", ["v15_sealed.jsonl"], "rejected",
+    ("eg1-1.1-c011", "1.1", "v15", ["v15_sealed.jsonl"], "rejected",
      "SFT marker classes. Superseded within the same line."),
-    ("1.1", "v15align", ["v15align_sealed.jsonl"], "rejected",
+    ("eg1-1.1-c012", "1.1", "v15align", ["v15align_sealed.jsonl"], "rejected",
      "v15 corpus trained ON a fuller prompt. p=1.00 — in SFT the system prompt is a "
      "constant prefix and carries no gradient."),
-    ("1.1", "v17", ["v17_sealed.jsonl"], "rejected",
+    ("eg1-1.1-c013", "1.1", "v17", ["v17_sealed.jsonl"], "rejected",
      "Marker prior rebalanced. First arm ever to beat EG-1 1.0 on self_correction."),
-    ("1.1", "v18", ["v18_sealed.jsonl", "v18_speechpath.jsonl"], "rejected",
+    ("eg1-1.1-c014", "1.1", "v18", ["v18_sealed.jsonl", "v18_speechpath.jsonl"], "rejected",
      "+ list-trigger prior rebalanced. Beat cloud +120/-89, p=0.038."),
-    ("1.1", "v19", ["v19_sealed.jsonl"], "rejected",
+    ("eg1-1.1-c015", "1.1", "v19", ["v19_sealed.jsonl"], "rejected",
      "Superseded by v20 within the same line."),
-    ("1.1", "v20", ["v20_sealed.jsonl", "v20_speechpath.jsonl",
+    ("eg1-1.1-c016", "1.1", "v20", ["v20_sealed.jsonl", "v20_speechpath.jsonl",
                     "eg1_v2_installed_sealed.jsonl"], "shipped",
      "SHIPPED as EG-1 1.1, delivery revision v3-eg2, shards eg-1-v2-*. Lineage evidence: "
      "branch feat/eg2-v20-model, docs/eg2-campaign/build_v20_manifest.py and shard_v20.sh, "
      "and the commit 'point the shipped manifests at model revision v3-eg2' on that branch."),
 
     # --- 1.2: the email-structure campaign
-    ("1.2", "v21email", ["sealed_v21.jsonl", "typeb_v21.jsonl", "tail_v21.jsonl"],
+    ("eg1-1.2-c001", "1.2", "v21email", ["sealed_v21.jsonl", "typeb_v21.jsonl", "tail_v21.jsonl"],
      "rejected", "Round 1. 4 genuine stable critical regressions against shipped 1.1."),
-    ("1.2", "v22round2", ["sealed_v22.jsonl", "email_v22.jsonl", "tail_v22.jsonl"],
+    ("eg1-1.2-c002", "1.2", "v22round2", ["sealed_v22.jsonl", "email_v22.jsonl", "tail_v22.jsonl"],
      "rejected", "Round 2. Made meaning WORSE (5 genuine regressions): a drill gate forced "
      "every one of 263 rows shorter, so the model learned to delete."),
-    ("1.2", "v23round3", ["sealed_v23.jsonl", "email_v23.jsonl", "typeb_v23.jsonl",
+    ("eg1-1.2-c003", "1.2", "v23round3", ["sealed_v23.jsonl", "email_v23.jsonl", "typeb_v23.jsonl",
                           "tail_v23.jsonl"],
      "selected", "Round 3. Zero genuine stable critical regressions, email held at +75. "
      "Won but NOT yet shipped: the shards are not uploaded, and two founder decisions are "
@@ -156,17 +159,19 @@ def main() -> int:
     # script happily writes an artifact with zero evaluations when a run directory has
     # been moved or deleted, and the row then reads as "never scored" rather than
     # "its receipt is gone".
-    missing = sorted({cf for _, _, cand_files, _, _ in ARMS
-                      for cf in cand_files if cf not in receipts})
+    missing = sorted({cf for row in ARMS for cf in row[3] if cf not in receipts})
     if missing:
         raise SystemExit(
             "REFUSED: these declared candidate files have no receipt under "
             f"{RUNS}:\n  " + "\n  ".join(missing) +
             "\nEither the receipts moved, or the table names a file that never existed.")
-    counters, records = {}, []
-    for release, legacy, cand_files, status, reason in ARMS:
-        counters[release] = counters.get(release, 0) + 1
-        artifact_id = f"eg1-{release}-c{counters[release]:03d}"
+    records, seen = [], set()
+    for artifact_id, release, legacy, cand_files, status, reason in ARMS:
+        if artifact_id in seen:
+            raise SystemExit(f"REFUSED: {artifact_id} appears twice in ARMS")
+        if not artifact_id.startswith(f"eg1-{release}-"):
+            raise SystemExit(f"REFUSED: {artifact_id} does not match release {release}")
+        seen.add(artifact_id)
         evals = []
         for cf in cand_files:
             evals.extend(receipts.get(cf, []))

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -128,7 +128,18 @@ def read_receipts() -> dict:
         # skipping an unreadable file is not, which is why they are separate.
         if not cand or o.get("total_scored") is None:
             continue
+        # WHICH PROMPT the run used, relative to the artifact's OWN training prompt.
+        # A prompt probe is an experiment ON an artifact, so it attaches to that
+        # artifact — but its score describes a configuration that was never selected
+        # or shipped, and merging it with the artifact's own runs reports the probe as
+        # the headline. Measured: v14, v14_promptprobe and v14_fluidprompt collapsed
+        # into one group and the fluid-prompt result was shown as v14's score.
+        # The receipts do not record prompt identity, so it is assigned here from the
+        # candidate filename, which is the only place the distinction survives.
+        probe = next((tag for tag in ("promptprobe", "fluidprompt", "probe_v3")
+                      if tag in cand), None)
         out.setdefault(cand, []).append({
+            "promptVariant": probe or "own",
             "corpus": ",".join(m.get("corpus_files") or []) or None,
             # A pinned identity where we have one; otherwise the coarse judge NAME,
             # PREFIXED so the two can never be mistaken for each other. An Azure

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Relabel every EG-1 model we have ever trained under the new artifact ID.
+
+The ONLY hand-authored part is the table below: which arm belongs to which product
+line, in what order, and what happened to it. Every NUMBER is read from the score
+receipts, never transcribed — the prose ledger this replaces warns in its own text
+that its earlier figures were transcribed rather than read, and two of them were
+wrong.
+
+Cloud-prompt arms (v7d, v10-founder, gemini/openai cand, v16-proselists) are NOT
+EG-1 models and are deliberately absent. Prompt probes on an existing model
+(`eg1_promptprobe`, `eg1_probe_v3`, `v14_promptprobe`, `v14_fluidprompt`) are
+experiments ON an artifact, not new artifacts, so they attach as evaluations of
+their subject rather than as rows of their own.
+"""
+import json
+import os
+from pathlib import Path
+
+# Receipts live in the MAIN checkout: `runs/` is gitignored, so a worktree has
+# none and a relative path here would silently rebuild an empty registry.
+RUNS = Path(os.environ.get("EW_EVAL_RUNS")
+            or "/Users/m4pro_sv/Developer/EnviousLabs/EnviousWispr/scripts/eval/runs")
+OUT = Path(__file__).parent / "model-registry.json"
+
+# release -> ordered arms. The candidate number is position in this list, which is
+# the ledger's own order (arm version numbers), NOT measured timestamps. Said out
+# loud in the file so nobody reads c007 as "trained seventh on the calendar".
+ARMS = [
+    # --- 1.0: the original EG-1, the only artifact of its line that we still have
+    ("1.0", "eg1-v1-monolith", ["eg1_sealed.jsonl", "eg1_shipped.jsonl",
+                                "arm_eg1_candidates.jsonl", "eg1_gold150_candidates.jsonl",
+                                "candidates_eg1_native_1890.jsonl",
+                                "eg1_shipped_holdout900.jsonl",
+                                "eg1_shipped_trained1690.jsonl",
+                                "eg1_promptprobe_sealed.jsonl",
+                                "eg1_probe_v3_sealed.jsonl",
+                                "arm_eg1_candidates_v3.jsonl"],
+     "superseded", "Replaced by 1.1. The monolith is retired and deleted on upgrade."),
+
+    # --- 1.1: the campaign that produced the shipped model
+    ("1.1", "v6capped", ["arm_v6capped_candidates.jsonl"], "rejected",
+     "No-op rate trimmed. +0.1pp, p=0.90 — null."),
+    ("1.1", "v6prod", ["arm_v6prod_candidates.jsonl"], "rejected",
+     "All non-production inputs reshaped. -2.0pp, p=0.015 — WORSE."),
+    ("1.1", "v7drills", ["arm_v7drills_candidates.jsonl"], "rejected",
+     "Drills reshaped to production shape. +0.5pp, p=0.55 — null."),
+    ("1.1", "v8", ["arm_v8_candidates.jsonl"], "rejected",
+     "+3,437 synthetic SFT drills. -2.0pp, p=0.021 — WORSE."),
+    ("1.1", "dpo1", ["dpo1_sealed.jsonl"], "rejected",
+     "Preference pairs at 5e-6 x1. 99% of outputs byte-identical to the base — null."),
+    ("1.1", "dpo2", [], "rejected",
+     "Preference pairs at 3e-5 x2. Over-optimised: formatted 100% of wanted cases AND "
+     "39.9% of flat ones, restraint 85% -> 49%. Killed before a sealed run, so it has "
+     "no evaluation receipt."),
+    ("1.1", "dpo3", ["dpo3_sealed.jsonl", "dpo3_speechpath.jsonl"], "rejected",
+     "Preference pairs at 1.2e-5 x1. Beaten by dpo4 on the same corpus."),
+    ("1.1", "dpo4", ["dpo4_sealed.jsonl", "dpo4_speechpath.jsonl"], "rejected",
+     "Meaning-weighted pairs, 30% structure. The only arm of its line to improve every "
+     "dimension at once, and still not the arm that shipped."),
+    ("1.1", "v13", ["v13_sealed.jsonl"], "rejected",
+     "SFT list drills. Lists solved, self_correction fell 71.2 -> 65.3."),
+    ("1.1", "v14", ["v14_sealed.jsonl", "v14_promptprobe_sealed.jsonl",
+                    "v14_fluidprompt_sealed.jsonl"], "rejected",
+     "SFT hinge gate. Superseded within the same line."),
+    ("1.1", "v15", ["v15_sealed.jsonl"], "rejected",
+     "SFT marker classes. Superseded within the same line."),
+    ("1.1", "v15align", ["v15align_sealed.jsonl"], "rejected",
+     "v15 corpus trained ON a fuller prompt. p=1.00 — in SFT the system prompt is a "
+     "constant prefix and carries no gradient."),
+    ("1.1", "v17", ["v17_sealed.jsonl"], "rejected",
+     "Marker prior rebalanced. First arm ever to beat EG-1 1.0 on self_correction."),
+    ("1.1", "v18", ["v18_sealed.jsonl", "v18_speechpath.jsonl"], "rejected",
+     "+ list-trigger prior rebalanced. Beat cloud +120/-89, p=0.038."),
+    ("1.1", "v19", ["v19_sealed.jsonl"], "rejected",
+     "Superseded by v20 within the same line."),
+    ("1.1", "v20", ["v20_sealed.jsonl", "v20_speechpath.jsonl",
+                    "eg1_v2_installed_sealed.jsonl"], "shipped",
+     "SHIPPED as EG-1 1.1, delivery revision v3-eg2, shards eg-1-v2-*. Lineage evidence: "
+     "branch feat/eg2-v20-model, docs/eg2-campaign/build_v20_manifest.py and shard_v20.sh, "
+     "and the commit 'point the shipped manifests at model revision v3-eg2' on that branch."),
+
+    # --- 1.2: the email-structure campaign
+    ("1.2", "v21email", ["sealed_v21.jsonl", "typeb_v21.jsonl", "tail_v21.jsonl"],
+     "rejected", "Round 1. 4 genuine stable critical regressions against shipped 1.1."),
+    ("1.2", "v22round2", ["sealed_v22.jsonl", "email_v22.jsonl", "tail_v22.jsonl"],
+     "rejected", "Round 2. Made meaning WORSE (5 genuine regressions): a drill gate forced "
+     "every one of 263 rows shorter, so the model learned to delete."),
+    ("1.2", "v23round3", ["sealed_v23.jsonl", "email_v23.jsonl", "typeb_v23.jsonl",
+                          "tail_v23.jsonl"],
+     "selected", "Round 3. Zero genuine stable critical regressions, email held at +75. "
+     "Won but NOT yet shipped: the shards are not uploaded, and two founder decisions are "
+     "open (the absolute S4 waiver, and two verbatim_passthrough refusals)."),
+]
+
+
+def read_receipts() -> dict:
+    """Every scored run, keyed by the candidate file it graded."""
+    out = {}
+    for f in sorted(RUNS.rglob("summary.json")):
+        try:
+            d = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        o, m = d.get("overall") or {}, d.get("meta") or {}
+        cand = m.get("candidates_file")
+        if not cand or o.get("total_scored") is None:
+            continue
+        out.setdefault(cand, []).append({
+            "corpus": ",".join(m.get("corpus_files") or []) or None,
+            "judgeIdentity": m.get("judge_identity") or m.get("judge"),
+            "rubricIdentity": m.get("rubric_identity"),
+            "runComplete": d.get("run_complete"),
+            "passRatePct": o.get("pass_rate_pct"),
+            "s4Count": o.get("critical_fail_count"),
+            "casesScored": o.get("total_scored"),
+            "verdict": (d.get("release_gate") or {}).get("verdict"),
+            "summaryPath": str(f.relative_to(RUNS.parent.parent.parent)),
+        })
+    return out
+
+
+def main() -> int:
+    receipts = read_receipts()
+    counters, records = {}, []
+    for release, legacy, cand_files, status, reason in ARMS:
+        counters[release] = counters.get(release, 0) + 1
+        artifact_id = f"eg1-{release}-c{counters[release]:03d}"
+        evals = []
+        for cf in cand_files:
+            evals.extend(receipts.get(cf, []))
+        evals.sort(key=lambda e: (e["corpus"] or "", e["summaryPath"]))
+        records.append({
+            "artifactId": artifact_id,
+            "release": release,
+            "status": status,
+            "statusReason": reason,
+            "legacyNames": [legacy] + cand_files,
+            "legacyExemption": True,
+            "evaluations": evals,
+        })
+
+    doc = {
+        "_comment": "Every EG-1 model we have trained, under the artifact-ID convention. "
+                    "The authority for candidate status and evaluation provenance. "
+                    "Numbers are read from score receipts, never typed.",
+        "_idFormat": "eg1-<release>-c<NNN>. The release is what the candidate was AIMED "
+                     "at; the candidate number resets when the release changes. A "
+                     "candidate is never renamed, including when it wins.",
+        "_candidateOrder": "For rows carrying legacyExemption, the candidate number is "
+                           "position in the historical arm ledger (arm version order), "
+                           "NOT a measured training timestamp. Do not read c007 as "
+                           "'trained seventh by date'.",
+        "_comparability": "An evaluation is comparable to another ONLY when corpus, "
+                          "rubricIdentity and judgeIdentity all match. Nine rubrics and "
+                          "38 corpora appear across this history; ranking across them is "
+                          "the mistake this file exists to prevent.",
+        "artifacts": records,
+    }
+    OUT.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"{len(records)} artifacts written to {OUT}")
+    for r in records:
+        n = len(r["evaluations"])
+        print(f"  {r['artifactId']:16s} {r['status']:11s} {n:>2} eval(s)  "
+              f"<- {r['legacyNames'][0]}")
+    orphans = sum(1 for r in records if not r["evaluations"] and r["status"] != "rejected")
+    print(f"\nartifacts with no receipt at all: "
+          f"{[r['artifactId'] for r in records if not r['evaluations']]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -15,6 +15,8 @@ their subject rather than as rows of their own.
 """
 import json
 import os
+import sys
+import tempfile
 from pathlib import Path
 
 # Receipts live in the MAIN checkout: `runs/` is gitignored, so a worktree has
@@ -214,7 +216,45 @@ def main() -> int:
                           "the mistake this file exists to prevent.",
         "artifacts": records,
     }
-    OUT.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    # VALIDATE BEFORE REPLACING, and refuse a rebuild that LOSES history.
+    #
+    # Writing first and validating afterwards means a malformed receipt overwrites a
+    # good registry and the damage is on disk by the time anything objects. And the
+    # earlier "every declared candidate file has a receipt" check is SET-based: a
+    # candidate whose four summaries became one still passes it, because the KEY is
+    # present. Comparing per-artifact evaluation COUNTS against the file being
+    # replaced catches that, which the key check cannot.
+    sys.path.insert(0, str(Path(__file__).parent))
+    import model_registry
+
+    if OUT.exists():
+        try:
+            previous = json.loads(OUT.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            raise SystemExit(f"REFUSED: the registry being replaced is unreadable ({exc})")
+        was = {a["artifactId"]: len(a.get("evaluations") or [])
+               for a in previous.get("artifacts", [])}
+        lost = [(r["artifactId"], was[r["artifactId"]], len(r["evaluations"]))
+                for r in records
+                if r["artifactId"] in was and len(r["evaluations"]) < was[r["artifactId"]]]
+        if lost:
+            raise SystemExit(
+                "REFUSED: this rebuild would LOSE evaluations:\n  " +
+                "\n  ".join(f"{aid}: {b} -> {a}" for aid, b, a in lost) +
+                "\nSome receipts are missing. Restore them, or say why history shrinks.")
+
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False,
+                                     encoding="utf-8") as fh:
+        json.dump(doc, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+        staged = Path(fh.name)
+    try:
+        model_registry.load(staged)
+    except model_registry.RegistryError as exc:
+        staged.unlink()
+        raise SystemExit(f"REFUSED: the registry this would write is invalid ({exc}). "
+                         f"The existing file is untouched.")
+    staged.replace(OUT)
 
     print(f"{len(records)} artifacts written to {OUT}")
     for r in records:

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -113,10 +113,16 @@ def read_receipts() -> dict:
     for f in sorted(RUNS.rglob("summary.json")):
         try:
             d = json.loads(f.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
+        except (OSError, ValueError) as exc:
+            # RAISE, never skip. A `continue` here drops real history and the script
+            # still exits 0 over a tracked file, so the loss is invisible exactly
+            # when it matters.
+            raise SystemExit(f"REFUSED: cannot read receipt {f} ({exc})")
         o, m = d.get("overall") or {}, d.get("meta") or {}
         cand = m.get("candidates_file")
+        # A summary with no candidate file or no score is not a receipt for any
+        # artifact — a partial write, or an aggregate. Skipping THOSE is correct;
+        # skipping an unreadable file is not, which is why they are separate.
         if not cand or o.get("total_scored") is None:
             continue
         out.setdefault(cand, []).append({
@@ -139,6 +145,18 @@ def main() -> int:
         raise SystemExit(
             f"REFUSED: {RUNS} holds no readable score receipts. Refusing to write a "
             f"registry with no evaluations over one that has them.")
+
+    # Every candidate file this table DECLARES must have a receipt. Without this the
+    # script happily writes an artifact with zero evaluations when a run directory has
+    # been moved or deleted, and the row then reads as "never scored" rather than
+    # "its receipt is gone".
+    missing = sorted({cf for _, _, cand_files, _, _ in ARMS
+                      for cf in cand_files if cf not in receipts})
+    if missing:
+        raise SystemExit(
+            "REFUSED: these declared candidate files have no receipt under "
+            f"{RUNS}:\n  " + "\n  ".join(missing) +
+            "\nEither the receipts moved, or the table names a file that never existed.")
     counters, records = {}, []
     for release, legacy, cand_files, status, reason in ARMS:
         counters[release] = counters.get(release, 0) + 1

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -127,7 +127,13 @@ def read_receipts() -> dict:
             continue
         out.setdefault(cand, []).append({
             "corpus": ",".join(m.get("corpus_files") or []) or None,
-            "judgeIdentity": m.get("judge_identity") or m.get("judge"),
+            # A pinned identity where we have one; otherwise the coarse judge NAME,
+            # PREFIXED so the two can never be mistaken for each other. An Azure
+            # deployment can be repointed in place, so `azure/gpt-5-6-luna` alone can
+            # name two different models — a bare fallback would silently let those
+            # compare as one judge, which is the failure this field exists to prevent.
+            "judgeIdentity": (m.get("judge_identity")
+                              or (f"name-only:{m['judge']}" if m.get("judge") else None)),
             "rubricIdentity": m.get("rubric_identity"),
             "runComplete": d.get("run_complete"),
             "passRatePct": o.get("pass_rate_pct"),

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -95,7 +95,20 @@ ARMS = [
 
 
 def read_receipts() -> dict:
-    """Every scored run, keyed by the candidate file it graded."""
+    """Every scored run, keyed by the candidate file it graded.
+
+    REFUSES when the receipt directory is absent or holds nothing. `runs/` is
+    gitignored and the default path names one user's checkout, so on a fresh clone
+    or any other machine `rglob` finds nothing, returns cleanly, and this script
+    would overwrite the tracked registry with zero evaluations — destroying the
+    record of which model won while exiting 0. That is the failure that matters
+    here, because it is silent and it is the normal state of every other machine.
+    """
+    if not RUNS.is_dir():
+        raise SystemExit(
+            f"REFUSED: no receipt directory at {RUNS}. Set EW_EVAL_RUNS to the "
+            f"checkout that holds scripts/eval/runs. Rebuilding from nothing would "
+            f"erase every evaluation in the tracked registry.")
     out = {}
     for f in sorted(RUNS.rglob("summary.json")):
         try:
@@ -122,6 +135,10 @@ def read_receipts() -> dict:
 
 def main() -> int:
     receipts = read_receipts()
+    if not receipts:
+        raise SystemExit(
+            f"REFUSED: {RUNS} holds no readable score receipts. Refusing to write a "
+            f"registry with no evaluations over one that has them.")
     counters, records = {}, []
     for release, legacy, cand_files, status, reason in ARMS:
         counters[release] = counters.get(release, 0) + 1


### PR DESCRIPTION
## Every EG-1 model we have trained now has one permanent id, and one place says which won

Founder, 2026-08-31: *"I can't have confusion on what is the final winner... so no future
version of you gets confused on what the 'winning' test models are vs previous test models
and their scores."*

Internal record-keeping only — nothing here ships to a user. The one thing with teeth is the
`floor()` reader, which a future release gate will consult.

### What lands

- **`scripts/eval/model-registry.json`** — 20 artifacts, 71 score receipts, tracked.
- **`model_registry.py`** — read, validate, and answer "what is the floor for this exam".
- **`rebuild-model-registry.py`** — regenerates the registry from the receipts.
- `.gitignore` allowlist entries, for the reason already written there: tooling that produces
  a number we later cite must survive in git.

Convention `eg1-<release>-c<NNN>`, minted before training, **never renamed including when it
wins** — renaming the winner destroys the only link between the winning evaluation and the
shipped bytes. `v20` is `eg1-1.1-c016` (SHIPPED); `v23round3` is `eg1-1.2-c003` (SELECTED).
Rule: `eg1-operations.md` RULE: eg1-artifact-identity-is-one-permanent-id. Design review:
`docs/audits/2026-08-31-eg1-naming-convention-design.txt`.

The prose arm table in `eg1-model-provenance.md` now points here and keeps only the lessons,
so there is one owner rather than two.

### Comparability is the whole point

The receipts hold **nine rubric identities, thirty-eight corpora, two judges and four
prompt-probe runs**. Two numbers from different rubrics are two different questions. Nothing
here ranks across a corpus, rubric, judge or prompt boundary — it refuses, and every refusal
says what to re-measure.

### Four local review rounds, four distinct findings, none a repeat

1. The gate change I originally bundled here would have **blocked every future run
   permanently** — `_rubric_identity()` hashes `behavior_judge.py` entirely, so editing the
   release gate invalidated every stored score with nothing on the other side. Reverted:
   `behavior_judge.py` is byte-identical to `origin/main`, confirmed by hashing both. The S4
   ratchet is separate work needing one re-grade to arm.
2. Silent-loss sweep: an unreadable receipt was swallowed; the rebuild could overwrite the
   tracked registry with zero evaluations on any other machine and exit 0; `comparable()`
   checked two of its three declared fields; a release could hold two winners; `validate`
   passed rows that crashed its own reader.
3. **Artifact ids were computed from list POSITION**, so inserting a forgotten historical arm
   would silently rename every later candidate including the shipped winner — the tool built
   to end name confusion was the one thing that could rename everything at once. Ids are
   pinned now; control: inserting an arm before the winner renames nothing.
4. **A prompt probe's score was being reported as v14's headline**, and on a winner would have
   set the floor from a prompt we do not serve. The prompt is now a comparability field.

Two more were caught by my own tooling rather than review: the scoreboard first showed round 1
at 92.1% from a run that never finished, making the loser look like the winner; and a UAT
helper flattens multi-line output, which reported a working email envelope as a missing
sign-off. Both have rules now.

### Verification

`rebuild` reproduces the checked-in registry byte-for-byte. `validate` passes on 20 artifacts
and 71 evaluations. `floor` resolves 31 from `eg1-1.2-c003` and returns NO FLOOR for an
unrecognised judge. `behavior_judge_test.py`: 135 passed, 0 failed.

Part of #2547.
