### PR TITLE
refactor(ci): both PR lanes set up through xcode-ci-setup, so the cache path list exists twice, not four times (#2592)

### DIFF
--- a/.github/actions/xcode-ci-setup/action.yml
+++ b/.github/actions/xcode-ci-setup/action.yml
@@ -1,19 +1,34 @@
 name: Xcode CI setup
 description: >-
-  Toolchain selection, Tuist install, DerivedData cache redirect, build-cache
-  restore, and Xcode project generation — the setup every macOS validation job
-  in main-post-merge.yml needs before it can build or test.
+  Toolchain selection, Tuist install, compilation-cache and DerivedData
+  redirects, build-cache restore, and Xcode project generation — the setup
+  every lane in pr-check.yml and main-post-merge.yml that builds the app with
+  xcodebuild needs before it can build or test. (eval-packages builds
+  standalone SwiftPM packages with `swift build` and deliberately does not
+  use it.)
 
 # Why this exists (#1994): main-post-merge.yml runs its debug and release
-# validation as two parallel jobs, and each needs an identical eleven-step
+# validation as two parallel jobs, and each needs the same multi-step
 # setup. Two hand-mirrored copies of one decision is the shape that diverges —
 # .claude/rules/workflow-process.md RULE: port-proven-patterns-wholesale
 # records two separate cases in this repo where exactly that happened. One
 # owner, both callers.
 #
+# #2592: pr-check.yml's build-debug and build-release lanes were the third and
+# fourth copies, hand-mirrored inline, and one of them is where #2580's cold
+# cache shipped from. They now call this action too, so the Xcode cache path
+# list exists in exactly TWO places — the restore below and the save in
+# main-post-merge.yml's release-validation job — instead of four.
+# scripts/ci/check-cache-paths.py asserts both against a literal expectation.
+#
 # The caller must check the repository out BEFORE using this action: a local
 # `uses: ./...` action is read from the working tree, so it cannot perform its
 # own checkout.
+#
+# Gating: the steps here carry no `if:`. pr-check.yml skips the whole setup
+# for a docs-only PR by putting `if: steps.changes.outputs.needs_build == 'true'`
+# on the step that USES this action — a caller-step condition governs every
+# step of a composite action — and main-post-merge.yml gates at the job level.
 
 inputs:
   derived-data-path:
@@ -31,10 +46,32 @@ outputs:
   cache-hit:
     description: Whether the restore was an exact hit on the primary key.
     value: ${{ steps.xcode-cache.outputs.cache-hit }}
+  cache-matched-key:
+    description: The key the restore actually matched (empty when nothing matched).
+    value: ${{ steps.xcode-cache.outputs.cache-matched-key }}
 
 runs:
   using: composite
   steps:
+    # A wrong input here produces a permanently cold cache and nothing red: an
+    # absolute path renders as `$GITHUB_WORKSPACE//abs` in the redirect and as
+    # `/abs/...` in the cache list, an empty one caches `/SourcePackages`, and
+    # a trailing slash spells every cache entry with `//`. Both callers pass a
+    # workspace-relative path; refuse anything else loudly. Spaces are fine —
+    # every shell use is quoted and cache entries are line-delimited.
+    - name: Check derived-data-path input
+      shell: bash
+      env:
+        DD: ${{ inputs.derived-data-path }}
+      run: |
+        set -euo pipefail
+        case "$DD" in
+          "") echo "::error::derived-data-path is empty"; exit 1 ;;
+          /*) echo "::error::derived-data-path must be workspace-relative, got '$DD'"; exit 1 ;;
+          */) echo "::error::derived-data-path must not end in '/', got '$DD'"; exit 1 ;;
+        esac
+        echo "derived-data-path: $DD"
+
     - name: Select Xcode
       uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
       with:
@@ -70,18 +107,30 @@ runs:
         "$HOME/.local/bin/mise" install "tuist@${TUIST_VERSION}"
         "$HOME/.local/bin/mise" x "tuist@${TUIST_VERSION}" -- tuist version
 
