### PR TITLE
perf(ci): make the build cache content-addressed, and cache what the readers build

### DIFF
--- a/.github/actions/xcode-ci-setup/action.yml
+++ b/.github/actions/xcode-ci-setup/action.yml
@@ -73,6 +73,15 @@ runs:
     # See pr-check.yml's "Configure DerivedData cache redirect" comment
     # (issue #1295) — same rationale. main-post-merge.yml remains the cache
     # WRITER, so it must produce the same directory shape pr-check.yml restores.
+    # #2580: see pr-check.yml's "Configure compilation cache" comment — same
+    # rationale, and this action is why it is stated once for both post-merge
+    # jobs. Must precede every xcodebuild below, which is what an exported
+    # XCODE_XCCONFIG_FILE gives without repeating three settings on ten
+    # command lines.
+    - name: Configure compilation cache
+      shell: bash
+      run: scripts/ci/configure-compilation-cache.sh
+
     - name: Configure DerivedData cache redirect
       shell: bash
       run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ inputs.derived-data-path }}"
@@ -105,7 +114,7 @@ runs:
       with:
         path: |
           ${{ inputs.derived-data-path }}/SourcePackages
-          ${{ inputs.derived-data-path }}/Build
+          ${{ inputs.derived-data-path }}/CompilationCache.noindex
           ${{ inputs.derived-data-path }}/*/SourcePackages
         key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
         restore-keys: |

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -243,6 +243,33 @@ jobs:
             ONLY_ACTIVE_ARCH=YES \
             VALID_ARCHS=arm64
 
+      # #2580: THE WRITER MUST BUILD WHAT THE READERS BUILD, and this is the one
+      # part of the original fix that survives. The only job that saves the cache
+      # built the Debug PRODUCT and never the Debug TESTS, so `EnviousWisprTests`
+      # — 624 files, ~350s, 62% of the PR compile window — could not be in any
+      # cache it wrote. Not a miss: by construction. A content-addressed cache
+      # changes nothing about that: it only holds compile jobs it has SEEN.
+      #
+      # NO COVERAGE FLAG, and that is load-bearing rather than an omission.
+      # debug-validation runs the same suite with `-enableCodeCoverage YES`,
+      # which instruments every first-party module and changes every compile
+      # command line — a different cache key. Those entries could not serve
+      # pr-check.yml's uninstrumented build-debug, so caching them would look
+      # correct, ship, and move wall clock by zero. The flags below mirror that
+      # lane's `xcodebuild test` invocation exactly, destination included.
+      - name: Build for testing (debug, Xcode)
+        run: |
+          set -euo pipefail
+          xcodebuild build-for-testing \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -destination 'platform=macOS,arch=arm64' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            VALID_ARCHS=arm64
+
       - name: Build (release, Xcode)
         run: |
           set -euo pipefail
@@ -341,7 +368,7 @@ jobs:
           # disagrees produces a permanently cold cache with no error anywhere.
           path: |
             ${{ env.DERIVED_DATA_PATH }}/SourcePackages
-            ${{ env.DERIVED_DATA_PATH }}/Build
+            ${{ env.DERIVED_DATA_PATH }}/CompilationCache.noindex
             ${{ env.DERIVED_DATA_PATH }}/*/SourcePackages
           key: ${{ steps.setup.outputs.cache-primary-key }}
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -114,6 +114,18 @@ jobs:
       # Redirecting the global default here, before generate runs and before
       # the cache is restored, makes that resolve land somewhere the cache
       # below actually covers.
+      # #2580: Xcode 26 compilation caching. Content-addressed, so what gets
+      # reused is decided by hashing a compile job's actual inputs — the file
+      # timestamps `actions/checkout` destroys stop mattering. Measured on one
+      # machine, paired arms: this lane's shape went 61s -> 20s with every one of
+      # its 1343 Swift compiles served from the cache, and two builds differing
+      # only in these flags produced byte-identical code in every binary.
+      # Owner, cost and the equivalence controls:
+      # scripts/ci/configure-compilation-cache.sh.
+      - name: Configure compilation cache
+        if: steps.changes.outputs.needs_build == 'true'
+        run: scripts/ci/configure-compilation-cache.sh
+
       - name: Configure DerivedData cache redirect
         if: steps.changes.outputs.needs_build == 'true'
         run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
