### PR TITLE
feat(snippets): say a keyword and a trigger, get the text you saved (#628)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoverySpoolReplayer.swift
@@ -106,6 +106,13 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
   private let currentVocabulary:
     @MainActor () -> (corrector: CorrectorVocabulary, polish: PolishVocabulary)
 
+  /// #628. Current snippets, on the same best-effort footing as the words above: the recording
+  /// snapshot carries settings, never vocabulary CONTENTS, so a replay uses what the user has
+  /// now. Deliberately NOT defaulted — `RecoveryTextProcessor` already had the seam and nothing
+  /// called it, so recovered speech kept "backslash my email" as literal words. A default here
+  /// is exactly what would let the next path go unwired the same way.
+  private let currentSnippets: @MainActor () -> SnippetVocabulary
+
   /// Test-only observation seam (GitHub cloud review, PR #1732): fires right
   /// after the attempt marker write succeeds, before the Keychain retrieve
   /// begins. Nil in production — exists so a test can deterministically
@@ -133,7 +140,8 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     now: @escaping @Sendable () -> Date = { Date() },
     currentVocabulary: @escaping @MainActor () -> (
       corrector: CorrectorVocabulary, polish: PolishVocabulary
-    )
+    ),
+    currentSnippets: @escaping @MainActor () -> SnippetVocabulary
   ) {
     self.now = now
     self.activeEngine = activeEngine
@@ -145,6 +153,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     self.outputClassifierHolder = outputClassifierHolder
     self.egOneRuntime = egOneRuntime
     self.currentVocabulary = currentVocabulary
+    self.currentSnippets = currentSnippets
   }
 
   /// #2207 test seam: invoked synchronously the instant the readiness-retry
@@ -424,6 +433,7 @@ final class RecoverySpoolReplayer: RecoverySpoolReplaying {
     if let settings = recovered.settings { processor.applySettings(settings) }
     let vocab = currentVocabulary()
     processor.applyCustomWordsVocabulary(corrector: vocab.corrector, polish: vocab.polish)
+    processor.applySnippetVocabulary(currentSnippets())
     let textOutcome = await processor.process(rawText: result.text)
     if isAborted() { return .aborted }
 

--- a/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
@@ -82,6 +82,9 @@ final class SnippetsCoordinator {
     } catch let error as SnippetValidationError {
       errorMessage = Self.message(for: error)
       return false
+    } catch let error as SnippetStoreError {
+      errorMessage = Self.message(for: error)
+      return false
     } catch {
       errorMessage = "That could not be saved. \(error.localizedDescription)"
       return false
@@ -99,6 +102,31 @@ final class SnippetsCoordinator {
     case .duplicateTrigger(let existing):
       return
         "You already have a snippet for those words: \u{201C}\(existing)\u{201D}. Change one of them."
+    case .keywordNotOneWord:
+      return "Your keyword has to be a single word. Pick one you would not say by accident."
     }
   }
+
+  /// The store's own failures, which are not the user's fault and must never read as one.
+  ///
+  /// `existingFileUnreadable` is the important sentence here. It stands between a temporary read
+  /// failure and a saved empty list overwriting snippets that still exist, so it tells the user
+  /// their snippets ARE still there rather than implying they are gone.
+  static func message(for error: SnippetStoreError) -> String {
+    switch error {
+    case .existingFileUnreadable:
+      return
+        "Your saved snippets could not be read, so nothing was changed. They are still on disk. Restart EnviousWispr, and tell us if it keeps happening."
+    case .busy:
+      return "Another copy of EnviousWispr is editing snippets right now. Try that again."
+    case .coordinationUnavailable:
+      return "Snippets could not be saved just now. Try that again."
+    case .writeFailed(let reason):
+      return "That could not be saved. \(reason)"
+    }
+  }
+
+  /// True when a file exists that could not be read. The screen shows this instead of an empty
+  /// list, because an empty list is a lie the user would act on by adding snippets over the top.
+  var storeUnreadable: Bool { manager.unreadableExisting }
 }