-    # See pr-check.yml's "Configure DerivedData cache redirect" comment
-    # (issue #1295) — same rationale. main-post-merge.yml remains the cache
-    # WRITER, so it must produce the same directory shape pr-check.yml restores.
-    # #2580: see pr-check.yml's "Configure compilation cache" comment — same
-    # rationale, and this action is why it is stated once for both post-merge
-    # jobs. Must precede every xcodebuild below, which is what an exported
-    # XCODE_XCCONFIG_FILE gives without repeating three settings on ten
-    # command lines.
+    # #2580: Xcode 26 compilation caching. Content-addressed, so what gets
+    # reused is decided by hashing a compile job's actual inputs — the file
+    # timestamps `actions/checkout` destroys stop mattering. Measured on one
+    # machine, paired arms: the debug lane's shape went 61s -> 20s with every
+    # one of its 1343 Swift compiles served from the cache, and two builds
+    # differing only in these flags produced byte-identical code in every
+    # binary. Owner, cost and the equivalence controls:
+    # scripts/ci/configure-compilation-cache.sh.
+    #
+    # Must precede every xcodebuild in the calling job, which is what an
+    # exported XCODE_XCCONFIG_FILE gives without repeating three settings on
+    # ten command lines.
     - name: Configure compilation cache
       shell: bash
       run: scripts/ci/configure-compilation-cache.sh
 
+    # tuist generate's internal `xcodebuild -resolvePackageDependencies` call
+    # passes no -derivedDataPath, so it resolves into Xcode's global default
+    # DerivedData location — NOT the directory this job caches — paying a
+    # full, uncached network resolution every run (issue #1295). Redirecting
+    # the global default here, before generate runs and before the cache is
+    # restored, makes that resolve land somewhere the cache below actually
+    # covers. main-post-merge.yml is the cache WRITER, so it must produce the
+    # same directory shape pr-check.yml restores; both go through this step.
     - name: Configure DerivedData cache redirect
       shell: bash
       run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ inputs.derived-data-path }}"
@@ -99,15 +148,45 @@ runs:
         )"
         echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
 
-    # The third path entry is a glob (issue #1295) — see pr-check.yml's restore
-    # step comment for why.
+    # Rolling key (github.sha suffix) so the primary key is never an exact hit
+    # on a PR. pr-check.yml is restore-only by design — main-post-merge.yml's
+    # release-validation job is the sole writer (issue #804), and it saves
+    # under this step's exported cache-primary-key. restore-keys fall through
+    # to the freshest cache.
+    #
+    # The third path entry is a glob (issue #1295): the redirect above makes
+    # tuist generate's implicit resolve write into a per-project hash-named
+    # subfolder under the DerivedData root (Xcode's normal global-default
+    # naming), a different shape from the flat SourcePackages the explicit
+    # -derivedDataPath build steps write to. The glob covers both without the
+    # workflow needing to predict the hash name.
     #
     # These paths are derived from the input rather than hardcoded to
-    # `.derivedData/CI`, which is what the single-job version did. With two
-    # callers the hardcoded form becomes a silent trap: a caller passing a
-    # different derived-data-path would build in one place and cache another,
-    # and the only symptom is a permanently cold cache. pr-check.yml's restore
-    # paths must continue to match whatever this resolves to.
+    # `.derivedData/CI`, which is what the single-job version did. With
+    # several callers the hardcoded form becomes a silent trap: a caller
+    # passing a different derived-data-path would build in one place and cache
+    # another, and the only symptom is a permanently cold cache. The save in
+    # main-post-merge.yml must continue to match whatever this resolves to.
+    #
+    # #2580: the compilation cache REPLACES Build/ here rather than joining it.
+    # Two numbers, and they are not the same measurement, which is why the
+    # earlier one-line version of this comment read as arithmetic that did not
+    # add up. LOCAL directory sizes: 1.5 GB of content cache against 2.4 GB of
+    # built products. REAL CI cache entries, which is what actually gets
+    # stored: 3.10 GB for the first entry written after the swap against 3.67
+    # GB before it, so 0.57 GB smaller per entry. The CI figure is the one that
+    # decides whether storage is bought, and it is the smaller of the two
+    # because SourcePackages dominates both. Linking is not content-cached and
+    # re-runs; that is the 5s between 20s and 25s locally.
+    #
+    # THIS PROSE MUST STAY OUTSIDE `path:`. It first shipped INSIDE the block
+    # scalar below (in pr-check.yml's then-inline copy of this step), where
+    # YAML has no comments — so `actions/cache` read eight comment lines as
+    # eight more paths, and since the cache VERSION is a hash of the path
+    # list, both PR lanes asked for a version no writer ever saves. Result:
+    # `Cache not found for input keys` on all four keys, a permanently cold
+    # cache, and nothing red anywhere. Guarded by
+    # scripts/ci/check-cache-paths.py.
     - name: Restore Xcode build cache
       id: xcode-cache
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
@@ -122,6 +201,19 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
           ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
 