@@ -144,8 +156,16 @@ jobs:
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
+            # #2580: the compilation cache REPLACES Build/ here rather than joining it.
+            # Measured: restoring only the content cache, with Build/ deleted
+            # outright, rebuilt in 25s against today's 61s — and it is SMALLER,
+            # 1.5 GB of content cache for 2.4 GB of built products, so the cache
+            # shrinks by ~0.9 GB per entry and no extra storage is bought.
+            # Linking is not content-cached, so it re-runs; that is the 5s
+            # between 20s and 25s. If CI shows that trade is wrong, adding
+            # Build/ back is one line in each of the four path lists.
             .derivedData/CI/SourcePackages
-            .derivedData/CI/Build
+            .derivedData/CI/CompilationCache.noindex
             .derivedData/CI/*/SourcePackages
           key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
@@ -338,6 +358,18 @@ jobs:
 
       # See build-debug's "Configure DerivedData cache redirect" comment
       # (issue #1295) — same rationale, mirrored for this lane.
+      # #2580: Xcode 26 compilation caching. Content-addressed, so what gets
+      # reused is decided by hashing a compile job's actual inputs — the file
+      # timestamps `actions/checkout` destroys stop mattering. Measured on one
+      # machine, paired arms: this lane's shape went 61s -> 20s with every one of
+      # its 1343 Swift compiles served from the cache, and two builds differing
+      # only in these flags produced byte-identical code in every binary.
+      # Owner, cost and the equivalence controls:
+      # scripts/ci/configure-compilation-cache.sh.
+      - name: Configure compilation cache
+        if: steps.changes.outputs.needs_build == 'true'
+        run: scripts/ci/configure-compilation-cache.sh
+
       - name: Configure DerivedData cache redirect
         if: steps.changes.outputs.needs_build == 'true'
         run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
@@ -359,8 +391,16 @@ jobs:
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
+            # #2580: the compilation cache REPLACES Build/ here rather than joining it.
+            # Measured: restoring only the content cache, with Build/ deleted
+            # outright, rebuilt in 25s against today's 61s — and it is SMALLER,
+            # 1.5 GB of content cache for 2.4 GB of built products, so the cache
+            # shrinks by ~0.9 GB per entry and no extra storage is bought.
+            # Linking is not content-cached, so it re-runs; that is the 5s
+            # between 20s and 25s. If CI shows that trade is wrong, adding
+            # Build/ back is one line in each of the four path lists.
             .derivedData/CI/SourcePackages
-            .derivedData/CI/Build
+            .derivedData/CI/CompilationCache.noindex
             .derivedData/CI/*/SourcePackages
           key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
           restore-keys: |
@@ -715,11 +755,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - name: CI self-tests (classify-changes + fetch-depth lint)
+      - name: CI self-tests (classify-changes + fetch-depth lint + compile cache)
         run: |
           set -euo pipefail
           scripts/ci/classify-changes.sh --self-test
           scripts/ci/check-pr-check-fetch-depth.sh
