### PR TITLE
feat(snippets): a fresh install starts with six working examples (#628)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/SnippetsCoordinator.swift
@@ -34,7 +34,11 @@ final class SnippetsCoordinator {
     // Assigned directly, not through `adopt`: nothing has registered a listener yet, and the
     // bootstrapper seeds both drivers from `vocabulary` immediately after construction. This is
     // the ONE site that may write it without publishing, and it is one line from the property.
-    vocabulary = manager.load()
+    //
+    // `loadOrSeedStarters` rather than `load`: a first launch writes the example snippets here,
+    // before either driver is seeded, so the examples are live in the very first dictation
+    // rather than after a restart.
+    vocabulary = manager.loadOrSeedStarters()
   }
 
   var snippets: [Snippet] { vocabulary.snippets }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
@@ -58,8 +58,12 @@ struct SnippetsView: View {
     } footnote: {
       // The example is worth its line: the rule is easy to state and easy to misread, and one
       // concrete sentence answers "so what do I actually say" faster than the description.
+      //
+      // It names "my email" because that is a STARTER trigger a new install really has, so the
+      // sentence is an instruction the reader can follow rather than an illustration. Phrased
+      // as "the snippet saved for those words" so it stays true after they delete that one.
       Text(
-        "Example — say \u{201C}\(coordinator.keyword) my email address\u{201D} and your email is pasted."
+        "For example, say \u{201C}\(coordinator.keyword) my email\u{201D} and the snippet saved for those words is pasted."
       )
       .settingsHelperCopy()
     }
@@ -174,7 +178,14 @@ struct SnippetsView: View {
     } label: {
       HStack(spacing: 12) {
         VStack(alignment: .leading, spacing: 2) {
-          Text(snippet.trigger).settingsRowLabel()
+          HStack(spacing: 7) {
+            Text(snippet.trigger).settingsRowLabel()
+            // Shown only while a starter is still exactly as it shipped. It is the one thing
+            // standing between "John Doe" and a real message, and it disappears the moment the
+            // user makes the snippet theirs, because the answer is recomputed from the text on
+            // screen rather than stored.
+            if SnippetStarters.isUneditedExample(snippet) { exampleTag }
+          }
           // One line, ellipsised: an expansion can be a whole signature, and a list that grows
           // a row to fit one of them stops being scannable.
           Text(oneLine(snippet.expansion))
@@ -193,7 +204,23 @@ struct SnippetsView: View {
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .accessibilityLabel("\(snippet.trigger), pastes \(oneLine(snippet.expansion))")
+    .accessibilityLabel(
+      SnippetStarters.isUneditedExample(snippet)
+        ? "\(snippet.trigger), example, pastes \(oneLine(snippet.expansion))"
+        : "\(snippet.trigger), pastes \(oneLine(snippet.expansion))")
+  }
+
+  /// The quiet tag on an untouched starter. Outlined rather than filled: it labels the row, and
+  /// a filled accent pill would read as a recommendation to keep the example rather than a note
+  /// that it is one.
+  private var exampleTag: some View {
+    Text("Example")
+      .font(.system(size: 11, weight: .semibold))
+      .foregroundStyle(Color.stTextTertiary)
+      .padding(.horizontal, 7)
+      .padding(.vertical, 1)
+      .background(Capsule().strokeBorder(Color.stDivider, lineWidth: 1))
+      .accessibilityHidden(true)
   }
 
   /// Line breaks flattened for the row preview only. The stored expansion keeps them — they are

--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetsView.swift
@@ -56,16 +56,26 @@ struct SnippetsView: View {
         Spacer(minLength: 0)
       }
     } footnote: {
-      // The example is worth its line: the rule is easy to state and easy to misread, and one
-      // concrete sentence answers "so what do I actually say" faster than the description.
-      //
-      // It names "my email" because that is a STARTER trigger a new install really has, so the
-      // sentence is an instruction the reader can follow rather than an illustration. Phrased
-      // as "the snippet saved for those words" so it stays true after they delete that one.
+      keywordExample.settingsHelperCopy()
+    }
+  }
+
+  /// The one concrete instruction on the screen: the rule is easy to state and easy to misread,
+  /// and one sentence answers "so what do I actually say" faster than the description does.
+  ///
+  /// Built from a trigger the user ACTUALLY HAS, never from a literal. A hardcoded "my email"
+  /// was true on a fresh install and became a lie the moment they renamed or deleted that
+  /// starter: the screen would keep telling them to say words that fire nothing. With no
+  /// snippets at all there is no honest example, so it names none.
+  @ViewBuilder private var keywordExample: some View {
+    if let trigger = coordinator.snippets.first?.trigger {
       Text(
-        "For example, say \u{201C}\(coordinator.keyword) my email\u{201D} and the snippet saved for those words is pasted."
+        "For example, say \u{201C}\(coordinator.keyword) \(trigger)\u{201D} and that snippet is pasted."
       )
-      .settingsHelperCopy()
+    } else {
+      Text(
+        "Say your keyword, then the words you saved a snippet under, and that snippet is pasted."
+      )
     }
   }
 

--- a/Sources/EnviousWisprCore/SnippetStarters.swift
+++ b/Sources/EnviousWisprCore/SnippetStarters.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// The example snippets a brand-new install starts with (#628, founder 2026-09-01).
+///
+/// A feature whose first screen is empty has to be explained; a feature whose first screen is
+/// already full of working examples explains itself. These six are written to the store once,
+/// on the first launch that finds no `snippets.json`, and are ordinary snippets from that
+/// moment on — editable, deletable, and never re-seeded. Deleting them all is a decision the
+/// store remembers, because the file then exists and is empty.
+///
+/// Every one of them FIRES. A decorative example the user cannot try is a screenshot, not an
+/// example, so the catalog is held to the same rules the edit sheet enforces and is checked
+/// against them by its own test rather than by inspection.
+///
+/// Two constraints the catalog must keep, both mechanically tested:
+///
+/// - **No two starters collide.** `SnippetsManager.validate` refuses a duplicate trigger, so a
+///   colliding pair would make the seeded file un-editable: every later save re-validates the
+///   whole list and would fail on a clash the user never created.
+/// - **Every expansion is one line.** A snippet carrying a newline is delivered to the
+///   clipboard rather than typed in place, because in a terminal a newline submits the command.
+///   That is correct behaviour and a poor first impression, so no starter has one.
+public enum SnippetStarters {
+
+  /// The canonical text of one starter, and the reason this is a separate type from `Snippet`:
+  /// the id and the text are FIXED, while a `Snippet` carries a `createdAt` that is not.
+  struct Starter {
+    let id: UUID
+    let trigger: String
+    let expansion: String
+  }
+
+  /// The six, in the order a new user sees them.
+  ///
+  /// Every trigger begins with "my" and ends in a single common word. That is a matching
+  /// decision, not a style one: the matcher compares transcript tokens literally, so a trigger
+  /// whose words the speech engine might run together ("sign off" heard as "signoff") would be
+  /// an example that silently does not work.
+  ///
+  /// The text is deliberately, visibly fictional. `example.com` is reserved for exactly this
+  /// (RFC 2606) and the 555-01xx phone range is reserved for fiction, so a starter pasted into
+  /// a real message by mistake reads as a placeholder rather than as someone's real address.
+  static let catalog: [Starter] = [
+    Starter(
+      id: UUID(uuidString: "9F1C7A20-4E6B-4C31-9E2A-1D5B8F0A3C71")!,
+      trigger: "my email",
+      expansion: "john.doe@example.com"),
+    Starter(
+      id: UUID(uuidString: "3B84D0E5-6A17-4F92-8C0D-7E2A9B4F1D63")!,
+      trigger: "my phone",
+      expansion: "(555) 010-4477"),
+    Starter(
+      id: UUID(uuidString: "C6E29B14-8D3F-4A70-B5E8-2F91C7D04A56")!,
+      trigger: "my address",
+      expansion: "1600 Example Way, Suite 200, Springfield, IL 62704"),
+    Starter(
+      id: UUID(uuidString: "5A0D3F81-2C94-4E6D-A17B-8B36E5C920F4")!,
+      trigger: "my calendar",
+      expansion: "https://cal.example.com/john-doe"),
+    Starter(
+      id: UUID(uuidString: "72B4E8C0-1F5A-4D39-96C7-4A0E2D8B7F15")!,
+      trigger: "my signature",
+      expansion: "Thanks so much. John Doe, Product at Example Co."),
+    Starter(
+      id: UUID(uuidString: "E8137C6A-9B02-4F58-8D41-6C3A5E90B2D7")!,
+      trigger: "my intro",
+      expansion:
+        "Hi, I'm John Doe. I lead product at Example Co, and I'm happy to help however I can."),
+  ]
+
+  /// The starters as storable snippets, stamped with the moment they are read.
+  ///
+  /// `createdAt` is the only field not fixed by the catalog, and it is deliberately taken at
+  /// call time rather than frozen: the store writes these once, so the honest value is when the
+  /// user's install created them.
+  public static var all: [Snippet] {
+    catalog.map { Snippet(id: $0.id, trigger: $0.trigger, expansion: $0.expansion) }
+  }
+
+  /// True when this snippet is a starter the user has not touched yet.
+  ///
+  /// Derived from the catalog rather than stored on `Snippet`, which is what keeps the badge
+  /// honest with no schema field and no migration: the answer is recomputed from the text on
+  /// screen, so the first edit clears it and nothing has to remember to.
+  ///
+  /// Both fields are compared. Matching on the id alone would keep calling a snippet an example
+  /// after the user had replaced its expansion with their own address, which is the one moment
+  /// the badge must be gone.
+  public static func isUneditedExample(_ snippet: Snippet) -> Bool {
+    guard let starter = catalog.first(where: { $0.id == snippet.id }) else { return false }
+    return starter.trigger == snippet.trigger && starter.expansion == snippet.expansion
+  }
+}

--- a/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
+++ b/Sources/EnviousWisprPipeline/SnippetExpansionStep.swift
@@ -33,6 +33,12 @@ public final class SnippetExpansionStep: TextProcessingStep {
   /// Disabled rather than run as a no-op. `TextProcessingRunner` skips a disabled step
   /// entirely, so an empty store costs one boolean and the chain is identical to a build
   /// without this file — which is premise P4, and it has a test rather than a hope.
+  ///
+  /// The property is unchanged since starter snippets landed; the population it covers is
+  /// smaller. A fresh install is no longer an empty store, because `SnippetStarters` are
+  /// written on the first launch, so this now reads false only for someone who deleted them
+  /// all. Examples that fire are worth the step running, and a decorative example nobody can
+  /// try is a screenshot.
   public var isEnabled: Bool { snippetVocabulary.canFire }
 
   /// One second, and the number is a measurement rather than a preference.

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -54,12 +54,20 @@ public final class SnippetsManager: @unchecked Sendable {
   }
 
   /// What is on disk right now. The `unreadable` case is the whole reason this is not an
-  /// optional.
+  /// optional, and `archivedCorrupt` is the second reason: THREE different situations produce
+  /// no readable snippets, and they do not all license the same next action.
   enum LoadResult: Equatable {
+    /// No file has ever been written here. The only state a fresh install is in.
     case missing
     case loaded(SnippetVocabulary)
-    /// The file exists and its contents are unknown — a read error, or a corrupt file that
-    /// could not be archived to safety. Either way the bytes must not be overwritten.
+    /// A file was there, could not be parsed, and was moved aside to a `.corrupted-<uuid>`
+    /// archive. Reading and writing may proceed from empty — but this is NOT a new user, and
+    /// anything that treats it as one acts on somebody's data-loss moment. Split out after
+    /// review found starter snippets being written into exactly this state, where they would
+    /// have read as recovered content.
+    case archivedCorrupt
+    /// The file exists and its contents are unknown — a read error, a file from a NEWER app, or
+    /// a corrupt file that could not be archived. Either way the bytes must not be overwritten.
     case unreadable
   }
 
@@ -122,6 +130,8 @@ public final class SnippetsManager: @unchecked Sendable {
     let empty = SnippetVocabulary(
       snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
     guard let result = try? withLock(blocking: true, { loadWhileLocked() }) else { return empty }
+    // `archivedCorrupt` renders as empty exactly like `missing`: the screen has to draw, and the
+    // bytes are safe in the archive. Only `loadOrSeedStarters` needs the two kept apart.
     if case .loaded(let vocabulary) = result { return vocabulary }
     return empty
   }
@@ -150,7 +160,10 @@ public final class SnippetsManager: @unchecked Sendable {
       switch loadWhileLocked() {
       case .loaded(let vocabulary):
         return vocabulary
-      case .unreadable:
+      case .unreadable, .archivedCorrupt:
+        // Neither is a new install. `archivedCorrupt` is the one that looks like one and is not:
+        // the user HAD snippets, they were just moved aside, and writing six John Doe examples
+        // into that moment presents sample data as recovered content.
         return empty
       case .missing:
         let seeded = SnippetVocabulary(
@@ -227,7 +240,7 @@ public final class SnippetsManager: @unchecked Sendable {
       Self.logger.error(
         "snippets.json could not be parsed; archived and starting empty. \(String(describing: error), privacy: .public)"
       )
-      return .missing
+      return .archivedCorrupt
     }
   }
 
@@ -268,7 +281,9 @@ public final class SnippetsManager: @unchecked Sendable {
     try withLock {
       let current: SnippetVocabulary
       switch loadWhileLocked() {
-      case .missing:
+      case .missing, .archivedCorrupt:
+        // A save is allowed after an archive: the old bytes are safe under their own name, and
+        // refusing here would leave the user unable to type anything new.
         current = SnippetVocabulary(
           snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
       case .loaded(let vocabulary):

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -126,6 +126,47 @@ public final class SnippetsManager: @unchecked Sendable {
     return empty
   }
 
+  /// Read the store, and on a brand-new install write the starter examples first (#628).
+  ///
+  /// The seed is attempted for `missing` ONLY, which is what makes it a one-time event: after
+  /// it runs the file exists, so a user who deletes every starter is left with a file holding
+  /// none, and the next launch loads that empty list instead of putting them back. An
+  /// `unreadable` file is never seeded over, for the same reason no mutation touches one — the
+  /// snippets on disk are still the only copy.
+  ///
+  /// The load and the write happen inside ONE lock hold. Two of these racing on first launch
+  /// (a shipped copy and a dev build both starting) would otherwise both read `missing` and
+  /// both write the starters, and the second rename would discard whichever edit the first
+  /// user had already made.
+  ///
+  /// A failed seed returns the EMPTY vocabulary rather than the starters it could not persist.
+  /// Showing a list the store does not hold is how the next delete writes a file with the other
+  /// five missing; the honest outcome is an empty screen now and the examples on the next
+  /// launch that can write.
+  public func loadOrSeedStarters() -> SnippetVocabulary {
+    let empty = SnippetVocabulary(
+      snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation)
+    let result = try? withLock(blocking: true) { () -> SnippetVocabulary in
+      switch loadWhileLocked() {
+      case .loaded(let vocabulary):
+        return vocabulary
+      case .unreadable:
+        return empty
+      case .missing:
+        let seeded = SnippetVocabulary(
+          snippets: SnippetStarters.all,
+          keyword: SnippetVocabulary.defaultKeyword,
+          generation: generation)
+        guard let saved = try? saveWhileLocked(seeded) else {
+          Self.logger.error("Starter snippets could not be written; starting empty.")
+          return empty
+        }
+        return saved
+      }
+    }
+    return result ?? empty
+  }
+
   /// True when a file exists that could not be read. The screen shows a banner, and saves are
   /// refused, rather than a silent empty list the next edit would make permanent.
   public var unreadableExisting: Bool {

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -237,6 +237,26 @@ public final class SnippetsManager: @unchecked Sendable {
         )
         return .unreadable
       }
+      // Put an EMPTY store back where the archived one was.
+      //
+      // This is the load-bearing half, and the in-memory `archivedCorrupt` case above is only
+      // the window before it lands. Archiving removed the file, and the FILE is the only
+      // durable answer to "has this install ever had a snippets store" — which is exactly the
+      // question `loadOrSeedStarters` asks. Without the tombstone the next launch reads
+      // `missing`, decides this is a new user, and writes six examples on top of somebody's
+      // data-loss event. Review found that twice, one round apart, which is what said the
+      // repair belonged on disk rather than in a return value.
+      //
+      // Enumerated rather than patched again. The producers of "no file at `fileURL`" are:
+      // never written (a real fresh install), this archive, a hand-deleted file, and a seed
+      // whose write failed. Only the archive was wrong, and only the archive is repaired here
+      // — deleting the file by hand is asking for a reset, and a failed seed must retry.
+      //
+      // Best effort on purpose: if this write fails the next launch re-seeds, which is the old
+      // behaviour, and refusing to load would be worse than that.
+      _ = try? saveWhileLocked(
+        SnippetVocabulary(
+          snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation))
       Self.logger.error(
         "snippets.json could not be parsed; archived and starting empty. \(String(describing: error), privacy: .public)"
       )

--- a/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetsManager.swift
@@ -166,6 +166,10 @@ public final class SnippetsManager: @unchecked Sendable {
         // into that moment presents sample data as recovered content.
         return empty
       case .missing:
+        // `missing` means no file HERE, NOW. It does not mean this install never had one: the
+        // corrupt-file archive moves the store aside, so the same read reports `missing` for a
+        // user who just lost their snippets. Ask the disk the question actually being asked.
+        guard !hasStoreHistoryOnDisk() else { return empty }
         let seeded = SnippetVocabulary(
           snippets: SnippetStarters.all,
           keyword: SnippetVocabulary.defaultKeyword,
@@ -178,6 +182,29 @@ public final class SnippetsManager: @unchecked Sendable {
       }
     }
     return result ?? empty
+  }
+
+  /// Whether anything on disk says this install has EVER held a snippets store.
+  ///
+  /// The single reader of the only question the seed needs answered, and it is deliberately
+  /// broader than "does `snippets.json` exist". Three rounds of review found three ways the
+  /// primary file can be absent from an install that had one, and every one of them ran through
+  /// the corrupt-file archive: the archive removes the file, so a read reports `missing`, so the
+  /// seed would write six John Doe examples into somebody's data-loss moment where they read as
+  /// recovered content.
+  ///
+  /// A `.corrupted-<uuid>` sibling is that history, and it needs no write to create — which is
+  /// what makes it strictly stronger than writing an empty file back, the previous fix. That
+  /// write could fail, and the failure landed on exactly the launch after a data loss.
+  ///
+  /// Deleting the archives is not covered and should not be: a user who cleared them out has
+  /// asked for a clean slate, and a clean slate is what they get.
+  private func hasStoreHistoryOnDisk() -> Bool {
+    if FileManager.default.fileExists(atPath: fileURL.path) { return true }
+    let directory = fileURL.deletingLastPathComponent()
+    let siblings =
+      (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
+    return siblings.contains { $0.hasPrefix("\(Self.fileName).corrupted-") }
   }
 
   /// True when a file exists that could not be read. The screen shows a banner, and saves are
@@ -237,26 +264,10 @@ public final class SnippetsManager: @unchecked Sendable {
         )
         return .unreadable
       }
-      // Put an EMPTY store back where the archived one was.
-      //
-      // This is the load-bearing half, and the in-memory `archivedCorrupt` case above is only
-      // the window before it lands. Archiving removed the file, and the FILE is the only
-      // durable answer to "has this install ever had a snippets store" — which is exactly the
-      // question `loadOrSeedStarters` asks. Without the tombstone the next launch reads
-      // `missing`, decides this is a new user, and writes six examples on top of somebody's
-      // data-loss event. Review found that twice, one round apart, which is what said the
-      // repair belonged on disk rather than in a return value.
-      //
-      // Enumerated rather than patched again. The producers of "no file at `fileURL`" are:
-      // never written (a real fresh install), this archive, a hand-deleted file, and a seed
-      // whose write failed. Only the archive was wrong, and only the archive is repaired here
-      // — deleting the file by hand is asking for a reset, and a failed seed must retry.
-      //
-      // Best effort on purpose: if this write fails the next launch re-seeds, which is the old
-      // behaviour, and refusing to load would be worse than that.
-      _ = try? saveWhileLocked(
-        SnippetVocabulary(
-          snippets: [], keyword: SnippetVocabulary.defaultKeyword, generation: generation))
+      // NOT repaired by writing an empty file back. That was the round-2 fix and it is
+      // dominated by `hasStoreHistoryOnDisk` below, which answers the same question and also
+      // survives the case where the replacement write itself fails. One reader for one
+      // question, and no write on a read path.
       Self.logger.error(
         "snippets.json could not be parsed; archived and starting empty. \(String(describing: error), privacy: .public)"
       )

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
@@ -119,6 +119,24 @@ struct SnippetStartersSeedingTests {
     #expect(siblings.filter { $0.contains("corrupted") }.count == 1)
   }
 
+  @Test("The launch AFTER an archive still gets no examples")
+  func archivedCorruptionSurvivesARelaunch() throws {
+    // Round 1 fixed the call that does the archiving; this is the call after it, which is where
+    // the state actually had to live. Archiving removed the file, and the file is the only
+    // durable answer to "has this install ever had a store", so the repair is a tombstone on
+    // disk rather than a value returned once.
+    let (manager, url) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    try Data("{ this is not json".utf8).write(to: url)
+    _ = manager.loadOrSeedStarters()
+
+    // A second manager over the same path is what the next launch actually is.
+    let afterRelaunch = SnippetsManager(fileURL: url).loadOrSeedStarters()
+
+    #expect(afterRelaunch.snippets.isEmpty)
+    #expect(FileManager.default.fileExists(atPath: url.path))
+  }
+
   @Test("After an archive the user can still save, and still gets no examples")
   func savingWorksAfterAnArchive() throws {
     let (manager, url) = makeStore()

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
@@ -134,7 +134,26 @@ struct SnippetStartersSeedingTests {
     let afterRelaunch = SnippetsManager(fileURL: url).loadOrSeedStarters()
 
     #expect(afterRelaunch.snippets.isEmpty)
-    #expect(FileManager.default.fileExists(atPath: url.path))
+    // And no file was written back to make that work. The `.corrupted-` sibling IS the history,
+    // which is why nothing has to succeed at writing for the next launch to stay correct.
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+    let siblings = try FileManager.default.contentsOfDirectory(
+      atPath: url.deletingLastPathComponent().path)
+    #expect(siblings.filter { $0.contains("corrupted") }.count == 1)
+  }
+
+  @Test("A store deleted by hand does seed again, and that is the deliberate boundary")
+  func handDeletedStoreDoesSeed() throws {
+    // The archive is what says "this install had snippets". Clearing everything out, archives
+    // included, is asking for a clean slate, and a clean slate is what it gets. Stated as a
+    // test so the boundary is a decision rather than an accident of the implementation.
+    let (manager, url) = makeStore()
+    _ = manager.loadOrSeedStarters()
+    try FileManager.default.removeItem(at: url)
+
+    let afterRelaunch = SnippetsManager(fileURL: url).loadOrSeedStarters()
+
+    #expect(afterRelaunch.snippets.count == SnippetStarters.all.count)
   }
 
   @Test("After an archive the user can still save, and still gets no examples")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
@@ -100,6 +100,37 @@ struct SnippetStartersSeedingTests {
     #expect(try Data(contentsOf: url) == bytesBefore)
   }
 
+  @Test("A corrupt store that was archived is not treated as a new install")
+  func archivedCorruptionIsNotSeeded() throws {
+    // Found by review, not imagined. `loadWhileLocked` archives a corrupt file and used to
+    // report `.missing`, which reads exactly like a fresh install — so the seed would write six
+    // John Doe examples into the one moment a user has just lost their own snippets, and they
+    // would read as recovered content.
+    let (manager, url) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    try Data("{ this is not json".utf8).write(to: url)
+
+    let loaded = manager.loadOrSeedStarters()
+
+    #expect(loaded.snippets.isEmpty)
+    // And the archive still holds the bytes, so this is a recovery state rather than a loss.
+    let siblings = try FileManager.default.contentsOfDirectory(
+      atPath: url.deletingLastPathComponent().path)
+    #expect(siblings.filter { $0.contains("corrupted") }.count == 1)
+  }
+
+  @Test("After an archive the user can still save, and still gets no examples")
+  func savingWorksAfterAnArchive() throws {
+    let (manager, url) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    try Data("{ this is not json".utf8).write(to: url)
+    _ = manager.loadOrSeedStarters()
+
+    try manager.upsert(Snippet(trigger: "my new one", expansion: "typed after the archive"))
+
+    #expect(manager.load().snippets.map(\.trigger) == ["my new one"])
+  }
+
   // MARK: - The seeded list has to be editable
 
   @Test("Every starter can be saved back through the real store without a refusal")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
@@ -84,6 +84,34 @@ struct SnippetStartersSeedingTests {
     #expect(!SnippetStarters.isUneditedExample(reloaded))
   }
 
+  @Test("Deleting some starters and renaming others leaves a coherent list")
+  func theRealFirstFiveMinutes() throws {
+    // What the founder actually did within minutes of the first build: kept four, deleted two,
+    // renamed two triggers, and replaced every expansion with his own. Worth a row because it
+    // is the only sequence that exercises delete, rename and re-expansion against ONE store,
+    // and because every survivor must come back with its badge gone.
+    let (manager, _) = makeStore()
+    let seeded = manager.loadOrSeedStarters()
+    let kept = Array(seeded.snippets.prefix(4))
+    for doomed in seeded.snippets.dropFirst(4) { try manager.remove(id: doomed.id) }
+    for (index, starter) in kept.enumerated() {
+      try manager.upsert(
+        Snippet(
+          id: starter.id,
+          trigger: index == 1 ? "my cell" : starter.trigger,
+          expansion: "mine-\(index)@enviouslabs.co",
+          createdAt: starter.createdAt))
+    }
+
+    let afterRelaunch = manager.loadOrSeedStarters()
+
+    #expect(afterRelaunch.snippets.count == 4)
+    #expect(afterRelaunch.snippets.contains { $0.trigger == "my cell" })
+    for snippet in afterRelaunch.snippets {
+      #expect(!SnippetStarters.isUneditedExample(snippet), "\(snippet.trigger) still reads as an example")
+    }
+  }
+
   // MARK: - The case where seeding must not happen at all
 
   @Test("An unreadable file is never seeded over")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
@@ -1,0 +1,213 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// #628 — the example snippets a fresh install starts with.
+///
+/// `.productOutcome`: the seed writes to the same file that holds the user's own snippets, so
+/// the failure that matters is not "no examples appeared" but "examples appeared on top of
+/// something", or "the ones I deleted came back". Both are the user's data, not ours.
+@Suite("Starter snippets (#628)", .tags(.productOutcome))
+struct SnippetStartersSeedingTests {
+
+  private func makeStore() -> (SnippetsManager, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-snip-seed-\(UUID().uuidString)", isDirectory: true)
+    let url = dir.appendingPathComponent("snippets.json")
+    return (SnippetsManager(fileURL: url), url)
+  }
+
+  // MARK: - The first launch
+
+  @Test("A first launch returns the starters and leaves them on disk")
+  func firstLaunchSeeds() throws {
+    let (manager, url) = makeStore()
+
+    let seeded = manager.loadOrSeedStarters()
+
+    #expect(seeded.snippets.map(\.trigger) == SnippetStarters.all.map(\.trigger))
+    // The oracle is the FILE. A seed that only populated memory would put the examples back on
+    // every launch, and the user's deletions would never stick.
+    #expect(FileManager.default.fileExists(atPath: url.path))
+    #expect(manager.load().snippets.count == SnippetStarters.all.count)
+  }
+
+  @Test("The seeded keyword is the default, so the examples can actually fire")
+  func seedCarriesTheDefaultKeyword() {
+    let (manager, _) = makeStore()
+
+    let seeded = manager.loadOrSeedStarters()
+
+    #expect(seeded.keyword == SnippetVocabulary.defaultKeyword)
+    #expect(seeded.canFire)
+  }
+
+  // MARK: - The second launch, which is where a re-seed would show up
+
+  @Test("Deleting every starter is remembered; they are not put back")
+  func deletingThemAllSticks() throws {
+    let (manager, _) = makeStore()
+    let seeded = manager.loadOrSeedStarters()
+    for snippet in seeded.snippets { try manager.remove(id: snippet.id) }
+
+    let afterRelaunch = manager.loadOrSeedStarters()
+
+    #expect(afterRelaunch.snippets.isEmpty)
+  }
+
+  @Test("A store that already has snippets is left exactly as it is")
+  func existingStoreIsNotSeeded() throws {
+    let (manager, _) = makeStore()
+    try manager.upsert(Snippet(trigger: "my own", expansion: "mine"))
+
+    let loaded = manager.loadOrSeedStarters()
+
+    #expect(loaded.snippets.map(\.trigger) == ["my own"])
+  }
+
+  @Test("An edited starter stays edited across a relaunch")
+  func editedStarterSurvives() throws {
+    let (manager, _) = makeStore()
+    let seeded = manager.loadOrSeedStarters()
+    let first = try #require(seeded.snippets.first)
+    try manager.upsert(
+      Snippet(
+        id: first.id, trigger: first.trigger, expansion: "real@enviouslabs.co",
+        createdAt: first.createdAt))
+
+    let afterRelaunch = manager.loadOrSeedStarters()
+
+    let reloaded = try #require(afterRelaunch.snippets.first { $0.id == first.id })
+    #expect(reloaded.expansion == "real@enviouslabs.co")
+    #expect(!SnippetStarters.isUneditedExample(reloaded))
+  }
+
+  // MARK: - The case where seeding must not happen at all
+
+  @Test("An unreadable file is never seeded over")
+  func unreadableFileIsNotSeeded() throws {
+    let (manager, url) = makeStore()
+    try manager.upsert(Snippet(trigger: "my email", expansion: "sam@example.com"))
+    let bytesBefore = try Data(contentsOf: url)
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: url.path)
+
+    let loaded = manager.loadOrSeedStarters()
+
+    #expect(loaded.snippets.isEmpty)
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    #expect(try Data(contentsOf: url) == bytesBefore)
+  }
+
+  // MARK: - The seeded list has to be editable
+
+  @Test("Every starter can be saved back through the real store without a refusal")
+  func seededListIsEditable() throws {
+    let (manager, _) = makeStore()
+    let seeded = manager.loadOrSeedStarters()
+
+    // A colliding pair in the catalog would pass every load and then make the whole list
+    // un-editable, because each save re-validates all of it against a clash the user never made.
+    for snippet in seeded.snippets {
+      try manager.upsert(snippet)
+    }
+
+    #expect(manager.load().snippets.count == SnippetStarters.all.count)
+  }
+}
+
+/// #628 — the catalog itself, checked against the rules the edit sheet enforces.
+///
+/// `.driftGuard`: nothing at runtime re-checks a hardcoded list, so the day someone adds a
+/// seventh starter is the day one of these properties can quietly stop holding.
+@Suite("Starter snippet catalog (#628)", .tags(.driftGuard))
+struct SnippetStartersCatalogTests {
+
+  @Test("No two starters fire on the same spoken words")
+  func noCollisions() {
+    let all = SnippetStarters.all
+    for (index, snippet) in all.enumerated() {
+      for other in all[(index + 1)...] {
+        #expect(!snippet.collidesWith(other), "\(snippet.trigger) collides with \(other.trigger)")
+      }
+    }
+  }
+
+  @Test("Every starter passes the store's own validation")
+  func everyStarterIsValid() throws {
+    let all = SnippetStarters.all
+    for snippet in all {
+      let others = all.filter { $0.id != snippet.id }
+      try SnippetsManager.validate(snippet, against: others)
+    }
+  }
+
+  @Test("The catalog holds exactly six starters, and every id string parses")
+  func catalogIsSix() {
+    // Building `all` is what forces every `UUID(uuidString:)` literal to be parsed. A typo in
+    // one of them traps, and this is where that has to happen: the catalog is first touched
+    // during app launch, so a malformed id that reached a release would be a launch crash for
+    // a decorative feature. The count is pinned so adding a seventh is a deliberate edit.
+    #expect(SnippetStarters.all.count == 6)
+  }
+
+  @Test("Every starter id is unique")
+  func idsAreUnique() {
+    let ids = SnippetStarters.all.map(\.id)
+    #expect(Set(ids).count == ids.count)
+  }
+
+  @Test("No starter expansion contains a newline")
+  func everyExpansionIsOneLine() {
+    // A snippet carrying a newline is delivered to the clipboard rather than typed in place.
+    // Correct, and a poor first impression: the example would look like it did nothing.
+    for snippet in SnippetStarters.all {
+      // Computed outside `#expect`: `contains(where:)` is `rethrows`, and the macro expansion
+      // does not carry the `try` the compiler then asks for.
+      let carriesNewline = snippet.expansion.contains(where: \.isNewline)
+      #expect(!carriesNewline, "\(snippet.trigger) would be delivered to the clipboard")
+    }
+  }
+
+  @Test("Every trigger survives normalisation as the words it is written as")
+  func triggersNormaliseToThemselves() {
+    // Written lowercase and unpunctuated on purpose. A trigger that normalised to something
+    // else would still match, but the row would show one thing and the user would have to say
+    // another.
+    for snippet in SnippetStarters.all {
+      #expect(snippet.triggerTokens == snippet.trigger.split(separator: " ").map(String.init))
+    }
+  }
+
+  @Test("Every starter is more than one spoken word after the keyword")
+  func triggersAreNotSingleWords() {
+    // A one-word trigger is the easiest kind to fire by accident, and the examples are the
+    // pattern a user copies when they write their own.
+    for snippet in SnippetStarters.all {
+      #expect(snippet.triggerTokens.count >= 2, "\(snippet.trigger) is a single word")
+    }
+  }
+
+  // MARK: - The badge
+
+  @Test("An untouched starter is an example; a changed one is not")
+  func badgeClearsOnEdit() throws {
+    let starter = try #require(SnippetStarters.all.first)
+
+    #expect(SnippetStarters.isUneditedExample(starter))
+    #expect(
+      !SnippetStarters.isUneditedExample(
+        Snippet(id: starter.id, trigger: starter.trigger, expansion: "mine@example.com")))
+    #expect(
+      !SnippetStarters.isUneditedExample(
+        Snippet(id: starter.id, trigger: "my work email", expansion: starter.expansion)))
+  }
+
+  @Test("A snippet the user wrote is never an example")
+  func userSnippetIsNeverAnExample() {
+    #expect(
+      !SnippetStarters.isUneditedExample(
+        Snippet(trigger: "my email", expansion: "john.doe@example.com")))
+  }
+}

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -12,21 +12,38 @@ A snippet is a voice shortcut. You save a piece of text once, then say a short p
 
 Snippets live in **Settings** \> **Snippets**.
 
+### What you start with
+
+EnviousWispr ships with six example snippets so you can try the feature before you write anything. They belong to a made-up person called John Doe, and each one is marked **Example** in the list until you change it.
+
+| Say | You get |
+| --- | --- |
+| `backslash my email` | john.doe@example.com |
+| `backslash my phone` | (555) 010-4477 |
+| `backslash my address` | 1600 Example Way, Suite 200, Springfield, IL 62704 |
+| `backslash my calendar` | https://cal.example.com/john-doe |
+| `backslash my signature` | Thanks so much. John Doe, Product at Example Co. |
+| `backslash my intro` | Hi, I'm John Doe. I lead product at Example Co, and I'm happy to help however I can. |
+
+These are ordinary snippets. Open one, replace John Doe's details with yours, and click **Save**. The **Example** mark disappears once the text is yours.
+
+Delete the ones you do not want. They stay deleted, and EnviousWispr will not add them back on the next launch.
+
 ### How a snippet fires
 
 A snippet only expands when you say your **keyword** first, then the trigger. The keyword is `backslash` unless you change it.
 
 Say this:
 
-> Feel free to email me at **backslash my email address** any time.
+> Feel free to email me at **backslash my email** any time.
 
 You get this:
 
-> Feel free to email me at you@example.com any time.
+> Feel free to email me at john.doe@example.com any time.
 
 The keyword is what keeps snippets out of your way. Say the same trigger without it and nothing happens:
 
-> Can you send me **my email address** from that form?
+> Can you send me **my email** from that form?
 
 That sentence comes out exactly as you said it.
 
@@ -48,7 +65,7 @@ Clearing the field puts the default back rather than switching snippets off.
 
 ### What EnviousWispr will not do to your snippet
 
-The text you save is pasted exactly as you typed it. AI Polish never rewrites it, so an email address, a web link or a signature arrives character for character. The rest of your dictation is still polished as normal.
+The text you save is pasted exactly as you typed it. AI Polish never rewrites it, so an email address, a web link or a signature arrives character for character. Everything else you dictate is still polished as normal.
 
 Line breaks are kept, so a two-line sign-off arrives as two lines.
 


### PR DESCRIPTION
A fresh install now starts with six working example snippets instead of an empty screen.

Founder ask: pre-load Snippets with John Doe examples that inspire, shipped on a fresh install, editable, and the edits stored. A feature whose first screen is empty has to be explained; one already full of working examples explains itself.

| Say | You get |
| --- | --- |
| `backslash my email` | john.doe@example.com |
| `backslash my phone` | (555) 010-4477 |
| `backslash my address` | 1600 Example Way, Suite 200, Springfield, IL 62704 |
| `backslash my calendar` | https://cal.example.com/john-doe |
| `backslash my signature` | Thanks so much. John Doe, Product at Example Co. |
| `backslash my intro` | Hi, I'm John Doe. I lead product at Example Co, and I'm happy to help however I can. |

Every one of them FIRES. A decorative example the user cannot try is a screenshot.

## The three decisions, each of which had an obvious wrong answer

**Seed on `missing` only, and write the file immediately.** Holding the examples in memory and persisting on first edit cannot distinguish "new user" from "user who deleted them all", so they would come back on every launch. Writing the file is what makes a deletion a decision the store remembers.

**A failed seed returns EMPTY, not the starters it could not persist.** Showing a list the store does not hold is how the next delete writes a file with the other five missing. An empty screen now and the examples on the next launch that can write is the honest outcome.

**The "Example" badge is DERIVED, not stored.** `SnippetStarters.isUneditedExample` matches a snippet's id against the catalog and requires the trigger AND the expansion to be unchanged. No schema field, no migration, and nothing has to remember to clear it: the edit sheet builds a fresh `Snippet`, so the first edit clears the badge by construction. It is also the only thing standing between "john.doe@example.com" and a real message.

## What review found

Three local diff rounds, a behavioural second pass, and a confirming round. Two real defects, both in the same place, and one finding rejected twice on the same evidence.

**An archived corrupt store was being treated as a fresh install.** `loadWhileLocked` archives a malformed `snippets.json` to `.corrupted-<uuid>` and returned `.missing` — indistinguishable from "no file has ever been written here". The seed then wrote six John Doe examples into the one moment a user has just lost their own snippets, where they read as recovered content rather than as samples.

`LoadResult` gains a fourth case, `archivedCorrupt`, so every caller's switch has to decide. `load` renders it empty as before; `mutate` still allows a save, because the old bytes are safe under their own name and refusing would leave the user unable to type anything new; `loadOrSeedStarters` refuses to seed.

**Then the same root came back one call later, and the third fix deleted the first two.** Archiving leaves NO file, so the next launch read `missing` and seeded anyway. A tombstone write fixed that, and then the behavioural pass pointed out the tombstone's own write can fail — landing on exactly the launch after a data loss. Three mechanisms had accumulated for one question: *has this install ever held a snippets store?*

`hasStoreHistoryOnDisk()` is now its single reader — `snippets.json` exists, OR any `snippets.json.corrupted-*` sibling exists. It strictly dominates the tombstone: everything the tombstone covered, plus the case where the tombstone fails, and it needs no write at all, which also takes a write off a read path. The tombstone is gone. The boundary is a test rather than an accident: a store deleted BY HAND, archives and all, does seed again — clearing it out is asking for a clean slate.

**And the enumeration found the fact worth keeping.** `CustomWordsManager` already distinguishes missing / loaded / unreadable / corrupted, credited to #1646 in its own comment. `SnippetsManager` shipped a three-valued copy of a four-valued design one file away, so both early rounds were recovering ground custom words already held. Not a bug in the seed — a regression against an existing owner. Recorded in the plan, because it becomes a live defect in that store the day someone adds a default to it.

**Rejected twice, on the same evidence: seeding a user who upgrades is not a defect.** `git merge-base --is-ancestor 99dbdbd4 v2.4.6` says NOT, and v2.4.6 is the newest tag, so with respect to Snippets an upgrading user and a brand new user are the same population. Gating on a fresh-install marker would hand an empty Snippets screen to every current user, which is every user, and the examples exist to prevent exactly that.

**One more of mine, caught by the reviewer and not by me.** The keyword card's example named a literal trigger, and the comment beside it claimed it stayed true after the user deleted that snippet. It did not: the sentence promised a snippet saved for those words would be pasted, and after the delete none is. It is now built from `coordinator.snippets.first?.trigger`, and with no snippets it names no trigger at all.

## Catalog constraints, mechanically tested rather than promised

- **No two starters collide.** A colliding pair would pass every load and then make the whole seeded list un-editable, because each save re-validates all of it against a clash the user never created.
- **Every expansion is one line.** A newline-bearing snippet goes to the clipboard, which is correct and a poor first impression: the example would look like it did nothing.
- **The catalog holds exactly six, and building it parses every id literal.** The catalog is first touched during app launch, so a malformed UUID string that reached a release would be a launch crash for a decorative feature. The test is where that has to happen.

`example.com` (RFC 2606) and the 555-01xx range are reserved for fiction, so a starter pasted into a real message by mistake reads as a placeholder.

## Two changes this caused, both in the diff

- The keyword card's example named "my email address", which is not a trigger any install has. It now names "my email", a real starter, phrased so it stays true after the user deletes that one.
- The help article's existing "The rest of your dictation", plus the new word "phone", made `reset my iphone` a confident exact search match on the Snippets article through two fuzzy hops. `check-help-search` caught it on exactly the query that assertion exists to protect. Reworded the prose, not the product.

## Known consequence, stated rather than found later

The expansion step is now armed for every new user rather than skipped on an empty store, so P4's "empty-store chain is byte-identical to a build without the step" no longer describes a fresh install. That is the cost of examples that actually fire.

## One-time cost, deliberate

The seed is a synchronous durable write (`flock`, `F_FULLFSYNC`, atomic rename) on the main actor during launch, because it has to complete before the bootstrapper seeds both dictation drivers from the coordinator's vocabulary. Doing it asynchronously would race the drivers and give the first dictation of a new install an empty snippet list. It runs on exactly one launch per install; every later launch takes the read path that was already there.

## Verification

- `scripts/xcode-test.sh`: **7,326 tests, TEST SUCCEEDED**, at this exact HEAD
- Help checks: routes 70 built, 70 in sitemap, 0 dead links · search 42 passed, 0 failed
- Live UAT on the built dev app, on a Mac with no `snippets.json`, so a genuine first launch:

| Said | Delivered |
|---|---|
| "Feel free to email me at **backslash my email** any time." | `Feel free to email me at john.doe@example.com anytime.` |
| "You can reach me on **backslash my phone** this afternoon." | `You can reach me on (555) 010-4477 this afternoon.` |
| "Please send that to **my email** when you get a chance." | unchanged — `Snippet Expansion: no change` |

The store was written 0600 with all six and `keyword: backslash`. The delivered text is read from the STORED transcript, not from the polish log line, because the polish log shows the sentinel and the question is what the user actually received. No sentinel reached storage.

The settings screen renders every row's badge: the accessibility labels come back as `my email, example, pastes john.doe@example.com`, and the keyword card reads `For example, say "backslash my email" and that snippet is pasted` — built from a live trigger, not a literal.

**Then the founder used it.** Within minutes he kept four, deleted two, renamed two triggers, and replaced every expansion with his own. All four came back with the badge gone and the deletions stuck. That sequence is now the last test in the suite.

Part of #628
