### PR TITLE
fix(ui): the recording status pill keeps its own space and its own words

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -317,14 +317,13 @@ struct StatusBadge: View {
     Group {
       switch liveRecordingState.pipelineState {
       case .recording:
-        HStack(spacing: 4) {
+        pill {
           Image(systemName: "mic.fill")
             .foregroundStyle(.stError)
             .symbolEffect(.pulse)
           Text(DictationNarrator.recordingStatus)
             .foregroundStyle(.secondary)
         }
-        .font(.caption)
 
       case .loadingModel:
         progressLabel(DictationNarrator.loadingModelBadge)
@@ -346,11 +345,26 @@ struct StatusBadge: View {
   }
 
   private func progressLabel(_ text: String) -> some View {
-    HStack(spacing: 4) {
+    pill {
       ProgressView().controlSize(.small)
       Text(text).foregroundStyle(.secondary)
     }
-    .font(.caption)
+  }
+
+  /// The badge owns its own capsule rather than borrowing the toolbar's.
+  /// macOS 26 draws a Liquid Glass capsule behind a toolbar item and sized it
+  /// narrower than this content, so the status words spilled past its
+  /// right-hand border (founder screenshot, 2026-09-02). Owning the shape means
+  /// the padding is ours; `fixedSize` keeps the words from being compressed by
+  /// whatever width the toolbar offers.
+  private func pill<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+    HStack(spacing: 4, content: content)
+      .font(.caption)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 5)
+      .background(Capsule().fill(Color.stTextSecondary.opacity(0.10)))
+      .overlay(Capsule().strokeBorder(Color.stDivider, lineWidth: 1))
+      .fixedSize()
   }
 }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -52,11 +52,30 @@ struct UnifiedWindowView: View {
         // rest. Placed trailing next to the record button (not centered, which
         // would collide with the principal wordmark) so pages without the
         // History status row still explain why the record button is disabled.
-        ToolbarItem(placement: .primaryAction) {
-          StatusBadge()
-        }
-        ToolbarItem(placement: .primaryAction) {
-          RecordButton()
+        // macOS 26 gives adjacent items in one placement a SHARED Liquid Glass
+        // capsule and packs them flush, so the record button's gradient pill was
+        // drawn over the status badge and covered its words. `ToolbarSpacer` is
+        // the documented way to split the run into separate groups. Both items
+        // paint their own pill, so both hide the system capsule for the same
+        // reason the principal wordmark does. Below macOS 26 there is no shared
+        // capsule and no spacer API, so the pair stays as it was.
+        if #available(macOS 26.0, *) {
+          ToolbarItem(placement: .primaryAction) {
+            StatusBadge()
+          }
+          .sharedBackgroundVisibility(.hidden)
+          ToolbarSpacer(.fixed, placement: .primaryAction)
+          ToolbarItem(placement: .primaryAction) {
+            RecordButton()
+          }
+          .sharedBackgroundVisibility(.hidden)
+        } else {
+          ToolbarItem(placement: .primaryAction) {
+            StatusBadge()
+          }
+          ToolbarItem(placement: .primaryAction) {
+            RecordButton()
+          }
         }
       }
     }


### PR DESCRIPTION
Part of #2597.

## What the user sees

While a recording is running, the toolbar's status pill now sits clear of the red Stop button, and the word "Recording" sits inside its own pill with even space on both sides.

## What was wrong

Two defects, the second hidden by the first:

1. macOS 26 gives adjacent `ToolbarItem`s in one placement a **shared** Liquid Glass capsule and packs them flush. `RecordButton` paints its own gradient pill inside that shared group, so it was drawn over `StatusBadge` and covered the status words. This is what the founder screenshotted.
2. Separating the two with `ToolbarSpacer` exposed the rest: the system capsule behind `StatusBadge` is sized **narrower than the badge's content**, so the trailing character of "Recording" was drawn across the capsule's right-hand border.

Both were captured from a dev build on macOS 26.7, before the change and after each of the two fixes.

## What changed

- `StatusBadge` draws its own capsule (`pill`), so the padding is ours; `fixedSize()` keeps the words from being compressed by whatever width the toolbar offers. Both the recording state and the three progress states share that one helper.
- The toolbar puts a `ToolbarSpacer(.fixed)` between the badge and the record button, and hides the system capsule on both items for the same reason the principal wordmark already does.
- Below macOS 26 there is no shared capsule and no `ToolbarSpacer`, so the pair keeps its existing arrangement and picks up the same pill, which makes the badge read identically across the supported range.

## Scope

`.toolbar {` / `ToolbarItem(` across `Sources/` returns hits in `SettingsView.swift` only, so this is the app's only toolbar and the change cannot reach another one.

No copy changed: `DictationNarrator` still owns every badge string, and its byte-level split (Unicode ellipsis for the badge, ASCII for pill and main window) is untouched.

## Validation

- `scripts/xcode-test.sh`: **TEST SUCCEEDED**, 7326 test cases, all accepted.
- Dev build + relaunch + live recording on macOS 26.7, window captured by window id at each step.

`Tier: SMALL | Test: none (visual layout) | Modules: AppKit views`
`Lane: Code`
`council-skip: zero-blast-radius (UI layout)`