+          # #2580. Runs here because the failure it catches is SILENT: a config
+          # missing a setting, or written and never exported, leaves every lane
+          # building correctly and slowly with nothing red. Needs no Xcode, so
+          # this ubuntu aggregator can hold it.
+          scripts/ci/configure-compilation-cache.sh --self-test
 
       - name: Lane verdict self-test (#2401)
         run: |

--- a/scripts/ci/configure-compilation-cache.sh
+++ b/scripts/ci/configure-compilation-cache.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# scripts/ci/configure-compilation-cache.sh
+# Turn on Xcode 26 compilation caching for every xcodebuild in the calling job,
+# by writing an xcconfig and exporting XCODE_XCCONFIG_FILE (#2580).
+#
+# WHY THIS AND NOT MTIME RESTORATION. Xcode decides whether to reuse work by
+# comparing each input's size and modification time. That is a PROXY for "did
+# the content change", and `actions/checkout` breaks the proxy by stamping every
+# tracked file with the checkout time — so a restored cache is discarded on
+# arrival despite byte-identical content.
+#
+# The obvious repair is to put the timestamps back. That was built, reviewed
+# three times, and abandoned: every round found the same defect in a new place,
+# because committer time is per-second and is not guaranteed to advance, so a
+# changed file can be handed the cached object's exact size and mtime. Each
+# round produced a better guard under the same leaking assumption.
+#
+# Compilation caching removes the assumption instead. It is content-addressed:
+# the compiler hashes a compile job's actual inputs and looks the result up by
+# that hash, so a timestamp cannot make a wrong result reachable. Different
+# content is a different key.
+#
+# MEASURED, one machine, paired arms, same tree (M5 Max, Xcode 26.6):
+#   cold, from nothing .......................  84s   2130 SwiftCompile
+#   warm, nothing touched (the ceiling) ......   3s      0
+#   warm, every mtime freshened = today's CI ..  61s   1343
+#   same, with this enabled ..................  20s   1343  (all cache hits)
+#   content cache ALONE, Build/ deleted ......  25s   2130  (all cache hits)
+#
+# OUTPUT EQUIVALENCE, two-way controlled, because "it is content-addressed"
+# is a claim about the design and not evidence about our binaries. Two cold
+# builds differing ONLY in these flags are byte-identical across every Mach-O
+# the build produces — 0 differing instruction lines in the 1.86M-line main
+# dylib. An INCREMENTAL build differs from both by 6078 lines in the same
+# positions, which is ordinary build non-determinism and not this feature. The
+# first comparison run looked damning and was measuring the app's launcher stub,
+# 454 instructions for a whole product; see code-validation.md
+# FACT: build-artifact-inspection-traps.
+#
+# COST: a cold build is ~19% slower (84s -> 100s) because it populates the
+# cache. Only the first build after a dependency or toolchain change pays it.
+#
+# Usage:
+#   configure-compilation-cache.sh              write the xcconfig, export it
+#   configure-compilation-cache.sh --self-test  contract check, no Xcode needed
+set -euo pipefail
+
+# COMPILATION_CACHE_ENABLE_CACHING is the umbrella; the two per-compiler
+# switches are what Swift and Clang actually read. All three are declared by
+# Xcode 26.6's own build-settings specs (CoreBuildSystem, Swift and Clang
+# .xcspec), which is where these names were taken from rather than from a blog.
+SETTINGS=(
+  "COMPILATION_CACHE_ENABLE_CACHING = YES"
+  "SWIFT_ENABLE_COMPILE_CACHE = YES"
+  "CLANG_ENABLE_COMPILE_CACHE = YES"
+)
+
+# XCODE_XCCONFIG_FILE applies on top of every target, so ONE export covers every
+# xcodebuild in the job — including invocations added later. The alternative was
+# three settings repeated on each of ten command lines, which is the
+# hand-mirrored-copies shape #1994 built .github/actions/xcode-ci-setup to stop.
+write_config() {
+  local dest="${1:-${RUNNER_TEMP:-/tmp}/ew-compilation-cache.xcconfig}"
+
+  printf '// Written by scripts/ci/configure-compilation-cache.sh (#2580). Do not edit.\n' >"$dest"
+  printf '%s\n' "${SETTINGS[@]}" >>"$dest"
+
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "XCODE_XCCONFIG_FILE=$dest" >>"$GITHUB_ENV"
+  else
+    echo "==> GITHUB_ENV unset; export it yourself: XCODE_XCCONFIG_FILE=$dest" >&2
+  fi
+
+  echo "==> compilation caching armed via $dest"
+  sed 's/^/    /' "$dest"
+}
+
+# REQUIRED: the expectation, written out as literals on purpose.
+#
+# The first version of this suite looped over ${SETTINGS[@]} — the same array
+# the writer uses — so deleting a setting from SETTINGS made the suite pass with
+# two. An expectation built from the mechanism under test cannot fail; both
+# sides move together. Caught by mutating SETTINGS and watching the suite stay
+# green. validation-discipline.md
+# RULE: an-expectation-built-with-the-mechanism-under-test-cannot-fail.
+#
+# So these three names are duplicated deliberately. Adding a fourth setting
+# means adding it in both places, which is the point: the second place is what
+# notices when the first one loses one.
+REQUIRED=(
+  "COMPILATION_CACHE_ENABLE_CACHING = YES"
+  "SWIFT_ENABLE_COMPILE_CACHE = YES"
+  "CLANG_ENABLE_COMPILE_CACHE = YES"
+)
+
+# _verify: 0 if <config> declares every REQUIRED setting and <env-file> points
+# at it. One checker, run against the real output and against deliberately
+# broken fixtures — a checker only ever run on correct input is a checker nobody
+# has seen fail.
+_verify() {
+  local cfg="$1" envf="$2" s
+  for s in "${REQUIRED[@]}"; do
+    /usr/bin/grep -qxF "$s" "$cfg" || return 1
+  done
+  # The export is the half that makes the file do anything. A config nothing
+  # points at is a file, not a setting.
+  /usr/bin/grep -qxF "XCODE_XCCONFIG_FILE=$cfg" "$envf" || return 1
+}
+
+# self_test: the contract this script owns, checkable without Xcode so it runs
+# on the ubuntu aggregator beside the other CI self-tests.
+#
+# It does NOT prove Xcode honours the file. That is a claim about the toolchain
+# and it was established separately, by running `xcodebuild -showBuildSettings`
+# against the real generated project with and without XCODE_XCCONFIG_FILE set:
+# all three absent without it, all three YES with it. Stated rather than
+# implied, so nobody reads this suite as covering more than it does.
+self_test() {
+  local tmp fail=0
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  GITHUB_ENV="$tmp/env" write_config "$tmp/cfg.xcconfig" >/dev/null
+  if _verify "$tmp/cfg.xcconfig" "$tmp/env"; then
+    echo "ok   [contract] all ${#REQUIRED[@]} required settings written and exported"
+  else
+    echo "FAIL [contract] the script did not write every required setting"
+    echo "     wanted:"
+    printf '       %s\n' "${REQUIRED[@]}"
+    echo "     got:"
+    sed 's/^/       /' "$tmp/cfg.xcconfig"
+    fail=1
+  fi
+
+  # Two-way controls, one per way the contract can break. Both feed the checker
+  # a fixture this suite wrote, so nothing in the live script gains a knob for
+  # the sake of being testable.
+  printf '%s\n' "${REQUIRED[0]}" >"$tmp/partial.xcconfig"
+  echo "XCODE_XCCONFIG_FILE=$tmp/partial.xcconfig" >"$tmp/env-partial"
+  if _verify "$tmp/partial.xcconfig" "$tmp/env-partial"; then
+    echo "FAIL [control: missing setting] a config with 1 of ${#REQUIRED[@]} settings passed"
+    fail=1
+  else
+    echo "ok   [control: missing setting] an incomplete config is rejected"
+  fi
+
+  printf '%s\n' "${REQUIRED[@]}" >"$tmp/orphan.xcconfig"
+  : >"$tmp/env-orphan"
+  if _verify "$tmp/orphan.xcconfig" "$tmp/env-orphan"; then
+    echo "FAIL [control: no export] a config nothing points at passed"
+    fail=1
+  else
+    echo "ok   [control: no export] a config nothing points at is rejected"
+  fi
+
+  if [ "$fail" -ne 0 ]; then
+    echo "== configure-compilation-cache self-test FAIL =="
+    return 1
+  fi
+  echo "== configure-compilation-cache self-test PASS =="
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "") write_config ;;
+  *)
+    echo "::error::configure-compilation-cache.sh: unknown argument '$1'" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What this does