+    # The one line that says whether the cache did anything. `Cache not found
+    # for input keys` on every key is what a permanently cold cache looks like
+    # (#2580), and it is otherwise buried in the restore step's own output.
+    # A diagnostic must never be the thing that fails the lane.
+    - name: Log Xcode cache restore
+      continue-on-error: true
+      shell: bash
+      env:
+        MATCHED: ${{ steps.xcode-cache.outputs.cache-matched-key }}
+        HIT: ${{ steps.xcode-cache.outputs.cache-hit }}
+      run: |
+        echo "==> Xcode cache: matched=${MATCHED:-<none>} hit=${HIT:-false}"
+
     - name: Generate Xcode project
       shell: bash
       env:
@@ -129,6 +221,7 @@ runs:
       run: |
         set -euo pipefail
         "$HOME/.local/bin/mise" x "tuist@${TUIST_VERSION}" -- tuist generate --no-open
+        # Generated project / DerivedData must never be committed.
         git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
 
     - name: Log DerivedData package-resolution location

--- a/.github/workflows/main-post-merge.yml
+++ b/.github/workflows/main-post-merge.yml
@@ -75,9 +75,10 @@ env:
 # ~36 after the debug run has eaten into them.
 #
 # `release-validation` remains the sole cache WRITER and still builds BOTH
-# configurations, because pr-check.yml restores this cache (two restore steps,
-# no save) and depends on its directory shape. Splitting the cache across two
-# writers would change that contract; this change deliberately does not.
+# configurations, because pr-check.yml restores this cache (both lanes, through
+# the same composite action, no save) and depends on its directory shape.
+# Splitting the cache across two writers would change that contract; this
+# change deliberately does not.
 jobs:
   # Cheap Linux gate so both macOS jobs share ONE classification decision
   # rather than each computing its own and risking disagreement.
@@ -366,6 +367,9 @@ jobs:
           # MUST stay identical to the restore paths in
           # .github/actions/xcode-ci-setup/action.yml — a save/restore pair that
           # disagrees produces a permanently cold cache with no error anywhere.
+          # Since #2592 that restore is the ONLY other copy of this list (all
+          # four macOS lanes go through it), and scripts/ci/check-cache-paths.py
+          # holds both to the same literal expectation.
           path: |
             ${{ env.DERIVED_DATA_PATH }}/SourcePackages
             ${{ env.DERIVED_DATA_PATH }}/CompilationCache.noindex

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,11 +49,6 @@ jobs:
           # build runs. Do not re-shallow without explicitly fetching BASE_SHA.
           fetch-depth: 0
 
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          xcode-version: latest-stable
-
       - name: Detect code changes
         id: changes
         env:
@@ -79,126 +74,19 @@ jobs:
       # #2146's clipboard guard followed the same path for the same reason: the shell scanner and its
       # two CI steps are gone, and `ClipboardIsolationFreezeTests` parses with SwiftParser inside this
       # lane's existing `xcodebuild test`.
-      - name: Verify environment
+
+      # #2592: the whole Xcode setup (toolchain through project generation) is
+      # ONE owner, shared with both main-post-merge.yml jobs. This lane and
+      # build-release used to carry it inline, hand-mirrored, and that is where
+      # #2580's permanently cold cache shipped from. The `if:` here skips the
+      # entire action for a docs-only PR; the action's header says why the
+      # steps inside carry none.
+      - name: Xcode CI setup
+        id: setup
         if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          swift --version
