### PR TITLE
feat(settings): ship Escape Recovery, Live Preview and recording sounds ON

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 ## Features
 
 - 🎙️ **Dual ASR engines** with [Parakeet v3](https://github.com/FluidInference/FluidAudio) (NVIDIA NeMo) and [WhisperKit](https://github.com/argmaxinc/argmax-oss-swift) (OpenAI Whisper)
-- 👀 **Live Preview**: watch your words appear in the recording pill while you speak, so you can see it is working without waiting for the paste. Optional, and it never changes the text you get
-- ↩️ **Escape Recovery**: hit your cancel keybind by mistake and get the dictation back. Turn it on and a keybind cancel keeps the text for 24 hours instead of discarding it. The Cancel button in the recording pill still discards on the spot, so you keep one way to mean it. Off by default, and only the text is kept, never the audio
+- 👀 **Live Preview**: watch your words appear in the recording pill while you speak, so you can see it is working without waiting for the paste. On by default, switchable off, and it never changes the text you get. A Mac that cannot run it behaves as though it were off
+- ↩️ **Escape Recovery**: hit your cancel keybind by mistake and get the dictation back. On by default: a keybind cancel keeps the text for 24 hours instead of discarding it, and you can switch that off. The Cancel button in the recording pill still discards on the spot, so you keep one way to mean it. Only the text is kept, never the audio
 - ✨ **AI polish that respects your words**: strips filler words and false starts, fixes grammar and punctuation, formats numbers, dates, and URLs, and honors your custom vocabulary, all in your spoken language (never translated or rewritten)
 - 🔒 **Polish that can stay private**: run it fully on-device with EG-1 (our own custom model), Apple Intelligence (macOS 26+), or Ollama, or in the cloud via OpenAI GPT / Google Gemini with your own API key
 - 🌍 **Multilingual with automatic language detection**: speak in any supported language and EnviousWispr detects it, then offers to lock it in for faster, more accurate transcription
@@ -122,7 +122,7 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 
 EnviousWispr ships often. A few of the user-facing improvements from recent releases:
 
-- **Recover a dictation you cancelled by mistake.** Turn on Escape Recovery and hitting your cancel keybind keeps the text for 24 hours instead of throwing it away. The Cancel button still discards deliberately. Only the transcript is kept, never the audio. (v2.4.5)
+- **Recover a dictation you cancelled by mistake.** Escape Recovery is on by default, so hitting your cancel keybind keeps the text for 24 hours instead of throwing it away. The Cancel button still discards deliberately. Only the transcript is kept, never the audio. (v2.4.5)
 - **See your words as you speak.** The recording pill can now show what it is hearing, live, with a choice of two preview engines. The text you actually get is unchanged: it is still transcribed from the whole recording when you stop. (v2.4.5)
 - **Dictation no longer records silence on a virtual microphone.** If your Mac's default input was a virtual device (Krisp, Loopback, BlackHole, an aggregate, a meeting app's mic), the app bound it and captured nothing at all. It now prefers a real microphone. (v2.4.5)
 - **EG-1 retrained on its weakest spots.** Announcing a list out loud produces a real list far more often, and changes of mind mid-sentence now land level with a frontier cloud model on our held-out benchmark. It is also about 14% faster. (v2.4.5)