CI's build cache has never worked. Every pull request recompiles from scratch even when nothing changed. This makes the cache content-addressed, so what gets reused is decided by hashing a compile job's real inputs rather than by comparing file timestamps.

## Why the cache was worthless

Xcode decides whether to reuse work by comparing each input's size and modification time. That is a **proxy** for "did the content change", and `actions/checkout` breaks the proxy by stamping every tracked file with the checkout time. A restored cache is discarded on arrival despite byte-identical content. Reproduced locally: `touch` every tracked file, no content change, 661 first-party `SwiftCompile`.

## Why not just put the timestamps back

That was built and reviewed three times on `feat/2580-ci-cache-mtime`. Every round found the same defect somewhere new, because committer time is per-second and is not guaranteed to advance — so a changed file can be handed the cached object's exact size and mtime. Each round produced a better guard under the same leaking assumption. Abandoned in full.

Xcode 26 compilation caching removes the assumption instead of guarding it. Three settings, taken from Xcode 26.6's own `.xcspec` files rather than a blog, exported once per job through `XCODE_XCCONFIG_FILE` so one place covers every `xcodebuild` — including invocations added later.

## Measured, one machine, paired arms, same tree

M5 Max, Xcode 26.6. Absolute seconds do not transfer to a CI runner; the ratios are the claim.