-          xcodebuild -version
-          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
-          echo "macOS SDK: $SDK_VER"
-
-          if ! swift --version 2>&1 | grep -q "Swift version 6"; then
-            echo "::error::Swift 6.0+ required"
-            exit 1
-          fi
-
-          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
-            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
-            exit 1
-          fi
-
-      - name: Install mise + Tuist
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          curl https://mise.run | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mise" install tuist@4.195.11
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
-
-      # tuist generate's internal `xcodebuild -resolvePackageDependencies` call
-      # passes no -derivedDataPath, so it resolves into Xcode's global default
-      # DerivedData location — NOT the .derivedData/CI path this job caches —
-      # paying a full, uncached network resolution every run (issue #1295).
-      # Redirecting the global default here, before generate runs and before
-      # the cache is restored, makes that resolve land somewhere the cache
-      # below actually covers.
-      # #2580: Xcode 26 compilation caching. Content-addressed, so what gets
-      # reused is decided by hashing a compile job's actual inputs — the file
-      # timestamps `actions/checkout` destroys stop mattering. Measured on one
-      # machine, paired arms: this lane's shape went 61s -> 20s with every one of
-      # its 1343 Swift compiles served from the cache, and two builds differing
-      # only in these flags produced byte-identical code in every binary.
-      # Owner, cost and the equivalence controls:
-      # scripts/ci/configure-compilation-cache.sh.
-      - name: Configure compilation cache
-        if: steps.changes.outputs.needs_build == 'true'
-        run: scripts/ci/configure-compilation-cache.sh
-
-      - name: Configure DerivedData cache redirect
-        if: steps.changes.outputs.needs_build == 'true'
-        run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
-
-      - name: Compute Xcode build cache key
-        id: xcode-cache-key
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          TOOLCHAIN_ID="$(
-            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version; } |
-            shasum -a 256 | cut -c1-12
-          )"
-          echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
-
-      # Rolling key (github.sha suffix) so the primary key is never an exact hit
-      # here. pr-check.yml is restore-only by design — main-post-merge.yml is the
-      # sole writer (issue #804). restore-keys fall through to the freshest cache.
-      # The third path entry is a glob (issue #1295): the redirect above makes
-      # tuist generate's implicit resolve write into a per-project hash-named
-      # subfolder under .derivedData/CI (Xcode's normal global-default naming),
-      # a different shape from the flat SourcePackages/Build the explicit
-      # -derivedDataPath build step below writes to. The glob covers both
-      # without the workflow needing to predict the hash name.
-      # #2580: the compilation cache REPLACES Build/ here rather than joining it —
-      # Two numbers, and they are not the same measurement, which is why the
-      # earlier one-line version of this comment read as arithmetic that did not
-      # add up. LOCAL directory sizes: 1.5 GB of content cache against 2.4 GB of
-      # built products. REAL CI cache entries, which is what actually gets
-      # stored: 3.10 GB for the first entry written after the swap against 3.67
-      # GB before it, so 0.57 GB smaller per entry. The CI figure is the one that
-      # decides whether storage is bought, and it is the smaller of the two
-      # because SourcePackages dominates both. Linking is not content-cached and
-      # re-runs; that is the 5s between 20s and 25s locally.
-      #
-      # THIS PROSE MUST STAY OUTSIDE `path:`. It first shipped INSIDE the block
-      # scalar below, where YAML has no comments — so `actions/cache` read eight
-      # comment lines as eight more paths, and since the cache VERSION is a hash
-      # of the path list, these two lanes asked for a version no writer ever
-      # saves. Result: `Cache not found for input keys` on all four keys, a
-      # permanently cold cache, and nothing red anywhere. Guarded by
-      # scripts/ci/check-cache-paths.py.
-      - name: Restore Xcode build cache
-        id: xcode-cache
-        if: steps.changes.outputs.needs_build == 'true'
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: ./.github/actions/xcode-ci-setup
         with:
