### PR TITLE
chore(ci): measure the content cache on a real run — DO NOT MERGE

### DIFF
--- a/Sources/EnviousWisprAppKit/App/LastRecordingResult.swift
+++ b/Sources/EnviousWisprAppKit/App/LastRecordingResult.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Observation
 
+// #2580 cache measurement, not for merge. A one-line inert edit is how #805
+// established that a workflow-only change cannot exercise the build cache —
+// `classify-changes.sh` excludes `.github/`, so a real Swift file has to move.
+// This PR exists to read `build-debug`'s wall clock against the 15.7-21.3 min
+// baseline of the twelve runs before compilation caching landed. Close it, do
+// not merge it.
+
 /// PR7 of epic #763. Owns post-recording polish/error state — the single
 /// observable fact "did the last polish fail, and with what message" — for
 /// views to render an error banner after a recording completes.


### PR DESCRIPTION
## DO NOT MERGE — this exists to be measured, then closed

One inert comment in one Swift file. That is the only way a pull request can exercise the build cache: `classify-changes.sh` excludes `.github/`, so a workflow-only change cannot do it. #805 established this and used the same file.

## Why, and the correction is the point

**PR #2587's own ship criterion was wrong for the design that shipped.** It said a warm cache should show `(in target 'EnviousWisprTests')` compile count = **0**.

That is the right oracle for **mtime restoration**, where the build system skips the compile tasks outright. It is the wrong oracle for **content caching**, which still schedules every task and serves each from a content hash.

Measured locally, same tree, paired arms:

| arm | wall | Swift compiles |
|---|---|---|
| warm, freshened mtimes, no caching | 61s | 1343 |
| same, caching on | 20s | **1343** |

A criterion counting compiles would have read "no change" on a 3x improvement. This is the shape `validation-discipline.md` RULE: verify-the-feature-not-the-crash warns about — a green that is measuring the wrong thing.

## The corrected oracle: wall clock

Baseline, `build-debug` successful runs before this landed:

| completed | build-debug |
|---|---|
| 2026-09-01 19:24 | 21.3 min |
| 2026-09-01 21:35 | 18.7 min |
| 2026-09-02 02:44 | 15.7 min |
| 2026-09-02 03:26 | 17.4 min ← PR #2587's own run, cold by construction |

The first cache holding compilation-cache entries was written by post-merge run `33587255718` at 04:07 UTC. It is **3.10 GB**, down from **3.67 GB** — the `Build/` → `CompilationCache.noindex` swap shrank it by 0.57 GB, in the predicted direction though smaller than the 0.9 GB I estimated.

## What would falsify the change

`build-debug` landing inside the 15.7–21.3 min baseline band means the content cache is not being restored, or not being hit, and the change has not earned its place. Say so and investigate rather than reporting the merge as a win.

Close once `build-debug` reports.