| arm | wall | Swift compiles |
|---|---|---|
| cold, from nothing | 84s | 2130 |
| warm, nothing touched — the ceiling | 3s | 0 |
| **warm, every mtime freshened — today's CI** | **61s** | 1343 |
| **same, with caching on** | **20s** | 1343, all cache hits |
| content cache alone, `Build/` deleted | 25s | 2130, all cache hits |

Cost: a cold build is ~19% slower (84s → 100s) while it populates the cache. Only the first build after a dependency or toolchain change pays it.

## Output equivalence, two-way controlled

"Content-addressed" is a claim about the design, not evidence about our binaries.

Two cold builds differing **only** in these flags are byte-identical across every Mach-O the build produces — 0 differing instruction lines in the 1.86M-line main dylib. An incremental build differs from both by 6078 lines in the same positions, which is ordinary build non-determinism and not this feature.

The first comparison read clean and was measuring the app's launcher stub: 454 instructions for a whole product. That is the trap `code-validation.md` FACT: build-artifact-inspection-traps already names.

## The cache gets smaller

The compilation cache **replaces** `Build/` in all four path lists rather than joining them: 1.5 GB of content cache for 2.4 GB of built products, about 0.9 GB less per entry. No extra storage is bought, so `GR-NO-CLOUD-SPEND` does not bind. Linking is not content-cached and re-runs; that is the 5s between 20s and 25s. If CI shows the trade is wrong, adding `Build/` back is one line in each of the four lists.

## The one piece of the abandoned work that survives

`release-validation` is the only job that saves the cache, and it built the Debug **product**, never the Debug **tests**. `EnviousWisprTests` — 624 files, ~350s, 62% of the PR compile window — could not be in any cache it wrote. By construction, not by miss. A content-addressed cache changes nothing about that: it only holds compile jobs it has **seen**.

Added deliberately **without** `-enableCodeCoverage`, which instruments every first-party module and changes every compile command line, so those entries could not serve `pr-check`'s uninstrumented `build-debug`.

## Testing

`configure-compilation-cache.sh --self-test` runs in `build-check`, because the failure it catches is silent: a config missing a setting, or written and never exported, leaves every lane building correctly and slowly with nothing red.

Its expectation is a **literal list**, not the array the writer uses. The first version looped over that array and stayed green when a setting was deleted from it — `validation-discipline.md` RULE: an-expectation-built-with-the-mechanism-under-test-cannot-fail. Verified by mutation: dropping a setting from the writer now reds the suite.

**Not covered by that suite, stated rather than implied:** whether Xcode honours the file at all. That is a toolchain claim, established separately by running `xcodebuild -showBuildSettings` against the real generated project with and without `XCODE_XCCONFIG_FILE` — all three settings absent without it, all three `YES` with it.

## Ship criterion

On a warm cache, a pull request touching one leaf file shows `(in target 'EnviousWisprTests')` compile count at **0** in the `build-debug` log. Two-way control: a pull request changing a widely-imported module must show non-zero.

## Also found, not acted on

The vendor-recompile theory the plan spent a step on does not reproduce. Vendor C code was reused across a freshened checkout with no special setting at all. Step A of the plan was chasing something that is not there.

Closes #2580
