### PR TITLE
fix(post-processing): correct split EG-1 spellings (#2557)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -187,6 +187,13 @@ public final class CustomWordsManager {
         category: .brand
       )),
     BuiltinWord(
+      id: "eg1",
+      word: CustomWord(
+        canonical: "EG-1",
+        aliases: ["E G One", "EG 1", "E G 1"],
+        category: .brand
+      )),
+    BuiltinWord(
       id: "macos",
       word: CustomWord(
         canonical: "macOS",

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -235,3 +235,16 @@ struct CustomWordsTransferDocumentTests {
     #expect(user.ownedByUser() == user)
   }
 }
+
+@MainActor
+@Suite("Built-in custom words", .tags(.productOutcome))
+struct BuiltinCustomWordsTests {
+  @Test(
+    "EG-1 corrects the real split ASR spellings",
+    arguments: ["E G One", "e G One", "EG 1", "E G 1"])
+  func egOneBuiltinCorrectsRealSplitSpellings(_ alias: String) throws {
+    let word = try #require(CustomWordsManager.builtinDefaults.first { $0.id == "eg1" }).word
+    let result = WordCorrector().correct("Use the \(alias) prompt", against: [word])
+    #expect(result.corrected == "Use the EG-1 prompt")
+  }
+}

--- a/scripts/eval/acceptance_gate.py
+++ b/scripts/eval/acceptance_gate.py
@@ -172,6 +172,7 @@ DEFAULT_CUSTOM_VOCAB = [
         ],
     ),
     ("Envious Labs", ["envious laps"]),
+    ("EG-1", ["E G One", "EG 1", "E G 1"]),
     ("macOS", ["mac OS", "Mack OS"]),
     ("iOS", ["I OS", "eye OS"]),
     ("GitHub", ["git hub", "get hub"]),


### PR DESCRIPTION
Closes #2557

## What changes

- Adds `EG-1` to the built-in custom-word list for every install.
- Corrects the real split ASR spellings `E G One`, `e G One`, `EG 1`, and `E G 1` to `EG-1`.
- Keeps the evaluation vocabulary mirror synchronized.
- Adds a product-outcome test, with overnight mutation recipe #2563.

## User outcome

Someone discussing the EG-1 model no longer has to repair the common split-letter spellings by hand.

## Scope

- Primary lane: Code
- `mixed_pr: true` because the required evaluation mirror lives under `scripts/eval/`
- `council-skip: zero-blast-radius (single-value config)`
- No new setting, API, control flow, schema, migration, or optional-pack dependency

## Validation

- New test proved red before the production fix: four failures because the `eg1` built-in did not exist.
- Focused `BuiltinCustomWordsTests`: 1 test, 4 parameter cases, all passed.
- Full Debug lane: 7,228 tests, all accepted.
- Full Release lane: 6,594 tests, all accepted.
- `acceptance_gate.py --mode selftest`: passed.
- Mutation recipe #2563: 1 of 1 rows runnable.
- Independent Codex review: clean.
- Strict Phase 3 verifier: passed at `.validation/runs/2026-09-01T05-28-19Z-d301974f`.

## Live UAT

Rebuilt and launched the app from this worktree. A local synthetic voice dictated `Use the E. G. One prompt.` through the real Parakeet, correction, polish, and paste pipeline. Observed final transcript: `Use the EG-1 prompt.`

The first control run produced the already-accepted `EG1` spelling and correctly did not claim to exercise this fix. The paced split-letter run produced and verified the changed outcome.