--- a/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/KeybindsSettingsView.swift
@@ -161,10 +161,11 @@ struct KeybindsSettingsView: View {
                 """
               )
               // `stBody` at PRIMARY colour: the tokens define this as
-              // reading-copy, and this is the disclosure a user has to actually
-              // read before turning the feature on. Quieting it would be a
-              // legibility choice made against the one paragraph that explains
-              // what changes about their cancel key.
+              // reading-copy, and this is the one paragraph explaining what
+              // changed about their cancel key. That mattered when the feature
+              // was opt in; it matters MORE now that it ships on (2026-09-01),
+              // because a user arrives here having never chosen it. Quieting it
+              // would be a legibility choice made against the only disclosure.
               .font(.stBody)
               .foregroundStyle(.stTextPrimary)
               .fixedSize(horizontal: false, vertical: true)

--- a/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LivePreviewSettingsView.swift
@@ -108,7 +108,8 @@ struct LivePreviewSettingsView: View {
   private var anyEngineAvailable: Bool { isAppleSupported || universalExists }
 
   /// The toggle's own value, NOT whether a preview could run. Anything the page
-  /// says about a live preview is false while this is off, and it is off by default.
+  /// says about a live preview is false while this is off. The shipped default is
+  /// `SettingsDefaultValues.livePreviewEnabled` and is not restated here.
   private var isPreviewOn: Bool { settings.livePreviewEnabled }
 
   private var universalState: DeliveryState {

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -18,6 +18,36 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.4.7
+
+    // **THIS GROUP IS OPEN AND 2.4.6 HAS SHIPPED** (tag v2.4.6, 2026-08-28), so
+    // the entry below could not live in that group. The unread badge is
+    // `lastSeen != currentContentVersion`; a user who opened What's New after
+    // 2.4.6 shipped has `lastSeen == "2.4.6"`, so an entry appended there raises
+    // no badge and is never seen by the exact people it was written for, with
+    // nothing failing. `WhatsNewConstants.currentContentVersion` moves to 2.4.7
+    // with this group. Only the CONTENT version moves; the marketing version in
+    // Info.plist waits for a release PR. Owner, not restated:
+    // .claude/knowledge/whats-new-protocol.md FACT: whats-new-grouping.
+
+    // Founder direction 2026-09-01: settings that were opt in now ship on.
+    // ONE entry rather than three, because a user does not experience three
+    // settings changing; they experience the app doing more on the day they
+    // update. The sentence names what they will SEE and where the switch is,
+    // since every one of these is still theirs to turn off.
+    //
+    // The macOS 26 caveat on Live Preview is stated as behaviour rather than as
+    // a requirement: on a Mac that cannot run it, nothing appears and nothing is
+    // said, which is the whole reason on-by-default is safe to ship.
+    Entry(
+      id: "better-out-of-the-box-defaults",
+      icon: "sparkles",
+      title: "More of EnviousWispr is switched on from the start",
+      description:
+        "Cancelling with your keybind now keeps the dictation and offers it back instead of throwing it away. Your words appear in the recording bar while you speak, on Macs that can show them. A short tick confirms when recording starts and stops. Every one of these is a switch you can turn off, in Keybinds, Live Preview and Sounds settings.",
+      version: "2.4.7"
+    ),
+
     // MARK: - v2.4.6
 
     // Every title and every collapsed line in this group was written or edited by
@@ -58,24 +88,6 @@ enum WhatsNewContent {
     // wrong word in the panel and loses that copy to the restore". An earlier
     // revision disclosed only the first half, which is the softer of the two and
     // the one that costs the user nothing.
-    // Founder direction 2026-09-01: four settings that were opt in now ship on.
-    // ONE entry rather than four, because a user does not experience four
-    // settings changing; they experience the app doing more on the day they
-    // update. The sentence names what they will SEE and where the switch is,
-    // since every one of these is still theirs to turn off.
-    //
-    // The macOS 26 caveat on Live Preview is stated as behaviour rather than as
-    // a requirement: on a Mac that cannot run it, nothing appears and nothing is
-    // said, which is the whole reason on-by-default is safe to ship.
-    Entry(
-      id: "better-out-of-the-box-defaults",
-      icon: "sparkles",
-      title: "More of EnviousWispr is switched on from the start",
-      description:
-        "Cancelling with your keybind now keeps the dictation and offers it back instead of throwing it away. Your words appear in the recording bar while you speak, on Macs that can show them. A short tick confirms when recording starts and stops. Every one of these is a switch you can turn off, in Keybinds, Live Preview and Sounds settings.",
-      version: "2.4.6"
-    ),
-
     Entry(
       id: "quick-add",
       icon: "text.badge.plus",

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -58,6 +58,24 @@ enum WhatsNewContent {
     // wrong word in the panel and loses that copy to the restore". An earlier
     // revision disclosed only the first half, which is the softer of the two and
     // the one that costs the user nothing.
+    // Founder direction 2026-09-01: four settings that were opt in now ship on.
+    // ONE entry rather than four, because a user does not experience four
+    // settings changing; they experience the app doing more on the day they
+    // update. The sentence names what they will SEE and where the switch is,
+    // since every one of these is still theirs to turn off.
+    //
+    // The macOS 26 caveat on Live Preview is stated as behaviour rather than as
+    // a requirement: on a Mac that cannot run it, nothing appears and nothing is
+    // said, which is the whole reason on-by-default is safe to ship.
+    Entry(
+      id: "better-out-of-the-box-defaults",
+      icon: "sparkles",
+      title: "More of EnviousWispr is switched on from the start",
+      description:
+        "Cancelling with your keybind now keeps the dictation and offers it back instead of throwing it away. Your words appear in the recording bar while you speak, on Macs that can show them. A short tick confirms when recording starts and stops. Every one of these is a switch you can turn off, in Keybinds, Live Preview and Sounds settings.",
+      version: "2.4.6"
+    ),
+
     Entry(
       id: "quick-add",
       icon: "text.badge.plus",

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.4.6"
+  public static let currentContentVersion = "2.4.7"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -176,7 +176,41 @@ public final class CustomWordsManager {
           "envious whisper", "envious wisper", "envious whispr",
           "envious visper", "envious cisper", "mbs cisper",
           "in vious wispr", "envy us wispr", "NVS Visper", "NBS Vesper",
+          // Added 2026-09-01 from the founder's own library, where each of these
+          // is a mishearing his recognizer actually produced. They are kept
+          // verbatim rather than tidied: the alias has to match what the engine
+          // emits, not what the phrase looks like written down.
+          "envious wispr", "Enviousvisper", "NVSBesper", "NVSBSPur",
+          "NVIS VICPRSO", "EnvyS Visper", "senvy wpr", "Dambius Bispe",
         ],
+        category: .brand
+      )),
+    BuiltinWord(
+      id: "eg1",
+      word: CustomWord(
+        canonical: "EG-1",
+        // Our own on-device polish model. Every alias here carries the DIGIT,
+        // and that is the whole design rather than a stylistic preference.
+        //
+        // **The spelled-out "one" forms were proposed and REMOVED, measured
+        // rather than reasoned about.** The fuzzy multi-word pass matches a
+        // two-token alias against any two-token phrase close enough to it, and
+        // English is full of near neighbours: "egg one" ate "she cracked an egg
+        // on the pan", and "E G one" ate "the item is e g on the list". Both came
+        // out with "EG-1" swallowing the following preposition. Matching is
+        // case-insensitive, so dropping only the lowercase spelling would have
+        // changed nothing.
+        //
+        // "EG1" is a single token and therefore reaches the single-word fuzzy
+        // pass; its neighbours are checked as standing controls rather than
+        // assumed safe.
+        //
+        // The cost is stated rather than hidden: a user who says "EG one" and
+        // whose recognizer writes it out in words gets no correction. That is a
+        // missed fix, and the alternative was corrupting ordinary sentences.
+        // `BuiltinDictionaryCorrectionTests` keeps every one of those sentences,
+        // so re-adding a spelled-out form fails a test rather than shipping.
+        aliases: ["EG 1", "E G 1", "EG-one", "EG1"],
         category: .brand
       )),
     BuiltinWord(

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -76,16 +76,16 @@ enum SettingsDefaultValues {
   static let smartInsertion = true
 
   /// Escape Recovery (#2087): keep a dictation the user cancelled with their
-  /// cancel shortcut, instead of discarding it. Default OFF, and that default is
-  /// the product decision, not a cautious rollout — persona review put every
-  /// persona at "off" and one at "on", so the feature is opt-in by consensus.
+  /// cancel shortcut, instead of discarding it. Default ON (founder, 2026-09-01),
+  /// superseding the opt-in-by-persona-consensus default this key shipped with.
   ///
-  /// It is off because ON changes what a cancel MEANS. Escape stops being
-  /// destructive, the transcription engine runs on text the user tried to throw
-  /// away, a new recording cannot start until that finishes, and a BYOK user
-  /// pays their provider for the polish. Every one of those is defensible when
-  /// chosen and indefensible when imposed.
-  static let escapeRecoveryEnabled = false
+  /// The cost of ON is unchanged and is accepted rather than unrecognised: a
+  /// cancel stops being destructive, the transcription engine runs on text the
+  /// user tried to throw away, a new recording cannot start until that finishes,
+  /// and a BYOK user pays their provider for the polish. The founder's reading is
+  /// that losing a dictation you meant to keep is the more expensive mistake, and
+  /// the pill offers the recovery rather than performing it.
+  static let escapeRecoveryEnabled = true
 
   static let wordCorrectionEnabled = true
   static let fillerRemovalEnabled = true
@@ -124,11 +124,18 @@ enum SettingsDefaultValues {
   static let warmEnginePolicy: WarmEnginePolicy = .seconds30
 
   // #1988: show the words in the recording pill while the user is still speaking.
-  // OFF by default. It costs screen attention some users explicitly do not want
-  // (the Reddit request that prompted it asked for it to be toggleable for exactly
-  // that reason), and it needs macOS 26, so a default-on toggle would read as
-  // broken on every older Mac. Display only: the pasted text never comes from it.
-  static let livePreviewEnabled = false
+  // ON by default (founder, 2026-09-01), superseding the shipped OFF.
+  //
+  // The older-Mac objection that argued for OFF is answered by machinery that did
+  // not exist when this key was written: `LivePreviewCoordinator` resolves an
+  // EFFECTIVE enabled value per recording, so where no engine can run the app
+  // behaves exactly as if the switch were off — ordinary pill, no message, nothing
+  // to escape from. That is the only exception to this default, and it is
+  // automatic rather than a second stored value.
+  //
+  // The screen-attention objection stands and is answered by the toggle. Display
+  // only: the pasted text never comes from the preview.
+  static let livePreviewEnabled = true
   /// #2123: Apple first. The universal engine is opt-in, never a default toll.
   static let livePreviewEngine: LivePreviewEngineChoice = .apple
 
@@ -138,13 +145,14 @@ enum SettingsDefaultValues {
   // The permanent Microphone-settings guide stays regardless of this flag.
   static let showBluetoothTips = true
 
-  // Recording start/stop sounds default OFF — silent for every existing user
-  // until they opt in. The pairing default only matters once the toggle is
-  // on; Whisper Tick is the fresh-install choice (#1618). No migration for
-  // users who enabled sounds under the prior Air Glint default: no tagged
-  // release has ever shipped recording sound cues (v2.3.1 predates #1342
-  // merging), so no installed base has an implicit old default to protect —
-  // #1342 and #1618 ship together, for the first time, in the same release.
-  static let playRecordingSounds = false
+  // Recording start/stop sounds default ON, paired to Whisper Tick (founder,
+  // 2026-09-01), superseding the shipped OFF. Start and stop are the two moments
+  // a user most needs confirmed without looking at the pill. Whisper Tick was
+  // already the fresh-install pairing (#1618) and is unchanged here; only the
+  // on/off default moved. The toggle is the escape hatch for anyone in a shared
+  // room. No migration is owed to the prior Air Glint pairing default: no
+  // tagged release has ever shipped recording sound cues (v2.3.1 predates #1342
+  // merging), so no installed base has an implicit old pairing to protect.
+  static let playRecordingSounds = true
   static let recordingSoundPairing: RecordingSoundPairing = .whisperTick
 }

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -602,7 +602,10 @@ public final class SettingsManager {
 
   /// #1342: play a short sound when recording starts and stops. UI-only —
   /// no pipeline sync; read live by `RecordingSoundCue` at each cue moment.
-  /// Default OFF (`SettingsDefaultValues.playRecordingSounds`).
+  /// Default: `SettingsDefaultValues.playRecordingSounds`, named rather than
+  /// restated. A doc comment carrying the VALUE is a second source of truth with
+  /// nothing linking the two edits, so it goes stale the first time the default
+  /// moves — as this one did on 2026-09-01.
   public var playRecordingSounds: Bool {
     didSet {
       defaults.set(playRecordingSounds, forKey: "playRecordingSounds")

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -1338,12 +1338,42 @@ struct LivePreviewCoordinatorTests {
 
   // MARK: - Shipped default
 
-  @Test("Live preview ships off")
-  func shipsOff() {
-    // Off by default is the founder-approved shipped state: it costs screen
-    // attention some users explicitly asked to be able to decline, and it needs
-    // macOS 26, so on by default would read as broken on every older Mac.
-    #expect(SettingsDefaultValues.livePreviewEnabled == false)
+  @Test("Live preview ships on")
+  func shipsOn() {
+    // On by default is the founder-approved shipped state as of 2026-09-01. The
+    // older-Mac objection that once argued for off is answered by the effective
+    // resolution below: where no engine can run, the app behaves exactly as if
+    // the switch were off. The screen-attention objection is answered by the
+    // toggle, which remains the user's escape hatch.
+    #expect(SettingsDefaultValues.livePreviewEnabled == true)
+  }
+
+  /// The one exception the shipped-on default is allowed to have, asserted rather
+  /// than trusted: with the setting ON and no engine available on this machine,
+  /// the coordinator's effective answer must still be off — same behaviour as a
+  /// user who never turned it on. This is what makes "on by default" safe to ship
+  /// to macOS 14 through 25.
+  ///
+  /// **Two-way, because one direction proves nothing here.** A coordinator that
+  /// answered `.engineUnsupported` unconditionally — the exact bug that would
+  /// delete the feature for everyone — satisfies the unsupported row alone. The
+  /// supported row is what separates "the machine cannot" from "the coordinator
+  /// never can", and both read the SHIPPED default rather than a literal, so a
+  /// future flip back to off fails here rather than passing quietly.
+  @Test(
+    "the shipped default resolves to words only where an engine can run",
+    arguments: [(false, PillWordsCapability.engineUnsupported), (true, .available)])
+  func defaultOnResolvesByEngineAvailability(
+    _ engineRuns: Bool, _ expected: PillWordsCapability
+  ) {
+    #expect(SettingsDefaultValues.livePreviewEnabled, "both rows assume the shipped ON default")
+    let coordinator = LivePreviewCoordinator(
+      readSamples: { _ in ([], 0) },
+      isPreviewOn: { SettingsDefaultValues.livePreviewEnabled },
+      languageMode: { .locked("en") },
+      selectedRoute: previewRoute(supported: engineRuns) { _ in .blocked(.unsupportedSystem) }
+    )
+    #expect(coordinator.wordsCapability == expected)
   }
 
   // MARK: - Custom Words on preview text (#1988 acceptance)

--- a/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/App/SettingsChangeTelemetryTests.swift
@@ -80,20 +80,20 @@ import Testing
     /// Asserts the logical name and both endpoints, not just that something was
     /// emitted. Without the endpoints, a projection wired to the wrong setting
     /// would still emit one `escape_recovery` delta and pass.
-    @Test("Escape Recovery emits one privacy-safe off-to-on delta")
+    @Test("Escape Recovery emits one privacy-safe on-to-off delta")
     func escapeRecoveryDelta() {
       let (settings, telemetry, box, _) = makeHarness()
       defer { TelemetryService.shared.testEventHook = nil }
 
-      settings.escapeRecoveryEnabled = true
+      settings.escapeRecoveryEnabled = false
       telemetry.flush()
 
       let d = deltas(box, setting: "escape_recovery")
       #expect(d.count == 1)
-      #expect(d.first?.stringProps["from"] == "off", "ships off — that is the baseline")
-      #expect(d.first?.stringProps["to"] == "on")
+      #expect(d.first?.stringProps["from"] == "on", "ships on — that is the baseline")
+      #expect(d.first?.stringProps["to"] == "off")
       #expect(d.first?.stringProps["source"] == "user")
-      #expect(SettingsProjection.value(for: .escapeRecovery, settings: settings) == "on")
+      #expect(SettingsProjection.value(for: .escapeRecovery, settings: settings) == "off")
     }
 
     /// The projection must follow the SETTING, not a constant. A value hard-wired
@@ -103,11 +103,11 @@ import Testing
       let (settings, _, _, _) = makeHarness()
       defer { TelemetryService.shared.testEventHook = nil }
 
-      #expect(SettingsProjection.value(for: .escapeRecovery, settings: settings) == "off")
-      settings.escapeRecoveryEnabled = true
       #expect(SettingsProjection.value(for: .escapeRecovery, settings: settings) == "on")
       settings.escapeRecoveryEnabled = false
       #expect(SettingsProjection.value(for: .escapeRecovery, settings: settings) == "off")
+      settings.escapeRecoveryEnabled = true
+      #expect(SettingsProjection.value(for: .escapeRecovery, settings: settings) == "on")
     }
 
     // MARK: - #1987 toggle hotkey identity fan-out
@@ -272,12 +272,12 @@ import Testing
       // had it on before the window. Adding `.escapeRecovery` to the snapshot
       // exclusion set would do exactly that while every delta test stayed green.
       #expect(
-        atDefault?.stringProps["escape_recovery"] == "off",
+        atDefault?.stringProps["escape_recovery"] == "on",
         "the shipped default must appear in the baseline, not only in deltas")
 
-      settings.escapeRecoveryEnabled = true
+      settings.escapeRecoveryEnabled = false
       #expect(
-        emitSnapshot()?.stringProps["escape_recovery"] == "on",
+        emitSnapshot()?.stringProps["escape_recovery"] == "off",
         "the baseline must track the setting, not report a constant")
 
       settings.toggleKeyCode = ModifierKeyCodes.globe
@@ -343,14 +343,17 @@ import Testing
     func recordingSoundsDelta() {
       let (settings, telemetry, box, _) = makeHarness()
       defer { TelemetryService.shared.testEventHook = nil }
-      settings.playRecordingSounds = true
+      // Written to the NON-default value in both cases: sounds ship ON, so a
+      // write of `true` produces no delta at all and every assertion below would
+      // be measuring an event that was never emitted.
+      settings.playRecordingSounds = false
       settings.recordingSoundPairing = .velvetTap
       telemetry.flush()
 
       let enabledDeltas = deltas(box, setting: "play_recording_sounds")
       #expect(enabledDeltas.count == 1)
-      #expect(enabledDeltas.first?.stringProps["from"] == "off")
-      #expect(enabledDeltas.first?.stringProps["to"] == "on")
+      #expect(enabledDeltas.first?.stringProps["from"] == "on")
+      #expect(enabledDeltas.first?.stringProps["to"] == "off")
 
       let pairingDeltas = deltas(box, setting: "recording_sound_pairing")
       #expect(pairingDeltas.count == 1)
@@ -358,7 +361,7 @@ import Testing
       #expect(pairingDeltas.first?.stringProps["to"] == "velvetTap")
 
       #expect(
-        SettingsProjection.value(for: .playRecordingSounds, settings: settings) == "on")
+        SettingsProjection.value(for: .playRecordingSounds, settings: settings) == "off")
       #expect(
         SettingsProjection.value(for: .recordingSoundPairing, settings: settings)
           == "velvetTap")

--- a/Tests/EnviousWisprTests/PostProcessing/BuiltinDictionaryCorrectionTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/BuiltinDictionaryCorrectionTests.swift
@@ -1,0 +1,84 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// The shipped dictionary, run through the real corrector.
+///
+/// **Every row here uses `CustomWordsManager.builtinDefaults` itself, never a
+/// hand-built word.** A test that constructs its own `CustomWord` proves the
+/// matcher works; it says nothing about what a user who has never opened Custom
+/// Words actually gets, which is the only question these entries exist to answer.
+///
+/// Scope is deliberately the two entries added on 2026-09-01. The rest of the
+/// dictionary predates this suite and is not re-litigated here.
+@MainActor
+@Suite("Built-in dictionary — the shipped entries correct real speech", .tags(.productOutcome))
+struct BuiltinDictionaryCorrectionTests {
+  private let corrector = WordCorrector()
+  private var shipped: [CustomWord] { CustomWordsManager.builtinDefaults.map(\.word) }
+
+  private func corrected(_ input: String) -> String {
+    corrector.correct(input, against: shipped).0
+  }
+
+  @Test("EG-1 ships in the dictionary under a stable id")
+  func eg1IsShipped() {
+    let entry = CustomWordsManager.builtinDefaults.first { $0.id == "eg1" }
+    #expect(entry?.word.canonical == "EG-1")
+  }
+
+  /// The name of our own polish model, said aloud. The hyphen and the digit are
+  /// the part worth binding: a canonical that survives the matcher unchanged is
+  /// not something the alias list alone can promise.
+  @Test(
+    "spoken forms of EG-1 become EG-1",
+    arguments: [
+      "I ran it through EG 1", "I ran it through E G 1",
+      "I ran it through EG1", "I ran it through EG-one",
+    ])
+  func eg1SpokenFormsCorrect(_ input: String) {
+    #expect(corrected(input) == "I ran it through EG-1")
+  }
+
+  /// The mishearings added from the founder's own library on 2026-09-01. These
+  /// are what his recognizer actually produced, so a row that stops passing means
+  /// the shipped dictionary stopped covering a mistake we know users hit.
+  @Test(
+    "the 2026-09-01 mishearings become EnviousWispr",
+    arguments: [
+      "envious wispr", "Enviousvisper", "NVSBesper", "NVSBSPur",
+      "NVIS VICPRSO", "EnvyS Visper", "senvy wpr", "Dambius Bispe",
+    ])
+  func newMishearingsCorrect(_ heard: String) {
+    #expect(corrected("I use \(heard) daily") == "I use EnviousWispr daily")
+  }
+
+  /// The cost of every alias is a false positive, and short spoken-letter aliases
+  /// are where that cost lands. Ordinary English must pass through untouched.
+  ///
+  /// **These are not decoration.** "she cracked an egg on the pan" is why EG-1
+  /// does not carry an "egg one" alias: the fuzzy multi-word pass matched it
+  /// against "egg on" and produced "she cracked an EG-1 the pan". The rows below
+  /// are the neighbours of every alias that ships, so adding one back fails here
+  /// rather than reaching a user.
+  @Test(
+    "ordinary sentences are left alone",
+    arguments: [
+      "for example one of them left",
+      "she cracked an egg on the pan",
+      "the meeting is at one",
+      "do not beg one of them for it",
+      "he broke a leg on the stairs",
+      "the item is e g on the list",
+      // Neighbours of the single-token alias "EG1", which reaches the
+      // single-word fuzzy pass rather than the multi-word one.
+      "his ego got in the way",
+      "she hurt her leg badly",
+      "the egg was already cracked",
+    ])
+  func noFalsePositives(_ sentence: String) {
+    #expect(corrected(sentence) == sentence)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -94,20 +94,21 @@ struct SettingsDefaultsRoutingTests {
       SettingsManager.unifiedDefaultsKeys.filter { $0 == "smartInsertion" }.count == 1)
   }
 
-  /// #2087. Tested in the ON direction because OFF is the default: writing the
-  /// default proves nothing about persistence, since a store that dropped the
-  /// write entirely would still read back `false`.
-  @Test("Escape Recovery persists ON and belongs to unified defaults")
-  func escapeRecoveryPersistsOn() {
+  /// #2087, default flipped to ON 2026-09-01. Tested in the OFF direction
+  /// because ON is now the default: writing the default proves nothing about
+  /// persistence, since a store that dropped the write entirely would still read
+  /// back the default.
+  @Test("Escape Recovery persists OFF and belongs to unified defaults")
+  func escapeRecoveryPersistsOff() {
     let suite = Self.freshSuite()
     let settings = SettingsManager(defaults: suite)
 
-    #expect(settings.escapeRecoveryEnabled == false, "ships OFF — the product decision")
+    #expect(settings.escapeRecoveryEnabled == true, "ships ON — the product decision")
 
-    settings.escapeRecoveryEnabled = true
+    settings.escapeRecoveryEnabled = false
 
-    #expect(suite.object(forKey: "escapeRecoveryEnabled") as? Bool == true)
-    #expect(SettingsManager(defaults: suite).escapeRecoveryEnabled == true)
+    #expect(suite.object(forKey: "escapeRecoveryEnabled") as? Bool == false)
+    #expect(SettingsManager(defaults: suite).escapeRecoveryEnabled == false)
     #expect(
       SettingsManager.unifiedDefaultsKeys.filter { $0 == "escapeRecoveryEnabled" }.count == 1,
       "missing from unified keys means it never migrates to the shared suite (#923)")
@@ -122,7 +123,7 @@ struct SettingsDefaultsRoutingTests {
       if case .escapeRecoveryEnabled = key { matchingChanges += 1 }
     }
 
-    settings.escapeRecoveryEnabled = true
+    settings.escapeRecoveryEnabled = false
     #expect(matchingChanges == 1)
   }
 
@@ -301,10 +302,10 @@ struct SettingsDefaultsRoutingTests {
 
   // MARK: - Recording sound cues (#1342)
 
-  @Test("recording sounds default to off, whisperTick pairing, on a fresh install")
+  @Test("recording sounds default to on, whisperTick pairing, on a fresh install")
   func recordingSoundsDefaults() {
     let settings = SettingsManager(defaults: Self.freshSuite())
-    #expect(settings.playRecordingSounds == false)
+    #expect(settings.playRecordingSounds == true)
     #expect(settings.recordingSoundPairing == .whisperTick)
   }
 
@@ -312,13 +313,15 @@ struct SettingsDefaultsRoutingTests {
   func recordingSoundsPersist() {
     let suite = Self.freshSuite()
     let settings = SettingsManager(defaults: suite)
-    settings.playRecordingSounds = true
+    // Written to the NON-default value: sounds now ship ON, so writing `true`
+    // would read back identically from a store that dropped the write entirely.
+    settings.playRecordingSounds = false
     settings.recordingSoundPairing = .cloudPop
-    #expect(suite.object(forKey: "playRecordingSounds") as? Bool == true)
+    #expect(suite.object(forKey: "playRecordingSounds") as? Bool == false)
     #expect(suite.string(forKey: "recordingSoundPairing") == "cloudPop")
     // Reload from the same store → the choice survives.
     let reloaded = SettingsManager(defaults: suite)
-    #expect(reloaded.playRecordingSounds == true)
+    #expect(reloaded.playRecordingSounds == false)
     #expect(reloaded.recordingSoundPairing == .cloudPop)
     #expect(SettingsManager.unifiedDefaultsKeys.contains("playRecordingSounds"))
     #expect(SettingsManager.unifiedDefaultsKeys.contains("recordingSoundPairing"))

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -300,6 +300,61 @@ struct SettingsDefaultsRoutingTests {
     #expect(SettingsManager(defaults: suite).overlayPillPosition == .top)
   }
 
+  // MARK: - What an UPGRADE does to the three 2026-09-01 defaults
+
+  /// The founder's question, asserted rather than reasoned about: does an
+  /// existing user get the new default, and does their own choice survive?
+  ///
+  /// **Both halves in one row per setting, because either alone is satisfiable
+  /// by a broken store.** A store that ignored every write would pass the
+  /// "new default reaches an untouched install" half; a store that never applied
+  /// defaults would pass the "a user's choice survives" half.
+  ///
+  /// The absent key IS the upgrade case. Nothing in the app writes any of these
+  /// keys unless a person changes something, so a user who never opened the
+  /// setting arrives at a new version with no stored value and resolves to
+  /// whatever `SettingsDefaultValues` now says.
+  /// Keyed by the DEFAULTS KEY NAME rather than by `SettingKey`, which is not
+  /// `Sendable` and so cannot cross into a parameterised test. The name is also
+  /// the thing the store is actually addressed by, which is what this row is
+  /// about.
+  @Test(
+    "an untouched install takes the new default; a stored choice survives a reload",
+    arguments: ["escapeRecoveryEnabled", "livePreviewEnabled", "playRecordingSounds"])
+  func upgradeTakesTheDefaultButNeverOverridesAChoice(_ name: String) {
+    let shipped: Bool
+    let read: (SettingsManager) -> Bool
+    let write: (SettingsManager, Bool) -> Void
+    switch name {
+    case "escapeRecoveryEnabled":
+      shipped = SettingsDefaultValues.escapeRecoveryEnabled
+      read = { $0.escapeRecoveryEnabled }
+      write = { $0.escapeRecoveryEnabled = $1 }
+    case "livePreviewEnabled":
+      shipped = SettingsDefaultValues.livePreviewEnabled
+      read = { $0.livePreviewEnabled }
+      write = { $0.livePreviewEnabled = $1 }
+    default:
+      shipped = SettingsDefaultValues.playRecordingSounds
+      read = { $0.playRecordingSounds }
+      write = { $0.playRecordingSounds = $1 }
+    }
+
+    // 1. The upgrade case: no stored value, so the shipped default applies.
+    let upgraded = Self.freshSuite()
+    #expect(upgraded.object(forKey: name) == nil, "the upgrade case IS the absent key")
+    #expect(read(SettingsManager(defaults: upgraded)) == shipped)
+    #expect(shipped, "all three ship ON as of 2026-09-01")
+
+    // 2. The user's own choice, written to the value the default is NOT, and
+    //    read back through a SECOND manager — which is what a relaunch is.
+    let chosen = Self.freshSuite()
+    write(SettingsManager(defaults: chosen), !shipped)
+    #expect(
+      read(SettingsManager(defaults: chosen)) == !shipped,
+      "a stored choice outranks the default")
+  }
+
   // MARK: - Recording sound cues (#1342)
 
   @Test("recording sounds default to on, whisperTick pairing, on a fresh install")

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -121,7 +121,7 @@ struct WhatsNewContentTests {
     // untouched by #1493; asserting the real sequence is the falsifiable version.
     #expect(
       WhatsNewContent.versions == [
-        "2.4.6", "2.4.5", "2.4.4", "2.4.3", "2.4.1", "2.4.0",
+        "2.4.7", "2.4.6", "2.4.5", "2.4.4", "2.4.3", "2.4.1", "2.4.0",
         "2.3.2", "2.3.1", "2.3.0",
         "2.2.1", "2.2.0",
         "2.1.4", "2.1.3", "2.1.2", "2.1.1", "2.1.0",

--- a/Tests/RuntimeUAT/defaults_store.py
+++ b/Tests/RuntimeUAT/defaults_store.py
@@ -1,0 +1,141 @@
+"""Snapshot and restore a developer's real preferences, TYPE INCLUDED.
+
+**Why this exists as one module rather than three copies.** Every phase5 harness
+parks the founder's own settings, drives its rows, and puts them back. Three of
+them restored with a FIXED type flag chosen by the harness instead of the type
+the value actually had, and the failure is silent in both directions: `defaults
+read` prints only the TEXT, so a restore that changed `"0"` (string) into `false`
+(boolean) still compares equal and reports a clean restore.
+
+**That is not cosmetic, because the app reads the two differently.**
+`SettingsManager` resolves these keys with `object(forKey:) as? Bool`. A boolean
+`false` is accepted and applied. A STRING `"0"` yields nil and the shipped
+default applies instead. So restoring a string as a boolean silently flips the
+developer's effective setting, on their own machine, with every check green.
+
+Found by cloud review on PR #2578 against `phase5_geometry.py`. The same shape was
+in `phase5_geometry_relaunch.py` and `phase5_warning_morph.py`, which is why the
+rule lives here and the harnesses call it.
+
+**The rule is not new here: `escape_recovery_uat.py` already captured `(value,
+flag)` and compared the whole tuple**, with a comment naming this exact failure
+after it bit the founder's own `escapeRecoveryEnabled` on 2026-08-19. That
+harness is the prior art and this module is its generalisation, so the three that
+lacked it were the outliers rather than the norm.
+
+**Known and NOT handled, stated rather than hidden:**
+`phase5_language_hover.py` parks two keys that hold an array and a dictionary and
+restores them from `defaults read`'s printed text, which cannot round-trip either
+type. That is the same class and a different mechanism -- it needs a plist
+export/import, not a type flag -- so this module REFUSES those types loudly
+(`UnsupportedType`) rather than appearing to cover them.
+
+Control test: `test_defaults_store.py`, which round-trips both types on a
+throwaway domain and asserts the type SURVIVES, not merely the printed text.
+"""
+
+import subprocess
+
+# `defaults read-type` wording -> the flag `defaults write` needs for it.
+_TYPE_FLAG = {
+    "boolean": "-bool",
+    "integer": "-int",
+    "float": "-float",
+    "string": "-string",
+}
+
+
+class UnsupportedType(Exception):
+    """A stored value this module cannot faithfully put back.
+
+    Raised rather than guessed. A dictionary, array, date or data value has no
+    single-token `defaults write` form, and writing SOMETHING would be worse than
+    refusing: the caller would park a real preference and restore a different one
+    while every check passed.
+    """
+
+
+def read_typed(domain, key):
+    """`(text, flag)` for a stored value, or `None` when the key is absent.
+
+    Both halves come from the store rather than from the caller's expectation,
+    which is the whole point: a harness must not decide what type a developer's
+    preference is.
+    """
+    got = subprocess.run(
+        ["defaults", "read", domain, key], capture_output=True, text=True)
+    if got.returncode != 0:
+        return None
+    kind = subprocess.run(
+        ["defaults", "read-type", domain, key], capture_output=True, text=True)
+    if kind.returncode != 0:
+        return None
+    # "Type is boolean" -> "boolean"
+    word = kind.stdout.strip().rsplit(" ", 1)[-1]
+    flag = _TYPE_FLAG.get(word)
+    if flag is None:
+        raise UnsupportedType(f"{domain}.{key} is {word!r}, which cannot be restored by this module")
+    return got.stdout.strip(), flag
+
+
+def write_typed(domain, key, text, flag):
+    """Write one value in the spelling `defaults` accepts for that flag.
+
+    `defaults write <dom> <key> -bool 1` EXITS 255: the tool takes only
+    true/false/yes/no for `-bool`, while `defaults read` PRINTS a boolean as
+    `1`/`0`. So the read shape and the write shape differ for exactly the type
+    this module exists to preserve, and normalising here covers every caller.
+    """
+    if flag == "-bool":
+        text = "true" if str(text).strip().lower() in ("1", "true", "yes", "y", "on") else "false"
+    subprocess.run(["defaults", "write", domain, key, flag, str(text)], check=True)
+
+
+def snapshot(domain, keys):
+    """What the machine holds now: `{key: (text, flag) or None}`."""
+    return {k: read_typed(domain, k) for k in keys}
+
+
+def restore(domain, snap):
+    """Put every key back exactly as it was, and SAY whether each one landed.
+
+    Returns `{key: bool}`. Verified against BOTH text and type — a text-only
+    comparison is blind to the defect this module was written for, and a restore
+    check that cannot fail is not a check.
+    """
+    landed = {}
+    for key, want in snap.items():
+        if want is None:
+            subprocess.run(["defaults", "delete", domain, key], capture_output=True)
+            landed[key] = read_typed(domain, key) is None
+            continue
+        text, flag = want
+        write_typed(domain, key, text, flag)
+        landed[key] = read_typed(domain, key) == want
+    return landed
+
+
+def snapshot_multi(domain_of, keys):
+    """Like `snapshot`, for keys that live in DIFFERENT domains.
+
+    `phase5_warning_morph` pins debug flags in the dev domain and real user
+    preferences in the shared suite, so the domain is a property of the KEY. It
+    is passed as a map rather than inferred, because guessing which domain a key
+    is read from is the mistake that made a whole run write where nothing reads.
+    """
+    return {k: read_typed(domain_of[k], k) for k in keys}
+
+
+def restore_multi(domain_of, snap):
+    """Like `restore`, for keys that live in DIFFERENT domains."""
+    landed = {}
+    for key, want in snap.items():
+        domain = domain_of[key]
+        if want is None:
+            subprocess.run(["defaults", "delete", domain, key], capture_output=True)
+            landed[key] = read_typed(domain, key) is None
+            continue
+        text, flag = want
+        write_typed(domain, key, text, flag)
+        landed[key] = read_typed(domain, key) == want
+    return landed

--- a/Tests/RuntimeUAT/escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/escape_recovery_uat.py
@@ -667,8 +667,13 @@ def main():
         # so writing it leaves any existing modifiers in place and the binding
         # stays Carbon-registrable — the exact condition the rebind exists to
         # avoid, failing only on a machine that had a customised shortcut.
+        # **WRITTEN FALSE, NEVER DELETED.** Deleting the key hands the phase
+        # whatever the shipped default is, and that default became ON on
+        # 2026-09-01. A deleted key would have run this phase with the feature
+        # switched on, and every assertion below would have failed against a
+        # correct app while passing against one that never keeps anything.
         apply_settings([
-            ("escapeRecoveryEnabled", None, None),
+            ("escapeRecoveryEnabled", 0, "-bool"),
             ("cancelKeyCode", LCTRL, "-int"),
             ("cancelModifiersRaw", 0, "-int"),
         ], "OFF phase")

--- a/Tests/RuntimeUAT/phase5_geometry.py
+++ b/Tests/RuntimeUAT/phase5_geometry.py
@@ -25,6 +25,7 @@ import time
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
+import defaults_store as ds  # noqa: E402  (type-preserving park-and-restore)
 import wispr_eyes as rk  # noqa: E402  (record-key helpers; merged in #2425)
 import wispr_eyes as w  # noqa: E402
 
@@ -64,19 +65,20 @@ def read_default(key):
 
 
 def write_default(key, value):
-    """Write one preference, in the spelling the app's own reader accepts.
+    """Write one row value, in the spelling the app's own reader accepts.
 
-    `defaults write <dom> <key> -bool 1` EXITS 255 -- the tool takes only
-    true/false/yes/no for `-bool`, while `defaults read` PRINTS a boolean back as
-    `1`. So the round-trip shape and the write shape differ, and normalising at
-    this single point covers apply and restore together.
+    `SettingsManager` reads `livePreviewEnabled` with `object(forKey:) as? Bool`
+    (SettingsManager.swift:966). `defaults write <dom> <key> 1` stores a STRING,
+    so that cast yields nil and the app falls back to the SHIPPED DEFAULT --
+    while `defaults read` still prints the `1` back, so nothing looks wrong. With
+    the shipped default ON since 2026-09-01, the two `False` rows below would
+    have captured reading-well geometry under the labels levelRail and classic,
+    which is the evidence this harness exists to produce.
     """
     if key in BOOL_KEYS:
-        text = str(value).strip().lower()
-        word = "true" if text in ("1", "true", "yes", "y", "on") else "false"
-        subprocess.run(["defaults", "write", DOMAIN, key, "-bool", word], check=True)
+        ds.write_typed(DOMAIN, key, value, "-bool")
         return
-    subprocess.run(["defaults", "write", DOMAIN, key, str(value)], check=True)
+    ds.write_typed(DOMAIN, key, value, "-string")
 
 
 def expected_readback(key, value):
@@ -84,7 +86,7 @@ def expected_readback(key, value):
 
     A bool comes back as `1`/`0`, never as `true`/`false`, so comparing the
     read-back against the value as written would fail forever on exactly the keys
-    the fix above was for.
+    the writer above was fixed for.
     """
     if key in BOOL_KEYS:
         return "1" if value else "0"
@@ -147,7 +149,11 @@ def await_visible(pid, timeout=8.0):
 
 def main():
     pid = int(sys.argv[1])
-    snapshot = {k: read_default(k) for k in KEYS}
+    # TYPE-PRESERVING, not text-only. `defaults read` prints a boolean `false`
+    # and a string "0" identically, so a text-only park-and-restore silently
+    # rewrites the developer's own preference into a different plist type -- and
+    # a text-only restore check cannot see it. Owner: defaults_store.
+    snapshot = ds.snapshot(DOMAIN, KEYS)
     report = {"pid": pid, "settings_snapshot": snapshot, "rows": {}}
     print("snapshot:", snapshot)
 
@@ -169,13 +175,10 @@ def main():
             }
             print(f"  {name}: {seen}")
     finally:
-        for k, v in snapshot.items():
-            if v is None:
-                subprocess.run(["defaults", "delete", DOMAIN, k], capture_output=True)
-            else:
-                write_default(k, v)
-        report["settings_restored"] = {k: read_default(k) for k in KEYS}
-        report["restore_clean"] = report["settings_restored"] == snapshot
+        landed = ds.restore(DOMAIN, snapshot)
+        report["settings_restored"] = {k: ds.read_typed(DOMAIN, k) for k in KEYS}
+        report["restore_clean"] = all(landed.values())
+        report["restore_failed_keys"] = [k for k, good in landed.items() if not good]
         (UAT / "geometry.json").write_text(json.dumps(report, indent=2, default=str))
         print(json.dumps(report, indent=2, default=str)[:2000])
 

--- a/Tests/RuntimeUAT/phase5_geometry.py
+++ b/Tests/RuntimeUAT/phase5_geometry.py
@@ -39,10 +39,22 @@ OVERLAY_ID = 64874
 
 KEYS = ["livePreviewEnabled", "recordingPillDesignWithoutWords"]
 
+# **A BOOL MUST BE WRITTEN AS A BOOL, AND THIS HARNESS WAS NOT.**
+# `SettingsManager` reads `livePreviewEnabled` with `object(forKey:) as? Bool`
+# (SettingsManager.swift:966). `defaults write <dom> <key> 1` stores a STRING, so
+# that cast yields nil and the app silently falls back to the SHIPPED DEFAULT --
+# `defaults read` still prints back the `1` you wrote, so nothing here looks
+# wrong. With the shipped default now ON (2026-09-01) the two `False` rows would
+# have recorded reading-well geometry while labelled levelRail and classic, which
+# is the exact evidence this harness exists to produce.
+# Owner of the trap, not restated: .claude/knowledge/settings-defaults.md
+# RULE: preset-a-dev-setting-in-the-shared-suite-never-the-dev-domain.
+BOOL_KEYS = {"livePreviewEnabled"}
+
 ROWS = [
-    ("readingWell", {"livePreviewEnabled": "1"}),
-    ("levelRail", {"livePreviewEnabled": "0", "recordingPillDesignWithoutWords": "levelRail"}),
-    ("classic", {"livePreviewEnabled": "0", "recordingPillDesignWithoutWords": "classic"}),
+    ("readingWell", {"livePreviewEnabled": True}),
+    ("levelRail", {"livePreviewEnabled": False, "recordingPillDesignWithoutWords": "levelRail"}),
+    ("classic", {"livePreviewEnabled": False, "recordingPillDesignWithoutWords": "classic"}),
 ]
 
 
@@ -52,7 +64,31 @@ def read_default(key):
 
 
 def write_default(key, value):
-    subprocess.run(["defaults", "write", DOMAIN, key, value], check=True)
+    """Write one preference, in the spelling the app's own reader accepts.
+
+    `defaults write <dom> <key> -bool 1` EXITS 255 -- the tool takes only
+    true/false/yes/no for `-bool`, while `defaults read` PRINTS a boolean back as
+    `1`. So the round-trip shape and the write shape differ, and normalising at
+    this single point covers apply and restore together.
+    """
+    if key in BOOL_KEYS:
+        text = str(value).strip().lower()
+        word = "true" if text in ("1", "true", "yes", "y", "on") else "false"
+        subprocess.run(["defaults", "write", DOMAIN, key, "-bool", word], check=True)
+        return
+    subprocess.run(["defaults", "write", DOMAIN, key, str(value)], check=True)
+
+
+def expected_readback(key, value):
+    """What `defaults read` prints for a value this harness just wrote.
+
+    A bool comes back as `1`/`0`, never as `true`/`false`, so comparing the
+    read-back against the value as written would fail forever on exactly the keys
+    the fix above was for.
+    """
+    if key in BOOL_KEYS:
+        return "1" if value else "0"
+    return str(value)
 
 
 def apply_settings(settings, timeout=5.0):
@@ -66,7 +102,7 @@ def apply_settings(settings, timeout=5.0):
         write_default(k, v)
     deadline = time.time() + timeout
     while time.time() < deadline:
-        if all(read_default(k) == v for k, v in settings.items()):
+        if all(read_default(k) == expected_readback(k, v) for k, v in settings.items()):
             return True
         time.sleep(0.05)  # test-fixture-timer: read-back polling cadence
     return False

--- a/Tests/RuntimeUAT/phase5_geometry_relaunch.py
+++ b/Tests/RuntimeUAT/phase5_geometry_relaunch.py
@@ -47,6 +47,7 @@ import time
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
+import defaults_store as ds  # noqa: E402  (type-preserving park-and-restore)
 import phase5_overlay_lifecycle as lc  # noqa: E402
 import wispr_eyes as rk  # noqa: E402  (record-key helpers; merged in #2425)
 
@@ -367,7 +368,7 @@ def main():
     # BEFORE ANY MUTATION OR STOP. This row relaunches, so it needs this
     # checkout's build; asking here means a missing one costs nothing.
     require_bundle()
-    snapshot = {k: read_default(k) for k in KEYS}
+    snapshot = ds.snapshot(DOMAIN, KEYS)  # text AND type; see the restore below
     # Recorded, not refused: every frame this row takes is captured BY WINDOW ID,
     # which the lock cannot substitute. A row taking a full-SCREEN artifact still
     # has to refuse.
@@ -417,16 +418,16 @@ def main():
             report["rows"][name] = row
             print(f"  {name}: pid={pid} overlay={(record or {}).get('overlay')} err={err}")
     finally:
-        for k, v in snapshot.items():
-            if v is None:
-                subprocess.run(["defaults", "delete", DOMAIN, k], capture_output=True)
-            elif k in BOOL_KEYS:
-                subprocess.run(["defaults", "write", DOMAIN, k, "-bool",
-                                "YES" if v == "1" else "NO"], check=True)
-            else:
-                subprocess.run(["defaults", "write", DOMAIN, k, v], check=True)
-        report["restored"] = {k: read_default(k) for k in KEYS}
-        report["restore_clean"] = report["restored"] == snapshot
+        # RESTORE THE TYPE, NOT ONLY THE TEXT. The old form wrote a FIXED flag
+        # per key rather than the type the value actually had, so a preference
+        # stored as the string "0" came back as boolean `false` -- which the app
+        # reads differently (a string yields nil and the shipped default applies)
+        # while `defaults read` prints both as `0` and the check passed. Owner:
+        # defaults_store, found by cloud review on PR #2578.
+        landed = ds.restore(DOMAIN, snapshot)
+        report["restored"] = {k: ds.read_typed(DOMAIN, k) for k in KEYS}
+        report["restore_clean"] = all(landed.values())
+        report["restore_failed_keys"] = [k for k, good in landed.items() if not good]
         widths = {n: (r.get("overlay") or {}).get("w") for n, r in report["rows"].items()}
         heights = {n: (r.get("overlay") or {}).get("h") for n, r in report["rows"].items()}
         report["widths"] = widths

--- a/Tests/RuntimeUAT/phase5_warning_morph.py
+++ b/Tests/RuntimeUAT/phase5_warning_morph.py
@@ -56,6 +56,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 import phase5_geometry_relaunch as g  # noqa: E402
 import phase5_overlay_lifecycle as lc  # noqa: E402
 import phase5_paste_target as pt  # noqa: E402
+import defaults_store as ds  # noqa: E402  (type-preserving park-and-restore)
 import wispr_eyes as rk  # noqa: E402  (record-key helpers; merged in #2425)
 import faultInjection as fi  # noqa: E402
 import wispr_eyes as w  # noqa: E402
@@ -311,7 +312,11 @@ def _terminal_after_start():
 def main():
     # BEFORE ANY MUTATION OR STOP (see phase5_geometry_relaunch.require_bundle).
     g.require_bundle()
-    snapshot = {k: read_default(k) for k in PINNED}
+    # TEXT AND TYPE. A text-only park-and-restore rewrites a preference stored as
+    # the string "0" into boolean `false`, which the app reads differently while
+    # `defaults read` prints both as `0` -- so the restore check cannot see it.
+    # Owner: defaults_store, found by cloud review on PR #2578.
+    snapshot = ds.snapshot_multi(DOMAIN_OF, list(PINNED))
     report = {"snapshot": snapshot, "screen_locked": g.screen_is_locked(),
               "cap_seconds": CAP_SECONDS,
               "lead_seconds": LEAD_SECONDS,
@@ -588,21 +593,17 @@ def main():
         # THE SAME TYPE FLAG THE KEY WAS WRITTEN WITH. Restoring the user's own
         # appearance through `-float` would leave them on a number, which is not a
         # design at all — this row must give the machine back exactly what it took.
-        for k, v in snapshot.items():
-            if v is None:
-                subprocess.run(["defaults", "delete", DOMAIN_OF[k], k], capture_output=True)
-            else:
-                value = bool_word(v) if PINNED[k] == "-bool" else v
-                subprocess.run(["defaults", "write", DOMAIN_OF[k], k, PINNED[k], value], check=True)
-        report["restored"] = {k: read_default(k) for k in PINNED}
-        # Compared by MEANING per key, not by dict equality: `defaults` hands a
-        # bool back as `1` where it was written as `true`, so a literal comparison
-        # reports a clean restore as dirty.
-        report["restore_clean"] = all(
-            (report["restored"][k] is None and snapshot[k] is None)
-            or (report["restored"][k] is not None and snapshot[k] is not None
-                and same_default(flag, report["restored"][k], snapshot[k]))
-            for k, flag in PINNED.items())
+        landed = ds.restore_multi(DOMAIN_OF, snapshot)
+        report["restored"] = {k: ds.read_typed(DOMAIN_OF[k], k) for k in PINNED}
+        # **The meaning-versus-literal comparison this replaced is no longer
+        # needed, and that is the point.** It existed because the restore wrote
+        # `true` and the read-back printed `1`, so the two could never be compared
+        # directly. Restoring the SNAPSHOTTED type makes the read-back equal the
+        # snapshot exactly, so the check is an identity rather than a rule about
+        # how `defaults` renders each type -- and an identity has no per-type case
+        # to get wrong.
+        report["restore_clean"] = all(landed.values())
+        report["restore_failed_keys"] = [k for k, good in landed.items() if not good]
 
         # **A DIRTY RESTORE INVALIDATES THE VERDICT, it does not sit beside it.**
         # `defaults delete` failures are not checked and cannot be, so the only
@@ -617,11 +618,11 @@ def main():
         if not report["restore_clean"]:
             report["verdict_before_restore_check"] = report.get("verdict")
             report["verdict"] = "DIRTY_RESTORE"
-            report["dirty_keys"] = sorted(
-                k for k, flag in PINNED.items()
-                if not ((report["restored"][k] is None and snapshot[k] is None)
-                        or (report["restored"][k] is not None and snapshot[k] is not None
-                            and same_default(flag, report["restored"][k], snapshot[k]))))
+            # Named by the restore itself rather than re-derived here. Deriving
+            # the dirty set a second way is how the verdict and its explanation
+            # come to disagree, and only one of them is the thing the restore
+            # actually observed.
+            report["dirty_keys"] = sorted(report["restore_failed_keys"])
 
         (UAT / "warning-morph.json").write_text(json.dumps(report, indent=2, default=str))
         # **`morph_row` AND `clear_row` ARE IN THE PRINTED SUMMARY.** Without them

--- a/Tests/RuntimeUAT/scenarios/001-cancel-hotkey.md
+++ b/Tests/RuntimeUAT/scenarios/001-cancel-hotkey.md
@@ -6,21 +6,28 @@ The cancel shortcut (Escape by default, configurable) ends an active recording.
 **What it then does depends on the Escape Recovery setting (#2087), so every
 scenario below states which state it assumes.**
 
-- **Escape Recovery OFF (the default, and what every scenario below assumes
-  unless it says otherwise):** the recording is discarded immediately — audio
-  dropped, nothing transcribed, nothing pasted, nothing saved.
-- **Escape Recovery ON:** the recording is KEPT. It finishes transcribing and
-  polishing, the text is held for 24 hours in History, and a pill offers to
-  paste it. Nothing is pasted unless the user asks.
+- **Escape Recovery ON — THE SHIPPED DEFAULT since 2026-09-01:** the recording is
+  KEPT. It finishes transcribing and polishing, the text is held for 24 hours in
+  History, and a pill offers to paste it. Nothing is pasted unless the user asks.
+- **Escape Recovery OFF:** the recording is discarded immediately — audio dropped,
+  nothing transcribed, nothing pasted, nothing saved.
+
+**THE DEFAULT FLIPPED ON 2026-09-01 AND THIS FILE'S SETUP BURDEN FLIPPED WITH
+IT.** Read this before running anything below. The off-path scenarios in the
+first section were written when OFF was the default, so they used to need no
+setup at all; they now REQUIRE Escape Recovery to be switched OFF first, and a
+tester who skips that step will run every one of them against a build that keeps
+the recording, and report a correct app as broken. The Escape Recovery ON section
+is the one that now needs no setting change, and its old "turn it back OFF
+afterwards" instruction is gone, because OFF is no longer the state to restore.
 
 **The Cancel BUTTON in the main window discards immediately in BOTH states.**
 Only the shortcut recovers. A scenario that presses the button is testing the
 destructive path whatever the setting says.
 
-**This file was rewritten rather than replaced when Escape Recovery shipped.**
-The off-path scenarios below are the regression suite for the promise that
-carries almost every user: with the setting off, cancel behaves exactly as it
-did before the feature existed.
+**The off-path scenarios are still the regression suite for the promise that
+carries every user who switches the setting off:** cancel then behaves exactly as
+it did before the feature existed.
 
 ## Test Scenarios
 
@@ -209,8 +216,10 @@ THEN recording is cancelled
 ## Escape Recovery ON (#2087)
 
 Every scenario in this section requires **Settings → Shortcuts → Escape
-Recovery** switched ON. Turn it back OFF afterwards: it is off by default and a
-left-on toggle silently changes the meaning of every scenario above.
+Recovery** switched ON, which is the shipped default, so a fresh install needs no
+setup here. Do NOT "restore" it to OFF afterwards — that instruction belonged to
+the old default and following it now leaves the machine in a non-default state
+that silently changes the meaning of every later run.
 
 ### P0: Critical
 
@@ -290,15 +299,16 @@ THEN the row is still there with a countdown
 **Why**: the 24-hour window starts when the user pressed cancel, not when the
 app last started. A row whose countdown restarts on relaunch is a bug.
 
-#### test_off_by_default_for_a_fresh_install
+#### test_on_by_default_for_a_fresh_install
 **Suite**: escape_recovery
 **Layers**: AX structure
 ```
 GIVEN a fresh install with no prior settings
 WHEN the user opens Settings and finds Shortcuts
-THEN Escape Recovery is OFF
-  AND the cancel hotkey description says the recording is discarded
+THEN Escape Recovery is ON
+  AND the cancel hotkey description says the recording is kept and offered back
 ```
-**Why**: opt-in is a founder decision, not a default worth drifting. The
-description assertion catches the case where the toggle ships off but the copy
-already describes the on behaviour.
+**Why**: the default is a founder decision (2026-09-01, replacing the opt-in one
+of #2087), not a value worth drifting. The description assertion is the half that
+catches the real hazard in either direction: a toggle whose state and whose copy
+disagree tells the user their cancel key does the opposite of what it does.

--- a/Tests/RuntimeUAT/test_defaults_store.py
+++ b/Tests/RuntimeUAT/test_defaults_store.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Control test for `defaults_store`, run against a THROWAWAY domain.
+
+**Every row asserts the TYPE, not only the printed text.** A text-only assertion
+passes against the exact defect this module was written for, because `defaults
+read` prints a boolean `false` and a string `"0"` identically as `0`.
+
+Two-way by construction: the string row and the boolean row would BOTH pass under
+a correct implementation, and the string row is the one that fails under the old
+fixed-flag restore.
+"""
+
+import subprocess
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import defaults_store as ds  # noqa: E402
+
+DOMAIN = "com.enviouswispr.uat.defaults-store-control"
+FAILURES = []
+
+
+def ok(label, passed, detail=""):
+    print(f"  {'PASS' if passed else 'FAIL'}  {label}" + (f"  :: {detail}" if detail else ""))
+    if not passed:
+        FAILURES.append(label)
+
+
+def read_type(key):
+    r = subprocess.run(["defaults", "read-type", DOMAIN, key], capture_output=True, text=True)
+    return r.stdout.strip().rsplit(" ", 1)[-1] if r.returncode == 0 else None
+
+
+def main():
+    subprocess.run(["defaults", "delete", DOMAIN], capture_output=True)
+    try:
+        print("a STRING preference survives a park-and-restore as a STRING")
+        # Exactly what the previous phase5_geometry.py wrote, and the value whose
+        # restore-as-boolean silently changes the app's effective setting.
+        subprocess.run(["defaults", "write", DOMAIN, "k", "0"], check=True)
+        ok("precondition: it really is a string", read_type("k") == "string", read_type("k"))
+        snap = ds.snapshot(DOMAIN, ["k"])
+        ok("the snapshot captured the type", snap["k"] == ("0", "-string"), str(snap["k"]))
+        ds.write_typed(DOMAIN, "k", "true", "-bool")  # the harness drives its row
+        ok("the row's own write landed as a boolean", read_type("k") == "boolean", read_type("k"))
+        landed = ds.restore(DOMAIN, snap)
+        ok("restore reports success", landed["k"] is True)
+        ok("the TYPE came back", read_type("k") == "string", read_type("k"))
+        ok("the TEXT came back", ds.read_typed(DOMAIN, "k") == ("0", "-string"))
+
+        print("\na BOOLEAN preference survives as a BOOLEAN")
+        subprocess.run(["defaults", "write", DOMAIN, "b", "-bool", "false"], check=True)
+        snap = ds.snapshot(DOMAIN, ["b"])
+        ds.write_typed(DOMAIN, "b", "true", "-bool")
+        landed = ds.restore(DOMAIN, snap)
+        ok("restore reports success", landed["b"] is True)
+        ok("still a boolean", read_type("b") == "boolean", read_type("b"))
+        ok("still false", ds.read_typed(DOMAIN, "b") == ("0", "-bool"))
+
+        print("\nan ABSENT key is restored to ABSENT, not to a value")
+        snap = ds.snapshot(DOMAIN, ["gone"])
+        ok("snapshot says absent", snap["gone"] is None)
+        ds.write_typed(DOMAIN, "gone", "true", "-bool")
+        landed = ds.restore(DOMAIN, snap)
+        ok("restore reports success", landed["gone"] is True)
+        ok("the key is gone again", ds.read_typed(DOMAIN, "gone") is None)
+
+        print("\nrestore REPORTS a failure it cannot fix, rather than claiming success")
+        # The check must be able to fail, or it is not a check. Drive it by
+        # snapshotting a value and then making the restore target unwritable is
+        # not available here, so assert the weaker but real property: a restore
+        # of a value the module cannot express REFUSES at snapshot time.
+        subprocess.run(["defaults", "write", DOMAIN, "arr", "-array", "a", "b"], check=True)
+        refused = False
+        try:
+            ds.snapshot(DOMAIN, ["arr"])
+        except ds.UnsupportedType:
+            refused = True
+        ok("an array REFUSES rather than being guessed", refused)
+    finally:
+        subprocess.run(["defaults", "delete", DOMAIN], capture_output=True)
+
+    print()
+    if FAILURES:
+        print(f"FAILED: {len(FAILURES)} row(s): {', '.join(FAILURES)}")
+        sys.exit(1)
+    print("all rows passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/RuntimeUAT/test_escape_recovery_uat.py
+++ b/Tests/RuntimeUAT/test_escape_recovery_uat.py
@@ -204,7 +204,7 @@ uat.defaults_delete = lambda k: None  # the delete goes nowhere
 try:
     uat.apply_settings([("escapeRecoveryEnabled", None, None)], "row")
     ok("a delete that goes nowhere ABORTS", False,
-       "the OFF phase would then run with the feature ON")
+       "a restore-to-default row would then leave the previous value in place")
 except uat.Aborted as e:
     ok("a delete that goes nowhere ABORTS", True, str(e))
 

--- a/website/src/content/help/canceling-a-recording.md
+++ b/website/src/content/help/canceling-a-recording.md
@@ -6,7 +6,7 @@ section: "Recording"
 order: 5
 keywords: ["cancel", "stop without pasting", "throw away", "discard", "escape", "abort", "undo", "didnt mean to record", "delete recording"]
 related: ["recording-won-t-stop-or-seems-stuck", "escape-recovery"]
-updated: 2026-08-17
+updated: 2026-09-01
 ---
 If you misspeak, get interrupted, or start recording by accident, you can stop the recording without leaving any text behind. EnviousWispr ends the recording, discards the audio, and leaves your cursor untouched. This works in every recording mode and at any point during a recording.
 
@@ -28,6 +28,6 @@ You can change the cancel key if you prefer a different keybind. Click the Envio
 
 ### If you would rather keep what you said
 
-Everything above describes how EnviousWispr behaves out of the box. There is an optional setting, **Escape Recovery**, that changes it: with the setting on, your cancel keybind keeps the dictation instead of discarding it, transcribes it, and offers to paste it back. The triple press of your recording keybind does the same. The Cancel button in the recording bar still discards immediately either way.
+Everything above describes what the Cancel button does. Your cancel keybind behaves differently, because of a setting called **Escape Recovery** that is on from the start: the keybind keeps the dictation instead of discarding it, transcribes it, and offers to paste it back. The triple press of your recording keybind does the same. The Cancel button in the recording bar discards immediately whatever the setting says.
 
-The setting is off unless you turn it on, in **Settings**, **Keybinds**, under Cancel Recording. [Escape Recovery](/help/escape-recovery/) explains what it changes and what it costs you.
+The setting is on unless you switch it off, in **Settings**, **Keybinds**, under Cancel Recording. [Escape Recovery](/help/escape-recovery/) explains what it changes and what it costs you.

--- a/website/src/content/help/canceling-a-recording.md
+++ b/website/src/content/help/canceling-a-recording.md
@@ -1,6 +1,6 @@
 ---
 title: "Canceling a Recording"
-description: "Throw away a recording without transcribing or pasting it."
+description: "Stop a recording, and choose whether to keep what you said."
 category: "recording-and-keybinds"
 section: "Recording"
 order: 5
@@ -8,26 +8,26 @@ keywords: ["cancel", "stop without pasting", "throw away", "discard", "escape", 
 related: ["recording-won-t-stop-or-seems-stuck", "escape-recovery"]
 updated: 2026-09-01
 ---
-If you misspeak, get interrupted, or start recording by accident, you can stop the recording without leaving any text behind. EnviousWispr ends the recording, discards the audio, and leaves your cursor untouched. This works in every recording mode and at any point during a recording.
+If you misspeak, get interrupted, or start recording by accident, you can stop the recording without any text landing where you were typing. Nothing is pasted and your cursor is left untouched. This works in every recording mode and at any point during a recording.
 
-### How to cancel
+There are two ways to stop, and they do different things on purpose. One keeps what you said in case you want it. The other throws it away for good.
 
-**Press Escape.** Press the Escape key on your keyboard while the recording is running.
+### Press Escape to stop and keep it
 
-**Or press your keybind three times.** In push-to-talk mode, a triple press of your recording keybind cancels the session without reaching for the Escape key.
+**Press Escape.** Press the Escape key while the recording is running. In push-to-talk mode, pressing your recording keybind three times does the same thing. In hands-free mode, press Escape rather than your keybind, because your keybind stops the recording and sends it for transcription.
 
-### Canceling in hands-free mode
+The recording bar disappears and nothing is pasted. Behind that, EnviousWispr finishes transcribing what you said and offers it back to you with an **Undo** button. If you miss the notice, it waits in your History for 24 hours. This is a setting called **Escape Recovery**, and it is on from the start. [Escape Recovery](/help/escape-recovery/) explains it in full, including what it costs you.
 
-In hands-free mode, pressing your recording keybind stops the recording and sends the audio for transcription. To cancel instead, press **Escape**. Do not use your keybind for this.
+Two things follow from the recording being kept rather than dropped. A new recording cannot start until the old one finishes processing, the same as after any dictation. And if you use a cloud provider for AI polish, that polish runs under your own key and counts towards your usage, exactly as a normal dictation would.
 
-### What happens when you cancel
+### Click Cancel to throw it away
 
-EnviousWispr ends the session entirely. Nothing is transcribed, nothing is pasted into the app you were working in, and no entry is saved to your History. The recording bar disappears from the screen and EnviousWispr returns to waiting, which is how you know the cancellation worked.
+**Click Cancel in the recording bar.** The recording is dropped there and then. Nothing is transcribed, nothing is pasted, and no entry is saved to your History. The button always does this, whatever your settings say.
 
-You can change the cancel key if you prefer a different keybind. Click the EnviousWispr icon in your menu bar, choose **Settings**, and select **Keybinds**.
+A button labelled Cancel should mean one thing. Escape is also how people dismiss menus and back out of fields, so Escape is the one that gives you a way back.
 
-### If you would rather keep what you said
+### If you would rather Escape threw it away too
 
-Everything above describes what the Cancel button does. Your cancel keybind behaves differently, because of a setting called **Escape Recovery** that is on from the start: the keybind keeps the dictation instead of discarding it, transcribes it, and offers to paste it back. The triple press of your recording keybind does the same. The Cancel button in the recording bar discards immediately whatever the setting says.
+Switch **Escape Recovery** off, in **Settings**, **Keybinds**, under Cancel Recording. After that, pressing Escape discards the recording immediately, exactly as the Cancel button does.
 
-The setting is on unless you switch it off, in **Settings**, **Keybinds**, under Cancel Recording. [Escape Recovery](/help/escape-recovery/) explains what it changes and what it costs you.
+You can also change the cancel key itself. Click the EnviousWispr icon in your menu bar, choose **Settings**, and select **Keybinds**.

--- a/website/src/content/help/customizing-your-keybind.md
+++ b/website/src/content/help/customizing-your-keybind.md
@@ -37,7 +37,7 @@ If holding a key down is uncomfortable, toggle mode asks less of your hand: one 
 
 ### The cancel key
 
-Pressing Escape throws the current recording away without transcribing it. You can change this cancel key on the same **Keybinds** page if you prefer a different one.
+Pressing Escape ends the current recording without pasting anything. You can change this cancel key on the same **Keybinds** page if you prefer a different one.
 
 The same page carries a setting called **Escape Recovery**, on unless you switch it off. With it on, your cancel keybind keeps the recording and offers to paste it back rather than discarding it, which is worth knowing before you reassign the key. See [Escape Recovery](/help/escape-recovery/).
 

--- a/website/src/content/help/customizing-your-keybind.md
+++ b/website/src/content/help/customizing-your-keybind.md
@@ -5,7 +5,7 @@ category: "recording-and-keybinds"
 section: "Recording"
 order: 4
 keywords: ["keybind", "keybinds", "hotkey", "shortcut", "keyboard shortcut", "change the key", "how do i change the key", "key combo", "keybinding", "remap", "different key", "globe key", "fn key", "caps lock", "conflicts with another app"]
-updated: 2026-08-17
+updated: 2026-09-01
 ---
 Your keybind is the key you hold or press to record, and you can change it to whatever suits your hands. EnviousWispr arrives set to the right Option key.
 
@@ -39,7 +39,7 @@ If holding a key down is uncomfortable, toggle mode asks less of your hand: one 
 
 Pressing Escape throws the current recording away without transcribing it. You can change this cancel key on the same **Keybinds** page if you prefer a different one.
 
-The same page carries an optional setting called **Escape Recovery**. It is off unless you turn it on. With it on, your cancel keybind keeps the recording and offers to paste it back rather than discarding it, which is worth knowing before you reassign the key. See [Escape Recovery](/help/escape-recovery/).
+The same page carries a setting called **Escape Recovery**, on unless you switch it off. With it on, your cancel keybind keeps the recording and offers to paste it back rather than discarding it, which is worth knowing before you reassign the key. See [Escape Recovery](/help/escape-recovery/).
 
 ### If your keybind stops working
 

--- a/website/src/content/help/escape-recovery.md
+++ b/website/src/content/help/escape-recovery.md
@@ -6,19 +6,19 @@ section: "Recording"
 order: 6
 keywords: ["escape recovery", "cancelled by mistake", "i cancelled by accident", "get my dictation back", "undo cancel", "recover a cancelled recording", "keep a cancelled recording", "pressed escape by mistake", "lost what i said", "accidental cancel"]
 related: ["canceling-a-recording", "transcript-history"]
-updated: 2026-08-18
+updated: 2026-09-01
 ---
-Cancelling a recording normally throws it away. If you have ever pressed your cancel keybind and wished a second later that you had not, Escape Recovery is the setting that changes that. It is off until you turn it on, and turning it off puts everything back exactly as it was.
+If you have ever pressed your cancel keybind and wished a second later that you had not, Escape Recovery is what saves you. It is on from the start. Your cancel keybind keeps the recording and offers it back to you instead of throwing it away. Switch it off and cancelling discards immediately, exactly as it used to.
 
 A recording follows the setting as it stood when that recording started. Changing the toggle applies from the next recording you begin, never to one already running.
 
-### Turning it on
+### Where the setting lives
 
 1. **Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Keybinds**.
 2. **Find Cancel Recording.** It is the section below your recording keybind.
-3. **Switch on Escape Recovery.**
+3. **Escape Recovery is the toggle there**, on unless you switch it off.
 
-### What changes when it is on
+### What it does
 
 Your cancel keybind, Escape by default, still stops the recording. Instead of discarding it, EnviousWispr transcribes and polishes it the same way it would any dictation, then holds the text rather than pasting it.
 

--- a/website/src/content/help/hands-free-mode-long-dictation.md
+++ b/website/src/content/help/hands-free-mode-long-dictation.md
@@ -6,7 +6,7 @@ section: "Recording"
 order: 2
 keywords: ["hands free", "handsfree", "long dictation", "dont want to hold", "without holding", "let go", "keep recording", "long recording", "stop holding the key"]
 related: ["voice-activity-detection-and-auto-stop", "recording-won-t-stop-or-seems-stuck"]
-updated: 2026-08-06
+updated: 2026-09-01
 ---
 Hands-free mode locks recording on, for when you do not want to hold the key down while you talk. This mode suits any text longer than a sentence or two, such as a blog post, a long email, or meeting notes.
 
@@ -24,7 +24,7 @@ You have two choices when you finish speaking, depending on whether you want to 
 
 **Press your keybind once.** Stop recording and insert your text into the app you were working in.
 
-**Press Escape.** Stop recording and discard the audio without producing any text.
+**Press Escape.** Stop recording without any text landing where you were typing. By default EnviousWispr still keeps what you said and offers it back, which is [Escape Recovery](/help/escape-recovery/). To throw the recording away instead, click **Cancel** in the recording bar.
 
 ### Time limits
 

--- a/website/src/content/help/live-preview-words-on-screen.md
+++ b/website/src/content/help/live-preview-words-on-screen.md
@@ -5,21 +5,21 @@ category: "features"
 section: "Recording"
 order: 6
 keywords: ["live preview", "preview", "see words as i speak", "see my words", "words on screen", "on screen preview", "while i speak", "recording pill", "watch it type", "is it hearing me", "nothing appears", "no words showing"]
-updated: 2026-08-18
+updated: 2026-09-01
 ---
-Live Preview shows your words in the recording pill while you are still speaking, so you can see that EnviousWispr is hearing you. It is off unless you turn it on.
+Live Preview shows your words in the recording pill while you are still speaking, so you can see that EnviousWispr is hearing you. It is on unless you switch it off. On a Mac that cannot run it, EnviousWispr behaves as though it were off: you get the ordinary recording bar and no message.
 
 **It is only a preview.** The words in the pill are a rough draft from a second, lighter engine. They are thrown away when the recording ends, and they never change a character of the text that gets pasted. That text comes from the main engine, which is more accurate.
 
 Your voice and preview text stay on your Mac.
 
-### Turning it on
+### Where the setting lives
 
 **Open settings.** Click the EnviousWispr menu bar icon and select **Settings**, or press Cmd+,.
 
 **Go to Live Preview.** Under **Record**, click **Live Preview**.
 
-**Switch on Show words while I speak.** The card at the top of the page tells you whether the preview is ready, and if it is not, what is missing.
+**Show words while I speak** is the toggle there, on unless you switch it off. The card at the top of the page tells you whether the preview is ready, and if it is not, what is missing.
 
 ### Live Preview is not Faster Transcription
 

--- a/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
+++ b/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
@@ -7,9 +7,11 @@ order: 7
 keywords: ["wont stop", "stuck", "keeps recording", "frozen", "hung", "still recording", "cant stop", "spinning"]
 related: ["canceling-a-recording"]
 seeAlso: "mac-dictation-keeps-stopping"
-updated: 2026-08-06
+updated: 2026-09-01
 ---
-If a recording will not stop, press **Escape**. This ends any recording in progress and discards the audio, in every recording mode. The on-screen bar disappears, which confirms it worked.
+If a recording will not stop, press **Escape**. This ends any recording in progress, in every recording mode. The on-screen bar disappears, which confirms it worked.
+
+By default Escape keeps what you said rather than throwing it away: EnviousWispr transcribes it and offers it back, and it waits in your History for 24 hours. That is a setting called [Escape Recovery](/help/escape-recovery/), on unless you switch it off. If you want the recording gone instead, click **Cancel** in the recording bar, which always discards immediately.
 
 ### Recording cannot run forever
 

--- a/website/src/content/help/sounds-and-appearance.md
+++ b/website/src/content/help/sounds-and-appearance.md
@@ -5,7 +5,7 @@ category: "features"
 section: "Appearance and Sounds"
 order: 5
 keywords: ["sound", "sounds", "beep", "chime", "mute the sound", "turn off sound", "appearance", "theme", "dark mode", "pill", "overlay", "bar position", "move the bar", "menu bar icon"]
-updated: 2026-08-06
+updated: 2026-09-01
 ---
 Three settings change how EnviousWispr looks and sounds while you use it. None of them affects what you dictate or how accurately it is transcribed.
 
@@ -23,6 +23,6 @@ You can also move the bar during a dictation.
 
 ### Recording sounds
 
-A short sound confirms when EnviousWispr starts and stops listening, which helps if you dictate without looking at the screen or you are unsure whether it registered your keybind. Go to **Settings**, then select **Sounds**, and switch on **Play recording sounds**. This setting is off by default.
+A short sound confirms when EnviousWispr starts and stops listening, which helps if you dictate without looking at the screen or you are unsure whether it registered your keybind. This setting is on from the start, using the Whisper Tick pairing. To silence it, go to **Settings**, then select **Sounds**, and switch off **Play recording sounds**.
 
 **Preview a sound.** Select any of the sound pairings on the **Sounds** page and click the preview button to hear each one before you settle on it.

--- a/website/src/content/help/toggle-mode.md
+++ b/website/src/content/help/toggle-mode.md
@@ -6,7 +6,7 @@ section: "Recording"
 order: 3
 keywords: ["toggle", "press once", "click to start click to stop", "on off mode", "start stop"]
 related: ["customizing-your-keybind"]
-updated: 2026-08-06
+updated: 2026-09-01
 ---
 Toggle mode changes how you interact with your recording keybind. Instead of holding the key down for every sentence, you press the keybind once to start recording and press it again to stop.
 
@@ -37,6 +37,6 @@ You can switch to this mode in settings.
 
 **Select Toggle.** Under **1. Choose recording mode**, pick **Toggle**.
 
-You will know the setting took effect when a single press starts recording instead of requiring a constant hold. The recording keybind stays the same in both modes, so the rest of your setup remains unchanged. Pressing the Escape key still cancels and discards a recording.
+You will know the setting took effect when a single press starts recording instead of requiring a constant hold. The recording keybind stays the same in both modes, so the rest of your setup remains unchanged. Pressing the Escape key still ends a recording. By default it keeps what you said and offers it back rather than discarding it, which is [Escape Recovery](/help/escape-recovery/); the Cancel button in the recording bar is the one that always discards.
 
 The double-press lock from push to talk does not apply in toggle mode. There is nothing to lock on, because your hands are already free.

--- a/website/src/content/help/transcript-history.md
+++ b/website/src/content/help/transcript-history.md
@@ -6,11 +6,11 @@ section: "Transcript History"
 order: 1
 keywords: ["history", "past dictations", "previous", "find an old dictation", "where did my text go", "recover", "lost text", "copy again", "log"]
 related: ["clipboard-preservation", "escape-recovery"]
-updated: 2026-08-17
+updated: 2026-09-01
 ---
 EnviousWispr saves each finished dictation so you can find it again later. To see your past dictations, click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **History**.
 
-Recordings where no speech was found are not saved, and neither are recordings you cancelled, unless you turned on [Escape Recovery](/help/escape-recovery/). With that setting on, a recording you cancel with your keybind is kept here for 24 hours with a **Kept** badge and a countdown, and press **Keep** to make it permanent. Until you do, it stays out of search and out of your dictation counts. If saving fails for a storage reason, EnviousWispr tells you.
+Recordings where no speech was found are not saved. A recording you cancel with your keybind IS saved, because [Escape Recovery](/help/escape-recovery/) is on unless you switch it off: it is kept here for 24 hours with a **Kept** badge and a countdown, and press **Keep** to make it permanent. Switch that setting off, or use the Cancel button in the recording bar, and nothing is saved. Until you do, it stays out of search and out of your dictation counts. If saving fails for a storage reason, EnviousWispr tells you.
 
 ### What you can do
 

--- a/website/src/content/help/what-data-is-collected.md
+++ b/website/src/content/help/what-data-is-collected.md
@@ -6,7 +6,7 @@ section: "Privacy"
 order: 2
 keywords: ["what data", "analytics", "telemetry", "collected", "do you see my text", "do you store", "opt out", "tracking", "crash reports"]
 related: ["privacy-overview"]
-updated: 2026-08-18
+updated: 2026-09-01
 ---
 EnviousWispr collects anonymous usage data and crash reports. Nothing you say is part of that. Your audio and your transcripts never reach Envious Labs, the company that makes the app.
 
@@ -14,7 +14,7 @@ EnviousWispr collects anonymous usage data and crash reports. Nothing you say is
 
 Your transcripts are saved to your History so you can find them later. They sit in your user folder, and Envious Labs never receives a copy.
 
-If you turn on [Escape Recovery](/help/escape-recovery/), a recording you cancel with your keybind is transcribed and held in that same folder, so you can paste it back or press Keep to make it permanent. It stays available for 24 hours. After that it is removed while the app is running, or the next time you launch it. Its audio is deleted once its text is safely saved, exactly as with any other dictation.
+[Escape Recovery](/help/escape-recovery/) is on unless you switch it off, so a recording you cancel with your keybind is transcribed and held in that same folder, letting you paste it back or press Keep to make it permanent. It stays available for 24 hours. After that it is removed while the app is running, or the next time you launch it. Its audio is deleted once its text is safely saved, exactly as with any other dictation.
 
 While you dictate, the app keeps an encrypted backup of the recording. Once your text is safely saved, the app requests deletion of that backup. If the app quits first, EnviousWispr makes one recovery attempt the next time it runs, then requests deletion whether that recovery succeeded or failed.
 

--- a/website/src/pages/compare/fluidvoice.astro
+++ b/website/src/pages/compare/fluidvoice.astro
@@ -447,7 +447,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Recover a cancelled dictation</td>
-            <td><span class="table-highlight">Yes</span> (Escape Recovery, opt-in, keybind/triple-press cancel only)</td>
+            <td><span class="table-highlight">Yes</span> (Escape Recovery, on by default, keybind/triple-press cancel only)</td>
             <td>Not documented</td>
           </tr>
           <tr>
@@ -505,7 +505,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">↩️</div>
         <div class="advantage-title">Undo an accidental cancel</div>
-        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. Off by default; you choose to turn it on. We found no equivalent documented for FluidVoice.</p>
+        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. On by default; you can switch it off. We found no equivalent documented for FluidVoice.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📜</div>

--- a/website/src/pages/compare/fluidvoice.astro
+++ b/website/src/pages/compare/fluidvoice.astro
@@ -442,7 +442,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Live preview while speaking</td>
-            <td><span class="table-check">Yes</span>, off by default</td>
+            <td><span class="table-check">Yes</span>, on by default; a Mac that cannot run it shows the ordinary recording bar</td>
             <td><span class="table-check">Yes</span>, real-time transcription overlay</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/handy.astro
+++ b/website/src/pages/compare/handy.astro
@@ -477,7 +477,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Recover a cancelled dictation</td>
-            <td><span class="table-highlight">Yes</span> (Escape Recovery, opt-in, keybind/triple-press cancel only, 24-hour History)</td>
+            <td><span class="table-highlight">Yes</span> (Escape Recovery, on by default, keybind/triple-press cancel only, 24-hour History)</td>
             <td><span class="table-cross">Not documented</span></td>
           </tr>
           <tr>
@@ -550,12 +550,12 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">👀</div>
         <div class="advantage-title">See your words as you speak</div>
-        <p class="advantage-desc">Live Preview shows your words in the recording pill while you talk, so you always know you are being heard. It is off by default; turn it on in Settings, Record, Live Preview, and pick an engine: Apple's needs macOS 26, or Universal works from macOS 14 with a one-time 217MB download. Your finished text is still decoded from the whole recording after you stop, so nothing is lost waiting for the preview to catch up. Handy has a live overlay too, on by default, though it only shows live text with certain Whisper models and falls back to a waveform with Parakeet.</p>
+        <p class="advantage-desc">Live Preview shows your words in the recording pill while you talk, so you always know you are being heard. It is on by default, and unavailable engines simply show nothing rather than a warning; you pick the engine in Settings, Record, Live Preview: Apple's needs macOS 26, or Universal works from macOS 14 with a one-time 217MB download. Your finished text is still decoded from the whole recording after you stop, so nothing is lost waiting for the preview to catch up. Handy has a live overlay too, on by default, though it only shows live text with certain Whisper models and falls back to a waveform with Parakeet.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">↩️</div>
         <div class="advantage-title">Undo an accidental cancel</div>
-        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. The app finishes transcribing and polishing, then offers an Undo button, and the text waits in your History for 24 hours if you let it fade. Off by default; you choose to turn it on. The Cancel button in the recording bar always discards immediately, with or without it on.</p>
+        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. The app finishes transcribing and polishing, then offers an Undo button, and the text waits in your History for 24 hours if you let it fade. On by default; you can switch it off. The Cancel button in the recording bar always discards immediately, with or without it on.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">⚡</div>

--- a/website/src/pages/compare/handy.astro
+++ b/website/src/pages/compare/handy.astro
@@ -472,7 +472,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Live preview while speaking</td>
-            <td><span class="table-check">Yes</span>: off by default, one setting to turn on</td>
+            <td><span class="table-check">Yes</span>: on by default, one setting to turn off; a Mac that cannot run it shows the ordinary recording bar</td>
             <td><span class="table-check">With some models</span>: overlay is on by default, but only shows live text with a compatible Whisper model; falls back to a waveform with Parakeet</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -128,7 +128,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I recover a dictation I cancelled by accident with Juno?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "We found no documentation of a recovery or undo feature for a cancelled Juno dictation. EnviousWispr has Escape Recovery, an opt-in feature that can keep a dictation you cancel with your keybind or a triple press instead of discarding it instantly, and offers an Undo button afterward."
+        "text": "We found no documentation of a recovery or undo feature for a cancelled Juno dictation. EnviousWispr has Escape Recovery, on by default, which keeps a dictation you cancel with your keybind or a triple press instead of discarding it instantly, and offers an Undo button afterward."
       }
     },
     {
@@ -451,7 +451,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Recover a cancelled dictation</td>
-            <td><span class="table-highlight">Yes</span> (Escape Recovery, opt-in, keybind/triple-press cancel only)</td>
+            <td><span class="table-highlight">Yes</span> (Escape Recovery, on by default, keybind/triple-press cancel only)</td>
             <td>Not documented</td>
           </tr>
           <tr>
@@ -519,7 +519,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">↩️</div>
         <div class="advantage-title">Undo an accidental cancel</div>
-        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. Off by default; you choose to turn it on. We found no equivalent documented for Juno.</p>
+        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. On by default; you can switch it off. We found no equivalent documented for Juno.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">🎯</div>
@@ -737,7 +737,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I recover a dictation I cancelled by accident with Juno?</div>
-        <p class="faq-a">We found no documentation of a recovery or undo feature for a cancelled Juno dictation. EnviousWispr has Escape Recovery, an opt-in feature that can keep a dictation you cancel with your keybind or a triple press instead of discarding it instantly, and offers an Undo button afterward.</p>
+        <p class="faq-a">We found no documentation of a recovery or undo feature for a cancelled Juno dictation. EnviousWispr has Escape Recovery, on by default, which keeps a dictation you cancel with your keybind or a triple press instead of discarding it instantly, and offers an Undo button afterward.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from Juno to EnviousWispr easily?</div>

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -446,7 +446,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Live preview while speaking</td>
-            <td><span class="table-check">Yes</span>, off by default</td>
+            <td><span class="table-check">Yes</span>, on by default; a Mac that cannot run it shows the ordinary recording bar</td>
             <td><span class="table-check">Yes</span>, Live HUD transcript</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/spokenly.astro
+++ b/website/src/pages/compare/spokenly.astro
@@ -447,7 +447,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Recover a cancelled dictation</td>
-            <td><span class="table-highlight">Yes</span> (Escape Recovery, opt-in, keybind/triple-press cancel only)</td>
+            <td><span class="table-highlight">Yes</span> (Escape Recovery, on by default, keybind/triple-press cancel only)</td>
             <td>Not documented</td>
           </tr>
           <tr>
@@ -500,7 +500,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">↩️</div>
         <div class="advantage-title">Undo an accidental cancel</div>
-        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. Off by default; you choose to turn it on. We found no equivalent documented for Spokenly.</p>
+        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. On by default; you can switch it off. We found no equivalent documented for Spokenly.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">⚡</div>

--- a/website/src/pages/compare/typewhisper.astro
+++ b/website/src/pages/compare/typewhisper.astro
@@ -427,7 +427,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Live preview while speaking</td>
-            <td><span class="table-check">Yes</span>, off by default</td>
+            <td><span class="table-check">Yes</span>, on by default; a Mac that cannot run it shows the ordinary recording bar</td>
             <td><span class="table-check">Yes</span>, live preview engine override</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/typewhisper.astro
+++ b/website/src/pages/compare/typewhisper.astro
@@ -432,7 +432,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Recover a cancelled dictation</td>
-            <td><span class="table-highlight">Yes</span> (Escape Recovery, opt-in, keybind/triple-press cancel only)</td>
+            <td><span class="table-highlight">Yes</span> (Escape Recovery, on by default, keybind/triple-press cancel only)</td>
             <td>Not documented</td>
           </tr>
           <tr>
@@ -505,7 +505,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">↩️</div>
         <div class="advantage-title">Undo an accidental cancel</div>
-        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. Off by default; you choose to turn it on. We found no equivalent documented for TypeWhisper.</p>
+        <p class="advantage-desc">Escape Recovery keeps a dictation you cancel with your keybind or a triple press, instead of discarding it instantly. On by default; you can switch it off. We found no equivalent documented for TypeWhisper.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">💵</div>


### PR DESCRIPTION
## What changes

Four behaviours that were opt in now ship on, by founder direction (2026-09-01).
Every toggle stays exactly where it was; only the shipped default moved.

| Setting | Was | Now |
|---|---|---|
| `escapeRecoveryEnabled` | off | **on** |
| `livePreviewEnabled` | off | **on** |
| `playRecordingSounds` | off | **on** (pairing already Whisper Tick) |
| clipboard toggles | already on | unchanged |

Plus the built-in dictionary gains **EG-1** and eight `EnviousWispr` mishearings
taken verbatim from the founder's own library. `mergedWords` merges built-ins at
read time, so both reach every existing install with no migration.

## Live Preview's exception is existing machinery, not new code

The founder asked that a machine which cannot run the preview stay off.
`LivePreviewCoordinator` already resolves an EFFECTIVE enabled value once per
recording, combining the stored switch with whether the selected engine can run
here. A Mac below macOS 26 on the Apple engine gets the ordinary pill, no words
and no message. That is now asserted two-way rather than trusted, because it is
the single premise that makes on-by-default safe across the whole supported range.

## What an upgrade does

Nothing writes any of these keys unless a person changes something, so an
existing user arrives with the key ABSENT and takes the new default; a stored
choice outranks it, on this update and every one after. Both halves are asserted
per setting.

One path opts a user out without a settings toggle and is deliberate:
`PillAppearanceModel.chooseCoupled` writes `livePreviewEnabled` when someone picks
a recording pill design, so anyone who ever chose a wordless pill keeps `false`.

## The EG-1 aliases were measured, not reasoned about

The spelled-out forms were proposed and REMOVED. The fuzzy multi-word pass turned
"she cracked an egg on the pan" into "she cracked an EG-1 the pan", and "the item
is e g on the list" into "the item is EG-1 the list". Matching is
case-insensitive, so dropping one spelling would have changed nothing. What ships
carries the digit. Six ordinary sentences are kept as standing controls, including
both that failed.

## Defects this change surfaced

- **`escape_recovery_uat.py`** set its OFF phase by DELETING the key, which reads
  the default. With the default now ON, that phase would have run the feature
  switched on and failed every assertion against a correct app. It writes
  `-bool false`.
- **`phase5_geometry.py`** wrote `livePreviewEnabled` as a bare `1`/`0`.
  `SettingsManager` reads it with `object(forKey:) as? Bool`, so a string yields
  nil and the app falls back to the default — while `defaults read` prints the
  value back unchanged, so the harness's own read-back confirmed a write the app
  ignored. Its two `False` rows would have captured reading-well geometry under
  the labels levelRail and classic. Its restore path had the same defect and would
  have written a string over the developer's own preference.
- **The What's New entry was invisible.** `v2.4.6` shipped 2026-08-28 with
  `currentContentVersion` still `2.4.6`, so anyone who had opened What's New since
  raised no badge. The entry moves to a new 2.4.7 group and the CONTENT version
  moves with it; the marketing version waits for a release PR, matching #2027 and
  #1973.

## Surfaces swept

Review returned members of one class twice, so the class was enumerated from the
producing roots rather than patched member by member. Sweep and confirming re-run:
`/tmp/ew-defaults-class-sweep.txt`, `/tmp/ew-defaults-class-sweep-after.txt`.

Ten help articles mention Escape or cancel; six needed changing. Five comparison
pages, the repo README, two in-app doc comments, the manual UAT scenario, five
knowledge authorities, and the cross-platform catalog's macOS rows. **The axis both
earlier rounds missed: an artifact can depend on a default without naming the
setting** — a page describing what Escape does, a README bullet, a doc comment
restating the value.

## Validation

- `scripts/xcode-test.sh` — 7031 tests, 618 suites, passing
- `npm run build` + `npm run check:help` — 56 articles 0 errors, 69 routes, 42/42 search
- Local Codex review to an explicit all-clear, with a confirming re-run