--- a/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
@@ -31,6 +31,9 @@ final class SnippetsCoordinator {
 
   init(manager: SnippetsManager = SnippetsManager()) {
     self.manager = manager
+    // Assigned directly, not through `adopt`: nothing has registered a listener yet, and the
+    // bootstrapper seeds both drivers from `vocabulary` immediately after construction. This is
+    // the ONE site that may write it without publishing, and it is one line from the property.
     vocabulary = manager.load()
   }
 
@@ -74,10 +77,8 @@ final class SnippetsCoordinator {
   /// user's next dictation running against the previous list.
   private func apply(_ mutation: () throws -> SnippetVocabulary) -> Bool {
     do {
-      let updated = try mutation()
-      vocabulary = updated
+      adopt(try mutation())
       errorMessage = nil
-      onVocabularyChanged?(updated)
       return true
     } catch let error as SnippetValidationError {
       errorMessage = Self.message(for: error)
@@ -133,8 +134,21 @@ final class SnippetsCoordinator {
   /// snapshot would omit or resurrect snippets without saying so.
   @discardableResult
   func refreshFromDisk() -> SnippetVocabulary {
-    vocabulary = manager.load()
-    return vocabulary
+    adopt(manager.load())
+  }
+
+  /// Adopt a vocabulary and publish it. THE ONLY writer of `vocabulary`.
+  ///
+  /// `apply` below already carried a comment saying the adopt-and-publish pair must never be
+  /// done by one caller and forgotten by the next — and then `refreshFromDisk` was added and
+  /// forgot the publish, leaving the settings screen showing one list while both dictation
+  /// drivers still held the previous one. A comment asking callers to remember is not a
+  /// mechanism; a single private writer is. Nothing else in this type assigns `vocabulary`.
+  @discardableResult
+  private func adopt(_ updated: SnippetVocabulary) -> SnippetVocabulary {
+    vocabulary = updated
+    onVocabularyChanged?(updated)
+    return updated
   }
 
   /// True when a file exists that could not be read. The screen shows this instead of an empty

--- a/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
@@ -126,6 +126,17 @@ final class SnippetsCoordinator {
     }
   }
 
+  /// Re-read the store and adopt what is on disk.
+  ///
+  /// For the export, which asks the user for a destination first: another EnviousWispr process
+  /// can change the store while that panel is open, and a backup written from the pre-panel
+  /// snapshot would omit or resurrect snippets without saying so.
+  @discardableResult
+  func refreshFromDisk() -> SnippetVocabulary {
+    vocabulary = manager.load()
+    return vocabulary
+  }
+
   /// True when a file exists that could not be read. The screen shows this instead of an empty
   /// list, because an empty list is a lie the user would act on by adding snippets over the top.
   var storeUnreadable: Bool { manager.unreadableExisting }

--- a/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
@@ -1,0 +1,104 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+import Observation
+
+/// Owns the user's snippets for the UI, and publishes each change to the pipeline (#628).
+///
+/// One writer, by design. Custom words are written from several places — the settings list,
+/// import, auto-learn, the debounced usage counter — which is why `CustomWordsCoordinator` is
+/// large. Snippets are written only from the Snippets screen, so this stays a thin observable
+/// wrapper over `SnippetsManager` and gains nothing from mirroring that machinery.
+@MainActor @Observable
+final class SnippetsCoordinator {
+  /// The live vocabulary. The single source the list, the sheet and the pipeline all read, so
+  /// no two of them can disagree about what is saved.
+  private(set) var vocabulary: SnippetVocabulary = .empty
+
+  /// The last failure, in the user's words, or nil. Shown in the screen rather than logged and
+  /// swallowed: these snippets are typed by hand and exist nowhere else, so a save that did not
+  /// happen must say so.
+  var errorMessage: String?
+
+  /// Called after every successful change, with the new vocabulary.
+  ///
+  /// A closure rather than a propagator with weak boxes: snippets have exactly ONE live
+  /// consumer (the expansion step on the live driver), and a registration mechanism built for
+  /// four consumers would be four-fifths ceremony. The bootstrapper owns the wiring.
+  var onVocabularyChanged: ((SnippetVocabulary) -> Void)?
+
+  private let manager: SnippetsManager
+
+  init(manager: SnippetsManager = SnippetsManager()) {
+    self.manager = manager
+    vocabulary = manager.load()
+  }
+
+  var snippets: [Snippet] { vocabulary.snippets }
+  var keyword: String { vocabulary.keyword }
+
+  /// Snippets matching `query` against BOTH the trigger and the expansion.
+  ///
+  /// The expansion is searched too because that is how a user finds a snippet whose trigger
+  /// they have forgotten — they remember the address, not the words they picked for it.
+  func filtered(by query: String) -> [Snippet] {
+    let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !needle.isEmpty else { return snippets }
+    return snippets.filter {
+      $0.trigger.lowercased().contains(needle) || $0.expansion.lowercased().contains(needle)
+    }
+  }
+
+  // MARK: - Mutations
+
+  @discardableResult
+  func save(_ snippet: Snippet) -> Bool {
+    apply { try manager.upsert(snippet) }
+  }
+
+  @discardableResult
+  func delete(_ snippet: Snippet) -> Bool {
+    apply { try manager.remove(id: snippet.id) }
+  }
+
+  @discardableResult
+  func setKeyword(_ keyword: String) -> Bool {
+    apply { try manager.setKeyword(keyword) }
+  }
+
+  /// Run a store mutation, adopt its result, publish it, and turn any failure into a sentence
+  /// the user can act on. Returns whether it succeeded, so a sheet knows whether to close.
+  ///
+  /// Every mutation goes through here so the adopt-and-publish pair can never be done by one
+  /// caller and forgotten by the next — a screen that saved without publishing would leave the
+  /// user's next dictation running against the previous list.
+  private func apply(_ mutation: () throws -> SnippetVocabulary) -> Bool {
+    do {
+      let updated = try mutation()
+      vocabulary = updated
+      errorMessage = nil
+      onVocabularyChanged?(updated)
+      return true
+    } catch let error as SnippetValidationError {
+      errorMessage = Self.message(for: error)
+      return false
+    } catch {
+      errorMessage = "That could not be saved. \(error.localizedDescription)"
+      return false
+    }
+  }
+
+  /// One sentence per closed-set case, written for the person who typed the thing.
+  static func message(for error: SnippetValidationError) -> String {
+    switch error {
+    case .triggerEmpty:
+      return "Give the snippet something to say. A trigger of only punctuation can never match."
+    case .expansionEmpty:
+      return
+        "Add the text this snippet should paste. An empty snippet would delete the words you said."
+    case .duplicateTrigger(let existing):
+      return
+        "You already have a snippet for those words: \u{201C}\(existing)\u{201D}. Change one of them."
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/SnippetsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsExportAction.swift
@@ -1,0 +1,95 @@
+import AppKit
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import UniformTypeIdentifiers
+
+/// Write the user's snippets to a file they choose (#628).
+///
+/// Shipped in v1 even though Import is deferred, and the order is deliberate: an export that
+/// exists first means Import later lands against a format already in the wild, rather than
+/// inventing one and then having to keep two. It is also the only way a user moving Macs keeps
+/// snippets they typed by hand.
+@MainActor
+enum SnippetsExportAction {
+  static let defaultFilename = "EnviousWispr Snippets.json"
+
+  enum Outcome: Equatable {
+    case cancelled
+    case nothingToExport
+    /// The destination IS the app's own store. Refused, never written.
+    case refusedLiveStore
+    case written(URL, count: Int)
+    case failed(String)
+  }
+
+  /// The exported shape. Deliberately the same field names the store persists, so a file a user
+  /// keeps for a year still means what it says, and Import has nothing to translate.
+  struct Document: Encodable {
+    let version: Int
+    let keyword: String
+    let snippets: [Snippet]
+  }
+
+  static func run(vocabulary: SnippetVocabulary) -> Outcome {
+    // Checked BEFORE the panel: opening a save dialog and then announcing there was nothing to
+    // save wastes the one interaction the user paid for.
+    guard !vocabulary.snippets.isEmpty else { return .nothingToExport }
+
+    let panel = NSSavePanel()
+    panel.nameFieldStringValue = defaultFilename
+    panel.allowedContentTypes = [.json]
+    panel.canCreateDirectories = true
+    panel.message = summary(count: vocabulary.snippets.count)
+    panel.directoryURL =
+      FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)
+      .first
+
+    guard panel.runModal() == .OK, let destination = panel.url else { return .cancelled }
+
+    // The data-loss guard. Choosing the app's own store would replace it with this document,
+    // and the next launch would archive it as corrupt — the user destroying their snippets by
+    // backing them up. Compared through the filesystem, not the strings.
+    if let live = SnippetsManager.liveFileURL,
+      DurableJSONFile.isSameFile(destination, as: live)
+    {
+      return .refusedLiveStore
+    }
+
+    do {
+      try DurableJSONFile.write(
+        Document(
+          version: SnippetsManager.currentVersion,
+          keyword: vocabulary.keyword,
+          snippets: vocabulary.snippets),
+        to: destination,
+        tempPrefix: ".ew-snippets-export")
+      return .written(destination, count: vocabulary.snippets.count)
+    } catch {
+      return .failed(error.localizedDescription)
+    }
+  }
+
+  /// What the panel says the export will contain, read in the dialog that produces it. No zero
+  /// case: `run` returns before opening a panel when there is nothing to write.
+  static func summary(count: Int) -> String {
+    count == 1
+      ? "Exporting 1 snippet and your keyword."
+      : "Exporting \(count) snippets and your keyword."
+  }
+
+  /// One sentence per outcome, for the screen. `.cancelled` and `.written` say nothing — a
+  /// cancel needs no explanation, and a successful save is visible in Finder.
+  static func message(for outcome: Outcome) -> String? {
+    switch outcome {
+    case .cancelled, .written:
+      return nil
+    case .nothingToExport:
+      return "There are no snippets to export yet."
+    case .refusedLiveStore:
+      return
+        "That is EnviousWispr's own snippets file. Pick somewhere else — saving over it would erase your snippets."
+    case .failed(let reason):
+      return "The export did not finish. \(reason)"
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/SnippetsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsExportAction.swift
@@ -36,7 +36,15 @@ enum SnippetsExportAction {
   /// destination, and running them here would freeze the settings window until the storage
   /// answers. Only the panel needs the main actor; the bytes do not. Matches the custom-words
   /// export path, which learned this in its own review.
-  static func run(vocabulary: SnippetVocabulary) async -> Outcome {
+  /// - Parameter currentVocabulary: re-read AFTER the panel closes. A save panel is modal for
+  ///   this process and not for any other, so a second EnviousWispr — a shipped copy beside a
+  ///   dev build, which is routine — can add or delete a snippet while the dialog is open. A
+  ///   backup written from the pre-panel snapshot would silently omit what was added and keep
+  ///   what was deleted, and the user would not find out until they restored it.
+  static func run(
+    vocabulary: SnippetVocabulary,
+    currentVocabulary: () -> SnippetVocabulary = { .empty }
+  ) async -> Outcome {
     // Checked BEFORE the panel: opening a save dialog and then announcing there was nothing to
     // save wastes the one interaction the user paid for.
     guard !vocabulary.snippets.isEmpty else { return .nothingToExport }
@@ -61,11 +69,15 @@ enum SnippetsExportAction {
       return .refusedLiveStore
     }
 
+    // Re-read here, not before the panel: this is the latest moment before the bytes are
+    // written, and it is the only read whose result the file actually reflects.
+    let latest = currentVocabulary()
+    let exported = latest.snippets.isEmpty ? vocabulary : latest
     let document = Document(
       version: SnippetsManager.currentVersion,
-      keyword: vocabulary.keyword,
-      snippets: vocabulary.snippets)
-    return await write(document, to: destination, count: vocabulary.snippets.count)
+      keyword: exported.keyword,
+      snippets: exported.snippets)
+    return await write(document, to: destination, count: exported.snippets.count)
   }
 
   /// `@concurrent` so this always runs OFF the caller's actor. A plain `async` on a `@MainActor`

--- a/Sources/EnviousWisprAppKit/App/SnippetsExportAction.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsExportAction.swift
@@ -24,13 +24,19 @@ enum SnippetsExportAction {
 
   /// The exported shape. Deliberately the same field names the store persists, so a file a user
   /// keeps for a year still means what it says, and Import has nothing to translate.
-  struct Document: Encodable {
+  struct Document: Encodable, Sendable {
     let version: Int
     let keyword: String
     let snippets: [Snippet]
   }
 
-  static func run(vocabulary: SnippetVocabulary) -> Outcome {
+  /// Ask for a destination on the main actor, then WRITE off it.
+  ///
+  /// The write and its full filesystem sync are not free on a network, external or cloud-synced
+  /// destination, and running them here would freeze the settings window until the storage
+  /// answers. Only the panel needs the main actor; the bytes do not. Matches the custom-words
+  /// export path, which learned this in its own review.
+  static func run(vocabulary: SnippetVocabulary) async -> Outcome {
     // Checked BEFORE the panel: opening a save dialog and then announcing there was nothing to
     // save wastes the one interaction the user paid for.
     guard !vocabulary.snippets.isEmpty else { return .nothingToExport }
@@ -55,15 +61,23 @@ enum SnippetsExportAction {
       return .refusedLiveStore
     }
 
+    let document = Document(
+      version: SnippetsManager.currentVersion,
+      keyword: vocabulary.keyword,
+      snippets: vocabulary.snippets)
+    return await write(document, to: destination, count: vocabulary.snippets.count)
+  }
+
+  /// `@concurrent` so this always runs OFF the caller's actor. A plain `async` on a `@MainActor`
+  /// type would inherit that isolation and put the slow write straight back on the main thread —
+  /// the whole point of splitting it out.
+  @concurrent
+  private static func write(
+    _ document: Document, to destination: URL, count: Int
+  ) async -> Outcome {
     do {
-      try DurableJSONFile.write(
-        Document(
-          version: SnippetsManager.currentVersion,
-          keyword: vocabulary.keyword,
-          snippets: vocabulary.snippets),
-        to: destination,
-        tempPrefix: ".ew-snippets-export")
-      return .written(destination, count: vocabulary.snippets.count)
+      try DurableJSONFile.write(document, to: destination, tempPrefix: ".ew-snippets-export")
+      return .written(destination, count: count)
     } catch {
       return .failed(error.localizedDescription)
     }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -681,8 +681,16 @@ package final class WisprBootstrapper {
     // custom-words wiring above has to satisfy. Seed both now, then republish on every change
     // so a snippet saved mid-session is live on the next dictation without a relaunch.
     //
-    // Recovery is NOT wired here: `RecoveryTextProcessor` is built per replay and takes the
-    // store through its own `applySnippetVocabulary` seam at that point.
+    // KNOWN LIMIT, stated rather than claimed away: this replaces the vocabulary on the live
+    // step, so a snippet edited WHILE a dictation is in flight applies to that take. The step's
+    // own header used to call this a per-take freeze, and that was an overclaim — corrected
+    // there. It matches how custom words already behave (`CustomWordsPropagator` can replace
+    // `correctorVocabulary` mid-session, which `KernelFinalizationWiring` says out loud), and
+    // the outcome is that the user's NEWEST snippet wins rather than any data being wrong.
+    // A real record-start freeze is a separate change with a hook recording does not have yet.
+    //
+    // Recovery is wired separately, at `RecoverySpoolReplayer`'s `currentSnippets` provider,
+    // because that processor is built per replay.
     let seedSnippets: @MainActor (SnippetVocabulary) -> Void = {
       [kernelDriver, whisperKitKernelDriver] vocabulary in
       kernelDriver.snippetExpansion.snippetVocabulary = vocabulary
@@ -858,7 +866,8 @@ package final class WisprBootstrapper {
         LanePartitioner.split(
           customWordsCoordinator.customWords,
           generation: UInt64(customWordsCoordinator.customWords.count) &+ 1)
-      })
+      },
+      currentSnippets: { [snippetsCoordinator] in snippetsCoordinator.vocabulary })
     // GitHub cloud review, PR #1732: captured by `isDictationActive` below,
     // assigned once `engineCoordinator` exists a few lines down. A record
     // press that has called `beginMinting()` but not yet reached an active

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -57,6 +57,7 @@ package final class WisprBootstrapper {
   /// capped at its single benchmark collaborator by design.
   let activeEngine: ActiveEngineOperation
   let customWordsCoordinator: CustomWordsCoordinator
+  let snippetsCoordinator: SnippetsCoordinator
   let contactsImportCoordinator: ContactsImportCoordinator
   /// #1701 Chunk 2 — UI Cancel routes through `customWordsCoordinator.cancelBulkImportEnrichment`.
   let bulkImportEnrichmentCoordinator: BulkImportEnrichmentCoordinator
@@ -187,6 +188,7 @@ package final class WisprBootstrapper {
       availableDevices: audioDeviceList.availableInputDevices)
     let captureTelemetry = CaptureTelemetryState()
     let customWordsCoordinator = CustomWordsCoordinator()
+    let snippetsCoordinator = SnippetsCoordinator()
     // #636: contacts-import orchestrator (opt-in import + bulk-remove + background
     // alias enrichment via the reused on-device suggester). #636 follow-up.
     let contactsImportCoordinator = ContactsImportCoordinator(
@@ -674,6 +676,20 @@ package final class WisprBootstrapper {
       coordinator: customWordsCoordinator,
       packManager: vocabularyPackManager
     )
+
+    // #628 snippet wiring. TWO drivers, and seeding one is half the job — the same shape the
+    // custom-words wiring above has to satisfy. Seed both now, then republish on every change
+    // so a snippet saved mid-session is live on the next dictation without a relaunch.
+    //
+    // Recovery is NOT wired here: `RecoveryTextProcessor` is built per replay and takes the
+    // store through its own `applySnippetVocabulary` seam at that point.
+    let seedSnippets: @MainActor (SnippetVocabulary) -> Void = {
+      [kernelDriver, whisperKitKernelDriver] vocabulary in
+      kernelDriver.snippetExpansion.snippetVocabulary = vocabulary
+      whisperKitKernelDriver.snippetExpansion.snippetVocabulary = vocabulary
+    }
+    seedSnippets(snippetsCoordinator.vocabulary)
+    snippetsCoordinator.onVocabularyChanged = seedSnippets
 
     // Restore persisted backend selection synchronously (no race with first record).
     asrManager.setInitialBackendType(settings.selectedBackend)
@@ -1187,6 +1203,7 @@ package final class WisprBootstrapper {
     self.asrManager = asrManager
     self.activeEngine = activeEngine
     self.customWordsCoordinator = customWordsCoordinator
+    self.snippetsCoordinator = snippetsCoordinator
     self.contactsImportCoordinator = contactsImportCoordinator
     self.bulkImportEnrichmentCoordinator = bulkImportEnrichmentCoordinator
     self.setup = setup
@@ -1411,6 +1428,7 @@ private struct MainWindowRoot: View {
       .environment(b.pillAppearance)
       .environment(b.permissions)
       .environment(b.customWordsCoordinator)
+      .environment(b.snippetsCoordinator)
       .environment(b.contactsImportCoordinator)
       .environment(b.setup)
       .environment(b.egOneRuntime)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -48,6 +48,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case keybinds
   case aiPolish
   case wordCorrection
+  case snippets
   case clipboard
   case permissions
   case checkForUpdates
@@ -70,6 +71,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .keybinds: return "Keybinds"
     case .aiPolish: return "AI Polish"
     case .wordCorrection: return "Dictionary"
+    case .snippets: return "Snippets"
     case .clipboard: return "Clipboard"
     case .permissions: return "Permissions"
     case .checkForUpdates: return "Check for Updates"
@@ -92,6 +94,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .keybinds: return "keyboard"
     case .aiPolish: return "sparkles"
     case .wordCorrection: return "textformat.abc"
+    case .snippets: return "curlybraces"
     case .clipboard: return "clipboard"
     case .permissions: return "lock.shield"
     case .checkForUpdates: return "arrow.triangle.2.circlepath"
@@ -118,6 +121,8 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .aiPolish: return "Clean up and rewrite your dictation with AI."
     case .wordCorrection:
       return "Improve recognition with your words and vocabulary."
+    case .snippets:
+      return "Say your keyword, then a snippet. The saved text lands for you."
     case .clipboard: return "How your transcript reaches the clipboard and the app you're in."
     case .permissions: return "The microphone and accessibility access EnviousWispr needs."
     case .checkForUpdates: return ""
@@ -133,7 +138,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     switch self {
     case .history, .whatsNew, .appearance: return .app
     case .speechEngine, .livePreview, .audio, .recordingSounds, .keybinds: return .record
-    case .aiPolish, .wordCorrection: return .process
+    case .aiPolish, .wordCorrection, .snippets: return .process
     case .clipboard: return .output
     case .permissions, .checkForUpdates, .openSourceLicenses: return .system
     #if DEBUG

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -191,6 +191,8 @@ struct UnifiedWindowView: View {
       page(.aiPolish) { AIPolishSettingsView() }
     case .wordCorrection:
       page(.wordCorrection) { YourWordsView() }
+    case .snippets:
+      page(.snippets) { SnippetsView() }
     case .clipboard:
       page(.clipboard) { ClipboardSettingsView() }
     case .permissions:

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetEditSheet.swift
@@ -1,0 +1,171 @@
+import EnviousWisprCore
+import SwiftUI
+
+/// Add or edit one snippet (#628), to the approved design's sheet.
+///
+/// The live preview is the reason this sheet is worth its size. The keyword rule is easy to
+/// state and easy to misread, and a user typing a trigger cannot otherwise tell what they will
+/// have to say. Showing "You say" and "You get" as they type answers that without a manual.
+struct SnippetEditSheet: View {
+  @Environment(SnippetsCoordinator.self) private var coordinator
+  @Environment(\.dismiss) private var dismiss
+
+  let draft: SnippetDraft
+  /// Passed in rather than read from the coordinator inside `body`: the preview must show the
+  /// keyword as it was when the sheet opened, so it cannot change under the user mid-edit.
+  let keyword: String
+
+  @State private var trigger = ""
+  @State private var expansion = ""
+  @State private var error: String?
+  @State private var didLoad = false
+
+  private var isEditing: Bool { draft.snippet != nil }
+
+  private var canSave: Bool {
+    !trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      && !expansion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text(isEditing ? "Edit snippet" : "New snippet")
+        .font(.system(size: 22, weight: .semibold))
+        .foregroundStyle(.stTextPrimary)
+
+      triggerField
+      expansionField
+      preview
+
+      Spacer(minLength: 0)
+      footer
+    }
+    .padding(20)
+    .frame(width: 480, height: 600)
+    .background(Color.stPageBg)
+    .onAppear(perform: load)
+  }
+
+  private func load() {
+    guard !didLoad else { return }
+    didLoad = true
+    trigger = draft.snippet?.trigger ?? ""
+    expansion = draft.snippet?.expansion ?? ""
+  }
+
+  // MARK: - Fields
+
+  private var triggerField: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Snippet").settingsRowLabel()
+      HStack(spacing: 8) {
+        // The keyword is shown, not editable here: it belongs to every snippet, so editing it
+        // in one snippet's sheet would silently change all of them.
+        Text(keyword)
+          .font(.stRowLabel)
+          .foregroundStyle(.stAccent)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 6)
+          .background(Color.stAccentLight, in: Capsule())
+          .overlay(Capsule().strokeBorder(Color.stAccent.opacity(0.28), lineWidth: 1))
+        TextField("my email address", text: $trigger)
+          .textFieldStyle(.roundedBorder)
+      }
+      Text("Matched word for word, and only after you say \u{201C}\(keyword)\u{201D}.")
+        .settingsHelperCopy()
+    }
+  }
+
+  private var expansionField: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Expands to").settingsRowLabel()
+      TextEditor(text: $expansion)
+        .font(.stBody)
+        .frame(height: 110)
+        .scrollContentBackground(.hidden)
+        .padding(6)
+        .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+          RoundedRectangle(cornerRadius: 8)
+            .strokeBorder(Color.stAccent.opacity(0.22), lineWidth: 1))
+      Text("Pasted exactly as written. AI Polish never rewrites it.").settingsHelperCopy()
+    }
+  }
+
+  // MARK: - Preview
+
+  private var preview: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("PREVIEW")
+        .font(.stSectionHeader)
+        .tracking(0.6)
+        .foregroundStyle(.stAccent)
+
+      VStack(alignment: .leading, spacing: 3) {
+        Text("You say").settingsHelperCopy()
+        Text("\(keyword) \(trigger)")
+          .font(.stRowLabel)
+          .foregroundStyle(.stAccent)
+      }
+      Divider().overlay(Color.stDivider)
+      VStack(alignment: .leading, spacing: 3) {
+        Text("You get").settingsHelperCopy()
+        Text(expansion.isEmpty ? " " : expansion)
+          .font(.stRowLabel)
+          .foregroundStyle(.stSuccess)
+          // The expansion's line breaks are its point, so the preview must show them rather
+          // than collapsing them into one line the way the list row deliberately does.
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(14)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 10))
+    .overlay(
+      RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1))
+  }
+
+  // MARK: - Footer
+
+  private var footer: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      if let error {
+        Text(error)
+          .font(.stHelper)
+          .foregroundStyle(.stError)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      HStack(spacing: 8) {
+        if let existing = draft.snippet {
+          SettingsActionButton(title: "Delete", isEnabled: true, emphasis: .destructive) {
+            if coordinator.delete(existing) { dismiss() } else { error = coordinator.errorMessage }
+          }
+        }
+        Spacer(minLength: 0)
+        SettingsActionButton(
+          title: "Cancel", isEnabled: true, emphasis: .outlined, shortcut: .cancelAction
+        ) { dismiss() }
+        SettingsActionButton(title: "Save", isEnabled: canSave, emphasis: .filled) { save() }
+      }
+    }
+  }
+
+  private func save() {
+    let snippet = Snippet(
+      id: draft.snippet?.id ?? UUID(),
+      trigger: trigger.trimmingCharacters(in: .whitespacesAndNewlines),
+      // The expansion is NOT trimmed. Leading or trailing whitespace can be deliberate — a
+      // snippet that starts with a newline, or ends with a space before the next word — and
+      // "exactly as written" has to mean exactly.
+      expansion: expansion,
+      createdAt: draft.snippet?.createdAt ?? Date())
+
+    if coordinator.save(snippet) {
+      dismiss()
+    } else {
+      // Held locally as well as on the coordinator: the sheet stays open on a refusal, and the
+      // message has to be visible where the user is looking rather than behind it.
+      error = coordinator.errorMessage
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
@@ -100,8 +100,11 @@ struct SnippetsView: View {
       SettingsActionButton(
         title: "Export", isEnabled: !coordinator.snippets.isEmpty, emphasis: .outlined
       ) {
-        exportMessage = SnippetsExportAction.message(
-          for: SnippetsExportAction.run(vocabulary: coordinator.vocabulary))
+        let vocabulary = coordinator.vocabulary
+        Task {
+          exportMessage = SnippetsExportAction.message(
+            for: await SnippetsExportAction.run(vocabulary: vocabulary))
+        }
       }
       SettingsActionButton(title: "Add snippet", isEnabled: true, emphasis: .filled) {
         editing = SnippetDraft(snippet: nil)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
@@ -17,6 +17,10 @@ struct SnippetsView: View {
   /// Held here rather than on the coordinator: an export never changes the store, so a failed
   /// one must not sit in the same slot as a failed save and read as though a snippet was lost.
   @State private var exportMessage: String?
+  /// The keyword field commits on focus loss as well as on Return. Only `.onSubmit` meant a
+  /// user could type a new keyword, click Add snippet, and be silently left on the old one,
+  /// with nothing on screen saying Return was required.
+  @FocusState private var keywordFocused: Bool
 
   var body: some View {
     SettingsContentView {
@@ -43,7 +47,11 @@ struct SnippetsView: View {
         TextField("", text: $keywordField)
           .textFieldStyle(.roundedBorder)
           .frame(width: 190)
+          .focused($keywordFocused)
           .onSubmit { commitKeyword() }
+          .onChange(of: keywordFocused) { _, focused in
+            if !focused { commitKeyword() }
+          }
         Text("then your snippet, and it expands.").settingsHelperCopy()
         Spacer(minLength: 0)
       }
@@ -71,7 +79,11 @@ struct SnippetsView: View {
     BrandedSection(header: "Your snippets") {
       VStack(alignment: .leading, spacing: 0) {
         header
-        if coordinator.snippets.isEmpty {
+        if coordinator.storeUnreadable {
+          // NOT the empty state. An empty list is a lie the user would act on by adding
+          // snippets over the top of ones that still exist.
+          unreadableState
+        } else if coordinator.snippets.isEmpty {
           emptyState
         } else {
           searchField
@@ -186,6 +198,24 @@ struct SnippetsView: View {
   /// the point of the sign-off case.
   private func oneLine(_ text: String) -> String {
     text.split(whereSeparator: \.isNewline).joined(separator: " ")
+  }
+
+  private var unreadableState: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: 34, weight: .light))
+        .foregroundStyle(.stWarning)
+        .accessibilityHidden(true)
+      Text("Your snippets could not be read").settingsRowTitle()
+      Text(
+        "They are still saved on your Mac. Nothing has been changed or deleted, and EnviousWispr will not write over them. Restart the app, and tell us if this keeps happening."
+      )
+      .settingsHelperCopy()
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: 380)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 32)
   }
 
   // MARK: - Empty state

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
@@ -1,0 +1,209 @@
+import EnviousWisprCore
+import SwiftUI
+
+/// The Snippets page (#628), built to the approved Claude Design prototype
+/// (`docs/feature-requests/issue-628-design/EnviousWispr Snippets.dc.html`).
+///
+/// Three cards: the keyword, the list, and — when the list is empty — the state that explains
+/// what a snippet is for. Import ships visible and DISABLED, marked "Coming soon" (founder,
+/// 2026-09-01): the button occupies the place the design gives it so the shape of the screen
+/// does not change when the flow lands.
+struct SnippetsView: View {
+  @Environment(SnippetsCoordinator.self) private var coordinator
+
+  @State private var query = ""
+  @State private var editing: SnippetDraft?
+  @State private var keywordField = ""
+
+  var body: some View {
+    SettingsContentView {
+      keywordCard
+      listCard
+    }
+    .onAppear { keywordField = coordinator.keyword }
+    .sheet(item: $editing) { draft in
+      SnippetEditSheet(draft: draft, keyword: coordinator.keyword)
+    }
+  }
+
+  // MARK: - Keyword
+
+  private var keywordCard: some View {
+    BrandedPanel(
+      icon: "mic",
+      header: "Keyword",
+      description:
+        "A snippet only fires when you say this word first. Say the trigger on its own and your dictation is left alone."
+    ) {
+      HStack(spacing: 10) {
+        Text("Say").settingsRowLabel()
+        TextField("", text: $keywordField)
+          .textFieldStyle(.roundedBorder)
+          .frame(width: 190)
+          .onSubmit { commitKeyword() }
+        Text("then your snippet, and it expands.").settingsHelperCopy()
+        Spacer(minLength: 0)
+      }
+    } footnote: {
+      // The example is worth its line: the rule is easy to state and easy to misread, and one
+      // concrete sentence answers "so what do I actually say" faster than the description.
+      Text(
+        "Example — say \u{201C}\(coordinator.keyword) my email address\u{201D} and your email is pasted."
+      )
+      .settingsHelperCopy()
+    }
+  }
+
+  private func commitKeyword() {
+    guard keywordField != coordinator.keyword else { return }
+    _ = coordinator.setKeyword(keywordField)
+    // Read back rather than keeping what was typed: a blank field becomes the default, so the
+    // field must show what was actually saved, not what the user last had on screen.
+    keywordField = coordinator.keyword
+  }
+
+  // MARK: - List
+
+  private var listCard: some View {
+    BrandedSection(header: "Your snippets") {
+      VStack(alignment: .leading, spacing: 0) {
+        header
+        if coordinator.snippets.isEmpty {
+          emptyState
+        } else {
+          searchField
+          Divider().overlay(Color.stDivider)
+          rows
+        }
+      }
+    } footer: {
+      if let message = coordinator.errorMessage {
+        Text(message)
+          .font(.stHelper)
+          .foregroundStyle(.stError)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+
+  private var header: some View {
+    HStack(spacing: 8) {
+      Text(countLabel).settingsHelperCopy()
+      Spacer(minLength: 0)
+      // Visible and inert, on purpose. A greyed control with an honest label tells the user the
+      // path exists and is not ready; hiding it would make the feature look absent instead.
+      SettingsActionButton(title: "Import", isEnabled: false, emphasis: .outlined) {}
+        .help("Coming soon")
+      SettingsActionButton(title: "Add snippet", isEnabled: true, emphasis: .filled) {
+        editing = SnippetDraft(snippet: nil)
+      }
+    }
+    .padding(.horizontal, SettingsLayout.rowPaddingH)
+    .padding(.vertical, SettingsLayout.rowPaddingV)
+  }
+
+  private var countLabel: String {
+    let shown = coordinator.filtered(by: query).count
+    let total = coordinator.snippets.count
+    if !query.trimmingCharacters(in: .whitespaces).isEmpty { return "\(shown) of \(total)" }
+    return total == 1 ? "1 snippet" : "\(total) snippets"
+  }
+
+  private var searchField: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "magnifyingglass")
+        .foregroundStyle(.stTextTertiary)
+        .accessibilityHidden(true)
+      TextField("Search snippets", text: $query)
+        .textFieldStyle(.plain)
+    }
+    .padding(.horizontal, SettingsLayout.rowPaddingH)
+    .padding(.bottom, 10)
+  }
+
+  @ViewBuilder
+  private var rows: some View {
+    let shown = coordinator.filtered(by: query)
+    if shown.isEmpty {
+      VStack(spacing: 8) {
+        Text("No snippets match \u{201C}\(query.trimmingCharacters(in: .whitespaces))\u{201D}")
+          .settingsRowLabel()
+        SettingsActionButton(title: "Clear search", isEnabled: true, emphasis: .outlined) {
+          query = ""
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 32)
+    } else {
+      ForEach(Array(shown.enumerated()), id: \.element.id) { index, snippet in
+        if index > 0 { Divider().overlay(Color.stDivider) }
+        row(snippet)
+      }
+    }
+  }
+
+  private func row(_ snippet: Snippet) -> some View {
+    Button {
+      editing = SnippetDraft(snippet: snippet)
+    } label: {
+      HStack(spacing: 12) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(snippet.trigger).settingsRowLabel()
+          // One line, ellipsised: an expansion can be a whole signature, and a list that grows
+          // a row to fit one of them stops being scannable.
+          Text(oneLine(snippet.expansion))
+            .settingsHelperCopy()
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.stTextTertiary)
+          .accessibilityHidden(true)
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("\(snippet.trigger), pastes \(oneLine(snippet.expansion))")
+  }
+
+  /// Line breaks flattened for the row preview only. The stored expansion keeps them — they are
+  /// the point of the sign-off case.
+  private func oneLine(_ text: String) -> String {
+    text.split(whereSeparator: \.isNewline).joined(separator: " ")
+  }
+
+  // MARK: - Empty state
+
+  private var emptyState: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "curlybraces")
+        .font(.system(size: 40, weight: .light))
+        .foregroundStyle(Color.stAccent.opacity(0.25))
+        .accessibilityHidden(true)
+      Text("No snippets yet").settingsRowTitle()
+      Text(
+        "Save the text you type over and over. An email address, a signature, a link you always paste."
+      )
+      .settingsHelperCopy()
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: 340)
+      SettingsActionButton(title: "Add your first snippet", isEnabled: true, emphasis: .filled) {
+        editing = SnippetDraft(snippet: nil)
+      }
+      .padding(.top, 4)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 36)
+  }
+}
+
+/// A sheet's subject, keyed by request rather than by a bare boolean, so `.sheet(item:)` gets a
+/// fresh presentation per row — the pattern `YourWordsView` already uses for the same reason.
+struct SnippetDraft: Identifiable {
+  let id = UUID()
+  let snippet: Snippet?
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
@@ -115,7 +115,9 @@ struct SnippetsView: View {
         let vocabulary = coordinator.vocabulary
         Task {
           exportMessage = SnippetsExportAction.message(
-            for: await SnippetsExportAction.run(vocabulary: vocabulary))
+            for: await SnippetsExportAction.run(
+              vocabulary: vocabulary,
+              currentVocabulary: { coordinator.refreshFromDisk() }))
         }
       }
       SettingsActionButton(title: "Add snippet", isEnabled: true, emphasis: .filled) {

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
@@ -14,6 +14,9 @@ struct SnippetsView: View {
   @State private var query = ""
   @State private var editing: SnippetDraft?
   @State private var keywordField = ""
+  /// Held here rather than on the coordinator: an export never changes the store, so a failed
+  /// one must not sit in the same slot as a failed save and read as though a snippet was lost.
+  @State private var exportMessage: String?
 
   var body: some View {
     SettingsContentView {
@@ -77,7 +80,7 @@ struct SnippetsView: View {
         }
       }
     } footer: {
-      if let message = coordinator.errorMessage {
+      if let message = coordinator.errorMessage ?? exportMessage {
         Text(message)
           .font(.stHelper)
           .foregroundStyle(.stError)
@@ -94,6 +97,12 @@ struct SnippetsView: View {
       // path exists and is not ready; hiding it would make the feature look absent instead.
       SettingsActionButton(title: "Import", isEnabled: false, emphasis: .outlined) {}
         .help("Coming soon")
+      SettingsActionButton(
+        title: "Export", isEnabled: !coordinator.snippets.isEmpty, emphasis: .outlined
+      ) {
+        exportMessage = SnippetsExportAction.message(
+          for: SnippetsExportAction.run(vocabulary: coordinator.vocabulary))
+      }
       SettingsActionButton(title: "Add snippet", isEnabled: true, emphasis: .filled) {
         editing = SnippetDraft(snippet: nil)
       }

--- a/Sources/EnviousWisprCore/Snippet.swift
+++ b/Sources/EnviousWisprCore/Snippet.swift
@@ -14,7 +14,7 @@ import Foundation
 /// compares literally — this is deliberately NOT fuzzy, unlike `WordCorrector`.
 public enum SnippetText {
   /// Punctuation dropped from the FRONT of a spoken token before comparison.
-  private static let leading: Set<Character> = ["(", "[", "{", "\"", "'", "\u{201C}", "\u{2018}"]
+  static let leading: Set<Character> = ["(", "[", "{", "\"", "'", "\u{201C}", "\u{2018}"]
 
   /// Punctuation dropped from the END of a spoken token before comparison. This is also the
   /// set `SnippetExpander` re-attaches AFTER an expansion, so a full stop that clung to the
@@ -39,6 +39,22 @@ public enum SnippetText {
     while let first = s.first, leading.contains(first) { s = s.dropFirst() }
     while let last = s.last, trailing.contains(last) { s = s.dropLast() }
     return String(s.trimmingWhitespace())
+  }
+
+  /// The leading punctuation run on a token, in source order.
+  ///
+  /// Its partner below handles the end of the trigger; this handles the start of the KEYWORD.
+  /// Both are needed, and having only one is a silent loss: in a quoted phrase the opening
+  /// quote is stripped so the keyword can match, and without restoring it the user gets the
+  /// pasted text with a closing quote and no opening one.
+  public static func leadingPunctuation(_ token: String) -> String {
+    var run: [Character] = []
+    var s = Substring(token)
+    while let first = s.first, leading.contains(first) {
+      run.append(first)
+      s = s.dropFirst()
+    }
+    return String(run)
   }
 
   /// The trailing punctuation run on a token, in source order — what `normalize` removed from

--- a/Sources/EnviousWisprCore/Snippet.swift
+++ b/Sources/EnviousWisprCore/Snippet.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// The comparison form for snippet matching, and the ONE place it is defined (#628).
+///
+/// Lives in Core rather than beside the matcher in PostProcessing because three callers need
+/// the identical answer and they are in different modules: `SnippetExpander` (matching),
+/// the edit sheet (refusing a duplicate trigger), and import comparison. A second
+/// implementation is how two of them come to disagree about whether "My Email." and
+/// "my email" are the same trigger.
+///
+/// Ported from the approved design prototype's `norm()`
+/// (`docs/feature-requests/issue-628-design/EnviousWispr Snippets.dc.html`): lowercase, drop a
+/// leading opening bracket or quote, drop trailing sentence punctuation. Everything else
+/// compares literally — this is deliberately NOT fuzzy, unlike `WordCorrector`.
+public enum SnippetText {
+  /// Punctuation dropped from the FRONT of a spoken token before comparison.
+  private static let leading: Set<Character> = ["(", "[", "{", "\"", "'", "\u{201C}", "\u{2018}"]
+
+  /// Punctuation dropped from the END of a spoken token before comparison. This is also the
+  /// set `SnippetExpander` re-attaches AFTER an expansion, so a full stop that clung to the
+  /// last trigger word survives the substitution. The two uses share this one list on purpose:
+  /// a token stripped here and not re-attached there would silently eat the user's punctuation.
+  public static let trailing: Set<Character> = [
+    ".", ",", "!", "?", ";", ":", ")", "]", "}", "\"", "'", "\u{201D}", "\u{2019}",
+  ]
+
+  /// A spoken token reduced to its comparison form.
+  ///
+  /// Whitespace is trimmed at BOTH ends, and that is not redundant with the tokeniser: the
+  /// keyword arrives from a text field the user types into, not from splitting a transcript.
+  /// Without the trim a keyword of "   " normalises to "   ", which is non-empty, so
+  /// `SnippetVocabulary.canFire` reports true and the expansion step arms itself against a
+  /// keyword nobody can speak. Caught by its own test rather than by a user.
+  ///
+  /// The order matters: trim, then strip punctuation, then trim again, so ' "hello" ' and
+  /// '"hello"' reach the same form.
+  public static func normalize(_ token: String) -> String {
+    var s = Substring(token.lowercased()).trimmingWhitespace()
+    while let first = s.first, leading.contains(first) { s = s.dropFirst() }
+    while let last = s.last, trailing.contains(last) { s = s.dropLast() }
+    return String(s.trimmingWhitespace())
+  }
+
+  /// The trailing punctuation run on a token, in source order — what `normalize` removed from
+  /// the end and what the expansion must carry forward.
+  public static func trailingPunctuation(_ token: String) -> String {
+    var run: [Character] = []
+    var s = Substring(token)
+    while let last = s.last, trailing.contains(last) {
+      run.append(last)
+      s = s.dropLast()
+    }
+    return String(run.reversed())
+  }
+}
+
+extension Substring {
+  /// Whitespace-only trim on a `Substring`, so `SnippetText.normalize` never copies the string
+  /// twice just to trim it.
+  fileprivate func trimmingWhitespace() -> Substring {
+    var s = self
+    while let first = s.first, first.isWhitespace { s = s.dropFirst() }
+    while let last = s.last, last.isWhitespace { s = s.dropLast() }
+    return s
+  }
+}
+
+/// One voice-triggered text expansion (#628).
+///
+/// A snippet fires only when the user speaks their keyword (`SnippetVocabulary.keyword`,
+/// default "backslash") immediately before `trigger`, and `trigger` matches word for word.
+/// `expansion` is then delivered byte-for-byte — it is masked behind a per-run sentinel so
+/// AI Polish never sees it, and `SnippetFinalizer` substitutes it back before anything is
+/// stored or delivered.
+///
+/// Deliberately NOT a `CustomWord` variant. `CustomWord` repairs what the speech engine
+/// misheard and matches FUZZILY on purpose (`WordCorrector`'s six passes); a snippet trigger
+/// must be literal, or "my email address" spoken in ordinary prose starts pasting an address.
+/// #630 argued that separation and the approved design settles it by giving Snippets its own
+/// surface.
+public struct Snippet: Codable, Identifiable, Sendable, Hashable {
+  public let id: UUID
+  /// The words spoken after the keyword. Matched word for word after normalisation, never fuzzily.
+  public var trigger: String
+  /// The text delivered in the trigger's place, exactly as the user typed it, newlines included.
+  public var expansion: String
+  public var createdAt: Date
+
+  public init(
+    id: UUID = UUID(),
+    trigger: String,
+    expansion: String,
+    createdAt: Date = Date()
+  ) {
+    self.id = id
+    self.trigger = trigger
+    self.expansion = expansion
+    self.createdAt = createdAt
+  }
+
+  /// The trigger's comparison form: the tokens the matcher compares against, in order.
+  public var triggerTokens: [String] {
+    trigger
+      .split(whereSeparator: { $0.isWhitespace })
+      .map { SnippetText.normalize(String($0)) }
+      .filter { !$0.isEmpty }
+  }
+
+  /// True when both snippets would be matched by the same spoken words. The duplicate rule,
+  /// stated once, so the edit sheet, import, and any future caller cannot drift apart.
+  public func collidesWith(_ other: Snippet) -> Bool {
+    let mine = triggerTokens
+    return !mine.isEmpty && mine == other.triggerTokens
+  }
+}

--- a/Sources/EnviousWisprCore/Snippet.swift
+++ b/Sources/EnviousWisprCore/Snippet.swift
@@ -41,6 +41,16 @@ public enum SnippetText {
     return String(s.trimmingWhitespace())
   }
 
+  /// Punctuation that ENDS a sentence. A subset of `trailing`, and the distinction matters: a
+  /// comma inside a matched phrase is noise, a full stop is a boundary.
+  public static let sentenceEnding: Set<Character> = [".", "!", "?"]
+
+  /// True when this token ends a sentence.
+  public static func endsSentence(_ token: String) -> Bool {
+    guard let last = token.last else { return false }
+    return sentenceEnding.contains(last)
+  }
+
   /// The leading punctuation run on a token, in source order.
   ///
   /// Its partner below handles the end of the trigger; this handles the start of the KEYWORD.

--- a/Sources/EnviousWisprCore/VocabularyLanes.swift
+++ b/Sources/EnviousWisprCore/VocabularyLanes.swift
@@ -48,3 +48,40 @@ public struct PolishVocabulary: Sendable, Equatable {
 
   public static let empty = PolishVocabulary(terms: [], generation: 0)
 }
+
+/// Snippet vocabulary (#628) — the THIRD lane, and it reaches neither of the other two.
+///
+/// A snippet trigger must never enter the polish prompt (the model would then see the words
+/// the user is trying to replace) and must never enter `WordCorrector` (its passes are fuzzy,
+/// and a snippet trigger that fires approximately is a defect, not a feature). Giving it its
+/// own value type makes both leaks a compile error rather than a code-review promise, the same
+/// reasoning Phase 0 (#640) applied to the corrector/polish split above.
+///
+/// `keyword` rides in this lane rather than being read live because it is a matching input:
+/// the whole snapshot must be frozen together for a take, or a mid-dictation edit in Settings
+/// changes the rule for text already in flight.
+public struct SnippetVocabulary: Sendable, Equatable {
+  public let snippets: [Snippet]
+  /// The word the user must speak before a trigger. Compared through `SnippetText.normalize`.
+  public let keyword: String
+  public let generation: UInt64
+
+  public init(snippets: [Snippet], keyword: String, generation: UInt64) {
+    self.snippets = snippets
+    self.keyword = keyword
+    self.generation = generation
+  }
+
+  public static let empty = SnippetVocabulary(snippets: [], keyword: "", generation: 0)
+
+  /// The default keyword (founder, 2026-09-01). Chosen because nothing in the text pipeline
+  /// consumes a spoken "backslash" — unlike "slash", which `InverseTextNormalizer` already
+  /// converts contextually for URLs, dates and ranges, so it has a second owner.
+  public static let defaultKeyword = "backslash"
+
+  /// Nothing can fire without both halves, so the expansion step is disabled rather than run
+  /// as a no-op. Keeps the empty-store chain byte-identical to a build without the step (P4).
+  public var canFire: Bool {
+    !snippets.isEmpty && !SnippetText.normalize(keyword).isEmpty
+  }
+}

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -719,6 +719,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   // MARK: Limb-step accessors (read by `PipelineSettingsSync` + custom-words)
 
   public var wordCorrection: WordCorrectionStep { steps.wordCorrection }
+  /// #628. Exposed for the same reason as `wordCorrection`: the App layer owns the store and
+  /// must hand this driver its frozen vocabulary, and there are TWO drivers, so a caller that
+  /// seeds one has done half the job.
+  public var snippetExpansion: SnippetExpansionStep { steps.snippetExpansion }
   public var fillerRemoval: FillerRemovalStep { steps.fillerRemoval }
   public var emojiFormatter: EmojiFormatterStep { steps.emojiFormatter }
   public var llmPolish: LLMPolishStep { steps.llmPolish }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -84,12 +84,40 @@ private final class TerminalResumeLatch: Sendable {
 /// the final step, re-inserting emoji the on-device polish stripped (#761).
 @MainActor
 struct LimbSteps {
+  /// #628. Listed first because it runs first: a snippet trigger is matched literally, so it
+  /// must read the raw ASR surface before the fuzzy corrector can alter one of its words.
+  /// Its partner is NOT in this struct — `SnippetFinalizer` is not a step, and its own header
+  /// says why.
+  let snippetExpansion: SnippetExpansionStep
   let wordCorrection: WordCorrectionStep
   let fillerRemoval: FillerRemovalStep
   let emojiFormatter: EmojiFormatterStep
   let inverseTextNormalization: InverseTextNormalizationStep
   let llmPolish: LLMPolishStep
   let emojiRestore: EmojiRestoreStep
+
+  /// The post-ASR chain, in order, and the ONLY place that order is written (#628).
+  ///
+  /// Before this existed, the live path and the recovery path each spelled the array out for
+  /// themselves. Two lists that must agree and nothing making them agree is a defect waiting on
+  /// whoever adds the next step and updates one of them — which is exactly what adding the
+  /// snippet step surfaced. One property means a new limb is added once, and the paths cannot
+  /// drift.
+  ///
+  /// `snippetExpansion` is first because a snippet trigger is matched literally and must read
+  /// the raw ASR surface before the fuzzy corrector can alter one of its words. `llmPolish` sits
+  /// after `inverseTextNormalization` so ITN doubles as the raw-fallback floor (#145), and
+  /// `emojiRestore` sits after polish because it repairs what polish dropped (#761).
+  ///
+  /// The chain is NOT the last thing that touches the text: `SnippetFinalizer` runs after the
+  /// runner in both paths, and `CursorInsertionRepair` runs after that on the live path.
+  @MainActor
+  var orderedChain: [any TextProcessingStep] {
+    [
+      snippetExpansion, wordCorrection, fillerRemoval, emojiFormatter,
+      inverseTextNormalization, llmPolish, emojiRestore,
+    ]
+  }
 }
 
 /// Issue #1339: sessionless model-load wedge guard for `ensureEngineWarm`.

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -411,6 +411,7 @@ public enum KernelDictationDriverFactory {
     // no-ops when no emoji were dropped) — NOT gated on the converter toggle, so
     // a mid-dictation toggle flip can never strand an already-inserted glyph.
     let limbSteps = LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -158,6 +158,15 @@ final class KernelSessionContext {
   /// Canonicals only. Aliases are recognition triggers — the misheard forms we
   /// correct FROM — never protected output spellings.
   var protectedSpellings: Set<String> = []
+  /// #628. True when a snippet expanded on this take, which makes the delivered text carry a
+  /// span that must arrive byte-for-byte.
+  ///
+  /// Its neighbour above answers a DIFFERENT question and cannot be reused for this:
+  /// `protectedSpellings` is a set of custom-word canonicals, and `CursorInsertionRepair`
+  /// consults it only to veto LEADING RECASING. The same repair may still change seam spacing
+  /// and delete a repeated leading token, so protecting an expansion through that set would be
+  /// a fix that covers one third of the ways the text can move.
+  var snippetExpansionFired = false
 
   init() {}
 }
@@ -365,17 +374,20 @@ struct KernelFinalizationWiring {
         rawText: raw,
         language: language,
         targetAppName: context.targetApp?.localizedName,
-        steps: [
-          steps.wordCorrection, steps.fillerRemoval, steps.emojiFormatter,
-          steps.inverseTextNormalization, steps.llmPolish, steps.emojiRestore,
-        ],
+        steps: steps.orderedChain,
         // #1846: the LIVE in-flight take, not the concluded one. Polish runs before
         // the session terminal, and starting a session CLEARS `kernel.lastTakeID`,
         // so it is nil here — substituting it would emit no take key at all. Same
         // key as the completion events, read at a different point; swapping the two
         // reads would silently blank one family.
         takeID: telemetryState.takeID)
-      let ctx = result.context
+      var ctx = result.context
+      // #628. Mandatory, non-throwing, and it MUST be here: every read below — the outcome
+      // field copy, the empty-output floor, storage, History, the paste cascade — happens
+      // after this line, and any of them seeing a raw sentinel is the failure this whole
+      // design exists to make impossible. A no-op when no snippet fired.
+      SnippetFinalizer.finalize(&ctx)
+      context.snippetExpansionFired = !ctx.protectedExpansions.isEmpty
       // #145: thread the ITN run outcome onto `dictation.completed` (metadata
       // only — `telemetry-privacy-boundary`). Read on the same actor right after
       // the chain; `itn_floor_delivered` is computed later in
@@ -646,7 +658,20 @@ struct KernelFinalizationWiring {
         // `withOrderedDeadline`, not bare `withDeadline`: on timeout the runtime
         // must be latched BEFORE paste resumes, so a later dictation can never
         // race an abandoned call against AppKit's one shared spell checker.
-        let repairContext: CursorInsertionRepair.CaretText? = caretContext.map {
+        // #628. A take that expanded a snippet takes the LEGACY payload: `repair` with no caret
+        // context returns exactly that, so refusing the context here is the whole bypass and
+        // needs no new branch inside the repair.
+        //
+        // The cost is real and was accepted at Gate 2 (plan §14.4): this take loses the
+        // join-up that makes a half-typed sentence and a dictated ending read as one person's
+        // writing. It is the safe answer for v1 because the repair owns seam spacing, seam
+        // capitalisation and cross-seam de-duplication, any of which would silently edit a
+        // saved email address, and "exactly as written" is the promise the feature is FOR.
+        // Teaching the repair to treat a resolved expansion as an opaque region is filed as
+        // the follow-up.
+        let snippetFired = context.snippetExpansionFired
+        let repairContext: CursorInsertionRepair.CaretText? =
+          snippetFired ? nil : caretContext.map {
           CursorInsertionRepair.CaretText(
             left: $0.leftWindow, right: $0.rightWindow,
             // Read, not derived. This was `leftWindow.utf16.count ==

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -953,9 +953,34 @@ struct KernelFinalizationWiring {
         //
         // Clipboard-only rather than a silent drop: the text still exists and is one Cmd+V
         // away, which is the shape every other refused delivery here already takes.
+        //
+        // Written as "is the destination POSITIVELY KNOWN to be safe", not "is it known to be
+        // dangerous", and the inversion is the point.
+        //
+        // Counting the routes here found three, not one. A caret context that is screen-derived
+        // is a terminal. A target whose bundle id is in `TerminalSurface` is a terminal without
+        // any caret read — which matters because `caretContext` is nil whenever Smart Insertion
+        // is off or the read failed, and delivery still falls back to a blind Cmd+V. And
+        // `TerminalSurface` knows exactly three apps (Ghostty, Terminal.app, iTerm2), so Warp,
+        // kitty, Alacritty and WezTerm are terminals it cannot name.
+        //
+        // A danger list has to be complete to be safe and this one is not, so the guard asks the
+        // other question: deliver a snippet-bearing newline automatically ONLY when we have a
+        // caret context, it is not screen-derived, and the app is not a terminal we recognise.
+        // Anything else goes to the clipboard. The cost is a two-line sign-off reaching the
+        // clipboard instead of the cursor when the caret read fails; the alternative cost is a
+        // line of the user's signature running as a shell command.
+        let targetIsKnownTerminal =
+          context.targetApp?.bundleIdentifier
+          .flatMap(TerminalSurface.init(bundleIdentifier:)) != nil
+        // Parenthesised deliberately. `??` binds tighter than `&&`, so the unparenthesised form
+        // means what is intended — and a safety condition should not require the reader to
+        // recall an operator precedence table to confirm that.
+        let destinationConfirmedSafeForNewline =
+          (caretContext.map { !$0.isScreenDerived } ?? false) && !targetIsKnownTerminal
         if context.snippetExpansionFired,
           payloads.legacyText.contains(where: \.isNewline),
-          caretContext?.isScreenDerived == true
+          !destinationConfirmedSafeForNewline
         {
           ClipboardCleanup.deliveryClaimsBoard()
           copyToClipboard(text)

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -954,33 +954,32 @@ struct KernelFinalizationWiring {
         // Clipboard-only rather than a silent drop: the text still exists and is one Cmd+V
         // away, which is the shape every other refused delivery here already takes.
         //
-        // Written as "is the destination POSITIVELY KNOWN to be safe", not "is it known to be
-        // dangerous", and the inversion is the point.
+        // A snippet-bearing payload containing a NEWLINE is never auto-pasted. It goes to the
+        // clipboard, always.
         //
-        // Counting the routes here found three, not one. A caret context that is screen-derived
-        // is a terminal. A target whose bundle id is in `TerminalSurface` is a terminal without
-        // any caret read — which matters because `caretContext` is nil whenever Smart Insertion
-        // is off or the read failed, and delivery still falls back to a blind Cmd+V. And
-        // `TerminalSurface` knows exactly three apps (Ghostty, Terminal.app, iTerm2), so Warp,
-        // kitty, Alacritty and WezTerm are terminals it cannot name.
+        // This is the third shape of this guard and the first honest one. Enumerating what we
+        // can actually KNOW about a destination closes the question:
+        //   - `caretContext.isScreenDerived` — which IS `terminalEvidence != nil` — says
+        //     terminal.
+        //   - a bundle id in `TerminalSurface` says terminal, without a caret read.
+        //   - everything else says NOTHING. Warp, kitty, Alacritty and WezTerm are terminals in
+        //     neither list, and they hand back an ordinary accessibility caret, so they land in
+        //     the same bucket as a text editor.
         //
-        // A danger list has to be complete to be safe and this one is not, so the guard asks the
-        // other question: deliver a snippet-bearing newline automatically ONLY when we have a
-        // caret context, it is not screen-derived, and the app is not a terminal we recognise.
-        // Anything else goes to the clipboard. The cost is a two-line sign-off reaching the
-        // clipboard instead of the cursor when the caret read fails; the alternative cost is a
-        // line of the user's signature running as a shell command.
-        let targetIsKnownTerminal =
-          context.targetApp?.bundleIdentifier
-          .flatMap(TerminalSurface.init(bundleIdentifier:)) != nil
-        // Parenthesised deliberately. `??` binds tighter than `&&`, so the unparenthesised form
-        // means what is intended — and a safety condition should not require the reader to
-        // recall an operator precedence table to confirm that.
-        let destinationConfirmedSafeForNewline =
-          (caretContext.map { !$0.isScreenDerived } ?? false) && !targetIsKnownTerminal
+        // There is no positive "this app is safe for a newline" signal to ask for. The previous
+        // version claimed to require one and did not: "has a caret, not screen-derived, not a
+        // known terminal" is satisfied exactly by an unrecognised terminal, so the inversion was
+        // wording rather than logic. A danger list has to be complete to be safe, and this one
+        // cannot be.
+        //
+        // So the guard stops trying to tell destinations apart. In a terminal a newline SUBMITS
+        // the line before it, and a multi-line sign-off would run whatever that line says. The
+        // cost of always using the clipboard is that a multi-line snippet needs one Cmd+V; the
+        // cost of the other default is a user's signature executing as a shell command. Nothing
+        // is lost — the text is on the clipboard, which is where every other refused delivery
+        // here puts it.
         if context.snippetExpansionFired,
-          payloads.legacyText.contains(where: \.isNewline),
-          !destinationConfirmedSafeForNewline
+          payloads.legacyText.contains(where: \.isNewline)
         {
           ClipboardCleanup.deliveryClaimsBoard()
           copyToClipboard(text)

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -940,83 +940,105 @@ struct KernelFinalizationWiring {
               : ""),
           level: .info, category: "KernelFinalizationWiring")
 
-        // The legacy payload is what a route falls back to; §6 decides per route
-        // whether the candidate may be committed instead.
-        let pasteText = payloads.legacyText
-        let result = await deliverPaste(
-          PasteDeliveryRequest(
-            legacyText: pasteText,
-            repairedText: payloads.repairedText,
-            caretContext: caretContext,
-            // Asked of the RULES, not enumerated here. Listing the destructive
-            // ones at this call site is how the first version missed
-            // `.droppedTerminalPeriod` — a rule that also removes a character
-            // the user dictated, found by cloud review. `deletesDictatedText`
-            // is an exhaustive switch beside the enum, so a new rule cannot
-            // inherit "not destructive" by being forgotten out here.
-            candidateDeletesDictatedText: payloads.candidateRules.contains {
-              $0.deletesDictatedText
-            },
-            targetApp: context.targetApp,
-            targetElement: context.targetElement,
-            // Same local boolean the outcome fields above were stamped from —
-            // not re-derived from `targetElement` presence, which cannot tell
-            // "retried and recovered" apart from "captured at record-start".
-            targetElementIsRetried: caretCaptureRetried,
-            restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,
-            terminalBudget: terminalBudget))
-        pasteResult = result
-
-        // WHICH payload actually went to the app, which `CURSOR_REPAIR` cannot
-        // say because it is logged before the write happens.
+        // #628. A snippet-bearing payload carrying a NEWLINE never reaches a terminal
+        // automatically. In a terminal a newline can SUBMIT the command, and a multi-line
+        // sign-off snippet would run whatever its first line happens to say.
         //
-        // This is the gap that made the founder's original report
-        // undiagnosable: the repair can decide `lowercased_first`, offer a
-        // candidate, and the route can still commit the LEGACY text because
-        // `payloadAtCommitBoundary` re-reads the caret and refuses when
-        // anything changed. From the log alone those two outcomes were
-        // indistinguishable — both showed `candidate=offered` and the user saw
-        // the capital survive.
+        // `CursorInsertionRepair`'s screen-derived refusal does NOT already cover this, and
+        // checking rather than assuming is what found it: that refusal declines the CONTEXTUAL
+        // repair and still returns the legacy text, newline included, so the payload went out
+        // either way. The behaviour predates snippets — but before snippets a newline in a
+        // terminal payload was rare, and a saved multi-line expansion makes it ordinary. The
+        // feature that made it reachable is the one that has to hold the line.
         //
-        // A second line rather than a field on the first, only because the fact
-        // does not exist until after the write. `tier` rides along so the two
-        // can be matched without a timestamp join.
-        // The FULL budget spend, which `CURSOR_REPAIR` structurally cannot show:
-        // that line is written before the paste, and the commit-boundary
-        // re-check runs after the target app is activated. On 2026-08-04 the
-        // repair line reported a healthy 1.6 ms and the breaker tripped anyway,
-        // because the whole overspend lived in the half no line covered.
-        //
-        // Everything before `|recheck|` was already on the repair line; the
-        // suffix is new, and the total is what the cumulative cap is judged
-        // against. That cap is `TerminalResolutionBudget.defaultTotal`, which
-        // owns the current value — do not restate the number here, because a
-        // second copy is what goes stale (it read "100 ms" until 2026-08-05).
-        await AppLogger.shared.log(
-          "CURSOR_COMMIT submitted=\(result.submittedPayload?.rawValue ?? "none") "
-            + "tier=\(result.pasteTierLabel ?? "none") "
-            + "timing=[\(terminalBudget.timingDescription)]",
-          level: .info, category: "KernelFinalizationWiring")
-
-        if case .delivered = result.outcome {
-          // The text that actually LANDED, which is not always the one this
-          // closure passed in: a route may have committed the contextual
-          // candidate. `pasteCompletionRegistry`'s subscriber (#629) watches for
-          // later edits to the pasted text and learns custom words from them, so
-          // announcing the legacy payload after delivering the repaired one
-          // would make our own spacing and casing look like the user correcting
-          // us. Falls back to the legacy payload for `.legacy` and for a
-          // delivered route that reported no payload at all.
-          let deliveredText =
-            result.submittedPayload == .repaired
-            ? (payloads.repairedText ?? pasteText) : pasteText
-          pasteCompletionRegistry?.emit(
-            PasteCompletionEvent(
-              pastedText: deliveredText,
-              destinationBundleID: context.targetApp?.bundleIdentifier))
-          deliveryOutcome = .pasted
-        } else {
+        // Clipboard-only rather than a silent drop: the text still exists and is one Cmd+V
+        // away, which is the shape every other refused delivery here already takes.
+        if context.snippetExpansionFired,
+          payloads.legacyText.contains(where: \.isNewline),
+          caretContext?.isScreenDerived == true
+        {
+          ClipboardCleanup.deliveryClaimsBoard()
+          copyToClipboard(text)
           deliveryOutcome = .clipboardOnly
+        } else {
+          // The legacy payload is what a route falls back to; §6 decides per route
+          // whether the candidate may be committed instead.
+          let pasteText = payloads.legacyText
+          let result = await deliverPaste(
+            PasteDeliveryRequest(
+              legacyText: pasteText,
+              repairedText: payloads.repairedText,
+              caretContext: caretContext,
+              // Asked of the RULES, not enumerated here. Listing the destructive
+              // ones at this call site is how the first version missed
+              // `.droppedTerminalPeriod` — a rule that also removes a character
+              // the user dictated, found by cloud review. `deletesDictatedText`
+              // is an exhaustive switch beside the enum, so a new rule cannot
+              // inherit "not destructive" by being forgotten out here.
+              candidateDeletesDictatedText: payloads.candidateRules.contains {
+                $0.deletesDictatedText
+              },
+              targetApp: context.targetApp,
+              targetElement: context.targetElement,
+              // Same local boolean the outcome fields above were stamped from —
+              // not re-derived from `targetElement` presence, which cannot tell
+              // "retried and recovered" apart from "captured at record-start".
+              targetElementIsRetried: caretCaptureRetried,
+              restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,
+              terminalBudget: terminalBudget))
+          pasteResult = result
+
+          // WHICH payload actually went to the app, which `CURSOR_REPAIR` cannot
+          // say because it is logged before the write happens.
+          //
+          // This is the gap that made the founder's original report
+          // undiagnosable: the repair can decide `lowercased_first`, offer a
+          // candidate, and the route can still commit the LEGACY text because
+          // `payloadAtCommitBoundary` re-reads the caret and refuses when
+          // anything changed. From the log alone those two outcomes were
+          // indistinguishable — both showed `candidate=offered` and the user saw
+          // the capital survive.
+          //
+          // A second line rather than a field on the first, only because the fact
+          // does not exist until after the write. `tier` rides along so the two
+          // can be matched without a timestamp join.
+          // The FULL budget spend, which `CURSOR_REPAIR` structurally cannot show:
+          // that line is written before the paste, and the commit-boundary
+          // re-check runs after the target app is activated. On 2026-08-04 the
+          // repair line reported a healthy 1.6 ms and the breaker tripped anyway,
+          // because the whole overspend lived in the half no line covered.
+          //
+          // Everything before `|recheck|` was already on the repair line; the
+          // suffix is new, and the total is what the cumulative cap is judged
+          // against. That cap is `TerminalResolutionBudget.defaultTotal`, which
+          // owns the current value — do not restate the number here, because a
+          // second copy is what goes stale (it read "100 ms" until 2026-08-05).
+          await AppLogger.shared.log(
+            "CURSOR_COMMIT submitted=\(result.submittedPayload?.rawValue ?? "none") "
+              + "tier=\(result.pasteTierLabel ?? "none") "
+              + "timing=[\(terminalBudget.timingDescription)]",
+            level: .info, category: "KernelFinalizationWiring")
+
+          if case .delivered = result.outcome {
+            // The text that actually LANDED, which is not always the one this
+            // closure passed in: a route may have committed the contextual
+            // candidate. `pasteCompletionRegistry`'s subscriber (#629) watches for
+            // later edits to the pasted text and learns custom words from them, so
+            // announcing the legacy payload after delivering the repaired one
+            // would make our own spacing and casing look like the user correcting
+            // us. Falls back to the legacy payload for `.legacy` and for a
+            // delivered route that reported no payload at all.
+            let deliveredText =
+              result.submittedPayload == .repaired
+              ? (payloads.repairedText ?? pasteText) : pasteText
+            pasteCompletionRegistry?.emit(
+              PasteCompletionEvent(
+                pastedText: deliveredText,
+                destinationBundleID: context.targetApp?.bundleIdentifier))
+            deliveryOutcome = .pasted
+          } else {
+            deliveryOutcome = .clipboardOnly
+          }
         }
       } else if config?.autoCopyToClipboard == true {
         // #2465: auto-copy never enters `PasteCascadeExecutor`, so it reaches the board without

--- a/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
+++ b/Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift
@@ -62,6 +62,7 @@ public final class RecoveryTextProcessor {
     // Intelligence, or local Ollama since #1948) and a glyph was dropped, so it
     // needs no settings from the snapshot.
     self.steps = LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),
@@ -149,6 +150,21 @@ public final class RecoveryTextProcessor {
     steps.llmPolish.polishVocabulary = polish
   }
 
+  /// Hand recovery the CURRENT snippet store and keyword (#628).
+  ///
+  /// A separate seam, deliberately parallel to `applyCustomWordsVocabulary` above, because
+  /// recovery has exactly the same shape of gap for both: `applySettings` restores record-time
+  /// TOGGLES, and the vocabulary CONTENTS are not in that snapshot — only its version. Without
+  /// this call the expansion step would replay every recovered dictation against an empty
+  /// vocabulary, which fails silently and looks like a recording that simply had no snippets.
+  ///
+  /// Current-store semantics rather than record-time, matching custom words: a snippet the
+  /// user has since edited replays with the text they have now, which is the version they
+  /// would expect to be pasted today.
+  public func applySnippetVocabulary(_ vocabulary: SnippetVocabulary) {
+    steps.snippetExpansion.snippetVocabulary = vocabulary
+  }
+
   /// Run the chain. Limb failures inside the chain (a step erroring or timing
   /// A blank polish is not a polish (#1948). Returns nil for nil, empty, or
   /// whitespace-only input so the caller delivers the deterministic floor instead.
@@ -175,10 +191,7 @@ public final class RecoveryTextProcessor {
         rawText: rawText,
         language: recordedLanguage,
         targetAppName: targetAppName,
-        steps: [
-          steps.wordCorrection, steps.fillerRemoval, steps.emojiFormatter,
-          steps.inverseTextNormalization, steps.llmPolish, steps.emojiRestore,
-        ])
+        steps: steps.orderedChain)
       // #1948: a BLANK polish is not a polish. Live finalization has an empty-output
       // recovery floor (`KernelFinalizationWiring` `:349`) that turns "" into the intact
       // deterministic text; this replay path has none, so a blank result would be saved to
@@ -190,9 +203,16 @@ public final class RecoveryTextProcessor {
       //
       // Normalising to nil here delivers `context.text`, the post-ITN deterministic floor,
       // which is what the live path's floor produces for the same input.
+      // #628. Before `usablePolish`, and before either field is read: this replay path has no
+      // empty-output floor of its own (see the comment above), so a sentinel reaching
+      // `RecoveryTextOutcome` would be written to History with nothing left to resolve it.
+      // The finalizer does NOT replace `usablePolish` — it resolves snippets, `usablePolish`
+      // normalises a blank polish, and the two answer different questions.
+      var context = result.context
+      SnippetFinalizer.finalize(&context)
       return RecoveryTextOutcome(
-        text: result.context.text,
-        polishedText: Self.usablePolish(result.context.polishedText),
+        text: context.text,
+        polishedText: Self.usablePolish(context.polishedText),
         polishError: result.polishError)
     } catch {
       return RecoveryTextOutcome(text: rawText, polishedText: nil, polishError: nil)

--- a/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
+++ b/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
@@ -35,9 +35,27 @@ public final class SnippetExpansionStep: TextProcessingStep {
   /// without this file — which is premise P4, and it has a test rather than a hope.
   public var isEnabled: Bool { snippetVocabulary.canFire }
 
-  /// Pure string work over one utterance. A generous runaway BACKSTOP, not a real budget —
-  /// mirrors `EmojiFormatterStep` and `EmojiRestoreStep`.
-  public var maxDuration: Duration { .milliseconds(50) }
+  /// One second, and the number is a measurement rather than a preference.
+  ///
+  /// The work here is microseconds — the same call runs 55 unit tests in 0.15s. But the runner's
+  /// budget covers the actor HOP as well as the work, and the FIRST step in the chain is the one
+  /// that pays it: every later step is already on the main actor and hops for free.
+  ///
+  /// Measured on the real app, two consecutive live dictations, with the 50ms backstop this file
+  /// originally copied from `EmojiFormatterStep`:
+  ///   `Snippet Expansion timed out after 51.7ms — skipping`
+  ///   `Snippet Expansion timed out after 51.8ms — skipping`
+  /// Consistent, so not a cold start; and every other step in the same take completed, so not a
+  /// stalled main actor. The step simply never got to run inside its own budget, and the user's
+  /// snippet silently did not fire.
+  ///
+  /// 50ms was wrong because it was copied from a step that runs LATE. `WordCorrectionStep` — the
+  /// step that was first before this one — declares 3 seconds, and had been absorbing this cost
+  /// invisibly for everyone.
+  ///
+  /// Still a runaway backstop, not a latency budget: nothing here should approach it, and if a
+  /// future change makes it does, the timeout is the right outcome.
+  public var maxDuration: Duration { .seconds(1) }
 
   private static let logger = Logger(
     subsystem: "com.enviouswispr.app", category: "SnippetExpansion")

--- a/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
+++ b/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
@@ -1,0 +1,63 @@
+import EnviousWisprCore
+import EnviousWisprPostProcessing
+import Foundation
+import OSLog
+
+/// Substitutes each fired snippet for a sentinel, FIRST in the post-ASR chain (#628).
+///
+/// **First on purpose, ahead of `WordCorrectionStep`.** A snippet trigger is matched literally,
+/// so it has to be read off the raw ASR surface before the fuzzy corrector can alter one of its
+/// words. Running after correction would make whether a snippet fires depend on the user's
+/// unrelated custom-word list.
+///
+/// This step only MASKS. `SnippetFinalizer` — which is not a step, for reasons its own header
+/// gives — resolves every sentinel after the runner. The pair exists so the user's saved text
+/// never reaches a polish model at all, which makes "delivered exactly as written" true by
+/// construction rather than by an instruction in a prompt that nothing enforces.
+///
+/// Limb semantics: pure CPU string work, no model, no network. Disabled outright when the
+/// frozen vocabulary cannot fire, so a user with no snippets takes a byte-identical chain.
+@MainActor
+final class SnippetExpansionStep: TextProcessingStep {
+  let name = "Snippet Expansion"
+
+  /// The frozen per-take vocabulary. Assigned by the wiring before the chain runs and never
+  /// read live, so an edit in Settings cannot change the rule for a dictation already in
+  /// flight — the same freeze `KernelFinalizationWiring` applies to `protectedSpellings`.
+  var snippetVocabulary: SnippetVocabulary = .empty
+
+  /// Disabled rather than run as a no-op. `TextProcessingRunner` skips a disabled step
+  /// entirely, so an empty store costs one boolean and the chain is identical to a build
+  /// without this file — which is premise P4, and it has a test rather than a hope.
+  var isEnabled: Bool { snippetVocabulary.canFire }
+
+  /// Pure string work over one utterance. A generous runaway BACKSTOP, not a real budget —
+  /// mirrors `EmojiFormatterStep` and `EmojiRestoreStep`.
+  var maxDuration: Duration { .milliseconds(50) }
+
+  private static let logger = Logger(
+    subsystem: "com.enviouswispr.app", category: "SnippetExpansion")
+
+  private let expander: SnippetExpander
+
+  init(expander: SnippetExpander = SnippetExpander()) {
+    self.expander = expander
+  }
+
+  func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
+    let outcome = expander.expand(context.text, using: snippetVocabulary)
+    guard outcome.didFire else { return context }
+
+    var updated = context
+    updated.text = outcome.text
+    // Appended rather than assigned: recovery and re-polish reuse a context, and silently
+    // dropping an earlier run's records would strand a sentinel with nothing to resolve it.
+    updated.protectedExpansions += outcome.records
+
+    // Counts only, never a trigger and never an expansion — `CLAUDE.md` privacy boundary, and
+    // the same shape-not-content rule the emoji and ITN stamps follow.
+    Self.logger.info(
+      "Snippet expansion fired for \(outcome.records.count, privacy: .public) snippet(s)")
+    return updated
+  }
+}

--- a/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
+++ b/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
@@ -18,33 +18,33 @@ import OSLog
 /// Limb semantics: pure CPU string work, no model, no network. Disabled outright when the
 /// frozen vocabulary cannot fire, so a user with no snippets takes a byte-identical chain.
 @MainActor
-final class SnippetExpansionStep: TextProcessingStep {
-  let name = "Snippet Expansion"
+public final class SnippetExpansionStep: TextProcessingStep {
+  public let name = "Snippet Expansion"
 
   /// The frozen per-take vocabulary. Assigned by the wiring before the chain runs and never
   /// read live, so an edit in Settings cannot change the rule for a dictation already in
   /// flight — the same freeze `KernelFinalizationWiring` applies to `protectedSpellings`.
-  var snippetVocabulary: SnippetVocabulary = .empty
+  public var snippetVocabulary: SnippetVocabulary = .empty
 
   /// Disabled rather than run as a no-op. `TextProcessingRunner` skips a disabled step
   /// entirely, so an empty store costs one boolean and the chain is identical to a build
   /// without this file — which is premise P4, and it has a test rather than a hope.
-  var isEnabled: Bool { snippetVocabulary.canFire }
+  public var isEnabled: Bool { snippetVocabulary.canFire }
 
   /// Pure string work over one utterance. A generous runaway BACKSTOP, not a real budget —
   /// mirrors `EmojiFormatterStep` and `EmojiRestoreStep`.
-  var maxDuration: Duration { .milliseconds(50) }
+  public var maxDuration: Duration { .milliseconds(50) }
 
   private static let logger = Logger(
     subsystem: "com.enviouswispr.app", category: "SnippetExpansion")
 
   private let expander: SnippetExpander
 
-  init(expander: SnippetExpander = SnippetExpander()) {
+  public init(expander: SnippetExpander = SnippetExpander()) {
     self.expander = expander
   }
 
-  func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
+  public func process(_ context: TextProcessingContext) async throws -> TextProcessingContext {
     let outcome = expander.expand(context.text, using: snippetVocabulary)
     guard outcome.didFire else { return context }
 

--- a/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
+++ b/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
@@ -21,9 +21,13 @@ import OSLog
 public final class SnippetExpansionStep: TextProcessingStep {
   public let name = "Snippet Expansion"
 
-  /// The frozen per-take vocabulary. Assigned by the wiring before the chain runs and never
-  /// read live, so an edit in Settings cannot change the rule for a dictation already in
-  /// flight — the same freeze `KernelFinalizationWiring` applies to `protectedSpellings`.
+  /// The active vocabulary, assigned by the wiring and re-assigned whenever the user saves.
+  ///
+  /// NOT a per-take freeze, and an earlier version of this comment said it was. The App layer
+  /// replaces this on every save, so a snippet edited while a dictation is in flight applies to
+  /// that take. Same behaviour custom words already have — `KernelFinalizationWiring` says so at
+  /// its `protectedSpellings` snapshot, which exists precisely because the vocabulary behind it
+  /// is NOT frozen. Nothing is delivered wrongly; the newest snippet simply wins.
   public var snippetVocabulary: SnippetVocabulary = .empty
 
   /// Disabled rather than run as a no-op. `TextProcessingRunner` skips a disabled step

--- a/Sources/EnviousWisprPipeline/SnippetFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/SnippetFinalizer.swift
@@ -1,0 +1,118 @@
+import EnviousWisprPostProcessing
+import Foundation
+
+/// Resolves every snippet sentinel back into the user's saved text (#628).
+///
+/// **This is deliberately NOT a `TextProcessingStep`, and that is the whole design.**
+/// `TextProcessingRunner` swallows a step's error and continues with that step's input
+/// (`TextProcessingRunner.swift`, catch block: "Heart & Limbs: limb failed, continue with input
+/// text"), and it skips a step whose `isEnabled` is false. Both are correct for a limb — losing
+/// an emoji is survivable. Neither is acceptable here: a swallowed failure would deliver text
+/// with a raw sentinel in it, straight into the user's document, their History, and the
+/// recovery spool at once. An output invariant cannot be something the runner is allowed to
+/// skip, so it is not a step.
+///
+/// Both paths that run the chain call this immediately after the runner and before anything
+/// reads the result: live (`KernelFinalizationWiring`, before the outcome field copy and before
+/// the empty-output floor) and recovery (`RecoveryTextProcessor`, before `usablePolish`).
+///
+/// The one rule this type exists to keep: **it never returns text containing a sentinel it
+/// owns.**
+enum SnippetFinalizer {
+
+  /// Why a resolved dictation did not keep its polished text. Closed set; `snippetSentinelLoss`
+  /// is the only member this type produces.
+  static let sentinelLossReason = "snippet_sentinel_loss"
+
+  struct Resolution: Equatable {
+    /// The deterministic text, with every expansion substituted in.
+    var text: String
+    /// The polished text with expansions substituted in, or nil when polish was rejected.
+    var polishedText: String?
+    /// True when polish produced output that could not be trusted to carry the expansions.
+    var rejectedPolish: Bool
+  }
+
+  /// Resolve `context` in place. A no-op when no snippet fired, so an ordinary dictation pays
+  /// one array-emptiness check and nothing else.
+  static func finalize(_ context: inout TextProcessingContext) {
+    let records = context.protectedExpansions
+    guard !records.isEmpty else { return }
+
+    let resolution = resolve(
+      text: context.text, polishedText: context.polishedText, records: records)
+
+    context.text = resolution.text
+    context.polishedText = resolution.polishedText
+
+    guard resolution.rejectedPolish else { return }
+
+    // A sentinel-loss fallback is a pipeline fallback, and saying so is not optional. Without
+    // these three the metrics report that polish did NOT fall back on exactly the takes where
+    // this type threw its output away — a counter whose name is a causal claim, measured on a
+    // state that now has a second producer.
+    //
+    // `TextProcessingStep.swift` states the invariant these two must satisfy together:
+    // `(polishFallbackReason != nil) == pipelineFellBackToRaw`.
+    context.pipelineFellBackToRaw = true
+    context.polishFallbackReason = sentinelLossReason
+    // Cleared because no remote polish survived into the delivered text. Provider, model and
+    // `polishMetadata` are deliberately RETAINED: polish was genuinely attempted, and erasing
+    // that would make an attempted-and-rejected take indistinguishable from one that never
+    // called a model.
+    context.polishRanRemote = nil
+  }
+
+  /// The pure decision, split out so it can be tested without building a context.
+  ///
+  /// Polished output is kept only when EVERY sentinel appears in it EXACTLY ONCE. Not "at
+  /// least once": a model that duplicated a sentinel would paste the user's saved text twice,
+  /// which is a wrong document rather than a missing flourish.
+  static func resolve(
+    text: String, polishedText: String?, records: [SnippetExpansionRecord]
+  ) -> Resolution {
+    let deterministic = substituting(records, into: text)
+
+    guard let polished = polishedText else {
+      return Resolution(text: deterministic, polishedText: nil, rejectedPolish: false)
+    }
+
+    let intact = records.allSatisfy { occurrences(of: $0.sentinel, in: polished) == 1 }
+    guard intact else {
+      // Whole-dictation fallback rather than per-anchor repair: the promise is that the saved
+      // text arrives exactly, and reconstructing a lost span at a guessed anchor trades that
+      // for a heuristic on the one property whose entire value is that it is not one.
+      return Resolution(text: deterministic, polishedText: nil, rejectedPolish: true)
+    }
+
+    return Resolution(
+      text: deterministic,
+      polishedText: substituting(records, into: polished),
+      rejectedPolish: false)
+  }
+
+  /// Substitute every record. Order is irrelevant because sentinels are mutually exclusive by
+  /// construction — `SnippetExpander.mintSentinel` rejects a candidate that appears in the raw
+  /// input, in any saved expansion, or in a sentinel already issued for the run — so no
+  /// substitution can create or destroy another's match.
+  private static func substituting(
+    _ records: [SnippetExpansionRecord], into text: String
+  ) -> String {
+    var out = text
+    for record in records {
+      out = out.replacingOccurrences(of: record.sentinel, with: record.expansion)
+    }
+    return out
+  }
+
+  private static func occurrences(of needle: String, in haystack: String) -> Int {
+    guard !needle.isEmpty else { return 0 }
+    var count = 0
+    var searchRange = haystack.startIndex..<haystack.endIndex
+    while let found = haystack.range(of: needle, range: searchRange) {
+      count += 1
+      searchRange = found.upperBound..<haystack.endIndex
+    }
+    return count
+  }
+}

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprPostProcessing
 import Foundation
 
 /// Context passed through the text processing chain after ASR transcription.
@@ -71,6 +72,21 @@ public struct TextProcessingContext: Sendable {
   /// module reads it, and a stringly-typed receipt is what let the first version of the
   /// emoji gate accept a family from the wrong provider.
   var promptFamily: PromptFamily?
+
+  /// Snippet expansions owed to the user (#628): each sentinel standing in the text, and the
+  /// saved text that must replace it before anything is stored, shown or pasted.
+  ///
+  /// Written ONLY by `SnippetExpansionStep` and read ONLY by `SnippetFinalizer` — one writer,
+  /// one reader, so "which spans must survive the chain byte-for-byte" has a single authority.
+  ///
+  /// Deliberately NOT folded into `KernelFinalizationWiring`'s `protectedSpellings`, which
+  /// looks adjacent and is not: that set is custom-word canonicals, its only consumer is
+  /// `CursorInsertionRepair`, and it vetoes LEADING RECASING alone. It carries words; this
+  /// carries positioned spans, and it must survive a different stage.
+  ///
+  /// Non-`Codable` and never persisted: a sentinel is meaningless outside the run that minted
+  /// it, and a stored one would be a live token pointing at nothing.
+  public var protectedExpansions: [SnippetExpansionRecord] = []
 
   public init(text: String, language: String?) {
     self.text = text

--- a/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsExportWriter.swift
@@ -30,28 +30,10 @@ package enum CustomWordsExportWriter {
   /// corrupt, and the user would have destroyed their dictionary by exporting
   /// it. Compared on resolved paths so a symlink or `..` cannot walk around it.
   package static func wouldOverwriteLiveWords(_ destination: URL) -> Bool {
+    // The filesystem-identity comparison, and the reasoning for it, moved to
+    // `DurableJSONFile.isSameFile` when #628 gave a second store an export. Same test, one owner.
     guard let live = CustomWordsManager.liveFileURL else { return false }
-    let target = destination.resolvingSymlinksInPath().standardizedFileURL
-    let liveURL = live.resolvingSymlinksInPath().standardizedFileURL
-
-    // Ask the FILESYSTEM whether these are the same file, not the strings
-    // (code review r6). macOS is case-insensitive by default, so
-    // `CUSTOM-WORDS.JSON` and `custom-words.json` are one file that string
-    // equality calls two — and picking the shouty spelling would walk straight
-    // past this guard into the data loss it exists to prevent.
-    if let targetID = try? target.resourceValues(forKeys: [.fileResourceIdentifierKey])
-      .fileResourceIdentifier,
-      let liveID = try? liveURL.resourceValues(forKeys: [.fileResourceIdentifierKey])
-        .fileResourceIdentifier
-    {
-      return targetID.isEqual(liveID)
-    }
-
-    // The destination may not exist yet, so there is no identity to compare.
-    // Fall back to a case-insensitive path match: on the default volume that
-    // is the truth, and on a case-sensitive one it is merely stricter than
-    // necessary — which is the safe direction to be wrong in.
-    return target.path.compare(liveURL.path, options: .caseInsensitive) == .orderedSame
+    return DurableJSONFile.isSameFile(destination, as: live)
   }
 
   /// `@concurrent` so this always runs OFF the caller's actor (code review r5).

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -145,24 +145,13 @@ public final class CustomWordsManager {
   /// case a backup restore or user action loosened permissions. Soft-fails on
   /// any filesystem operation. (V3 audit #561 / #562.)
   private static func prepareAppSupportDirectory(at url: URL) {
-    let fm = FileManager.default
-    try? fm.createDirectory(at: url, withIntermediateDirectories: true)
-    try? fm.setAttributes(
-      [.posixPermissions: 0o700],
-      ofItemAtPath: url.path
-    )
-    let marker = url.appendingPathComponent(".metadata_never_index")
-    if !fm.fileExists(atPath: marker.path) {
-      fm.createFile(atPath: marker.path, contents: Data(), attributes: nil)
-    }
+    DurableJSONFile.prepareDirectory(at: url)
   }
 
   /// Force `custom-words.json` to 0600 if it already exists. Migrates installs
   /// that pre-date this hardening.
   private static func tightenFileIfPresent(at url: URL) {
-    let fm = FileManager.default
-    guard fm.fileExists(atPath: url.path) else { return }
-    try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    DurableJSONFile.tightenFileIfPresent(at: url)
   }
 
   // MARK: - Built-in Defaults
@@ -1681,67 +1670,11 @@ public final class CustomWordsManager {
   /// `loadFileWhileLocked()` (reached only while a caller of THAT holds the
   /// lock).
   private func saveFileWhileLocked(_ file: CustomWordsFile) throws {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    let data = try encoder.encode(file)
-    let tmpURL = fileURL.deletingLastPathComponent()
-      .appendingPathComponent(".custom-words.json.\(UUID().uuidString).tmp")
-    let fm = FileManager.default
-    do {
-      let fd = Foundation.open(tmpURL.path, O_CREAT | O_EXCL | O_WRONLY, 0o600)
-      guard fd >= 0 else {
-        throw CocoaError(.fileWriteUnknown)
-      }
-      let fh = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
-      try fh.write(contentsOf: data)
-      // #1744: atomic (via the rename below) is not durable on its own — force
-      // the just-written bytes off the drive's write cache before the rename
-      // makes them live, so a crash/power-loss immediately after this call
-      // returns cannot silently revert to the prior save. Mirrors the shipped
-      // pattern in RecoverySpoolStore.writeAttemptMarker (write, F_FULLFSYNC,
-      // then atomic rename) — same primitive, this call's own error shape.
-      guard fcntl(fd, F_FULLFSYNC) != -1 else {
-        throw NSError(
-          domain: NSPOSIXErrorDomain, code: Int(errno),
-          userInfo: [
-            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
-            NSFilePathErrorKey: tmpURL.path,
-          ])
-      }
-      try fh.close()
-
-      // Same-directory temp file means same filesystem, which is what makes
-      // rename legal here.
-      guard Foundation.rename(tmpURL.path, fileURL.path) == 0 else {
-        throw NSError(
-          domain: NSPOSIXErrorDomain, code: Int(errno),
-          userInfo: [
-            NSLocalizedDescriptionKey: String(cString: strerror(errno)),
-            NSFilePathErrorKey: fileURL.path,
-          ])
-      }
-
-      // F_FULLFSYNC on the file makes the BYTES durable, but not the rename
-      // itself -- if the Mac loses power after rename() returns but before
-      // APFS commits the directory metadata, the new file's content is safe
-      // on disk while the rename that made it live can still be lost.
-      // Sync the containing directory too, BEST-EFFORT: by this point
-      // `rename()` has already succeeded, the new content is live, and the
-      // caller's in-memory state is about to be treated as consistent with
-      // disk. Throwing here (round 1 of this fix did) would make the caller
-      // believe the save failed and skip updating its own state while the
-      // file on disk had already changed -- correctness regression Codex
-      // review caught. A failure at this point only narrows the crash
-      // window this hardening closes; it does not undo the save.
-      let dirFD = Foundation.open(fileURL.deletingLastPathComponent().path, O_RDONLY)
-      if dirFD >= 0 {
-        _ = fcntl(dirFD, F_FULLFSYNC)
-        close(dirFD)
-      }
-    } catch {
-      try? fm.removeItem(at: tmpURL)
-      throw error
-    }
+    // The write sequence — unique temp, 0600, F_FULLFSYNC, atomic rename, best-effort
+    // directory sync — moved to `DurableJSONFile` when #628 added a second user-owned store.
+    // Same primitive, same order, same reasoning; it lives in one place so the next fix lands
+    // once. `DurableJSONFile`'s header carries the reasoning that used to sit here.
+    try DurableJSONFile.write(file, to: fileURL, tempPrefix: ".custom-words.json")
   }
 
   // MARK: - Runtime Merge

--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -514,25 +514,18 @@ public final class CustomWordsManager {
   private func withExclusiveFileLock<T>(
     blocking: Bool = false, _ body: () throws -> T
   ) throws -> T {
-    let lockURL = fileURL.appendingPathExtension("lock")
-    let fd = lockURL.path.withCString {
-      Foundation.open($0, O_RDWR | O_CREAT | O_CLOEXEC, 0o600)
-    }
-    guard fd >= 0 else {
+    // The companion-file `flock` mechanism moved to `DurableJSONFile.withExclusiveLock` when
+    // #628 gave a second user-owned store the same need. Still exactly ONE declaration here,
+    // and this function keeps what is genuinely this type's: the mapping onto
+    // `CustomWordsPersistenceError`, which callers throughout this file catch by case.
+    do {
+      return try DurableJSONFile.withExclusiveLock(
+        on: fileURL, blocking: blocking, lockSyscall: lockSyscall, body)
+    } catch DurableJSONFile.LockFailure.busy {
+      throw CustomWordsPersistenceError.libraryBusy
+    } catch DurableJSONFile.LockFailure.unavailable {
       throw CustomWordsPersistenceError.coordinationUnavailable
     }
-    defer { close(fd) }
-
-    let flags: Int32 = blocking ? LOCK_EX : (LOCK_EX | LOCK_NB)
-    guard lockSyscall(fd, flags) == 0 else {
-      if !blocking, errno == EWOULDBLOCK {
-        throw CustomWordsPersistenceError.libraryBusy
-      }
-      throw CustomWordsPersistenceError.coordinationUnavailable
-    }
-    defer { _ = flock(fd, LOCK_UN) }
-
-    return try body()
   }
 
   /// Wraps an explicit mutation's load-transform-save in one non-blocking

--- a/Sources/EnviousWisprPostProcessing/DurableJSONFile.swift
+++ b/Sources/EnviousWisprPostProcessing/DurableJSONFile.swift
@@ -24,6 +24,34 @@ import Foundation
 ///    already changed. A failure here only narrows the crash window; it does not undo the save.
 public enum DurableJSONFile {
 
+  /// Whether `destination` is the same file on disk as `live`.
+  ///
+  /// The guard behind every export: choosing the app's own store as the destination would
+  /// atomically replace it with the transfer format, and the next launch would archive it as
+  /// corrupt — the user destroying their own data by backing it up. Extracted from
+  /// `CustomWordsExportWriter.wouldOverwriteLiveWords` when #628 gave a second store an export.
+  ///
+  /// Ask the FILESYSTEM, not the strings. macOS is case-insensitive by default, so
+  /// `SNIPPETS.JSON` and `snippets.json` are ONE file that string equality calls two — and
+  /// picking the shouty spelling would walk straight past the guard into the loss it prevents.
+  ///
+  /// The destination may not exist yet, so there is no identity to compare. The fallback is a
+  /// case-insensitive path match: on the default volume that is the truth, and on a
+  /// case-sensitive one it is merely stricter than necessary — the safe direction to be wrong.
+  public static func isSameFile(_ destination: URL, as live: URL) -> Bool {
+    let target = destination.resolvingSymlinksInPath().standardizedFileURL
+    let liveURL = live.resolvingSymlinksInPath().standardizedFileURL
+
+    if let targetID = try? target.resourceValues(forKeys: [.fileResourceIdentifierKey])
+      .fileResourceIdentifier,
+      let liveID = try? liveURL.resourceValues(forKeys: [.fileResourceIdentifierKey])
+        .fileResourceIdentifier
+    {
+      return targetID.isEqual(liveID)
+    }
+    return target.path.compare(liveURL.path, options: .caseInsensitive) == .orderedSame
+  }
+
   /// Create the store's directory at 0700 and drop a `.metadata_never_index` Spotlight marker.
   ///
   /// Re-enforced on every init, in case a backup restore or a user action loosened permissions

--- a/Sources/EnviousWisprPostProcessing/DurableJSONFile.swift
+++ b/Sources/EnviousWisprPostProcessing/DurableJSONFile.swift
@@ -24,6 +24,48 @@ import Foundation
 ///    already changed. A failure here only narrows the crash window; it does not undo the save.
 public enum DurableJSONFile {
 
+  /// Why a cross-process lock could not be taken.
+  public enum LockFailure: Error, Equatable {
+    /// Another process holds the lock right now (non-blocking acquisition only).
+    case busy
+    /// The lock file could not be opened, or `flock` failed for a reason other than contention.
+    case unavailable
+  }
+
+  /// Hold an exclusive cross-process lock while `body` runs (#1690, generalised by #628).
+  ///
+  /// Takes `flock` on a stable COMPANION file beside the store, never on the store itself: the
+  /// store is replaced by rename on every save, so a lock held on it would be a lock on a file
+  /// that no longer exists the moment it mattered.
+  ///
+  /// Non-blocking by default, so a mutation fails closed rather than freezing the main actor
+  /// behind another process. Blocking acquisition is for a load path that can afford to wait.
+  ///
+  /// - Parameter lockSyscall: test seam. Production always passes the real `flock`; a test can
+  ///   force a non-contention failure without needing a second process.
+  public static func withExclusiveLock<T>(
+    on storeURL: URL,
+    blocking: Bool = false,
+    lockSyscall: (Int32, Int32) -> Int32 = { flock($0, $1) },
+    _ body: () throws -> T
+  ) throws -> T {
+    let lockURL = storeURL.appendingPathExtension("lock")
+    let fd = lockURL.path.withCString {
+      Foundation.open($0, O_RDWR | O_CREAT | O_CLOEXEC, 0o600)
+    }
+    guard fd >= 0 else { throw LockFailure.unavailable }
+    defer { close(fd) }
+
+    let flags: Int32 = blocking ? LOCK_EX : (LOCK_EX | LOCK_NB)
+    guard lockSyscall(fd, flags) == 0 else {
+      if !blocking, errno == EWOULDBLOCK { throw LockFailure.busy }
+      throw LockFailure.unavailable
+    }
+    defer { _ = flock(fd, LOCK_UN) }
+
+    return try body()
+  }
+
   /// Whether `destination` is the same file on disk as `live`.
   ///
   /// The guard behind every export: choosing the app's own store as the destination would

--- a/Sources/EnviousWisprPostProcessing/DurableJSONFile.swift
+++ b/Sources/EnviousWisprPostProcessing/DurableJSONFile.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// The one durable-write primitive for a user-owned JSON store on disk.
+///
+/// Extracted from `CustomWordsManager.saveFileWhileLocked` when #628 added a second store,
+/// rather than writing the sequence twice. Every comment below is the original reasoning,
+/// carried across with the code it explains — the crash-window this closes was found and fixed
+/// twice (#1744, then a Codex review round on the directory sync), and a second copy of the
+/// sequence would have started life one fix behind.
+///
+/// The order is load-bearing and each step answers a different failure:
+///
+/// 1. **Unique temp name**, not a fixed `.tmp`. Two writers on one fixed name can interleave.
+/// 2. **`O_CREAT | O_EXCL | O_WRONLY, 0o600`** — the file is never world-readable, not even for
+///    the instant between creation and a `chmod`.
+/// 3. **`F_FULLFSYNC` on the file.** Atomic is not durable: the rename can be committed while
+///    the bytes are still in the drive's write cache, so a power loss reverts to the prior save.
+/// 4. **`rename` within the same directory**, which is what makes the swap atomic — same
+///    directory means same filesystem.
+/// 5. **`F_FULLFSYNC` on the DIRECTORY, best-effort.** Syncing the file makes the bytes durable
+///    but not the rename itself. This one must NOT throw: by the time it runs the rename has
+///    already succeeded and the new content is live, so reporting failure would make the caller
+///    believe the save failed and skip updating its own state while the file on disk had
+///    already changed. A failure here only narrows the crash window; it does not undo the save.
+public enum DurableJSONFile {
+
+  /// Create the store's directory at 0700 and drop a `.metadata_never_index` Spotlight marker.
+  ///
+  /// Re-enforced on every init, in case a backup restore or a user action loosened permissions
+  /// (V3 audit #561 / #562). Soft-fails on every filesystem operation: a store that cannot
+  /// tighten its own directory must still work, and a throw here would take the app down at
+  /// launch over a permission bit.
+  public static func prepareDirectory(at url: URL) {
+    let fm = FileManager.default
+    try? fm.createDirectory(at: url, withIntermediateDirectories: true)
+    try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    let marker = url.appendingPathComponent(".metadata_never_index")
+    if !fm.fileExists(atPath: marker.path) {
+      fm.createFile(atPath: marker.path, contents: Data(), attributes: nil)
+    }
+  }
+
+  /// Force an existing store file to 0600. Migrates installs that pre-date this hardening.
+  public static func tightenFileIfPresent(at url: URL) {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: url.path) else { return }
+    try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+  }
+
+  /// Encode and write `value` to `url`, atomically and durably.
+  ///
+  /// - Parameter tempPrefix: the dot-prefixed basename stem for the temp file, so a stray temp
+  ///   left by a crash is identifiable as belonging to this store.
+  public static func write<Value: Encodable>(
+    _ value: Value, to url: URL, tempPrefix: String
+  ) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try write(data: try encoder.encode(value), to: url, tempPrefix: tempPrefix)
+  }
+
+  public static func write(data: Data, to url: URL, tempPrefix: String) throws {
+    let directory = url.deletingLastPathComponent()
+    let tmpURL = directory.appendingPathComponent("\(tempPrefix).\(UUID().uuidString).tmp")
+    do {
+      let fd = Foundation.open(tmpURL.path, O_CREAT | O_EXCL | O_WRONLY, 0o600)
+      guard fd >= 0 else { throw CocoaError(.fileWriteUnknown) }
+      let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+      try handle.write(contentsOf: data)
+
+      guard fcntl(fd, F_FULLFSYNC) != -1 else { throw posixError(path: tmpURL.path) }
+      try handle.close()
+
+      guard Foundation.rename(tmpURL.path, url.path) == 0 else {
+        throw posixError(path: url.path)
+      }
+
+      // Best-effort by contract — see the header. Never promote this to a throw.
+      let dirFD = Foundation.open(directory.path, O_RDONLY)
+      if dirFD >= 0 {
+        _ = fcntl(dirFD, F_FULLFSYNC)
+        close(dirFD)
+      }
+    } catch {
+      try? FileManager.default.removeItem(at: tmpURL)
+      throw error
+    }
+  }
+
+  private static func posixError(path: String) -> NSError {
+    NSError(
+      domain: NSPOSIXErrorDomain, code: Int(errno),
+      userInfo: [
+        NSLocalizedDescriptionKey: String(cString: strerror(errno)),
+        NSFilePathErrorKey: path,
+      ])
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -121,9 +121,14 @@ public struct SnippetExpander: Sendable {
       records.append(
         SnippetExpansionRecord(sentinel: sentinel, expansion: hit.snippet.expansion))
 
-      // The punctuation the user actually spoke belongs after the pasted text, not swallowed
-      // with the trigger. Same set `SnippetText.normalize` stripped, so the two cannot drift.
-      out += sentinel + SnippetText.trailingPunctuation(lastToken)
+      // The punctuation the user actually spoke belongs AROUND the pasted text, not swallowed
+      // with the trigger. Both ends, and both are load-bearing: the opening mark is stripped
+      // from the KEYWORD token so the match can happen, the closing one from the LAST trigger
+      // token. Restoring only the tail leaves an orphan closing quote, which review caught.
+      // Same sets `SnippetText.normalize` strips, so the pairs cannot drift apart.
+      out +=
+        SnippetText.leadingPunctuation(token) + sentinel
+        + SnippetText.trailingPunctuation(lastToken)
       if let gap = Self.whitespaceAfter(lastWordIndex, in: pieces) { out += gap }
       cursor += hit.length + 1
     }

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -88,7 +88,12 @@ public struct SnippetExpander: Sendable {
     let pieces = Self.split(text)
     let wordIndices = pieces.indices.filter { !pieces[$0].isWhitespaceRun }
 
-    var out = ""
+    // Seeded with any whitespace BEFORE the first word. The loop below walks word pieces and
+    // appends the gap that FOLLOWS each one, so a leading run belongs to no word and was
+    // silently dropped — on every dictation that armed the step, whether or not a snippet
+    // matched. Found by review, not by a test, because every fixture happened to start with a
+    // letter.
+    var out = pieces.first?.isWhitespaceRun == true ? pieces[0].text : ""
     var records: [SnippetExpansionRecord] = []
     var issued: Set<String> = []
     var cursor = 0

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -102,8 +102,18 @@ public struct SnippetExpander: Sendable {
       let pieceIndex = wordIndices[cursor]
       let token = pieces[pieceIndex].text
 
+      // The KEYWORD is a consumed token too, and it was the one the first version of this guard
+      // could not see: "backslash. My email address is below" has the boundary on the keyword,
+      // normalisation strips it, and the trigger words after it match perfectly. Checking the
+      // trigger tokens alone let that fire.
+      //
+      // The complete set a boundary must be checked against is every token the match CONSUMES —
+      // the keyword plus every trigger token — minus the last, which legitimately ends the
+      // sentence the trigger is in. Written as one named condition so the set is visible rather
+      // than split across two loops that each see half of it.
       guard
         SnippetText.normalize(token) == keyword,
+        !SnippetText.endsSentence(token),
         let hit = Self.longestMatch(
           in: vocabulary.snippets, pieces: pieces, wordIndices: wordIndices, startingAt: cursor + 1)
       else {
@@ -202,13 +212,10 @@ public struct SnippetExpander: Sendable {
           matched = false
           break
         }
-        // A trigger does not span a sentence boundary. Normalisation strips a full stop so the
-        // words still compare equal, which means "send me my. Email address is below" would
-        // otherwise match the trigger "my email address" and paste an address across two
-        // sentences the user never joined.
-        //
         // Only an INTERIOR boundary blocks: punctuation on the LAST token is the sentence the
-        // trigger legitimately ends, and it is re-attached after the expansion.
+        // trigger legitimately ends, and it is re-attached after the expansion. The keyword's
+        // own boundary is checked by the CALLER, because the keyword is consumed too and this
+        // loop cannot see it — see `consumedTokensSpanASentenceBoundary`.
         if offset < tokens.count - 1, SnippetText.endsSentence(piece.text) {
           matched = false
           break

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -202,6 +202,17 @@ public struct SnippetExpander: Sendable {
           matched = false
           break
         }
+        // A trigger does not span a sentence boundary. Normalisation strips a full stop so the
+        // words still compare equal, which means "send me my. Email address is below" would
+        // otherwise match the trigger "my email address" and paste an address across two
+        // sentences the user never joined.
+        //
+        // Only an INTERIOR boundary blocks: punctuation on the LAST token is the sentence the
+        // trigger legitimately ends, and it is re-attached after the expansion.
+        if offset < tokens.count - 1, SnippetText.endsSentence(piece.text) {
+          matched = false
+          break
+        }
       }
       guard matched else { continue }
       if best == nil || tokens.count > best!.length {

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -1,0 +1,235 @@
+import EnviousWisprCore
+import Foundation
+
+/// One expansion the pipeline owes the user: the sentinel that stands in for it through the
+/// text chain, and the exact text that must replace that sentinel before anything is stored,
+/// shown, or pasted (#628).
+public struct SnippetExpansionRecord: Sendable, Equatable {
+  /// The opaque token substituted into the text. Unique within its run.
+  public let sentinel: String
+  /// The user's saved text, byte-for-byte. Never sent to a model.
+  public let expansion: String
+
+  public init(sentinel: String, expansion: String) {
+    self.sentinel = sentinel
+    self.expansion = expansion
+  }
+}
+
+public struct SnippetExpansionOutcome: Sendable, Equatable {
+  /// The text with each fired snippet replaced by its sentinel.
+  public let text: String
+  /// One record per fired snippet, in the order they appear. Empty means nothing fired and
+  /// every downstream stage is a no-op.
+  public let records: [SnippetExpansionRecord]
+
+  public init(text: String, records: [SnippetExpansionRecord]) {
+    self.text = text
+    self.records = records
+  }
+
+  public var didFire: Bool { !records.isEmpty }
+}
+
+/// Pure, Sendable snippet matcher (#628). Sibling of `WordCorrector`, and deliberately its
+/// opposite: `WordCorrector` is fuzzy across six passes, this is literal in one.
+///
+/// Semantics ported from the approved design prototype's `expand()`
+/// (`docs/feature-requests/issue-628-design/EnviousWispr Snippets.dc.html`), which is the
+/// behavioural authority for matching:
+///
+/// - A snippet fires only when the keyword is spoken immediately before its trigger.
+/// - Trigger tokens compare through `SnippetText.normalize` — literal, never fuzzy.
+/// - **Longest match wins** when several triggers match at one position.
+/// - Trailing punctuation clinging to the last trigger word is re-attached AFTER the
+///   substitution, so "…backslash my email address." keeps its full stop.
+/// - The keyword is consumed on a hit and left in place on a miss, which is what makes
+///   "the path is backslash users" come through untouched.
+public struct SnippetExpander: Sendable {
+  /// Mints a sentinel candidate. Injectable so tests can force a collision rather than wait
+  /// for one — a uniqueness check whose failure branch is never executed is a comment.
+  public typealias CandidateSource = @Sendable () -> String
+
+  /// The sentinel shape, and the reasoning is the whole point of the choice.
+  ///
+  /// A single unbroken alphanumeric token: no whitespace for tokenisation to split, no
+  /// punctuation for `InverseTextNormalizer` to convert, not a word `FillerRemoval` knows, and
+  /// long and meaningless enough that `WordCorrector`'s similarity passes have no candidate
+  /// anywhere near it. Uppercase-and-hex so it reads as an opaque identifier to a polish model
+  /// rather than as prose to rewrite.
+  ///
+  /// This shape is a CANDIDATE, not a proven constant. Premise P2 in the plan requires it to be
+  /// driven through the full deterministic chain adversarially before it is depended on; if a
+  /// step mangles it, the fix is here and the tests fail loudly rather than a user seeing it.
+  static let prefix = "EWSNIP"
+
+  private let candidateSource: CandidateSource
+
+  public init(candidateSource: @escaping CandidateSource = SnippetExpander.randomCandidate) {
+    self.candidateSource = candidateSource
+  }
+
+  public static let randomCandidate: CandidateSource = {
+    var hex = ""
+    for _ in 0..<4 {
+      hex += String(format: "%08x", UInt32.random(in: UInt32.min...UInt32.max))
+    }
+    return prefix + hex
+  }
+
+  /// Expand every fired snippet in `text` into a sentinel.
+  ///
+  /// Returns the input unchanged with no records when the vocabulary cannot fire, so a user
+  /// with no snippets takes a byte-identical path.
+  public func expand(_ text: String, using vocabulary: SnippetVocabulary) -> SnippetExpansionOutcome
+  {
+    guard vocabulary.canFire else { return SnippetExpansionOutcome(text: text, records: []) }
+    let keyword = SnippetText.normalize(vocabulary.keyword)
+    let pieces = Self.split(text)
+    let wordIndices = pieces.indices.filter { !pieces[$0].isWhitespaceRun }
+
+    var out = ""
+    var records: [SnippetExpansionRecord] = []
+    var issued: Set<String> = []
+    var cursor = 0
+
+    while cursor < wordIndices.count {
+      let pieceIndex = wordIndices[cursor]
+      let token = pieces[pieceIndex].text
+
+      guard
+        SnippetText.normalize(token) == keyword,
+        let hit = Self.longestMatch(
+          in: vocabulary.snippets, pieces: pieces, wordIndices: wordIndices, startingAt: cursor + 1)
+      else {
+        out += token
+        if let gap = Self.whitespaceAfter(pieceIndex, in: pieces) { out += gap }
+        cursor += 1
+        continue
+      }
+
+      let lastWordIndex = wordIndices[cursor + hit.length]
+      let lastToken = pieces[lastWordIndex].text
+      let sentinel = mintSentinel(
+        rawInput: text, expansions: vocabulary.snippets.map(\.expansion), alreadyIssued: issued)
+      issued.insert(sentinel)
+      records.append(
+        SnippetExpansionRecord(sentinel: sentinel, expansion: hit.snippet.expansion))
+
+      // The punctuation the user actually spoke belongs after the pasted text, not swallowed
+      // with the trigger. Same set `SnippetText.normalize` stripped, so the two cannot drift.
+      out += sentinel + SnippetText.trailingPunctuation(lastToken)
+      if let gap = Self.whitespaceAfter(lastWordIndex, in: pieces) { out += gap }
+      cursor += hit.length + 1
+    }
+
+    return SnippetExpansionOutcome(text: out, records: records)
+  }
+
+  /// A sentinel that appears in NONE of: the raw input, any saved expansion, or the sentinels
+  /// already issued for this run.
+  ///
+  /// All three domains matter and the second is the one that is easy to miss: restoration
+  /// substitutes expansions back into the text, so an expansion containing a live sentinel would
+  /// reintroduce one after the finalizer had already checked. Re-minting is bounded — a
+  /// collision on 128 random bits is not a case that recurs — but the loop is written to
+  /// terminate rather than to trust that.
+  func mintSentinel(rawInput: String, expansions: [String], alreadyIssued: Set<String>) -> String {
+    for _ in 0..<8 {
+      let candidate = candidateSource()
+      if rawInput.contains(candidate) { continue }
+      if alreadyIssued.contains(candidate) { continue }
+      if expansions.contains(where: { $0.contains(candidate) }) { continue }
+      return candidate
+    }
+    // Exhausted only when the candidate source is degenerate (a test forcing a collision).
+    // Falling back to a value derived from the attempt count keeps the contract — a sentinel is
+    // returned and it is not one of the values we were told to avoid — rather than returning a
+    // known-colliding token and letting it reach the user.
+    var suffix = 0
+    while true {
+      let candidate = "\(Self.prefix)fallback\(suffix)"
+      let collides =
+        rawInput.contains(candidate) || alreadyIssued.contains(candidate)
+        || expansions.contains(where: { $0.contains(candidate) })
+      if !collides { return candidate }
+      suffix += 1
+    }
+  }
+
+  // MARK: - Matching
+
+  private struct Match {
+    let snippet: Snippet
+    /// Number of word tokens the trigger consumed.
+    let length: Int
+  }
+
+  /// The longest trigger matching the word tokens starting at `startingAt`, or nil.
+  ///
+  /// Longest-match rather than first-match because triggers nest: with both "my email" and
+  /// "my email address" saved, first-match would strand the word "address" after the pasted
+  /// address. Ties cannot arise — `Snippet.collidesWith` refuses a duplicate trigger at the
+  /// door, so two snippets never share a token sequence.
+  private static func longestMatch(
+    in snippets: [Snippet], pieces: [Piece], wordIndices: [Int], startingAt: Int
+  ) -> Match? {
+    var best: Match?
+    for snippet in snippets {
+      let tokens = snippet.triggerTokens
+      guard !tokens.isEmpty, startingAt + tokens.count <= wordIndices.count else { continue }
+      var matched = true
+      for offset in tokens.indices {
+        let piece = pieces[wordIndices[startingAt + offset]]
+        if SnippetText.normalize(piece.text) != tokens[offset] {
+          matched = false
+          break
+        }
+      }
+      guard matched else { continue }
+      if best == nil || tokens.count > best!.length {
+        best = Match(snippet: snippet, length: tokens.count)
+      }
+    }
+    return best
+  }
+
+  // MARK: - Tokenisation that preserves the original spacing
+
+  private struct Piece {
+    let text: String
+    let isWhitespaceRun: Bool
+  }
+
+  /// Split into alternating runs of whitespace and non-whitespace, keeping both.
+  ///
+  /// The whitespace is kept rather than re-synthesised because the expansion must land in text
+  /// that is otherwise untouched: rebuilding with single spaces would silently reformat the
+  /// user's line breaks and double spaces on every dictation that fires a snippet.
+  private static func split(_ text: String) -> [Piece] {
+    var pieces: [Piece] = []
+    var current = ""
+    var currentIsSpace: Bool?
+    for character in text {
+      let isSpace = character.isWhitespace
+      if currentIsSpace == nil || currentIsSpace == isSpace {
+        current.append(character)
+        currentIsSpace = isSpace
+      } else {
+        pieces.append(Piece(text: current, isWhitespaceRun: currentIsSpace!))
+        current = String(character)
+        currentIsSpace = isSpace
+      }
+    }
+    if let currentIsSpace, !current.isEmpty {
+      pieces.append(Piece(text: current, isWhitespaceRun: currentIsSpace))
+    }
+    return pieces
+  }
+
+  private static func whitespaceAfter(_ index: Int, in pieces: [Piece]) -> String? {
+    let next = index + 1
+    guard next < pieces.count, pieces[next].isWhitespaceRun else { return nil }
+    return pieces[next].text
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -126,8 +126,15 @@ public struct SnippetExpander: Sendable {
       // from the KEYWORD token so the match can happen, the closing one from the LAST trigger
       // token. Restoring only the tail leaves an orphan closing quote, which review caught.
       // Same sets `SnippetText.normalize` strips, so the pairs cannot drift apart.
+      // BOTH tokens that can carry an opening mark, because the user can put the quote in
+      // either place: `"backslash my email"` attaches it to the keyword, `backslash "my email"`
+      // to the first trigger word. Normalisation strips it from whichever one has it so the
+      // match can happen, and restoring only the keyword's left an orphan closing quote in the
+      // other arrangement. Two routes to one effect; fixing one looked exactly like fixing both.
+      let firstTriggerToken = pieces[wordIndices[cursor + 1]].text
       out +=
-        SnippetText.leadingPunctuation(token) + sentinel
+        SnippetText.leadingPunctuation(token)
+        + SnippetText.leadingPunctuation(firstTriggerToken) + sentinel
         + SnippetText.trailingPunctuation(lastToken)
       if let gap = Self.whitespaceAfter(lastWordIndex, in: pieces) { out += gap }
       cursor += hit.length + 1

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -12,23 +12,37 @@ public enum SnippetValidationError: Error, Equatable, Sendable {
   /// deletes the words the user spoke.
   case expansionEmpty
   /// Another snippet already fires on the same spoken words. Refusing here is what makes
-  /// `SnippetExpander`'s longest-match tie-break UNREACHABLE rather than merely unlikely —
-  /// without it two snippets could share a trigger and the winner would be list order, which is
-  /// a rule nobody chose.
+  /// `SnippetExpander`'s longest-match tie-break UNREACHABLE rather than merely unlikely.
   case duplicateTrigger(existing: String)
+  /// The keyword is more than one spoken word. The matcher compares the keyword against ONE
+  /// transcript token, so a multi-word keyword can never match — it would report itself armed
+  /// and silently switch every snippet off, which is worse than refusing it.
+  case keywordNotOneWord
+}
+
+/// Why the store cannot be written right now. Distinct from a validation error: nothing the
+/// user typed is wrong, the data on disk is the problem.
+public enum SnippetStoreError: Error, Equatable, Sendable {
+  /// An existing file could not be read, and its contents are still unknown. Every mutation is
+  /// refused: writing now would rename a new file over data we never managed to load.
+  case existingFileUnreadable
+  /// Another process holds the store.
+  case busy
+  /// The lock could not be taken at all.
+  case coordinationUnavailable
+  case writeFailed(String)
 }
 
 /// On-disk store for the user's snippets (#628).
 ///
-/// Mirrors `CustomWordsManager`'s durability discipline through the shared `DurableJSONFile`:
-/// 0700 directory with a Spotlight opt-out marker, 0600 file, unique-temp + fsync + atomic
-/// rename, and a corrupt file archived rather than silently replaced.
+/// Durability discipline shared with `CustomWordsManager` through `DurableJSONFile`: 0700
+/// directory with a Spotlight opt-out marker, 0600 file, unique-temp + fsync + atomic rename, a
+/// cross-process companion-file lock, and a corrupt file archived rather than replaced.
 ///
-/// Deliberately much smaller than `CustomWordsManager`, and the difference is not an oversight:
-/// that type carries built-in defaults, tombstones, a pack tier, debounced usage counters and a
-/// cross-process file lock because custom words are written from several places. Snippets have
-/// exactly one writer — the Settings screen — so a second copy of that machinery would be
-/// weight with no reader.
+/// **The load result is three-valued on purpose.** A missing file and an unreadable one are NOT
+/// the same thing: the first is a new user, the second is a user whose snippets exist and could
+/// not be read. Collapsing them means the next save renames an empty store over data that was
+/// merely temporarily unavailable — the user's snippets deleted by opening Settings.
 public final class SnippetsManager: @unchecked Sendable {
 
   /// The persisted shape. Versioned from the first release so a later migration has something
@@ -37,6 +51,16 @@ public final class SnippetsManager: @unchecked Sendable {
     var version: Int
     var keyword: String
     var snippets: [Snippet]
+  }
+
+  /// What is on disk right now. The `unreadable` case is the whole reason this is not an
+  /// optional.
+  enum LoadResult: Equatable {
+    case missing
+    case loaded(SnippetVocabulary)
+    /// The file exists and its contents are unknown — a read error, or a corrupt file that
+    /// could not be archived to safety. Either way the bytes must not be overwritten.
+    case unreadable
   }
 
   /// The schema version stamped into both the store and an export. Public because the export
@@ -48,16 +72,14 @@ public final class SnippetsManager: @unchecked Sendable {
   private static let logger = Logger(subsystem: "com.enviouswispr.app", category: "Snippets")
 
   private let fileURL: URL
-  private let lock = NSLock()
   /// Bumped on every successful save, and deliberately NOT persisted.
   ///
   /// A generation exists so a cross-actor reader can notice "I am holding an older snapshot
   /// than the other lane" WITHIN a process run (`VocabularyLanes.swift`). Nothing compares
-  /// generations across launches, so writing it to disk would store a runtime concern and
-  /// invite someone to read meaning into a number that only counts saves since app start.
+  /// generations across launches, so writing it to disk would store a runtime concern.
   ///
-  /// Its first version WAS inert — every load reset it to 0, so `current.generation &+ 1` was
-  /// always 1 — which the store's own test caught rather than a user.
+  /// Its first version WAS inert — every load reset it to 0 — which the store's own test caught
+  /// rather than a user.
   private var generation: UInt64 = 0
 
   public init() {
@@ -91,56 +113,86 @@ public final class SnippetsManager: @unchecked Sendable {
       .appendingPathComponent(fileName)
   }
 
-  // MARK: - Load and save
+  // MARK: - Load
 
-  /// Read the store. A missing file is the EMPTY store, not an error — that is what a user who
-  /// has never opened Snippets has, and it must not be reported as a failure.
+  /// Read the store for DISPLAY. An unreadable file reads as empty here, because the screen has
+  /// to render something — but `unreadableExisting` tells it to say so, and every mutation is
+  /// refused until the file can be read.
   public func load() -> SnippetVocabulary {
-    lock.lock()
-    defer { lock.unlock() }
-    return loadWhileLocked()
+    let empty = SnippetVocabulary(
+      snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
+    guard let result = try? withLock(blocking: true, { loadWhileLocked() }) else { return empty }
+    if case .loaded(let vocabulary) = result { return vocabulary }
+    return empty
   }
 
-  private func loadWhileLocked() -> SnippetVocabulary {
-    guard let data = try? Data(contentsOf: fileURL) else {
-      return SnippetVocabulary(
-        snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
+  /// True when a file exists that could not be read. The screen shows a banner, and saves are
+  /// refused, rather than a silent empty list the next edit would make permanent.
+  public var unreadableExisting: Bool {
+    (try? withLock(blocking: true) { loadWhileLocked() }) == .unreadable
+  }
+
+  private func loadWhileLocked() -> LoadResult {
+    guard FileManager.default.fileExists(atPath: fileURL.path) else { return .missing }
+
+    let data: Data
+    do {
+      data = try Data(contentsOf: fileURL)
+    } catch {
+      // The file is THERE and we could not read it. Saying "empty" here is what would let the
+      // next save rename a new store over snippets that still exist.
+      Self.logger.error(
+        "snippets.json exists but could not be read; refusing to write over it. \(String(describing: error), privacy: .public)"
+      )
+      return .unreadable
     }
+
     do {
       let file = try JSONDecoder().decode(StoredFile.self, from: data)
-      return SnippetVocabulary(
-        snippets: file.snippets,
-        keyword: file.keyword.isEmpty ? SnippetVocabulary.defaultKeyword : file.keyword,
-        generation: generation)
+      return .loaded(
+        SnippetVocabulary(
+          snippets: file.snippets,
+          keyword: file.keyword.isEmpty ? SnippetVocabulary.defaultKeyword : file.keyword,
+          generation: generation))
     } catch {
-      // Archived, never deleted and never overwritten in place. The user's snippets are typed
-      // by hand and exist nowhere else, so a parse failure must leave the bytes recoverable —
-      // same reasoning as `custom-words.json.corrupted-*`.
+      // Archived, never deleted and never overwritten in place. These snippets were typed by
+      // hand and exist nowhere else.
       let archive = fileURL.deletingLastPathComponent()
         .appendingPathComponent("\(Self.fileName).corrupted-\(UUID().uuidString)")
-      try? FileManager.default.moveItem(at: fileURL, to: archive)
+      do {
+        try FileManager.default.moveItem(at: fileURL, to: archive)
+      } catch {
+        // The bytes are still the only copy. Reporting empty-and-writable here would let a
+        // later save destroy the one recoverable version of the user's snippets.
+        Self.logger.error(
+          "snippets.json is corrupt AND could not be archived; refusing to write over it. \(String(describing: error), privacy: .public)"
+        )
+        return .unreadable
+      }
       Self.logger.error(
         "snippets.json could not be parsed; archived and starting empty. \(String(describing: error), privacy: .public)"
       )
-      return SnippetVocabulary(
-        snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
+      return .missing
     }
   }
 
   /// Persist, bump, and hand back the SAVED vocabulary stamped with its new generation.
   ///
-  /// Both halves of that matter. The bump happens only after the write returns, so a failed
-  /// save cannot advance a generation no reader's snapshot corresponds to. And the return value
-  /// is re-stamped rather than the caller's input being returned, because a caller who took the
-  /// pre-save value would publish a snapshot claiming a generation one behind the manager — a
-  /// staleness signal that itself reads stale.
+  /// The bump happens only after the write returns, so a failed save cannot advance a
+  /// generation no reader's snapshot corresponds to. And the return value is re-stamped rather
+  /// than echoing the caller's input, because a caller taking the pre-save value would publish
+  /// a snapshot claiming a generation one behind the manager — a staleness signal reading stale.
   private func saveWhileLocked(_ vocabulary: SnippetVocabulary) throws -> SnippetVocabulary {
-    try DurableJSONFile.write(
-      StoredFile(
-        version: Self.currentVersion, keyword: vocabulary.keyword,
-        snippets: vocabulary.snippets),
-      to: fileURL,
-      tempPrefix: ".\(Self.fileName)")
+    do {
+      try DurableJSONFile.write(
+        StoredFile(
+          version: Self.currentVersion, keyword: vocabulary.keyword,
+          snippets: vocabulary.snippets),
+        to: fileURL,
+        tempPrefix: ".\(Self.fileName)")
+    } catch {
+      throw SnippetStoreError.writeFailed(error.localizedDescription)
+    }
     generation &+= 1
     return SnippetVocabulary(
       snippets: vocabulary.snippets, keyword: vocabulary.keyword, generation: generation)
@@ -148,58 +200,89 @@ public final class SnippetsManager: @unchecked Sendable {
 
   // MARK: - Mutations
 
-  /// Add or update one snippet, validating first. Returns the new vocabulary so the caller has
-  /// exactly one source for what is now on disk.
+  /// Every mutation is one load-transform-save inside ONE cross-process lock hold, and refuses
+  /// outright when the existing file could not be read.
+  ///
+  /// The lock matters because two EnviousWispr processes can be open at once — a shipped copy
+  /// and a dev build on this machine, routinely. Without it both load the same snapshot and
+  /// atomically publish different valid files, and the second rename silently discards the
+  /// first person's edit.
+  private func mutate(
+    _ transform: (SnippetVocabulary) throws -> SnippetVocabulary
+  ) throws -> SnippetVocabulary {
+    try withLock {
+      let current: SnippetVocabulary
+      switch loadWhileLocked() {
+      case .missing:
+        current = SnippetVocabulary(
+          snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
+      case .loaded(let vocabulary):
+        current = vocabulary
+      case .unreadable:
+        throw SnippetStoreError.existingFileUnreadable
+      }
+      return try saveWhileLocked(try transform(current))
+    }
+  }
+
+  private func withLock<T>(blocking: Bool = false, _ body: () throws -> T) throws -> T {
+    do {
+      return try DurableJSONFile.withExclusiveLock(on: fileURL, blocking: blocking, body)
+    } catch DurableJSONFile.LockFailure.busy {
+      throw SnippetStoreError.busy
+    } catch DurableJSONFile.LockFailure.unavailable {
+      throw SnippetStoreError.coordinationUnavailable
+    }
+  }
+
   @discardableResult
   public func upsert(_ snippet: Snippet) throws -> SnippetVocabulary {
-    lock.lock()
-    defer { lock.unlock() }
-    let current = loadWhileLocked()
-    try Self.validate(snippet, against: current.snippets)
-
-    var snippets = current.snippets
-    if let index = snippets.firstIndex(where: { $0.id == snippet.id }) {
-      snippets[index] = snippet
-    } else {
-      snippets.insert(snippet, at: 0)
+    try mutate { current in
+      try Self.validate(snippet, against: current.snippets)
+      var snippets = current.snippets
+      if let index = snippets.firstIndex(where: { $0.id == snippet.id }) {
+        snippets[index] = snippet
+      } else {
+        snippets.insert(snippet, at: 0)
+      }
+      return SnippetVocabulary(
+        snippets: snippets, keyword: current.keyword, generation: current.generation)
     }
-    return try saveWhileLocked(
-      SnippetVocabulary(
-        snippets: snippets, keyword: current.keyword, generation: current.generation))
   }
 
   @discardableResult
   public func remove(id: UUID) throws -> SnippetVocabulary {
-    lock.lock()
-    defer { lock.unlock() }
-    let current = loadWhileLocked()
-    return try saveWhileLocked(
+    try mutate { current in
       SnippetVocabulary(
         snippets: current.snippets.filter { $0.id != id },
         keyword: current.keyword,
-        generation: current.generation))
+        generation: current.generation)
+    }
   }
 
-  /// Change the keyword. A blank keyword is stored as the default rather than refused: the user
-  /// is clearing a text field, not asking to disable the feature, and leaving the field empty
-  /// would silently switch every snippet off.
+  /// Change the keyword. A blank keyword restores the default rather than being refused: the
+  /// user is clearing a text field, not asking to disable the feature, and an empty field would
+  /// silently switch every snippet off.
   @discardableResult
   public func setKeyword(_ keyword: String) throws -> SnippetVocabulary {
-    lock.lock()
-    defer { lock.unlock() }
-    let current = loadWhileLocked()
-    let cleaned = SnippetText.normalize(keyword)
-    return try saveWhileLocked(
-      SnippetVocabulary(
-        snippets: current.snippets,
-        keyword: cleaned.isEmpty ? SnippetVocabulary.defaultKeyword : cleaned,
-        generation: current.generation))
+    try mutate { current in
+      let cleaned = SnippetText.normalize(keyword)
+      guard !cleaned.isEmpty else {
+        return SnippetVocabulary(
+          snippets: current.snippets,
+          keyword: SnippetVocabulary.defaultKeyword,
+          generation: current.generation)
+      }
+      try Self.validateKeyword(cleaned)
+      return SnippetVocabulary(
+        snippets: current.snippets, keyword: cleaned, generation: current.generation)
+    }
   }
 
   // MARK: - Validation
 
-  /// The two founder calls from Gate 2, in one place so the sheet and any future caller cannot
-  /// disagree about what a valid snippet is.
+  /// The rules from Gate 2, in one place so the sheet and any future caller cannot disagree
+  /// about what a valid snippet is.
   public static func validate(_ snippet: Snippet, against existing: [Snippet]) throws {
     guard !snippet.triggerTokens.isEmpty else { throw SnippetValidationError.triggerEmpty }
     guard !snippet.expansion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -208,5 +291,16 @@ public final class SnippetsManager: @unchecked Sendable {
     if let clash = existing.first(where: { $0.id != snippet.id && $0.collidesWith(snippet) }) {
       throw SnippetValidationError.duplicateTrigger(existing: clash.trigger)
     }
+  }
+
+  /// A keyword must be exactly one spoken word.
+  ///
+  /// `SnippetExpander` compares the keyword against ONE transcript token, so "hey wispr" would
+  /// pass `canFire` and never match — every snippet silently dead while the screen insists the
+  /// feature is on. Refusing at the door is the honest failure; the alternative is a feature
+  /// that reports itself working and is not.
+  public static func validateKeyword(_ keyword: String) throws {
+    let words = keyword.split(whereSeparator: { $0.isWhitespace })
+    guard words.count <= 1 else { throw SnippetValidationError.keywordNotOneWord }
   }
 }

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -1,0 +1,198 @@
+import EnviousWisprCore
+import Foundation
+import os
+
+/// Why a snippet could not be saved. A closed set, so the edit sheet renders one message per
+/// case rather than guessing from a bare `false`.
+public enum SnippetValidationError: Error, Equatable, Sendable {
+  /// The trigger is empty, or is punctuation only, so nothing could ever match it.
+  case triggerEmpty
+  /// The expansion is empty or whitespace only. Founder call, 2026-09-01: a snippet that pastes
+  /// nothing is not a snippet, and Save must refuse rather than store a trigger that silently
+  /// deletes the words the user spoke.
+  case expansionEmpty
+  /// Another snippet already fires on the same spoken words. Refusing here is what makes
+  /// `SnippetExpander`'s longest-match tie-break UNREACHABLE rather than merely unlikely —
+  /// without it two snippets could share a trigger and the winner would be list order, which is
+  /// a rule nobody chose.
+  case duplicateTrigger(existing: String)
+}
+
+/// On-disk store for the user's snippets (#628).
+///
+/// Mirrors `CustomWordsManager`'s durability discipline through the shared `DurableJSONFile`:
+/// 0700 directory with a Spotlight opt-out marker, 0600 file, unique-temp + fsync + atomic
+/// rename, and a corrupt file archived rather than silently replaced.
+///
+/// Deliberately much smaller than `CustomWordsManager`, and the difference is not an oversight:
+/// that type carries built-in defaults, tombstones, a pack tier, debounced usage counters and a
+/// cross-process file lock because custom words are written from several places. Snippets have
+/// exactly one writer — the Settings screen — so a second copy of that machinery would be
+/// weight with no reader.
+public final class SnippetsManager: @unchecked Sendable {
+
+  /// The persisted shape. Versioned from the first release so a later migration has something
+  /// to branch on; `CustomWordsManager` had to add its version field after the fact.
+  struct StoredFile: Codable {
+    var version: Int
+    var keyword: String
+    var snippets: [Snippet]
+  }
+
+  static let currentVersion = 1
+  private static let fileName = "snippets.json"
+  private static let logger = Logger(subsystem: "com.enviouswispr.app", category: "Snippets")
+
+  private let fileURL: URL
+  private let lock = NSLock()
+  /// Bumped on every successful save, and deliberately NOT persisted.
+  ///
+  /// A generation exists so a cross-actor reader can notice "I am holding an older snapshot
+  /// than the other lane" WITHIN a process run (`VocabularyLanes.swift`). Nothing compares
+  /// generations across launches, so writing it to disk would store a runtime concern and
+  /// invite someone to read meaning into a number that only counts saves since app start.
+  ///
+  /// Its first version WAS inert — every load reset it to 0, so `current.generation &+ 1` was
+  /// always 1 — which the store's own test caught rather than a user.
+  private var generation: UInt64 = 0
+
+  public init() {
+    let base =
+      FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+      ?? FileManager.default.temporaryDirectory
+    let directory = base.appendingPathComponent("EnviousWispr", isDirectory: true)
+    DurableJSONFile.prepareDirectory(at: directory)
+    fileURL = directory.appendingPathComponent(Self.fileName)
+    DurableJSONFile.tightenFileIfPresent(at: fileURL)
+  }
+
+  /// Test seam: a per-test temp file instead of the production Application Support path.
+  // periphery:ignore - test seam
+  package init(fileURL: URL) {
+    self.fileURL = fileURL
+    DurableJSONFile.prepareDirectory(at: fileURL.deletingLastPathComponent())
+    DurableJSONFile.tightenFileIfPresent(at: fileURL)
+  }
+
+  package var storageURL: URL { fileURL }
+
+  // MARK: - Load and save
+
+  /// Read the store. A missing file is the EMPTY store, not an error — that is what a user who
+  /// has never opened Snippets has, and it must not be reported as a failure.
+  public func load() -> SnippetVocabulary {
+    lock.lock()
+    defer { lock.unlock() }
+    return loadWhileLocked()
+  }
+
+  private func loadWhileLocked() -> SnippetVocabulary {
+    guard let data = try? Data(contentsOf: fileURL) else {
+      return SnippetVocabulary(
+        snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
+    }
+    do {
+      let file = try JSONDecoder().decode(StoredFile.self, from: data)
+      return SnippetVocabulary(
+        snippets: file.snippets,
+        keyword: file.keyword.isEmpty ? SnippetVocabulary.defaultKeyword : file.keyword,
+        generation: generation)
+    } catch {
+      // Archived, never deleted and never overwritten in place. The user's snippets are typed
+      // by hand and exist nowhere else, so a parse failure must leave the bytes recoverable —
+      // same reasoning as `custom-words.json.corrupted-*`.
+      let archive = fileURL.deletingLastPathComponent()
+        .appendingPathComponent("\(Self.fileName).corrupted-\(UUID().uuidString)")
+      try? FileManager.default.moveItem(at: fileURL, to: archive)
+      Self.logger.error(
+        "snippets.json could not be parsed; archived and starting empty. \(String(describing: error), privacy: .public)"
+      )
+      return SnippetVocabulary(
+        snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
+    }
+  }
+
+  /// Persist, bump, and hand back the SAVED vocabulary stamped with its new generation.
+  ///
+  /// Both halves of that matter. The bump happens only after the write returns, so a failed
+  /// save cannot advance a generation no reader's snapshot corresponds to. And the return value
+  /// is re-stamped rather than the caller's input being returned, because a caller who took the
+  /// pre-save value would publish a snapshot claiming a generation one behind the manager — a
+  /// staleness signal that itself reads stale.
+  private func saveWhileLocked(_ vocabulary: SnippetVocabulary) throws -> SnippetVocabulary {
+    try DurableJSONFile.write(
+      StoredFile(
+        version: Self.currentVersion, keyword: vocabulary.keyword,
+        snippets: vocabulary.snippets),
+      to: fileURL,
+      tempPrefix: ".\(Self.fileName)")
+    generation &+= 1
+    return SnippetVocabulary(
+      snippets: vocabulary.snippets, keyword: vocabulary.keyword, generation: generation)
+  }
+
+  // MARK: - Mutations
+
+  /// Add or update one snippet, validating first. Returns the new vocabulary so the caller has
+  /// exactly one source for what is now on disk.
+  @discardableResult
+  public func upsert(_ snippet: Snippet) throws -> SnippetVocabulary {
+    lock.lock()
+    defer { lock.unlock() }
+    let current = loadWhileLocked()
+    try Self.validate(snippet, against: current.snippets)
+
+    var snippets = current.snippets
+    if let index = snippets.firstIndex(where: { $0.id == snippet.id }) {
+      snippets[index] = snippet
+    } else {
+      snippets.insert(snippet, at: 0)
+    }
+    return try saveWhileLocked(
+      SnippetVocabulary(
+        snippets: snippets, keyword: current.keyword, generation: current.generation))
+  }
+
+  @discardableResult
+  public func remove(id: UUID) throws -> SnippetVocabulary {
+    lock.lock()
+    defer { lock.unlock() }
+    let current = loadWhileLocked()
+    return try saveWhileLocked(
+      SnippetVocabulary(
+        snippets: current.snippets.filter { $0.id != id },
+        keyword: current.keyword,
+        generation: current.generation))
+  }
+
+  /// Change the keyword. A blank keyword is stored as the default rather than refused: the user
+  /// is clearing a text field, not asking to disable the feature, and leaving the field empty
+  /// would silently switch every snippet off.
+  @discardableResult
+  public func setKeyword(_ keyword: String) throws -> SnippetVocabulary {
+    lock.lock()
+    defer { lock.unlock() }
+    let current = loadWhileLocked()
+    let cleaned = SnippetText.normalize(keyword)
+    return try saveWhileLocked(
+      SnippetVocabulary(
+        snippets: current.snippets,
+        keyword: cleaned.isEmpty ? SnippetVocabulary.defaultKeyword : cleaned,
+        generation: current.generation))
+  }
+
+  // MARK: - Validation
+
+  /// The two founder calls from Gate 2, in one place so the sheet and any future caller cannot
+  /// disagree about what a valid snippet is.
+  public static func validate(_ snippet: Snippet, against existing: [Snippet]) throws {
+    guard !snippet.triggerTokens.isEmpty else { throw SnippetValidationError.triggerEmpty }
+    guard !snippet.expansion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw SnippetValidationError.expansionEmpty
+    }
+    if let clash = existing.first(where: { $0.id != snippet.id && $0.collidesWith(snippet) }) {
+      throw SnippetValidationError.duplicateTrigger(existing: clash.trigger)
+    }
+  }
+}

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -39,7 +39,11 @@ public final class SnippetsManager: @unchecked Sendable {
     var snippets: [Snippet]
   }
 
-  static let currentVersion = 1
+  /// The schema version stamped into both the store and an export. Public because the export
+  /// document must carry the SAME number the store writes — two literals would let a schema
+  /// bump land in one and not the other, and the file that lies about its version is the one
+  /// a future import trusts.
+  public static let currentVersion = 1
   private static let fileName = "snippets.json"
   private static let logger = Logger(subsystem: "com.enviouswispr.app", category: "Snippets")
 
@@ -76,6 +80,16 @@ public final class SnippetsManager: @unchecked Sendable {
   }
 
   package var storageURL: URL { fileURL }
+
+  /// The production store's path, for the export guard. Static and `nonisolated` for the same
+  /// reason `CustomWordsManager.liveFileURL` is: the export writer runs off the main actor and
+  /// must be able to refuse the app's own file as a destination without holding a manager.
+  nonisolated public static var liveFileURL: URL? {
+    FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+      .appendingPathComponent("EnviousWispr", isDirectory: true)
+      .appendingPathComponent(fileName)
+  }
 
   // MARK: - Load and save
 

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -149,6 +149,20 @@ public final class SnippetsManager: @unchecked Sendable {
 
     do {
       let file = try JSONDecoder().decode(StoredFile.self, from: data)
+      // A file from a NEWER app is data we do not fully understand. Synthesized decoding accepts
+      // it happily and drops every field this version has never heard of, and the next save
+      // would then write our narrower shape back over it — the user losing whatever the newer
+      // release stored, by opening the older one.
+      //
+      // This is the same rule as the unreadable case one branch down, and the field it needs
+      // already existed: `version` was added "so a later migration has something to branch on"
+      // and then nothing branched on it. A version stamp nobody reads is a comment.
+      guard file.version <= Self.currentVersion else {
+        Self.logger.error(
+          "snippets.json is version \(file.version, privacy: .public), newer than this app understands (\(Self.currentVersion, privacy: .public)); refusing to write over it."
+        )
+        return .unreadable
+      }
       return .loaded(
         SnippetVocabulary(
           snippets: file.snippets,

--- a/Tests/EnviousWisprTests/App/DebugFaultEndpointInputFallbackTests.swift
+++ b/Tests/EnviousWisprTests/App/DebugFaultEndpointInputFallbackTests.swift
@@ -36,6 +36,7 @@ import Testing
       let clock = FakeClock()
       let engine = FakeEngine(behavior: .batchSuccess(text: "x"), clock: clock)
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillTests.swift
@@ -369,6 +369,7 @@ struct EscapeRecoveryPillTests {
 
   private static func makeHandler(recording box: IntentBox) -> PipelineStateChangeHandler {
     let steps = LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/App/EscapeRecoverySpoolReleaseTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoverySpoolReleaseTests.swift
@@ -35,6 +35,7 @@ struct EscapeRecoverySpoolReleaseTests {
 
   private func makeHandler(_ spy: Spy) -> PipelineStateChangeHandler {
     let steps = LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/PipelineStateChangeHandlerFactoryCopyTests.swift
@@ -32,6 +32,7 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
   /// transcript carries no recovery session so no cleanup fires.
   private func makeHandler(recording box: WarningBox) -> PipelineStateChangeHandler {
     let steps = LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),
@@ -147,6 +148,7 @@ struct PipelineStateChangeHandlerFactoryCopyTests {
       #expect(wrapper.testKernel.lastInputResolutionSource == source)
 
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -1095,6 +1095,19 @@ import Testing
       text: "let retry = await finalize(sid, batchSamples: Array(samples[trim...]))",
       classification: .transitivelyCoveredByCaller),
 
+    // #628 snippet finalization. The matcher catches the NAME `finalize`, and these two are
+    // not engine touches at all: `SnippetFinalizer` is a pure in-process substitution over the
+    // context, reaching no adapter, no XPC and no model. Both live and recovery must carry one,
+    // and their presence in this table is what makes a THIRD copy — or a missing one — visible.
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift", matcher: "finalize",
+      text: "SnippetFinalizer.finalize(&ctx)",
+      classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprPipeline/RecoveryTextProcessor.swift", matcher: "finalize",
+      text: "SnippetFinalizer.finalize(&context)",
+      classification: .structurallySafe),
+
     // MARK: ParakeetEngineAdapter — Chunk 11 additions.
     // Streaming-feed dispatch, guarded by session/terminal checks on the
     // `@MainActor` hop — session-scoped, same as this file's existing

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -178,6 +178,10 @@ import Testing
   ///   (`docs/feature-requests/issue-2377-2026-08-26-phase6-c4-idle-prewarm.md`
   ///   §3 step 4) places the app-lifetime overlay owner here rather than on
   ///   `AppLifecycleCoordinator`, which gains no overlay dependency.
+  /// - 41 → 42 in #628 (2026-09-01): App-owned `snippetsCoordinator`. Snippets is a new
+  ///   top-level Settings section with its own on-disk store, and the coordinator must outlive
+  ///   any one view so the pipeline can be re-seeded on every change. Sibling of
+  ///   `customWordsCoordinator`, placed here for the same reason.
   @Test func envWisprAppStoredPropertyCeilingHolds() throws {
     let body = try structBodyOfEnviousWisprApp()
     let count = countTopLevelStoredProperties(in: body)
@@ -186,7 +190,7 @@ import Testing
       // needs for the onboarding-dismissal policy change. ONE property, not two:
       // the panel seam is consumed by collaborators and is passed through rather
       // than retained here.
-      count <= 41,
+      count <= 42,
       """
       EnviousWisprApp stored-property ceiling exceeded: \(count) > 41. \
       Raising the ceiling requires a Bible changelog entry. \

--- a/Tests/EnviousWisprTests/Pipeline/CapWarningTakeIDTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CapWarningTakeIDTests.swift
@@ -147,6 +147,7 @@ import Testing
 
     private static func makeDriverFixture() -> DriverFixture {
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationInvokedPipelineWiringTests.swift
@@ -116,7 +116,9 @@ struct DictationInvokedPipelineWiringTests {
     let runCall = try Self.slice(
       wiringSource,
       from: "let result = try await textProcessingRunner.run(",
-      to: "let ctx = result.context"
+      // #628: `let` became `var` so `SnippetFinalizer.finalize(&ctx)` can resolve the context
+      // before anything reads it. Same line, same position in the flow.
+      to: "var ctx = result.context"
     )
     #expect(
       runCall.contains("takeID: telemetryState.takeID)"),

--- a/Tests/EnviousWisprTests/Pipeline/EscapeRecoveryAbandonmentTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EscapeRecoveryAbandonmentTests.swift
@@ -195,6 +195,7 @@ struct EscapeRecoveryAbandonmentTests {
           backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
         emitLifecycleEvent: { _ in })
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/EscapeRecoveryCompletionProducerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EscapeRecoveryCompletionProducerTests.swift
@@ -54,6 +54,7 @@ struct EscapeRecoveryCompletionProducerTests {
           backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
         emitLifecycleEvent: { _ in })
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/EscapeRecoveryCompletionTransportTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EscapeRecoveryCompletionTransportTests.swift
@@ -193,6 +193,7 @@ struct EscapeRecoveryCompletionTransportTests {
           backend: .parakeet, captureTelemetry: CaptureTelemetryState()),
         emitLifecycleEvent: { _ in })
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -341,6 +341,7 @@ private final class HeartPathHarness {
       context: context,
       adapter: adapter,
       steps: LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Issue1358EmptyRecoveryTests.swift
@@ -178,6 +178,7 @@ struct Issue1358EmptyRecoveryTests {
 
   private func makeSteps() -> LimbSteps {
     LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -41,6 +41,7 @@ import Testing
 
     private func makeFixture() -> Fixture {
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverConfigBindingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverConfigBindingTests.swift
@@ -36,6 +36,7 @@ import Testing
 
     private func makeFixture() -> Fixture {
       let steps = LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverTests.swift
@@ -779,6 +779,7 @@ import Testing
       emitLifecycleEvent: { _ in })
     let outcome = KernelFinalizationOutcome()
     let steps = LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringMetadataPropagationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringMetadataPropagationTests.swift
@@ -37,6 +37,7 @@ import Testing
       context: KernelSessionContext(),
       adapter: engine,
       steps: LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -1696,6 +1696,7 @@ import os
 
   private func makeSteps(polish: LLMPolishStep? = nil) -> LimbSteps {
     LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
       wordCorrection: WordCorrectionStep(),
       fillerRemoval: FillerRemovalStep(),
       emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/KernelInterruptedTranscriptTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelInterruptedTranscriptTests.swift
@@ -44,6 +44,7 @@ struct KernelInterruptedTranscriptTests {
       context: KernelSessionContext(),
       adapter: engine,
       steps: LimbSteps(
+        snippetExpansion: SnippetExpansionStep(),
         wordCorrection: WordCorrectionStep(),
         fillerRemoval: FillerRemovalStep(),
         emojiFormatter: EmojiFormatterStep(),

--- a/Tests/EnviousWisprTests/Pipeline/SnippetChainPlacementTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SnippetChainPlacementTests.swift
@@ -1,0 +1,134 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprPostProcessing
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #628 — where the snippet step sits in the chain, and what a user without snippets pays.
+///
+/// Two classes, deliberately split.
+///
+/// The ORDER test is `.driftGuard`: it fails when we change our own code, which is the point.
+/// The order is not arbitrary — every position in it was argued for in a different issue — and
+/// nothing else in the codebase would notice if a future change reordered it.
+///
+/// The empty-store test is `.productOutcome`: it is the promise that shipping this feature
+/// costs nothing to the user who never opens it. Premise P4 in the plan, and it is proved by
+/// RUNNING the chain rather than by reading that the step is disabled — reaching a guard is not
+/// reaching its branch.
+@Suite("Snippet chain placement (#628)")
+struct SnippetChainPlacementTests {
+
+  @MainActor
+  private func makeSteps() -> LimbSteps {
+    LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      inverseTextNormalization: InverseTextNormalizationStep(),
+      llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+      emojiRestore: EmojiRestoreStep())
+  }
+
+  @Test("The chain order is frozen, and snippet expansion is first", .tags(.driftGuard))
+  @MainActor
+  func chainOrderIsFrozen() {
+    let names = makeSteps().orderedChain.map(\.name)
+
+    #expect(
+      names == [
+        "Snippet Expansion",
+        "Word Correction",
+        "Filler Removal",
+        "Emoji Formatter",
+        "Inverse Text Normalization",
+        "LLM Polish",
+        "Emoji Restore",
+      ])
+  }
+
+  /// The structural half. `orderedChain` only removes the drift risk if BOTH paths actually
+  /// read it — a second literal array reintroduced in either file would compile, pass every
+  /// behavioural test, and silently give recovery a different chain from live.
+  ///
+  /// Reading the source is the right instrument here: the question is "does a second list
+  /// exist", and no runtime assertion can observe a list nobody called.
+  @Test("Both chain callers read the single ordered authority", .tags(.driftGuard))
+  func bothCallersUseTheSingleAuthority() throws {
+    for file in ["KernelFinalizationWiring.swift", "RecoveryTextProcessor.swift"] {
+      // Walk UP to the package root rather than counting `..` hops. A hop count is a
+      // measurement of where this test file currently sits, so moving the file silently
+      // repoints the read at a path that does not exist — which is a FAILING test on correct
+      // code, the direction that invites "fixing" a machine that was already right.
+      var root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+      while !FileManager.default.fileExists(atPath: root.appendingPathComponent("Package.swift").path) {
+        let parent = root.deletingLastPathComponent()
+        try #require(parent.path != root.path, "walked past the filesystem root looking for Package.swift")
+        root = parent
+      }
+      let url = root.appendingPathComponent("Sources/EnviousWisprPipeline/\(file)")
+      let source = try String(contentsOf: url, encoding: .utf8)
+
+      #expect(source.contains("steps: steps.orderedChain"), "\(file) must use the shared chain")
+      #expect(
+        !source.contains("steps.wordCorrection, steps.fillerRemoval"),
+        "\(file) has re-inlined a second chain array")
+    }
+  }
+
+  /// P4. Run the SAME text through the chain with the snippet step present and absent, and
+  /// require the outputs to be identical — not merely that the step reported itself disabled.
+  @Test("An empty snippet store leaves the chain output byte-identical", .tags(.productOutcome))
+  @MainActor
+  func emptyStoreChangesNothing() async throws {
+    let steps = makeSteps()
+    // Left at `.empty`, which is what a user who has never opened Snippets has.
+    #expect(steps.snippetExpansion.isEnabled == false)
+
+    let runner = TextProcessingRunner()
+    let input = "backslash my email address, and the path is backslash users"
+
+    let withStep = try await runner.run(
+      rawText: input, language: "en", targetAppName: nil, steps: steps.orderedChain)
+    let withoutStep = try await runner.run(
+      rawText: input, language: "en", targetAppName: nil,
+      steps: steps.orderedChain.filter { $0.name != "Snippet Expansion" })
+
+    #expect(withStep.context.text == withoutStep.context.text)
+    #expect(withStep.context.polishedText == withoutStep.context.polishedText)
+    #expect(withStep.context.protectedExpansions.isEmpty)
+    #expect(withStep.context.pipelineFellBackToRaw == withoutStep.context.pipelineFellBackToRaw)
+  }
+
+  /// The other half of P4: with a vocabulary loaded, the step is armed. Without this the test
+  /// above passes against a step that can NEVER fire, which is the shape of a guard that is
+  /// green because it is broken.
+  @Test("A loaded snippet store arms the step", .tags(.productOutcome))
+  @MainActor
+  func loadedStoreArmsTheStep() async throws {
+    let steps = makeSteps()
+    steps.snippetExpansion.snippetVocabulary = SnippetVocabulary(
+      snippets: [Snippet(trigger: "my email address", expansion: "sam@example.com")],
+      keyword: SnippetVocabulary.defaultKeyword,
+      generation: 1)
+
+    #expect(steps.snippetExpansion.isEnabled)
+
+    let runner = TextProcessingRunner()
+    let result = try await runner.run(
+      rawText: "email me at backslash my email address",
+      language: "en", targetAppName: nil, steps: steps.orderedChain)
+
+    #expect(result.context.protectedExpansions.count == 1)
+    #expect(result.context.protectedExpansions.first?.expansion == "sam@example.com")
+    // The chain carries the SENTINEL, not the address: the address must not reach polish.
+    #expect(!result.context.text.contains("sam@example.com"))
+
+    var resolved = result.context
+    SnippetFinalizer.finalize(&resolved)
+    #expect(resolved.text.contains("sam@example.com"))
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/SnippetChainPlacementTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SnippetChainPlacementTests.swift
@@ -18,7 +18,10 @@ import Testing
 /// costs nothing to the user who never opens it. Premise P4 in the plan, and it is proved by
 /// RUNNING the chain rather than by reading that the step is disabled — reaching a guard is not
 /// reaching its branch.
-@Suite("Snippet chain placement (#628)")
+// One class on the suite, as the inventory requires. `.productOutcome` rather than
+// `.driftGuard`: the empty-store test is the load-bearing one — it is the promise that a user
+// who never opens Snippets is unaffected — and the order freeze is the supporting detail.
+@Suite("Snippet chain placement (#628)", .tags(.productOutcome))
 struct SnippetChainPlacementTests {
 
   @MainActor
@@ -33,7 +36,7 @@ struct SnippetChainPlacementTests {
       emojiRestore: EmojiRestoreStep())
   }
 
-  @Test("The chain order is frozen, and snippet expansion is first", .tags(.driftGuard))
+  @Test("The chain order is frozen, and snippet expansion is first")
   @MainActor
   func chainOrderIsFrozen() {
     let names = makeSteps().orderedChain.map(\.name)
@@ -56,7 +59,7 @@ struct SnippetChainPlacementTests {
   ///
   /// Reading the source is the right instrument here: the question is "does a second list
   /// exist", and no runtime assertion can observe a list nobody called.
-  @Test("Both chain callers read the single ordered authority", .tags(.driftGuard))
+  @Test("Both chain callers read the single ordered authority")
   func bothCallersUseTheSingleAuthority() throws {
     for file in ["KernelFinalizationWiring.swift", "RecoveryTextProcessor.swift"] {
       // Walk UP to the package root rather than counting `..` hops. A hop count is a
@@ -81,7 +84,7 @@ struct SnippetChainPlacementTests {
 
   /// P4. Run the SAME text through the chain with the snippet step present and absent, and
   /// require the outputs to be identical — not merely that the step reported itself disabled.
-  @Test("An empty snippet store leaves the chain output byte-identical", .tags(.productOutcome))
+  @Test("An empty snippet store leaves the chain output byte-identical")
   @MainActor
   func emptyStoreChangesNothing() async throws {
     let steps = makeSteps()
@@ -103,32 +106,40 @@ struct SnippetChainPlacementTests {
     #expect(withStep.context.pipelineFellBackToRaw == withoutStep.context.pipelineFellBackToRaw)
   }
 
-  /// The other half of P4: with a vocabulary loaded, the step is armed. Without this the test
-  /// above passes against a step that can NEVER fire, which is the shape of a guard that is
-  /// green because it is broken.
-  @Test("A loaded snippet store arms the step", .tags(.productOutcome))
+  /// The other half of P4: with a vocabulary loaded, the step transforms. Without this the
+  /// test above passes against a step that can NEVER fire, which is a guard that is green
+  /// because it is broken.
+  ///
+  /// Driven through `process` directly, NOT through the runner, and that is deliberate. Every
+  /// step carries a wall-clock budget (`maxDuration`, 50 ms here), and the runner silently
+  /// skips a step that exceeds it, keeping that step's input. Under a full parallel suite this
+  /// machine can miss 50 ms of pure string work, so a chain-level assertion here would fail on
+  /// correct code — which it did, once, at 56 seconds. The load-dependent assertion is the
+  /// defect, not the budget: the question this test asks is what the STEP does, and the runner's
+  /// timing is a different question with its own coverage.
+  @Test("A loaded snippet store arms the step")
   @MainActor
   func loadedStoreArmsTheStep() async throws {
-    let steps = makeSteps()
-    steps.snippetExpansion.snippetVocabulary = SnippetVocabulary(
+    let step = SnippetExpansionStep()
+    step.snippetVocabulary = SnippetVocabulary(
       snippets: [Snippet(trigger: "my email address", expansion: "sam@example.com")],
       keyword: SnippetVocabulary.defaultKeyword,
       generation: 1)
 
-    #expect(steps.snippetExpansion.isEnabled)
+    #expect(step.isEnabled)
 
-    let runner = TextProcessingRunner()
-    let result = try await runner.run(
-      rawText: "email me at backslash my email address",
-      language: "en", targetAppName: nil, steps: steps.orderedChain)
+    let context = TextProcessingContext(
+      text: "email me at backslash my email address", language: "en")
+    let result = try await step.process(context)
 
-    #expect(result.context.protectedExpansions.count == 1)
-    #expect(result.context.protectedExpansions.first?.expansion == "sam@example.com")
+    #expect(result.protectedExpansions.count == 1)
+    #expect(result.protectedExpansions.first?.expansion == "sam@example.com")
     // The chain carries the SENTINEL, not the address: the address must not reach polish.
-    #expect(!result.context.text.contains("sam@example.com"))
+    #expect(!result.text.contains("sam@example.com"))
+    #expect(result.text.contains(try #require(result.protectedExpansions.first).sentinel))
 
-    var resolved = result.context
+    var resolved = result
     SnippetFinalizer.finalize(&resolved)
-    #expect(resolved.text.contains("sam@example.com"))
+    #expect(resolved.text == "email me at sam@example.com")
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/SnippetFinalizerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SnippetFinalizerTests.swift
@@ -1,0 +1,172 @@
+import EnviousWisprPostProcessing
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #628 — the mandatory sentinel resolver.
+///
+/// `.productOutcome`: when this fails the user's document receives either a raw internal token
+/// or their saved text duplicated. The assertion every case shares is the one that matters —
+/// **nothing this type returns may contain a sentinel** — because that is the invariant the
+/// whole sentinel design rests on, and it is the only one whose failure is unrecoverable once
+/// the text has been pasted, stored in History, and written to the recovery spool.
+@Suite("Snippet finalization (#628)", .tags(.productOutcome))
+struct SnippetFinalizerTests {
+
+  private let email = SnippetExpansionRecord(sentinel: "EWSNIPaaa", expansion: "sam@example.com")
+  private let signoff = SnippetExpansionRecord(
+    sentinel: "EWSNIPbbb", expansion: "Thanks,\nSam")
+
+  private func context(
+    text: String, polished: String?, records: [SnippetExpansionRecord]
+  ) -> TextProcessingContext {
+    var ctx = TextProcessingContext(text: text, language: "en")
+    ctx.polishedText = polished
+    ctx.protectedExpansions = records
+    ctx.llmProvider = "openai"
+    ctx.llmModel = "gpt-4o-mini"
+    ctx.polishRanRemote = true
+    return ctx
+  }
+
+  /// Applied to every case: the invariant, not a per-case detail.
+  private func expectNoSentinelSurvives(_ ctx: TextProcessingContext) {
+    for record in ctx.protectedExpansions {
+      #expect(!ctx.text.contains(record.sentinel))
+      #expect(!(ctx.polishedText ?? "").contains(record.sentinel))
+    }
+  }
+
+  // MARK: - The path an ordinary dictation takes
+
+  @Test("With no records the context is left exactly as it was")
+  func noRecordsIsANoOp() {
+    var ctx = context(text: "hello there", polished: "Hello there.", records: [])
+    let before = ctx
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.text == before.text)
+    #expect(ctx.polishedText == before.polishedText)
+    #expect(ctx.pipelineFellBackToRaw == false)
+    #expect(ctx.polishFallbackReason == nil)
+    #expect(ctx.polishRanRemote == true)
+  }
+
+  // MARK: - Polish accepted
+
+  @Test("Every sentinel intact: both the deterministic and the polished text are resolved")
+  func intactPolishKeepsPolish() {
+    var ctx = context(
+      text: "email me at EWSNIPaaa", polished: "Email me at EWSNIPaaa.", records: [email])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.text == "email me at sam@example.com")
+    #expect(ctx.polishedText == "Email me at sam@example.com.")
+    #expect(ctx.pipelineFellBackToRaw == false)
+    #expect(ctx.polishFallbackReason == nil)
+    expectNoSentinelSurvives(ctx)
+  }
+
+  @Test("Several sentinels, all intact, all resolved")
+  func severalIntactSentinels() {
+    var ctx = context(
+      text: "EWSNIPaaa and EWSNIPbbb",
+      polished: "EWSNIPaaa and EWSNIPbbb.",
+      records: [email, signoff])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == "sam@example.com and Thanks,\nSam.")
+    #expect(ctx.pipelineFellBackToRaw == false)
+    expectNoSentinelSurvives(ctx)
+  }
+
+  // MARK: - Polish rejected
+
+  @Test("A sentinel the model dropped costs the whole polished version, not a repair")
+  func missingSentinelRejectsPolish() {
+    var ctx = context(
+      text: "email me at EWSNIPaaa", polished: "Email me at your address.", records: [email])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.text == "email me at sam@example.com")
+    #expect(ctx.polishedText == nil)
+    #expect(ctx.pipelineFellBackToRaw == true)
+    #expect(ctx.polishFallbackReason == SnippetFinalizer.sentinelLossReason)
+    expectNoSentinelSurvives(ctx)
+  }
+
+  /// Duplication is the case "at least once" would wave through, and it is worse than loss:
+  /// the user's address gets pasted twice into their own sentence.
+  @Test("A sentinel the model duplicated also rejects polish")
+  func duplicatedSentinelRejectsPolish() {
+    var ctx = context(
+      text: "EWSNIPaaa", polished: "EWSNIPaaa and EWSNIPaaa", records: [email])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == nil)
+    #expect(ctx.text == "sam@example.com")
+    #expect(ctx.pipelineFellBackToRaw == true)
+    expectNoSentinelSurvives(ctx)
+  }
+
+  @Test("One lost sentinel rejects the polish even when its siblings survived")
+  func partialLossRejectsTheWholePolish() {
+    var ctx = context(
+      text: "EWSNIPaaa and EWSNIPbbb", polished: "EWSNIPaaa and goodbye", records: [email, signoff])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == nil)
+    #expect(ctx.text == "sam@example.com and Thanks,\nSam")
+    expectNoSentinelSurvives(ctx)
+  }
+
+  // MARK: - What the fallback must say about itself
+
+  @Test("A rejected polish still records that a model was called")
+  func rejectionRetainsAttemptEvidence() {
+    var ctx = context(text: "EWSNIPaaa", polished: "nothing here", records: [email])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    // Cleared: no remote polish survived into the delivered text.
+    #expect(ctx.polishRanRemote == nil)
+    // Retained: polish was genuinely attempted, and erasing this would make an
+    // attempted-and-rejected take look identical to one that never called a model.
+    #expect(ctx.llmProvider == "openai")
+    #expect(ctx.llmModel == "gpt-4o-mini")
+  }
+
+  /// `TextProcessingStep.swift` states it: `(polishFallbackReason != nil) == pipelineFellBackToRaw`.
+  @Test("The fallback flag and the fallback reason are always set together")
+  func fallbackInvariantHolds() {
+    for polished in ["EWSNIPaaa", "lost it", "EWSNIPaaa EWSNIPaaa", nil] {
+      var ctx = context(text: "EWSNIPaaa", polished: polished, records: [email])
+      SnippetFinalizer.finalize(&ctx)
+      #expect((ctx.polishFallbackReason != nil) == ctx.pipelineFellBackToRaw)
+    }
+  }
+
+  // MARK: - Polish never ran
+
+  @Test("With no polished text the deterministic text is still resolved, and nothing is flagged")
+  func polishAbsentResolvesDeterministicText() {
+    var ctx = context(text: "email me at EWSNIPaaa", polished: nil, records: [email])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.text == "email me at sam@example.com")
+    #expect(ctx.polishedText == nil)
+    // Polish did not fail here — it was skipped, disabled, or already swallowed by the runner.
+    // Stamping a snippet fallback would blame this type for someone else's outcome.
+    #expect(ctx.pipelineFellBackToRaw == false)
+    #expect(ctx.polishFallbackReason == nil)
+    expectNoSentinelSurvives(ctx)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsManagerLockingTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsManagerLockingTests.swift
@@ -1016,11 +1016,31 @@ struct CustomWordsManagerLockingTests {
       backupCallRange.lowerBound < shouldSaveTrueRange.lowerBound,
       "writePreImportBackup() must run before the transform returns shouldSave: true.")
 
-    // 10. The save helper's atomic-write shape is intact.
-    #expect(saveFileWhileLockedSlice.contains("Foundation.open"))
-    #expect(saveFileWhileLockedSlice.contains("O_EXCL"))
-    #expect(saveFileWhileLockedSlice.contains("0o600"))
-    #expect(saveFileWhileLockedSlice.contains("Foundation.rename"))
+    // 10. The atomic-write shape is intact — at its OWNER.
+    //
+    // #628 moved the sequence out of `saveFileWhileLocked` into `DurableJSONFile`, verbatim,
+    // when a second user-owned store needed the identical primitive. The guarantee this clause
+    // protects did not change; the address did. So it now asserts BOTH halves: the save helper
+    // delegates rather than growing its own write back, and the sequence still exists in one
+    // place. Asserting only the delegation would let the shape rot in the file nothing else
+    // checks, which is the failure mode extraction invites.
+    #expect(saveFileWhileLockedSlice.contains("DurableJSONFile.write"))
+    #expect(
+      saveFileWhileLockedSlice.contains("Foundation.open") == false,
+      "The save helper must delegate the write, not carry a second copy of it.")
+
+    let durableSource = try String(
+      contentsOf: RepoRoot.sourceURL(
+        "Sources/EnviousWisprPostProcessing/DurableJSONFile.swift"),
+      encoding: .utf8)
+    let durableWriteSlice = try functionBody(
+      in: durableSource,
+      declaring: "public static func write(data: Data, to url: URL, tempPrefix: String) throws")
+    #expect(durableWriteSlice.contains("Foundation.open"))
+    #expect(durableWriteSlice.contains("O_EXCL"))
+    #expect(durableWriteSlice.contains("0o600"))
+    #expect(durableWriteSlice.contains("F_FULLFSYNC"))
+    #expect(durableWriteSlice.contains("Foundation.rename"))
 
     // 11. Neither removed helper name reappears anywhere, as code or prose.
     let ns = source as NSString

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -177,6 +177,18 @@ struct SnippetExpanderTests {
     #expect(out.text == "he said \u{201C}EWSNIPq\u{201D} and left")
   }
 
+  /// The OTHER arrangement. The user can attach the opening mark to the keyword or to the first
+  /// trigger word, and a fix covering one looks identical to a fix covering both.
+  @Test("An opening mark on the first trigger word is kept too")
+  func openingMarkOnTriggerSurvives() {
+    let expander = fixedExpander(["EWSNIPt"])
+    let out = expander.expand(
+      "he said backslash \u{201C}my email\u{201D} and left",
+      using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.text == "he said \u{201C}EWSNIPt\u{201D} and left")
+  }
+
   @Test("A trigger in brackets keeps both brackets")
   func bracketsSurviveOnBothSides() {
     let expander = fixedExpander(["EWSNIPb"])

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -164,6 +164,29 @@ struct SnippetExpanderTests {
         == "  EWSNIPlead")
   }
 
+  /// Both ends of a quoted phrase. The opening mark is stripped from the KEYWORD so the match
+  /// can happen, the closing one from the last trigger word; restoring only the tail leaves an
+  /// orphan closing quote in the user's sentence.
+  @Test("A quoted trigger keeps BOTH quotes around the pasted text")
+  func quotesSurviveOnBothSides() {
+    let expander = fixedExpander(["EWSNIPq"])
+    let out = expander.expand(
+      "he said \u{201C}backslash my email\u{201D} and left",
+      using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.text == "he said \u{201C}EWSNIPq\u{201D} and left")
+  }
+
+  @Test("A trigger in brackets keeps both brackets")
+  func bracketsSurviveOnBothSides() {
+    let expander = fixedExpander(["EWSNIPb"])
+    let out = expander.expand(
+      "(backslash my email)",
+      using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.text == "(EWSNIPb)")
+  }
+
   // MARK: - The disabled path, which is what an ordinary user takes
 
   @Test("An empty store returns the input unchanged and identical")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -212,6 +212,17 @@ struct SnippetExpanderTests {
     #expect(out.records.isEmpty)
   }
 
+  /// The KEYWORD is consumed too, and it was the token the first boundary guard could not see.
+  @Test("A sentence boundary on the KEYWORD blocks the match")
+  func keywordBoundaryBlocksTheMatch() {
+    let input = "send me backslash. My email address is below"
+    let out = SnippetExpander().expand(
+      input, using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == input)
+    #expect(out.records.isEmpty)
+  }
+
   /// The other side of the same rule: punctuation on the LAST trigger word is the sentence the
   /// trigger legitimately ends, and it is re-attached after the expansion rather than blocking.
   @Test("A full stop on the last trigger word still matches, and survives")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -1,0 +1,238 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #628 — the snippet matcher.
+///
+/// When this fails the user gets the wrong text pasted into their document, so the class is
+/// `.productOutcome`. The three cases that carry the most weight are the two NEGATIVE ones —
+/// a trigger spoken without the keyword, and the keyword spoken with nothing matching after it
+/// — because those are what the keyword rule exists for, and a matcher that fires too eagerly
+/// looks like a working feature right up until it rewrites a sentence the user meant.
+@Suite("Snippet expansion (#628)", .tags(.productOutcome))
+struct SnippetExpanderTests {
+
+  private func vocabulary(
+    _ pairs: [(String, String)], keyword: String = SnippetVocabulary.defaultKeyword
+  ) -> SnippetVocabulary {
+    SnippetVocabulary(
+      snippets: pairs.map { Snippet(trigger: $0.0, expansion: $0.1) },
+      keyword: keyword,
+      generation: 1)
+  }
+
+  /// A predictable sentinel source so assertions can name the token. Real runs use random hex.
+  private func fixedExpander(_ values: [String]) -> SnippetExpander {
+    let box = Box(values)
+    return SnippetExpander(candidateSource: { box.next() })
+  }
+
+  private final class Box: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String]
+    private var index = 0
+    init(_ values: [String]) { self.values = values }
+    func next() -> String {
+      lock.lock()
+      defer { lock.unlock() }
+      let value = values[min(index, values.count - 1)]
+      index += 1
+      return value
+    }
+  }
+
+  // MARK: - The keyword rule
+
+  @Test("A trigger after the keyword expands in place, mid-sentence")
+  func expandsAfterKeyword() {
+    let expander = fixedExpander(["EWSNIPaaaa"])
+    let out = expander.expand(
+      "feel free to email me at backslash my email address any time",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "feel free to email me at EWSNIPaaaa any time")
+    #expect(
+      out.records == [SnippetExpansionRecord(sentinel: "EWSNIPaaaa", expansion: "sam@example.com")])
+  }
+
+  @Test("The same words WITHOUT the keyword are left completely alone")
+  func triggerWithoutKeywordDoesNothing() {
+    let input = "can you send me my email address from that form"
+    let out = SnippetExpander().expand(
+      input, using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == input)
+    #expect(out.records.isEmpty)
+    #expect(out.didFire == false)
+  }
+
+  @Test("The keyword with nothing matching after it is left in place")
+  func keywordWithoutMatchIsPreserved() {
+    let input = "the path is backslash users backslash shared"
+    let out = SnippetExpander().expand(
+      input, using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == input)
+    #expect(out.records.isEmpty)
+  }
+
+  // MARK: - Matching semantics carried from the approved design
+
+  @Test("The LONGEST trigger wins when two match at the same position")
+  func longestMatchWins() {
+    let expander = fixedExpander(["EWSNIPlong"])
+    let out = expander.expand(
+      "backslash my email address please",
+      using: vocabulary([
+        ("my email", "SHORT"),
+        ("my email address", "LONG"),
+      ]))
+
+    #expect(out.text == "EWSNIPlong please")
+    #expect(out.records.first?.expansion == "LONG")
+  }
+
+  @Test("Punctuation clinging to the last trigger word survives the substitution")
+  func trailingPunctuationSurvives() {
+    let expander = fixedExpander(["EWSNIPdot"])
+    let out = expander.expand(
+      "email me at backslash my email address.",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "email me at EWSNIPdot.")
+  }
+
+  @Test("Matching is case-insensitive, because speech is transcribed with sentence casing")
+  func matchIsCaseInsensitive() {
+    let expander = fixedExpander(["EWSNIPcase"])
+    let out = expander.expand(
+      "Backslash My Email Address",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "EWSNIPcase")
+  }
+
+  @Test("Two snippets in one utterance each fire, with distinct sentinels")
+  func twoSnippetsInOneUtterance() {
+    let expander = fixedExpander(["EWSNIPone", "EWSNIPtwo"])
+    let out = expander.expand(
+      "backslash my email or backslash support address",
+      using: vocabulary([
+        ("my email", "sam@example.com"),
+        ("support address", "help@example.com"),
+      ]))
+
+    #expect(out.text == "EWSNIPone or EWSNIPtwo")
+    #expect(out.records.count == 2)
+    #expect(Set(out.records.map(\.sentinel)).count == 2)
+  }
+
+  @Test("Original spacing and line breaks are preserved around an expansion")
+  func spacingIsPreserved() {
+    let expander = fixedExpander(["EWSNIPgap"])
+    let out = expander.expand(
+      "first line\n\nbackslash my email  trailing",
+      using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.text == "first line\n\nEWSNIPgap  trailing")
+  }
+
+  @Test("A trigger at the very end of the utterance still fires")
+  func triggerAtEndOfUtterance() {
+    let expander = fixedExpander(["EWSNIPend"])
+    let out = expander.expand(
+      "email me at backslash my email address",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "email me at EWSNIPend")
+    #expect(out.records.count == 1)
+  }
+
+  // MARK: - The disabled path, which is what an ordinary user takes
+
+  @Test("An empty store returns the input unchanged and identical")
+  func emptyStoreIsIdentity() {
+    let input = "backslash my email address"
+    let out = SnippetExpander().expand(input, using: .empty)
+
+    #expect(out.text == input)
+    #expect(out.records.isEmpty)
+  }
+
+  @Test("A blank keyword cannot fire, even with snippets saved")
+  func blankKeywordCannotFire() {
+    let input = "backslash my email address"
+    let vocab = SnippetVocabulary(
+      snippets: [Snippet(trigger: "my email address", expansion: "sam@example.com")],
+      keyword: "   ",
+      generation: 1)
+
+    #expect(vocab.canFire == false)
+    #expect(SnippetExpander().expand(input, using: vocab).text == input)
+  }
+
+  // MARK: - Sentinel uniqueness, all three domains
+
+  @Test("A sentinel already present in the dictated text is rejected")
+  func sentinelCollidingWithInputIsRejected() {
+    let expander = fixedExpander(["EWSNIPdupe", "EWSNIPfresh"])
+    let out = expander.expand(
+      "the code is EWSNIPdupe and backslash my email",
+      using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.records.first?.sentinel == "EWSNIPfresh")
+    #expect(out.text.contains("EWSNIPfresh"))
+  }
+
+  /// The domain that is easiest to miss: restoration substitutes expansions back INTO the text,
+  /// so a sentinel living inside an expansion would reappear after the finalizer had already
+  /// checked that none remained.
+  @Test("A sentinel that appears inside a saved expansion is rejected")
+  func sentinelCollidingWithAnExpansionIsRejected() {
+    let expander = fixedExpander(["EWSNIPinside", "EWSNIPclean"])
+    let out = expander.expand(
+      "backslash my email",
+      using: vocabulary([
+        ("my email", "sam@example.com"),
+        ("my note", "reference EWSNIPinside for details"),
+      ]))
+
+    #expect(out.records.first?.sentinel == "EWSNIPclean")
+  }
+
+  @Test("A degenerate source that always returns one value still yields distinct sentinels")
+  func exhaustedSourceStillYieldsDistinctSentinels() {
+    let expander = fixedExpander(["EWSNIPsame"])
+    let out = expander.expand(
+      "backslash my email or backslash support address",
+      using: vocabulary([
+        ("my email", "sam@example.com"),
+        ("support address", "help@example.com"),
+      ]))
+
+    #expect(out.records.count == 2)
+    #expect(out.records[0].sentinel != out.records[1].sentinel)
+  }
+
+  // MARK: - The duplicate rule, stated once on the type
+
+  @Test("Two triggers differing only by case and punctuation are the same trigger")
+  func duplicateTriggersCollide() {
+    let a = Snippet(trigger: "my email address", expansion: "one")
+    let b = Snippet(trigger: "My Email Address.", expansion: "two")
+    let c = Snippet(trigger: "my email", expansion: "three")
+
+    #expect(a.collidesWith(b))
+    #expect(!a.collidesWith(c))
+  }
+
+  @Test("An all-punctuation trigger collides with nothing, including itself")
+  func emptyTriggerTokensNeverCollide() {
+    let blank = Snippet(trigger: "...", expansion: "x")
+
+    #expect(blank.triggerTokens.isEmpty)
+    #expect(!blank.collidesWith(blank))
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -150,6 +150,20 @@ struct SnippetExpanderTests {
     #expect(out.records.count == 1)
   }
 
+  /// Leading whitespace belongs to no word, and the reconstruction walks words. It was dropped
+  /// on EVERY dictation once the step was armed — match or no match — and no fixture caught it
+  /// because every one of them started with a letter.
+  @Test("Whitespace before the first word survives, with and without a match")
+  func leadingWhitespaceIsPreserved() {
+    let vocab = vocabulary([("my email", "sam@example.com")])
+    let expander = fixedExpander(["EWSNIPlead"])
+
+    #expect(expander.expand("\n  hello there", using: vocab).text == "\n  hello there")
+    #expect(
+      fixedExpander(["EWSNIPlead"]).expand("  backslash my email", using: vocab).text
+        == "  EWSNIPlead")
+  }
+
   // MARK: - The disabled path, which is what an ordinary user takes
 
   @Test("An empty store returns the input unchanged and identical")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -199,6 +199,44 @@ struct SnippetExpanderTests {
     #expect(out.text == "(EWSNIPb)")
   }
 
+  /// A full stop INSIDE the phrase means the user said two sentences, not one trigger.
+  /// Normalisation strips it so the words still compare equal, which is exactly why this needs
+  /// its own guard rather than falling out of the comparison.
+  @Test("A trigger does not match across a sentence boundary")
+  func triggerDoesNotSpanASentenceBoundary() {
+    let input = "send me backslash my. Email address is below"
+    let out = SnippetExpander().expand(
+      input, using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == input)
+    #expect(out.records.isEmpty)
+  }
+
+  /// The other side of the same rule: punctuation on the LAST trigger word is the sentence the
+  /// trigger legitimately ends, and it is re-attached after the expansion rather than blocking.
+  @Test("A full stop on the last trigger word still matches, and survives")
+  func sentenceEndingOnLastTokenStillMatches() {
+    let expander = fixedExpander(["EWSNIPend2"])
+    let out = expander.expand(
+      "write to backslash my email address. Thanks.",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "write to EWSNIPend2. Thanks.")
+  }
+
+  /// Punctuation strictly INSIDE the phrase is dropped with the words it sat between, and that
+  /// is correct rather than a gap: the phrase is REPLACED, so an interior comma has no
+  /// destination in the pasted text. Frozen here so nobody "fixes" it back.
+  @Test("A comma inside the phrase is consumed with the phrase")
+  func interiorCommaIsConsumed() {
+    let expander = fixedExpander(["EWSNIPcomma"])
+    let out = expander.expand(
+      "email me at backslash my, email today",
+      using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.text == "email me at EWSNIPcomma today")
+  }
+
   // MARK: - The disabled path, which is what an ordinary user takes
 
   @Test("An empty store returns the input unchanged and identical")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetsManagerTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetsManagerTests.swift
@@ -1,0 +1,184 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #628 — the snippet store on disk.
+///
+/// `.productOutcome`: these snippets are typed by hand and exist nowhere else, so a store that
+/// loses them, refuses to save them, or lets two of them fight over one trigger is a user
+/// losing their own work. The corruption case matters most — it is the only one where the
+/// wrong behaviour (overwrite in place) destroys data instead of merely reporting an error.
+@Suite("Snippet store (#628)", .tags(.productOutcome))
+struct SnippetsManagerTests {
+
+  private func makeManager() -> SnippetsManager {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-snippets-\(UUID().uuidString)", isDirectory: true)
+    return SnippetsManager(fileURL: dir.appendingPathComponent("snippets.json"))
+  }
+
+  // MARK: - The empty case, which every new install is
+
+  @Test("A store with no file yet is empty and carries the default keyword")
+  func missingFileIsAnEmptyStore() {
+    let vocabulary = makeManager().load()
+
+    #expect(vocabulary.snippets.isEmpty)
+    #expect(vocabulary.keyword == SnippetVocabulary.defaultKeyword)
+    #expect(vocabulary.canFire == false)
+  }
+
+  // MARK: - Round trip
+
+  @Test("A saved snippet survives a reload, expansion byte-for-byte")
+  func savedSnippetRoundTrips() throws {
+    let manager = makeManager()
+    let signoff = Snippet(trigger: "sign off", expansion: "Thanks,\nSam — Envious Labs")
+
+    try manager.upsert(signoff)
+    let reloaded = manager.load()
+
+    #expect(reloaded.snippets.count == 1)
+    // Newlines are the whole point of the sign-off case; a store that normalised them would
+    // pass a shallower assertion.
+    #expect(reloaded.snippets.first?.expansion == "Thanks,\nSam — Envious Labs")
+    #expect(reloaded.canFire)
+  }
+
+  @Test("Editing a snippet updates it in place instead of adding a second one")
+  func editUpdatesInPlace() throws {
+    let manager = makeManager()
+    var snippet = Snippet(trigger: "my email", expansion: "old@example.com")
+    try manager.upsert(snippet)
+
+    snippet.expansion = "new@example.com"
+    try manager.upsert(snippet)
+
+    let reloaded = manager.load()
+    #expect(reloaded.snippets.count == 1)
+    #expect(reloaded.snippets.first?.expansion == "new@example.com")
+  }
+
+  @Test("Removing a snippet leaves the rest")
+  func removeLeavesTheRest() throws {
+    let manager = makeManager()
+    let keep = Snippet(trigger: "keep me", expansion: "kept")
+    let drop = Snippet(trigger: "drop me", expansion: "dropped")
+    try manager.upsert(keep)
+    try manager.upsert(drop)
+
+    try manager.remove(id: drop.id)
+
+    #expect(manager.load().snippets.map(\.trigger) == ["keep me"])
+  }
+
+  // MARK: - The two Gate 2 refusals
+
+  @Test("A snippet with no text to paste is refused")
+  func emptyExpansionIsRefused() throws {
+    let manager = makeManager()
+
+    #expect(throws: SnippetValidationError.expansionEmpty) {
+      try manager.upsert(Snippet(trigger: "my email", expansion: "   \n "))
+    }
+    #expect(manager.load().snippets.isEmpty)
+  }
+
+  @Test("A second snippet on the same spoken words is refused, and names the one that has it")
+  func duplicateTriggerIsRefused() throws {
+    let manager = makeManager()
+    try manager.upsert(Snippet(trigger: "my email address", expansion: "one@example.com"))
+
+    #expect(throws: SnippetValidationError.duplicateTrigger(existing: "my email address")) {
+      // Different casing and a trailing full stop: the same spoken words.
+      try manager.upsert(Snippet(trigger: "My Email Address.", expansion: "two@example.com"))
+    }
+    #expect(manager.load().snippets.count == 1)
+  }
+
+  /// The case a naive duplicate check gets wrong: editing a snippet must not collide with
+  /// ITSELF. Without the id comparison in `validate`, saving an edit would be impossible.
+  @Test("Editing a snippet does not collide with its own trigger")
+  func editDoesNotSelfCollide() throws {
+    let manager = makeManager()
+    var snippet = Snippet(trigger: "my email address", expansion: "one@example.com")
+    try manager.upsert(snippet)
+
+    snippet.expansion = "two@example.com"
+    #expect(throws: Never.self) { try manager.upsert(snippet) }
+  }
+
+  @Test("A trigger made only of punctuation is refused — nothing could ever match it")
+  func punctuationOnlyTriggerIsRefused() throws {
+    let manager = makeManager()
+
+    #expect(throws: SnippetValidationError.triggerEmpty) {
+      try manager.upsert(Snippet(trigger: "...", expansion: "something"))
+    }
+  }
+
+  // MARK: - Keyword
+
+  @Test("The keyword is stored and reloaded")
+  func keywordRoundTrips() throws {
+    let manager = makeManager()
+
+    try manager.setKeyword("shortcut")
+
+    #expect(manager.load().keyword == "shortcut")
+  }
+
+  @Test("Clearing the keyword field restores the default rather than disabling every snippet")
+  func blankKeywordFallsBackToTheDefault() throws {
+    let manager = makeManager()
+    try manager.setKeyword("shortcut")
+
+    try manager.setKeyword("   ")
+
+    #expect(manager.load().keyword == SnippetVocabulary.defaultKeyword)
+  }
+
+  // MARK: - Durability
+
+  /// The one case where the wrong behaviour destroys the user's work rather than reporting a
+  /// failure. Assert the bytes are still on disk, not merely that loading did not crash.
+  @Test("A corrupt file is archived, never overwritten, and the store starts empty")
+  func corruptFileIsArchived() throws {
+    let manager = makeManager()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    try Data("{ this is not json".utf8).write(to: manager.storageURL)
+
+    let reloaded = manager.load()
+
+    #expect(reloaded.snippets.isEmpty)
+    let siblings = try FileManager.default.contentsOfDirectory(
+      atPath: manager.storageURL.deletingLastPathComponent().path)
+    let archived = siblings.filter { $0.contains("corrupted") }
+    #expect(archived.count == 1)
+    let archivedURL = manager.storageURL.deletingLastPathComponent()
+      .appendingPathComponent(try #require(archived.first))
+    #expect(try String(contentsOf: archivedURL, encoding: .utf8) == "{ this is not json")
+  }
+
+  @Test("The store file is written 0600, not world-readable")
+  func storeFileIsOwnerOnly() throws {
+    let manager = makeManager()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: manager.storageURL.path)
+    let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+    #expect(permissions.int16Value == 0o600)
+  }
+
+  @Test("Every save advances the generation, so a stale lane read is detectable")
+  func generationAdvancesOnEverySave() throws {
+    let manager = makeManager()
+
+    let first = try manager.upsert(Snippet(trigger: "one", expansion: "1"))
+    let second = try manager.upsert(Snippet(trigger: "two", expansion: "2"))
+
+    #expect(second.generation > first.generation)
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetsStoreSafetyTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetsStoreSafetyTests.swift
@@ -134,6 +134,35 @@ struct SnippetsStoreSafetyTests {
     #expect(try Data(contentsOf: url) == bytesBefore)
   }
 
+  // MARK: - A file from a newer app
+
+  /// Same rule as an unreadable file, different cause: a store written by a LATER release holds
+  /// fields this version cannot see, and saving our narrower shape back would delete them. The
+  /// `version` field existed from the first commit and nothing read it until review asked.
+  @Test("A store from a newer app version refuses writes instead of narrowing it")
+  func newerSchemaRefusesMutation() throws {
+    let (manager, url) = makeStore()
+    let future = """
+      {"version": 99, "keyword": "backslash", "snippets": [], "somethingNew": true}
+      """
+    try Data(future.utf8).write(to: url)
+
+    #expect(manager.unreadableExisting)
+    #expect(throws: SnippetStoreError.existingFileUnreadable) {
+      try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    }
+    #expect(try String(contentsOf: url, encoding: .utf8) == future)
+  }
+
+  @Test("A store at the current version loads normally")
+  func currentSchemaLoads() throws {
+    let (manager, _) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+
+    #expect(manager.unreadableExisting == false)
+    #expect(manager.load().snippets.count == 1)
+  }
+
   // MARK: - Keyword validation
 
   /// A multi-word keyword passed `canFire` and could never match, so every snippet went quiet

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetsStoreSafetyTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetsStoreSafetyTests.swift
@@ -1,0 +1,159 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #628 — the store refusing to destroy data it cannot read.
+///
+/// `.productOutcome`, and it is the highest-stakes suite in the feature. Every case here was a
+/// live defect found by review, not imagined: the first version treated an unreadable file as
+/// an empty one, so the next save renamed a new empty store over snippets that still existed —
+/// a user losing hand-typed data by opening Settings.
+///
+/// The shared shape worth keeping: a three-valued read collapsed into two. "No file" and
+/// "cannot read the file" are different facts, and the second must never be actioned as the
+/// first.
+@Suite("Snippet store safety (#628)", .tags(.productOutcome))
+struct SnippetsStoreSafetyTests {
+
+  private func makeStore() -> (SnippetsManager, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-snip-safety-\(UUID().uuidString)", isDirectory: true)
+    let url = dir.appendingPathComponent("snippets.json")
+    return (SnippetsManager(fileURL: url), url)
+  }
+
+  /// Make the file unreadable while leaving it present, which is exactly the state the first
+  /// version could not distinguish from "no file yet".
+  private func makeUnreadable(_ url: URL) throws {
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: url.path)
+  }
+
+  // MARK: - The data-loss case
+
+  @Test("An unreadable file refuses every save rather than being overwritten")
+  func unreadableFileRefusesMutation() throws {
+    let (manager, url) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    let bytesBefore = try Data(contentsOf: url)
+    try makeUnreadable(url)
+
+    #expect(throws: SnippetStoreError.existingFileUnreadable) {
+      try manager.upsert(Snippet(trigger: "another", expansion: "text"))
+    }
+
+    // The oracle is the FILE, not the return value: the whole defect was a save that succeeded
+    // and left an empty store behind.
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    #expect(try Data(contentsOf: url) == bytesBefore)
+  }
+
+  @Test("An unreadable file is reported as unreadable, not as an empty list")
+  func unreadableFileIsReported() throws {
+    let (manager, url) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    try makeUnreadable(url)
+
+    #expect(manager.unreadableExisting)
+    // `load()` still returns something renderable — the screen has to draw — but the screen is
+    // told not to believe it.
+    #expect(manager.load().snippets.isEmpty)
+
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+  }
+
+  @Test("Deleting and changing the keyword are refused too, not just adding")
+  func everyMutationIsRefused() throws {
+    let (manager, url) = makeStore()
+    let existing = Snippet(trigger: "my email", expansion: "sam@example.com")
+    try manager.upsert(existing)
+    try makeUnreadable(url)
+
+    #expect(throws: SnippetStoreError.existingFileUnreadable) {
+      try manager.remove(id: existing.id)
+    }
+    #expect(throws: SnippetStoreError.existingFileUnreadable) { try manager.setKeyword("shortcut") }
+
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+  }
+
+  /// A missing file is NOT the unreadable case, and conflating the two in the other direction
+  /// would be just as wrong: a new user could never save anything.
+  @Test("A store that has never been written still accepts its first snippet")
+  func missingFileStillAcceptsWrites() throws {
+    let (manager, _) = makeStore()
+
+    #expect(manager.unreadableExisting == false)
+    #expect(throws: Never.self) {
+      try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    }
+  }
+
+  // MARK: - Corruption that cannot be archived
+
+  /// Corrupt bytes are the only copy of the user's snippets. If archiving them fails, treating
+  /// the store as empty-and-writable lets the next save destroy the one recoverable version.
+  ///
+  /// Staged with the file's IMMUTABLE flag rather than a read-only directory. A read-only
+  /// directory also blocks the lock file, so the mutation is refused one step earlier and this
+  /// test would pass without the archive path ever running — green for the wrong reason, which
+  /// is the failure mode a test of a safety property can least afford.
+  @Test("Corrupt content that cannot be archived refuses writes instead of being replaced")
+  func unarchivableCorruptionRefusesMutation() throws {
+    let (manager, url) = makeStore()
+    try Data("{ not json".utf8).write(to: url)
+    try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: url.path)
+    defer { try? FileManager.default.setAttributes([.immutable: false], ofItemAtPath: url.path) }
+
+    #expect(throws: SnippetStoreError.existingFileUnreadable) {
+      try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    }
+    #expect(try String(contentsOf: url, encoding: .utf8) == "{ not json")
+  }
+
+  /// The neighbouring case, asserted on the OUTCOME rather than on which refusal fired. When the
+  /// directory itself is read-only the lock cannot be created, so the store refuses earlier and
+  /// with a different code — and that is fine. What must hold either way is that nothing was
+  /// written and the bytes are untouched.
+  @Test("A read-only directory refuses the write and leaves the file alone")
+  func readOnlyDirectoryRefusesMutation() throws {
+    let (manager, url) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    let bytesBefore = try Data(contentsOf: url)
+    let directory = url.deletingLastPathComponent()
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: directory.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    }
+
+    #expect(throws: (any Error).self) {
+      try manager.upsert(Snippet(trigger: "another", expansion: "text"))
+    }
+    #expect(try Data(contentsOf: url) == bytesBefore)
+  }
+
+  // MARK: - Keyword validation
+
+  /// A multi-word keyword passed `canFire` and could never match, so every snippet went quiet
+  /// while the screen insisted the feature was on. The honest failure is refusing it.
+  @Test("A multi-word keyword is refused rather than silently disabling every snippet")
+  func multiWordKeywordIsRefused() throws {
+    let (manager, _) = makeStore()
+
+    #expect(throws: SnippetValidationError.keywordNotOneWord) {
+      try manager.setKeyword("hey wispr")
+    }
+    #expect(manager.load().keyword == SnippetVocabulary.defaultKeyword)
+  }
+
+  @Test("A one-word keyword with stray spaces is accepted and stored trimmed")
+  func paddedSingleWordKeywordIsAccepted() throws {
+    let (manager, _) = makeStore()
+
+    try manager.setKeyword("  shortcut  ")
+
+    #expect(manager.load().keyword == "shortcut")
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
@@ -225,7 +225,8 @@ struct ReadinessRetryTelemetryContractTests {
         keychainManager: KeychainManager(),
         outputClassifierHolder: OutputClassifierHolder(),
         now: { Date() },
-        currentVocabulary: { (.empty, .empty) })
+        currentVocabulary: { (.empty, .empty) },
+        currentSnippets: { .empty })
       var store = RecoverySpoolStore(directory: spoolDir)
       store.readinessRetryFileOps = ops
       let id = "readiness-\(UUID().uuidString)"

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -172,7 +172,8 @@ struct RecoverySpoolReplayerTests {
       keychainManager: KeychainManager(),
       outputClassifierHolder: OutputClassifierHolder(),
       now: now,
-      currentVocabulary: { (.empty, .empty) })
+      currentVocabulary: { (.empty, .empty) },
+        currentSnippets: { .empty })
     return Harness(
       replayer: replayer, asr: asr,
       spoolStore: RecoverySpoolStore(directory: spoolDir), spoolDir: spoolDir, keyStore: keyStore,
@@ -839,7 +840,8 @@ struct RecoverySpoolReplayerTests {
         transcriptCoordinator: TranscriptCoordinator(store: transcriptStore),
         keychainManager: KeychainManager(),
         outputClassifierHolder: OutputClassifierHolder(),
-        currentVocabulary: { (.empty, .empty) })
+        currentVocabulary: { (.empty, .empty) },
+        currentSnippets: { .empty })
       let id = "tel-defer-\(UUID().uuidString)"
       let box = await Self.capturingTelemetry {
         let outcome = await replayer.replay(recoverySessionID: id, isAborted: { false })

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -54,7 +54,7 @@ Line breaks are kept, so a two-line sign-off arrives as two lines.
 
 ### Two things worth knowing
 
-**In a terminal, a snippet with a line break will not paste.** EnviousWispr refuses to paste anything containing a line break into a terminal, because a line break can run a command. Single-line snippets work normally there.
+**In a terminal, a snippet with a line break goes to your clipboard instead of being typed.** A line break in a terminal can run whatever is on the line before it, so EnviousWispr will not put one there for you. Your text is on the clipboard, ready to paste with Command V once you have looked at it. Single-line snippets work normally.
 
 **A dictation containing a snippet skips the cursor tidy-up.** Normally, when you dictate into the middle of a sentence you already typed, EnviousWispr fixes the spacing and capital letters where the two halves meet. On a dictation that expanded a snippet, it leaves the text alone instead, so nothing can alter your saved text.
 

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -30,7 +30,7 @@ The keyword is what keeps snippets out of your way. Say the same trigger without
 
 That sentence comes out exactly as you said it.
 
-The same is true if you say the keyword and nothing after it matches a snippet you saved. "The path is backslash users" comes through untouched, keyword and all.
+The same is true if you say the keyword and nothing after it matches a snippet you saved. No snippet fires, and your words carry on through EnviousWispr normally. (Normally still includes AI Polish, so a sentence can be tidied up the way any other sentence would be. Snippets simply had nothing to do with it.)
 
 ### Add a snippet
 

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -54,7 +54,7 @@ Line breaks are kept, so a two-line sign-off arrives as two lines.
 
 ### Two things worth knowing
 
-**A snippet with a line break goes to your clipboard rather than being typed, unless EnviousWispr is sure the app is safe for it.** In a terminal, a line break runs whatever came before it, so we will not put one there for you. We only type a multi-line snippet straight in when we can confirm where your cursor is and that the app is not a terminal. Otherwise your text waits on the clipboard, ready for Command V. Single-line snippets are never affected.
+**A snippet with a line break goes to your clipboard instead of being typed in.** In a terminal, a line break runs whatever came before it, and we cannot reliably tell every terminal apart from every other app. Rather than guess, a multi-line snippet always waits on your clipboard, ready for Command V. Single-line snippets are never affected and type straight in as normal.
 
 **A dictation containing a snippet skips the cursor tidy-up.** Normally, when you dictate into the middle of a sentence you already typed, EnviousWispr fixes the spacing and capital letters where the two halves meet. On a dictation that expanded a snippet, it leaves the text alone instead, so nothing can alter your saved text.
 

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -1,0 +1,71 @@
+---
+title: "Using Snippets"
+description: "Say a short keyword and a trigger, and EnviousWispr pastes the text you saved."
+category: "features"
+section: "Text Processing"
+order: 7
+keywords: ["snippets", "text expansion", "voice shortcut", "paste my email", "keyword", "backslash", "signature", "expand phrase", "saved text"]
+related: ["adding-custom-words", "ai-polish-and-cloud-data"]
+updated: 2026-09-01
+---
+A snippet is a voice shortcut. You save a piece of text once, then say a short phrase to paste it. An email address, a sign-off, a link you send people every week.
+
+Snippets live in **Settings** \> **Snippets**.
+
+### How a snippet fires
+
+A snippet only expands when you say your **keyword** first, then the trigger. The keyword is `backslash` unless you change it.
+
+Say this:
+
+> Feel free to email me at **backslash my email address** any time.
+
+You get this:
+
+> Feel free to email me at you@example.com any time.
+
+The keyword is what keeps snippets out of your way. Say the same trigger without it and nothing happens:
+
+> Can you send me **my email address** from that form?
+
+That sentence comes out exactly as you said it.
+
+The same is true if you say the keyword and nothing after it matches a snippet you saved. "The path is backslash users" comes through untouched, keyword and all.
+
+### Add a snippet
+
+1. Open **Settings** \> **Snippets**.
+2. Click **Add snippet**.
+3. Type the words you will say in **Snippet**, and the text you want pasted in **Expands to**.
+4. Watch the preview. It shows what you will say and what you will get.
+5. Click **Save**.
+
+### Change your keyword
+
+The keyword field is at the top of the Snippets screen. Pick a word you would not say by accident. `backslash` is the default because most people rarely say it out loud.
+
+Clearing the field puts the default back rather than switching snippets off.
+
+### What EnviousWispr will not do to your snippet
+
+The text you save is pasted exactly as you typed it. AI Polish never rewrites it, so an email address, a web link or a signature arrives character for character. The rest of your dictation is still polished as normal.
+
+Line breaks are kept, so a two-line sign-off arrives as two lines.
+
+### Two things worth knowing
+
+**In a terminal, a snippet with a line break will not paste.** EnviousWispr refuses to paste anything containing a line break into a terminal, because a line break can run a command. Single-line snippets work normally there.
+
+**A dictation containing a snippet skips the cursor tidy-up.** Normally, when you dictate into the middle of a sentence you already typed, EnviousWispr fixes the spacing and capital letters where the two halves meet. On a dictation that expanded a snippet, it leaves the text alone instead, so nothing can alter your saved text.
+
+### Rules the screen enforces
+
+- A snippet needs both a trigger and some text. An empty snippet would delete the words you said.
+- Two snippets cannot share the same spoken words. If they did, there would be no way to say which one you meant.
+- Matching ignores capital letters and trailing punctuation, so "My Email Address." and "my email address" are the same trigger.
+
+### Keep a copy
+
+**Export** writes your snippets and your keyword to a file you choose. Useful when you move to a new Mac. EnviousWispr will refuse to save over its own snippets file, because that would erase the snippets you were trying to back up.
+
+Import is coming soon.

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -54,7 +54,7 @@ Line breaks are kept, so a two-line sign-off arrives as two lines.
 
 ### Two things worth knowing
 
-**In a terminal, a snippet with a line break goes to your clipboard instead of being typed.** A line break in a terminal can run whatever is on the line before it, so EnviousWispr will not put one there for you. Your text is on the clipboard, ready to paste with Command V once you have looked at it. Single-line snippets work normally.
+**A snippet with a line break goes to your clipboard rather than being typed, unless EnviousWispr is sure the app is safe for it.** In a terminal, a line break runs whatever came before it, so we will not put one there for you. We only type a multi-line snippet straight in when we can confirm where your cursor is and that the app is not a terminal. Otherwise your text waits on the clipboard, ready for Command V. Single-line snippets are never affected.
 
 **A dictation containing a snippet skips the cursor tidy-up.** Normally, when you dictate into the middle of a sentence you already typed, EnviousWispr fixes the spacing and capital letters where the two halves meet. On a dictation that expanded a snippet, it leaves the text alone instead, so nothing can alter your saved text.
 


### PR DESCRIPTION
Snippets: say a keyword and a short trigger, and EnviousWispr pastes the text you saved.

A new top-level Settings section under PROCESS, below Dictionary. A snippet fires only when the user speaks their keyword (default `backslash`) immediately before a trigger that matches word for word, so `backslash my email address` expands mid-sentence and `my email address` on its own does nothing.

## The design, and why it is shaped this way

**The expansion never reaches a polish model.** `SnippetExpansionStep` runs FIRST in the chain and substitutes a per-run SENTINEL; `SnippetFinalizer` puts the saved text back after the runner. "Delivered exactly as written" is therefore true by construction rather than by a prompt instruction nothing enforces.

**Restoration is deliberately NOT a `TextProcessingStep`.** `TextProcessingRunner` swallows a step error and continues with that step's input, and skips a disabled step. Both are correct for a limb — losing an emoji is survivable. Neither is acceptable here: a swallowed restore failure would paste a raw sentinel into the user's document, their History and the recovery spool at once. The finalizer is mandatory, non-throwing, and both paths call it immediately after the runner.

**One ordered chain, not two.** The live path and the recovery path each spelled the step array out separately with nothing making them agree. Adding a step is what surfaces that, so `LimbSteps.orderedChain` is now the single authority and a source-level test asserts neither file has re-inlined a second one.

**Three shared primitives extracted rather than copied.** The durable write (unique temp, 0600, `F_FULLFSYNC`, atomic rename, directory sync), the cross-process companion-file lock, and the "is this the app's own store" export guard all moved from `CustomWordsManager` into `DurableJSONFile`, and both stores call them. Each had been fixed at least once already; a second copy would have started life behind.

## Live UAT, on the built dev app

| Said | Delivered |
|---|---|
| "Feel free to email me at **backslash my email address** any time." | `Feel free to email me at uat-snippet@example.com anytime.` |
| "Can you send me **my email address** from that form?" | unchanged — `Snippet Expansion: no change` |
| "The path is **backslash** users **backslash** shared." | `Snippet Expansion: no change` |

The stored transcript carries the RESOLVED text with no sentinel, which is the finalizer running before History, storage and delivery. Polish logged `no change` on the sentinel-bearing text — the model left the opaque token alone.

## What UAT caught that no test did

The feature did not work on the first live run, and the app said why: `Snippet Expansion timed out after 51.7ms — skipping`, then `51.8ms`. The 50ms backstop was copied from `EmojiFormatterStep`, which runs LATE and is already on the main actor. This step runs FIRST and pays the actor hop, which the runner's budget covers along with the work. `WordCorrectionStep`, the step that was first before this one, declares 3 seconds and had been absorbing that cost invisibly. Now 1 second; the same step logs `completed in 53.4ms (budget: 1000ms)`.

The identical failure had appeared once in the parallel test suite and I attributed it to machine contention. The test was right.

## Review

Three grounded plan rounds (PIVOT → PROCEED-WITH-REVISIONS → PROCEED-AS-PLANNED) and three diff rounds (8 findings → 4 → 2). Eleven adopted, one adjudicated with repo evidence, all recorded in the plan at §18.

Two rounds each produced one member of the same class — a symbol added with no caller — so the class was enumerated rather than patched again: all 47 new symbols swept for call sites, exactly two returned none (one live defect, one legitimate test seam).

## Verification

- `scripts/xcode-test.sh`: **7,299 tests, TEST SUCCEEDED**
- Help checks: content 57 articles / 0 errors · routes 70 built, 70 in sitemap, 0 dead links · search 42 passed
- The test snippet written to the real store for UAT was removed afterwards

## Known limits, stated rather than discovered later

- **A dictation containing a snippet skips cursor-aware insertion.** `CursorInsertionRepair` owns seam spacing, capitalisation and cross-seam de-duplication, and `protectedSpellings` vetoes only leading recasing — one third of the ways that stage can edit a saved address. Accepted at Gate 2 (§14.4); teaching the repair to treat an expansion as an opaque region is the follow-up.
- **A multi-line snippet is delivered to the clipboard unless the destination is positively confirmed safe.** In a terminal a newline submits the command, and our terminal roster names three apps, so the guard asks for positive evidence of safety rather than trusting an incomplete danger list.
- **The vocabulary is not frozen at dictation start.** A snippet edited mid-take applies to that take. Custom words already behave this way; the newest snippet simply wins.
- **Import ships visible and disabled, marked "Coming soon"** (founder call). Export ships, so Import will land against a format already in the wild.

Part of #628