-          path: |
-            .derivedData/CI/SourcePackages
-            .derivedData/CI/CompilationCache.noindex
-            .derivedData/CI/*/SourcePackages
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
-
-      - name: Log Xcode cache restore
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          echo "==> Xcode cache (debug lane): matched=${{ steps.xcode-cache.outputs.cache-matched-key }} hit=${{ steps.xcode-cache.outputs.cache-hit }}"
-
-      - name: Generate Xcode project
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
-          # Generated project / DerivedData must never be committed.
-          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
-
-      - name: Log DerivedData package-resolution location
-        if: steps.changes.outputs.needs_build == 'true'
-        run: find "$DERIVED_DATA_PATH" -maxdepth 3 -type d -name SourcePackages -print 2>/dev/null || true
+          derived-data-path: ${{ env.DERIVED_DATA_PATH }}
 
       - name: Build (debug, Xcode)
         if: steps.changes.outputs.needs_build == 'true'
@@ -326,11 +214,6 @@ jobs:
           # build runs. Do not re-shallow without explicitly fetching BASE_SHA.
           fetch-depth: 0
 
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          xcode-version: latest-stable
-
       - name: Detect code changes
         id: changes
         env:
@@ -338,111 +221,13 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: scripts/ci/classify-changes.sh "$BASE_SHA" "$HEAD_SHA"
 
-      - name: Verify environment
+      # #2592: same shared setup as build-debug — see that lane's comment.
+      - name: Xcode CI setup
+        id: setup
         if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          swift --version
-          xcodebuild -version
-          SDK_VER="$(xcrun --sdk macosx --show-sdk-version)"
-          echo "macOS SDK: $SDK_VER"
-
-          if ! swift --version 2>&1 | grep -q "Swift version 6"; then
-            echo "::error::Swift 6.0+ required"
-            exit 1
-          fi
-
-          if [ "$(printf '%s\n' "26.0" "$SDK_VER" | sort -V | head -n1)" != "26.0" ]; then
-            echo "::error::macOS SDK 26.0+ required for FoundationModels (found: $SDK_VER)"
-            exit 1
-          fi
-
-      - name: Install mise + Tuist
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          curl https://mise.run | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mise" install tuist@4.195.11
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version
-
-      # See build-debug's "Configure DerivedData cache redirect" comment
-      # (issue #1295) — same rationale, mirrored for this lane.
-      # #2580: Xcode 26 compilation caching. Content-addressed, so what gets
-      # reused is decided by hashing a compile job's actual inputs — the file
-      # timestamps `actions/checkout` destroys stop mattering. Measured on one
-      # machine, paired arms: this lane's shape went 61s -> 20s with every one of
-      # its 1343 Swift compiles served from the cache, and two builds differing
-      # only in these flags produced byte-identical code in every binary.
-      # Owner, cost and the equivalence controls:
-      # scripts/ci/configure-compilation-cache.sh.
-      - name: Configure compilation cache
-        if: steps.changes.outputs.needs_build == 'true'
-        run: scripts/ci/configure-compilation-cache.sh
-
-      - name: Configure DerivedData cache redirect
-        if: steps.changes.outputs.needs_build == 'true'
-        run: scripts/ci/configure-tuist-deriveddata-cache.sh "$GITHUB_WORKSPACE/${{ env.DERIVED_DATA_PATH }}"
-
-      - name: Compute Xcode build cache key
-        id: xcode-cache-key
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          TOOLCHAIN_ID="$(
-            { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist version; } |
-            shasum -a 256 | cut -c1-12
-          )"
-          echo "toolchain_id=$TOOLCHAIN_ID" >> "$GITHUB_OUTPUT"
-
-      # #2580: the compilation cache REPLACES Build/ here rather than joining it —
-      # Two numbers, and they are not the same measurement, which is why the
-      # earlier one-line version of this comment read as arithmetic that did not
-      # add up. LOCAL directory sizes: 1.5 GB of content cache against 2.4 GB of
-      # built products. REAL CI cache entries, which is what actually gets
-      # stored: 3.10 GB for the first entry written after the swap against 3.67
-      # GB before it, so 0.57 GB smaller per entry. The CI figure is the one that
-      # decides whether storage is bought, and it is the smaller of the two
-      # because SourcePackages dominates both. Linking is not content-cached and
-      # re-runs; that is the 5s between 20s and 25s locally.
-      #
-      # THIS PROSE MUST STAY OUTSIDE `path:`. It first shipped INSIDE the block
-      # scalar below, where YAML has no comments — so `actions/cache` read eight
-      # comment lines as eight more paths, and since the cache VERSION is a hash
-      # of the path list, these two lanes asked for a version no writer ever
-      # saves. Result: `Cache not found for input keys` on all four keys, a
-      # permanently cold cache, and nothing red anywhere. Guarded by
-      # scripts/ci/check-cache-paths.py.
-      - name: Restore Xcode build cache
-        id: xcode-cache
-        if: steps.changes.outputs.needs_build == 'true'
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: ./.github/actions/xcode-ci-setup
         with:
-          path: |
-            .derivedData/CI/SourcePackages
-            .derivedData/CI/CompilationCache.noindex
-            .derivedData/CI/*/SourcePackages
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-${{ hashFiles('Package.resolved', 'Project.swift', 'Workspace.swift', 'Tuist.swift', 'Tuist/**/*.swift') }}-
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-${{ steps.xcode-cache-key.outputs.toolchain_id }}-
-            ${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-xcode-
-
-      - name: Log Xcode cache restore
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          echo "==> Xcode cache (release lane): matched=${{ steps.xcode-cache.outputs.cache-matched-key }} hit=${{ steps.xcode-cache.outputs.cache-hit }}"
-
-      - name: Generate Xcode project
-        if: steps.changes.outputs.needs_build == 'true'
-        run: |
-          set -euo pipefail
-          "$HOME/.local/bin/mise" x tuist@4.195.11 -- tuist generate --no-open
-          git status --porcelain -- '*.xcodeproj' '*.xcworkspace' '.derivedData'
-
-      - name: Log DerivedData package-resolution location
-        if: steps.changes.outputs.needs_build == 'true'
-        run: find "$DERIVED_DATA_PATH" -maxdepth 3 -type d -name SourcePackages -print 2>/dev/null || true
+          derived-data-path: ${{ env.DERIVED_DATA_PATH }}
 
       - name: Build (release, Xcode)
         if: steps.changes.outputs.needs_build == 'true'

--- a/scripts/ci/check-cache-paths.py
+++ b/scripts/ci/check-cache-paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""scripts/ci/check-cache-paths.py — the four Xcode cache path lists must agree.
+"""scripts/ci/check-cache-paths.py — the two Xcode cache path lists must agree.
 
 WHY THIS EXISTS, measured 2026-09-02 on #2580. `actions/cache` derives a cache
 VERSION from a hash of the path list. A restore only matches a save whose
@@ -18,6 +18,13 @@ The existing warning in main-post-merge.yml already said the lists "MUST stay
 identical … a save/restore pair that disagrees produces a permanently cold cache
 with no error anywhere". It was right, it was read, and prose does not execute.
 
+There were FOUR lists when this was written: the composite action's restore,
+the post-merge save, and pr-check.yml's two inline restores. #2592 wired both
+pr-check.yml lanes to the composite action, so there are now exactly two —
+one restore (used by all four macOS lanes) and one save. Two is the floor:
+`actions/cache/restore` and `actions/cache/save` are separate steps in
+separate workflows, and each must spell the list itself.
+
 WHAT IS CHECKED
   1. Every actions/cache restore or save step across the workflows and the
      composite action is found by PARSING, never by grepping for a name.
@@ -27,7 +34,7 @@ WHAT IS CHECKED
      called out separately so the failure names its own cause.
 
 Usage:
-  check-cache-paths.sh [--self-test]
+  check-cache-paths.py [--self-test]
 """
 import glob
 import subprocess
@@ -110,8 +117,8 @@ XCODE_KEY_MARKERS = ("-xcode-", "cache-primary-key")
 # WHAT THE ANSWER IS, stated independently of what the workflows happen to say.
 #
 # Two review rounds found the same root here and the second one is the reason
-# this exists: the guard compared the four lists TO EACH OTHER. Consistency is
-# not correctness. Four sites agreeing on `Build/` passed, and so did a writer
+# this exists: the guard compared the (then four) lists TO EACH OTHER.
+# Consistency is not correctness. Four sites agreeing on `Build/` passed, and so did a writer
 # that fell out of the family because its key was reworded — a smaller clean set
 # prints exactly like a complete one.
 #
@@ -130,8 +137,6 @@ EXPECTED_PATHS = (
 )
 
 EXPECTED_OWNERS = frozenset({
-    ("pr-check.yml", "build-debug"),
-    ("pr-check.yml", "build-release"),
     ("main-post-merge.yml", "release-validation"),
     ("action.yml", "composite"),
 })
@@ -360,11 +365,13 @@ def self_test() -> int:
                     .derivedData/CI/Build
         """)
 
+    empty = fixture("jobs:\n  e:\n    steps: []\n")
+
     cases = [
         ("two spellings of one list agree", [good_a, good_b], 0),
         ("a comment inside path: is caught", [good_a, commented], 1),
         ("two different lists are caught", [good_a, divergent], 1),
-        ("no Xcode cache steps at all is NOT clean", [fixture("jobs:\n  e:\n    steps: []\n")], 1),
+        ("no Xcode cache steps at all is NOT clean", [empty], 1),
         ("a DIFFERENT root is a difference, not <DD>", [good_a, other_root], 1),
         ("an unrelated cache is ignored, not reded", [good_a, good_b, unrelated], 0),
         ("a save keyed by cache-primary-key IS in the family", [good_a, primary_keyed], 1),
@@ -410,7 +417,22 @@ def self_test() -> int:
         print("FAIL [an expected writer missing from the family] passed")
         fails += 1
 
-    for p in [good_a, good_b, commented, divergent, other_root, unrelated, spaced, primary_keyed, shared_wrong]:
+    # The other direction: a site holding an in-family cache step that the
+    # expectation does not name. This is the branch #2592 relies on — the two
+    # pr-check.yml restores it removed must never come back unnoticed — and a
+    # world-mutation control (the new checker against a tree still holding four
+    # lists) is how it was first proven. Pinned here so the branch cannot be
+    # deleted with the self-test still green.
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = check([good_a], F, set())
+    if rc == 1:
+        print("ok   [an owner the check does not expect is caught] rc=1")
+    else:
+        print("FAIL [an owner the check does not expect] passed")
+        fails += 1
+
+    for p in [good_a, good_b, commented, divergent, other_root, unrelated, spaced, primary_keyed, shared_wrong, empty]:
         os.unlink(p)
 
     if fails:


### PR DESCRIPTION
Closes #2592

## What

`pr-check.yml`'s `build-debug` and `build-release` carried the Xcode setup inline, hand-mirrored from `.github/actions/xcode-ci-setup`. Both lanes now call the composite action, gated by the same step-level `needs_build` condition on the calling step. The Xcode cache path list exists in two places (the action's restore and the post-merge save) instead of four, and `scripts/ci/check-cache-paths.py`'s `EXPECTED_OWNERS` shrinks to those two.

## Why

`actions/cache` hashes the path list into the cache version and matches on version before key. Four lists that had to be byte-identical were four chances to be silently wrong, and #2580 shipped a permanently cold cache from one of the inline copies with every lane green. The guard from #2591 catches it; the duplication is the defect.

## Equivalence

Step by step the inline setups and the composite were identical: same scripts, arguments, order and Tuist pin. The one move is `Select Xcode`, which ran before the change classifier and now runs behind the gate; nothing between checkout and the setup uses the toolchain. The comments that lived beside the inline steps (#1295, #804, #2580) move into the composite beside their steps. The composite gains the per-lane cache-restore log (non-fatal), a `cache-matched-key` output, and a first step that refuses an empty, absolute or trailing-slash `derived-data-path` (each renders a different string into the cache list than into the redirect, which is a cold cache with nothing red).

Plan with the enumerated step-by-step diff table: `docs/feature-requests/issue-2592-2026-09-02-pr-check-composite.md` (local, `docs/` is gitignored).

## Validation

- `actionlint` and `yamllint` clean on all three CI files.
- `check-cache-paths.py --self-test` PASS, including a new case for the extra-owner branch (a checker mutant with that branch deleted fails the self-test). Real run reports `2 steps, one identical 3-entry list`.
- World-mutation control: the new checker run against a checkout still holding the four lists exits 1 naming both `pr-check.yml` lanes as unexpected owners.
- Input guard driven directly with empty, absolute, trailing-slash, normal and space-containing values: rejects the first three, accepts the last two.
- `check-pr-check-fetch-depth.sh`, `classify-changes.sh --self-test`, `configure-compilation-cache.sh --self-test` PASS.
- Codex grounded review: three rounds to PROCEED-AS-PLANNED, then the second-pass behavioural review. Its two deferred items: `env.DERIVED_DATA_PATH` is minted separately in each workflow and the checker normalises the expression without resolving its value, which is #2593 item 1's class and goes there; the toolchain-less fallback restore key and per-job runner pin are #804's deliberate design and are unchanged.

## Ship criteria on this PR's own run

Both PR lanes run with `needs_build=true` (touching `pr-check.yml` self-forces it). The composite's `Log Xcode cache restore` line in each lane must show a non-empty `matched=` key.

Lane: CI/workflow | Tier: MEDIUM
