### PR TITLE
fix(polish): the cleanup classifier learns the codename generation (#2602)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/ProviderModelID.swift
+++ b/Sources/EnviousWisprAppKit/App/ProviderModelID.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Facts about the SHAPE of a cloud provider's model id, shared by everything
+/// that has to recognise the same model under two spellings.
+///
+/// #2602: this exists because there were briefly two implementations of the
+/// same rule in this module — `SettingsChangeTelemetry.stripDateSnapshotSuffix`,
+/// which collapses a dated id onto its allowlist entry, and a copy added to
+/// `AIPolishModelClassifier` so a dated snapshot of a named model keeps its
+/// tier. One fact, one owner: two copies of a date rule diverge the moment a
+/// provider ships a shape only one of them was taught.
+///
+/// It is a provider-id fact rather than classifier policy, which is why it did
+/// not stay on `AIPolishModelClassifier` — that type's own note asks callers not
+/// to adopt it elsewhere without revisiting placement, and this is that.
+enum ProviderModelID {
+
+  /// The id with a trailing DATED SNAPSHOT removed, or `nil` when there is none.
+  ///
+  /// Two shapes and only two, because those are the two the providers ship:
+  /// OpenAI's dashed `-YYYY-MM-DD` (`gpt-5-mini-2025-08-07`) and Anthropic's
+  /// compact `-YYYYMMDD` (`claude-haiku-4-5-20251001`). Mixed separators are
+  /// refused — `-2025-1001` is nobody's format.
+  ///
+  /// A REAL CALENDAR DATE is required, not merely eight digits, because a model
+  /// id may legitimately end in a number: `claude-fable-5-1` and
+  /// `gemini-2.5-flash` must survive untouched. This is stricter than the
+  /// telemetry copy it replaces, which matched digit shapes alone and would
+  /// therefore have collapsed `gpt-4-20259999` onto `gpt-4`; a nonsense id now
+  /// reports as `custom`, which is the honest answer.
+  ///
+  /// OpenAI's older four-digit `MMDD` snapshots (`gpt-3.5-turbo-0125`) are
+  /// deliberately NOT stripped: four digits cannot be told from a version.
+  static func withoutDateSnapshot(_ id: String) -> String? {
+    // Dashed first: it is the longer suffix, so trying it first cannot be
+    // shadowed by the compact form.
+    strippingDate(from: id, dashed: true) ?? strippingDate(from: id, dashed: false)
+  }
+
+  /// Removes a trailing `-` plus a `YYYY MM DD` date, dashed between the groups
+  /// or run together, when the digits are a real date.
+  private static func strippingDate(from id: String, dashed: Bool) -> String? {
+    let groups = [4, 2, 2]
+    let suffixLength = groups.reduce(0, +) + (dashed ? groups.count - 1 : 0) + 1  // + leading "-"
+    guard id.count > suffixLength else { return nil }
+    let suffix = String(id.suffix(suffixLength))
+    guard suffix.hasPrefix("-") else { return nil }
+
+    var remainder = Substring(suffix.dropFirst())
+    var values: [Int] = []
+    for (index, groupLength) in groups.enumerated() {
+      if dashed && index > 0 {
+        guard remainder.first == "-" else { return nil }
+        remainder = remainder.dropFirst()
+      }
+      let group = remainder.prefix(groupLength)
+      guard group.count == groupLength,
+        group.allSatisfy({ $0.isASCII && $0.isNumber }),
+        let value = Int(group)
+      else { return nil }
+      values.append(value)
+      remainder = remainder.dropFirst(groupLength)
+    }
+    guard remainder.isEmpty else { return nil }
+
+    var components = DateComponents()
+    components.year = values[0]
+    components.month = values[1]
+    components.day = values[2]
+    guard (2000...2099).contains(values[0]),
+      components.isValidDate(in: Calendar(identifier: .gregorian))
+    else { return nil }
+
+    return String(id.dropLast(suffixLength))
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -260,6 +260,8 @@ enum SettingsProjection {
     "gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4", "gpt-4.1", "gpt-4.1-mini",
     "gpt-4.1-nano", "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro",
     "o1", "o1-mini", "o1-preview", "o3", "o3-mini", "o4-mini", "chatgpt-4o-latest",
+    "gpt-5.1", "gpt-5.2", "gpt-5.2-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
+    "gpt-5.4-pro", "gpt-5.5", "gpt-5.5-pro", "gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol",
     // Gemini
     "gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.5-flash-8b",
     "gemini-2.0-flash", "gemini-2.0-flash-lite",
@@ -277,29 +279,31 @@ enum SettingsProjection {
     "gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools",
     "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.6-flash",
     "gemini-3.7-flash",
+    // #2602: enumerated from the live model lists of all three keys on
+    // 2026-09-02, not from the previous entries. The same gap #1770 records for
+    // Gemini 3.x had reopened for every generation shipped since: OpenAI 5.1
+    // through 5.6 and Gemini 3.8 were all reconstructing as `custom`, which
+    // hides exactly the generation a settings snapshot is asked about. Luna is
+    // the one this issue promotes to Recommended, so it would have become the
+    // most-selected invisible model.
+    "gemini-3.8-flash",
     // Claude
     "claude-sonnet-5", "claude-fable-5", "claude-opus-4-8", "claude-opus-4-7",
     "claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-5", "claude-haiku-4-5",
-    "claude-sonnet-4-5", "claude-opus-4-1",
+    "claude-sonnet-4-5", "claude-opus-4-1", "claude-fable-5-1", "claude-opus-5",
   ]
 
   /// Strip a trailing provider date-snapshot suffix so dated variants match
   /// their base allowlist entry. The suffix is public/non-sensitive; this
-  /// only collapses cardinality. Two forms: OpenAI/Gemini's dashed
-  /// `-YYYY-MM-DD` (e.g. `gpt-5-mini-2025-08-07`) and Anthropic's compact,
-  /// undashed `-YYYYMMDD` (e.g. `claude-haiku-4-5-20251001`) — the two do
-  /// not share a pattern, so both are matched explicitly rather than
-  /// widening one regex to accidentally admit the other's shape.
+  /// only collapses cardinality.
+  ///
+  /// #2602 moved the rule itself to `ProviderModelID`, which the AI Polish
+  /// classifier also needs, and gave it a real calendar-date check. The one
+  /// behaviour change: an id whose digits are not a DATE no longer collapses
+  /// onto a base model, so `gpt-4-20259999` reports `custom` rather than
+  /// `gpt-4`. That is the honest answer for an id no provider ships.
   private static func stripDateSnapshotSuffix(_ id: String) -> String {
-    if let r = id.range(
-      of: "-[0-9]{4}-[0-9]{2}-[0-9]{2}$", options: .regularExpression)
-    {
-      return String(id[..<r.lowerBound])
-    }
-    if let r = id.range(of: "-[0-9]{8}$", options: .regularExpression) {
-      return String(id[..<r.lowerBound])
-    }
-    return id
+    ProviderModelID.withoutDateSnapshot(id) ?? id
   }
 
   private static func languageModeLabel(_ mode: LanguageMode) -> String {

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -112,34 +112,75 @@ enum AIPolishKeychainFailureMessage {
 /// can reach it via `@testable import EnviousWispr`.** Has no other consumers
 /// inside the app module; do not adopt it elsewhere without revisiting placement.
 ///
-/// A model is recommended when its lowercased id (split on `-./_/`) contains a
-/// positive token (mini, nano, flash) AND no disqualifier token. Disqualifiers
-/// rule out specialized variants that would polish poorly (code, audio, image,
-/// realtime, search, transcribe, native/live audio variants, music gen).
+/// A model is recommended when we have NAMED it, or when its lowercased id
+/// (split on `-./_/`) contains a positive token AND no disqualifier token.
+/// Disqualifiers rule out specialized variants that would polish poorly (code,
+/// audio, image, realtime, search, transcribe, native/live audio variants,
+/// music gen).
 ///
 /// Live validation against OpenAI + Gemini APIs (2026-05-04):
 /// `docs/audits/2026-05-04-issue-617-classifier-validation.txt`.
+/// Re-validated against OpenAI, Gemini and Claude (2026-09-02, #2602):
+/// `docs/audits/2026-09-02-issue-2602-classifier-revalidation.txt`.
 enum AIPolishModelClassifier {
+  /// #2602: ids whose vendor name carries NO tier word but which ARE the
+  /// cheap-and-fast tier.
+  ///
+  /// **A token cannot do this job any more, and that is what the 2026-09-02
+  /// sweep found.** `mini` and `nano` were OpenAI's small tier through the 4.x
+  /// and 5.0–5.5 generations; at 5.6 the tiers became CODENAMES — `luna` cheap,
+  /// `terra` middle, `sol` large. `luna` is a NAME, not a word meaning "small",
+  /// so adding it to `positives` would read as a rule and behave as a one-model
+  /// exception that expires at the next rename.
+  ///
+  /// Same move `OllamaModelPickerPresentation.groups(from:)` already made for
+  /// Ollama in #1950, for the reason stated there: the token classifier was
+  /// "wrong in both directions" for a naming scheme it was not built for, so
+  /// that provider got a curated verdict instead. And the same instrument
+  /// `LLMModelCapabilities` justifies — OpenAI's models endpoint returns ids
+  /// only, so a live tier lookup cannot exist.
+  ///
+  /// **A new generation needs a row here, not a new token.** Only the
+  /// cheap-and-fast member earns one: `terra` and `sol` are correctly absent,
+  /// both measured available on 2026-09-02 and both correctly left under the
+  /// other heading.
+  static let namedFastTierIDs: Set<String> = ["gpt-5.6-luna"]
+
   // "haiku" is Claude's fast/cheap tier — it has no "mini"/"nano"/"flash"
   // analog in Anthropic's naming, so without it no Claude model would ever
   // land in "Recommended for cleanup." Zero collision risk: no existing
   // OpenAI/Gemini id contains "haiku."
-  static let positives: Set<String> = ["mini", "nano", "flash", "haiku"]
+  //
+  // #2602 added "lite", Google's own second small-tier word. It closes no live
+  // gap on 2026-09-02 — every `-lite` id Gemini returns also carries `flash` —
+  // and is here so a lite that arrives without `flash` is not misfiled.
+  static let positives: Set<String> = ["mini", "nano", "flash", "haiku", "lite"]
+
+  // #2602 added "omni". `gemini-omni-1.1-flash` and `gemini-omni-flash-preview`
+  // are flash-named and would read as good cleanup models. Both answer the
+  // discovery probe with HTTP 400 (measured 2026-09-02), so `groups(from:)`
+  // sends them to `locked` and they never reach this function today — this is
+  // classifier hygiene, not a live fix, and it keeps the rule identical to the
+  // Android port of it.
   static let disqualifiers: Set<String> = [
     "realtime", "audio", "native", "live",
-    "tts", "image", "search", "transcribe", "banana", "codex",
+    "tts", "image", "search", "transcribe", "banana", "codex", "omni",
   ]
 
-  /// Returns true if the model id is a Mini/Nano/Flash variant suitable for
-  /// transcript cleanup.
+  /// Returns true if the model id is one we named, or a Mini/Nano/Flash/Lite
+  /// variant, suitable for transcript cleanup.
   static func isRecommendedForCleanup(_ id: String) -> Bool {
+    let lowered = id.lowercased()
     let tokens = Set(
-      id.lowercased()
+      lowered
         .split(whereSeparator: { "-._/".contains($0) })
         .map(String.init)
     )
-    return !tokens.isDisjoint(with: positives)
-      && tokens.isDisjoint(with: disqualifiers)
+    // A disqualifier still vetoes a NAMED id. Nothing in the set trips one, so
+    // this can only fire on our own mistake, and failing closed on that is
+    // cheaper than shipping a named id that says `transcribe`.
+    guard tokens.isDisjoint(with: disqualifiers) else { return false }
+    return namedFastTierIDs.contains(lowered) || !tokens.isDisjoint(with: positives)
   }
 }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -176,11 +176,77 @@ enum AIPolishModelClassifier {
         .split(whereSeparator: { "-._/".contains($0) })
         .map(String.init)
     )
-    // A disqualifier still vetoes a NAMED id. Nothing in the set trips one, so
-    // this can only fire on our own mistake, and failing closed on that is
-    // cheaper than shipping a named id that says `transcribe`.
+    // A disqualifier still vetoes a NAMED id, and it is judged on the FULL id,
+    // never the stripped one — `gpt-5.6-luna-transcribe-2026-01-01` must not
+    // become recommended by having its date removed. Nothing in the named set
+    // trips a disqualifier, so this can only fire on our own mistake, and
+    // failing closed on that is cheaper than shipping a named id that says
+    // `transcribe`.
     guard tokens.isDisjoint(with: disqualifiers) else { return false }
-    return namedFastTierIDs.contains(lowered) || !tokens.isDisjoint(with: positives)
+    if namedFastTierIDs.contains(lowered) { return true }
+    // A DATED SNAPSHOT of a named id is that id (cloud review #2603). A token
+    // survives its own snapshot because `mini` is still a token of
+    // `gpt-5-mini-2025-08-07`, which is why the tier words never needed this;
+    // an exact-name lookup does not, so `gpt-5.6-luna-2026-07-09` would have
+    // landed under the other heading while its own alias sat under Recommended.
+    if let base = withoutSnapshot(lowered), namedFastTierIDs.contains(base) { return true }
+    return !tokens.isDisjoint(with: positives)
+  }
+
+  /// The id with a trailing DATED SNAPSHOT removed, or `nil` when there is none.
+  ///
+  /// Two shapes and only two, because those are the two the providers ship:
+  /// OpenAI's `-YYYY-MM-DD` (`gpt-5-mini-2025-08-07`) and Anthropic's compact
+  /// `-YYYYMMDD` (`claude-haiku-4-5-20251001`). Mixed separators are refused —
+  /// `-2025-1001` is nobody's format, and accepting it would let an id inherit
+  /// a different model's verdict.
+  ///
+  /// A REAL CALENDAR DATE is required, not eight digits, because a model id may
+  /// legitimately end in a number: `claude-fable-5-1` and `gemini-2.5-flash`
+  /// must survive untouched. OpenAI's older four-digit `MMDD` snapshots
+  /// (`gpt-3.5-turbo-0125`) are deliberately NOT stripped: four digits cannot be
+  /// told from a version, and no named id has one.
+  static func withoutSnapshot(_ id: String) -> String? {
+    // Hyphenated first: it is the longer suffix, so trying it first cannot be
+    // shadowed by the compact form.
+    strippingSuffix(of: id, separated: true) ?? strippingSuffix(of: id, separated: false)
+  }
+
+  /// Removes a trailing `-` plus a `YYYY MM DD` date, either `-`-separated
+  /// between the groups or run together, when it is a real date.
+  private static func strippingSuffix(of id: String, separated: Bool) -> String? {
+    let digitGroups = [4, 2, 2]
+    let separatorCount = separated ? digitGroups.count - 1 : 0
+    let suffixLength = digitGroups.reduce(0, +) + separatorCount + 1  // + the leading "-"
+    guard id.count > suffixLength else { return nil }
+    let suffix = String(id.suffix(suffixLength))
+    guard suffix.hasPrefix("-") else { return nil }
+
+    var remainder = Substring(suffix.dropFirst())
+    var values: [Int] = []
+    for (index, groupLength) in digitGroups.enumerated() {
+      if separated && index > 0 {
+        guard remainder.first == "-" else { return nil }
+        remainder = remainder.dropFirst()
+      }
+      let group = remainder.prefix(groupLength)
+      guard group.count == groupLength, group.allSatisfy(\.isASCII), group.allSatisfy(\.isNumber),
+        let value = Int(group)
+      else { return nil }
+      values.append(value)
+      remainder = remainder.dropFirst(groupLength)
+    }
+    guard remainder.isEmpty, values.count == 3 else { return nil }
+
+    var components = DateComponents()
+    components.year = values[0]
+    components.month = values[1]
+    components.day = values[2]
+    guard (2000...2099).contains(values[0]),
+      components.isValidDate(in: Calendar(identifier: .gregorian))
+    else { return nil }
+
+    return String(id.dropLast(suffixLength))
   }
 }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -189,65 +189,12 @@ enum AIPolishModelClassifier {
     // `gpt-5-mini-2025-08-07`, which is why the tier words never needed this;
     // an exact-name lookup does not, so `gpt-5.6-luna-2026-07-09` would have
     // landed under the other heading while its own alias sat under Recommended.
-    if let base = withoutSnapshot(lowered), namedFastTierIDs.contains(base) { return true }
+    if let base = ProviderModelID.withoutDateSnapshot(lowered), namedFastTierIDs.contains(base) {
+      return true
+    }
     return !tokens.isDisjoint(with: positives)
   }
 
-  /// The id with a trailing DATED SNAPSHOT removed, or `nil` when there is none.
-  ///
-  /// Two shapes and only two, because those are the two the providers ship:
-  /// OpenAI's `-YYYY-MM-DD` (`gpt-5-mini-2025-08-07`) and Anthropic's compact
-  /// `-YYYYMMDD` (`claude-haiku-4-5-20251001`). Mixed separators are refused —
-  /// `-2025-1001` is nobody's format, and accepting it would let an id inherit
-  /// a different model's verdict.
-  ///
-  /// A REAL CALENDAR DATE is required, not eight digits, because a model id may
-  /// legitimately end in a number: `claude-fable-5-1` and `gemini-2.5-flash`
-  /// must survive untouched. OpenAI's older four-digit `MMDD` snapshots
-  /// (`gpt-3.5-turbo-0125`) are deliberately NOT stripped: four digits cannot be
-  /// told from a version, and no named id has one.
-  static func withoutSnapshot(_ id: String) -> String? {
-    // Hyphenated first: it is the longer suffix, so trying it first cannot be
-    // shadowed by the compact form.
-    strippingSuffix(of: id, separated: true) ?? strippingSuffix(of: id, separated: false)
-  }
-
-  /// Removes a trailing `-` plus a `YYYY MM DD` date, either `-`-separated
-  /// between the groups or run together, when it is a real date.
-  private static func strippingSuffix(of id: String, separated: Bool) -> String? {
-    let digitGroups = [4, 2, 2]
-    let separatorCount = separated ? digitGroups.count - 1 : 0
-    let suffixLength = digitGroups.reduce(0, +) + separatorCount + 1  // + the leading "-"
-    guard id.count > suffixLength else { return nil }
-    let suffix = String(id.suffix(suffixLength))
-    guard suffix.hasPrefix("-") else { return nil }
-
-    var remainder = Substring(suffix.dropFirst())
-    var values: [Int] = []
-    for (index, groupLength) in digitGroups.enumerated() {
-      if separated && index > 0 {
-        guard remainder.first == "-" else { return nil }
-        remainder = remainder.dropFirst()
-      }
-      let group = remainder.prefix(groupLength)
-      guard group.count == groupLength, group.allSatisfy(\.isASCII), group.allSatisfy(\.isNumber),
-        let value = Int(group)
-      else { return nil }
-      values.append(value)
-      remainder = remainder.dropFirst(groupLength)
-    }
-    guard remainder.isEmpty, values.count == 3 else { return nil }
-
-    var components = DateComponents()
-    components.year = values[0]
-    components.month = values[1]
-    components.day = values[2]
-    guard (2000...2099).contains(values[0]),
-      components.isValidDate(in: Calendar(identifier: .gregorian))
-    else { return nil }
-
-    return String(id.dropLast(suffixLength))
-  }
 }
 
 /// #1914: how the MODEL SELECTION DROPDOWN is split into sections.

--- a/Tests/EnviousWisprTests/LLM/LLMModelDiscoveryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMModelDiscoveryTests.swift
@@ -92,8 +92,10 @@ struct LLMModelDiscoveryTests {
   /// exact case ("left the picker listing... 'Gpt Oss' twice, which is what
   /// the founder screenshotted") — this test pins the fix at the layer #1947
   /// actually complained about AND through to `LLMModelInfo`, the row the
-  /// picker actually renders (`Text(model.displayName)`,
-  /// `AIPolishSettingsView.swift:977`) — a `DiscoveryCandidate`-only
+  /// picker actually renders (`Text(model.displayName)` in
+  /// `AIPolishSettingsView.swift`; cited by SYMBOL because the line number this
+  /// used to carry was already pointing at unrelated code, #2602) — a
+  /// `DiscoveryCandidate`-only
   /// assertion stops one hop short of what the picker consumes. Uses the
   /// daemon's real `remote_host` shape (`"https://ollama.com"`, not a bare
   /// hostname) per whole-diff review r1.

--- a/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
+++ b/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
@@ -49,26 +49,26 @@ struct AIPolishClassifierTests {
   /// a DIFFERENT model's verdict.
   @Test("Only a real trailing date is treated as a snapshot")
   func snapshotStripperIsExact() {
-    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-5-mini-2025-08-07") == "gpt-5-mini")
-    #expect(AIPolishModelClassifier.withoutSnapshot("claude-haiku-4-5-20251001") == "claude-haiku-4-5")
+    #expect(ProviderModelID.withoutDateSnapshot("gpt-5-mini-2025-08-07") == "gpt-5-mini")
+    #expect(ProviderModelID.withoutDateSnapshot("claude-haiku-4-5-20251001") == "claude-haiku-4-5")
     // A version that merely ends in digits must survive untouched.
-    #expect(AIPolishModelClassifier.withoutSnapshot("claude-fable-5-1") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("gemini-2.5-flash") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-4.1-mini") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("claude-fable-5-1") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("gemini-2.5-flash") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("gpt-4.1-mini") == nil)
     // Digits that are not a date.
-    #expect(AIPolishModelClassifier.withoutSnapshot("model-99999999") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("model-20251301") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("model-20250231") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("model-20250229") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("model-19991001") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("model-99999999") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("model-20251301") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("model-20250231") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("model-20250229") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("model-19991001") == nil)
     // Mixed separators are nobody's format.
-    #expect(AIPolishModelClassifier.withoutSnapshot("model-2025-1001") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("model-202510-01") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("model-2025-1001") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("model-202510-01") == nil)
     // OpenAI's older four-digit MMDD snapshot is deliberately left alone.
-    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-3.5-turbo-0125") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("gpt-3.5-turbo-0125") == nil)
     // A date anywhere but the end is not a suffix, and a bare date is not an id.
-    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-20240806-preview") == nil)
-    #expect(AIPolishModelClassifier.withoutSnapshot("-2026-07-09") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("gpt-20240806-preview") == nil)
+    #expect(ProviderModelID.withoutDateSnapshot("-2026-07-09") == nil)
   }
 
   /// Stripping must never rescue a disqualified id: the veto reads the FULL id.

--- a/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
+++ b/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
@@ -30,6 +30,54 @@ struct AIPolishClassifierTests {
     #expect(AIPolishModelClassifier.isRecommendedForCleanup("GPT-5.6-Luna"))
   }
 
+  /// Product Outcome (cloud review on #2603). A dated snapshot of a named id IS
+  /// that id. A tier WORD survives its own snapshot for free, because `mini` is
+  /// still a token of `gpt-5-mini-2025-08-07`; an exact-name lookup does not, so
+  /// without this a dated Luna would sit under "Other" while its own alias sat
+  /// under "Recommended".
+  @Test("A dated snapshot of a named id is still recommended")
+  func datedSnapshotOfNamedIDIsRecommended() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-luna-2026-07-09"))
+    // Anthropic's compact spelling of the same thing.
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-luna-20260709"))
+    // A leap day is a real date.
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-luna-2024-02-29"))
+  }
+
+  /// The stripper is swept in every meaning-changing class, because one that
+  /// trims too much is worse than one that trims nothing: it makes an id inherit
+  /// a DIFFERENT model's verdict.
+  @Test("Only a real trailing date is treated as a snapshot")
+  func snapshotStripperIsExact() {
+    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-5-mini-2025-08-07") == "gpt-5-mini")
+    #expect(AIPolishModelClassifier.withoutSnapshot("claude-haiku-4-5-20251001") == "claude-haiku-4-5")
+    // A version that merely ends in digits must survive untouched.
+    #expect(AIPolishModelClassifier.withoutSnapshot("claude-fable-5-1") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("gemini-2.5-flash") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-4.1-mini") == nil)
+    // Digits that are not a date.
+    #expect(AIPolishModelClassifier.withoutSnapshot("model-99999999") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("model-20251301") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("model-20250231") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("model-20250229") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("model-19991001") == nil)
+    // Mixed separators are nobody's format.
+    #expect(AIPolishModelClassifier.withoutSnapshot("model-2025-1001") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("model-202510-01") == nil)
+    // OpenAI's older four-digit MMDD snapshot is deliberately left alone.
+    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-3.5-turbo-0125") == nil)
+    // A date anywhere but the end is not a suffix, and a bare date is not an id.
+    #expect(AIPolishModelClassifier.withoutSnapshot("gpt-20240806-preview") == nil)
+    #expect(AIPolishModelClassifier.withoutSnapshot("-2026-07-09") == nil)
+  }
+
+  /// Stripping must never rescue a disqualified id: the veto reads the FULL id.
+  @Test("A dated snapshot does not launder a disqualifier")
+  func datedSnapshotDoesNotLaunderDisqualifier() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-luna-transcribe-2026-01-01"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-4o-mini-transcribe-2025-12-15"))
+  }
+
   /// The other two 5.6 codenames are the middle and large tiers. Both are
   /// available and both must stay under the other heading, or "recommended for
   /// cleanup" stops meaning cheap and fast.

--- a/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
+++ b/Tests/EnviousWisprTests/Settings/AIPolishClassifierTests.swift
@@ -9,10 +9,72 @@ import Testing
 /// (`docs/audits/2026-05-04-issue-617-classifier-validation.txt`) plus the
 /// adversarial set required for matcher-broadening tests (exercise each
 /// entry in its non-intended semantic class, not just the happy path).
+///
+/// #2602 re-validated the whole set against live OpenAI, Gemini and Anthropic
+/// keys (`docs/audits/2026-09-02-issue-2602-classifier-revalidation.txt`). The
+/// generation cases below are the ones that sweep found: OpenAI's tier words
+/// stop at 5.4, and 5.6 uses codenames.
 @Suite("AIPolishModelClassifier — recommended-for-cleanup classifier")
 struct AIPolishClassifierTests {
 
   // MARK: - Positives (must return true)
+
+  /// Product Outcome (#2602). Luna is OpenAI's cheapest and fastest model, it is
+  /// available (measured 2026-09-02), and the dropdown heading is the only steer
+  /// we give. When this fails the model we most want people on is the one they
+  /// have to go looking for.
+  @Test("A named cheap-tier codename is recommended even with no tier word")
+  func namedCodenameIsRecommended() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-luna"))
+    // Case is normalized like every other id.
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("GPT-5.6-Luna"))
+  }
+
+  /// The other two 5.6 codenames are the middle and large tiers. Both are
+  /// available and both must stay under the other heading, or "recommended for
+  /// cleanup" stops meaning cheap and fast.
+  @Test("The larger codenames of the same generation are not recommended")
+  func siblingCodenamesAreNotRecommended() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-terra"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-sol"))
+  }
+
+  /// The naming ran out at 5.4, which is what made a token insufficient. These
+  /// still classify on the words, and must keep doing so.
+  @Test("Tier words still classify the generations that use them")
+  func tierWordsStillClassify() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.4-mini"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.4-nano"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.5"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.4-pro"))
+  }
+
+  /// Google's second small-tier word. Every `-lite` id Gemini returns today also
+  /// carries `flash`, so this closes no live gap; it is here so a lite that
+  /// arrives without `flash` is not misfiled.
+  @Test("Gemini Lite variants are recommended")
+  func geminiLiteIsRecommended() {
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gemini-3.5-flash-lite"))
+    #expect(AIPolishModelClassifier.isRecommendedForCleanup("gemini-5-lite"))
+  }
+
+  /// A disqualifier vetoes a NAMED id too. Nothing in the named set trips one,
+  /// so this can only fire on our own mistake — and failing closed on that is
+  /// cheaper than shipping a named id that says `transcribe`.
+  @Test("A disqualifier still vetoes a named id")
+  func disqualifierVetoesNamedID() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gpt-5.6-luna-transcribe"))
+  }
+
+  /// `omni` carries `flash` and would read as a good cleanup model. Both omni
+  /// ids answer the discovery probe with 400 today, so they are locked upstream
+  /// and never reach this function — hygiene, not a live fix, and it keeps this
+  /// rule identical to the Android port of it.
+  @Test("Omni variants are disqualified despite carrying flash")
+  func omniDisqualifier() {
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gemini-omni-1.1-flash"))
+    #expect(!AIPolishModelClassifier.isRecommendedForCleanup("gemini-omni-flash-preview"))
+  }
 
   @Test("OpenAI Mini variants are recommended")
   func openAIMiniIsRecommended() {


### PR DESCRIPTION
Closes #2602.

## What a user gets

`gpt-5.6-luna` — the cheapest and fastest model OpenAI sells — appears under **"Recommended for cleanup"**
in the AI Polish model dropdown instead of under "Other".

## The defect

`AIPolishModelClassifier` recommends a model when its id carries `mini`, `nano`, `flash` or `haiku`. Its
own comment records the live validation date: **2026-05-04**.

**In the four months since, OpenAI stopped naming its tiers.** Those words ran through the 4.x and 5.0–5.5
generations. At 5.6 the tiers became codenames — `luna` cheap, `terra` middle, `sol` large. No token
classifies those, and adding `luna` to `positives` would read as a rule while behaving as a one-model
exception that expires at the next rename.

## Reachability was measured first

`groups(from:)` sends anything not `isAvailable` to `locked` before the classifier runs, so a model the
probe refuses can never be misclassified. Measured against the founder's live keys on 2026-09-02,
replicating the probe shapes in `LLMModelDiscovery`:

| Model | Probe | Result | Reaches the classifier? |
|---|---|---|---|
| `gpt-5.6-luna` | `chat/completions`, `max_completion_tokens: 5` | 200 | **yes — and lands under "Other"** |
| `gpt-5.6-terra` | same | 200 | yes, correctly stays under "Other" |
| `gpt-5.6-sol` | same | 200 | yes, correctly stays under "Other" |
| `gemini-omni-1.1-flash` | `generateContent`, `maxOutputTokens: 5` | 400 | no — locked upstream |
| `gemini-omni-flash-preview` | same | 400 | no — locked upstream |

## The change

- **`namedFastTierIDs`**, one entry today. The same move `groups(from:)` already made for Ollama in #1950,
  for the reason stated there, and the instrument `LLMModelCapabilities` already justifies: OpenAI's
  models endpoint returns ids only, so a live tier lookup cannot exist. A new generation needs a row, not
  a new token. A disqualifier still vetoes a named id, so a mistake in the set fails closed.
- **`lite`** added to the positives. Google's own second small-tier word; closes no live gap today because
  every `-lite` id Gemini returns also carries `flash`.
- **`omni`** added to the disqualifiers as **hygiene, and the comment says so** — both omni ids are locked
  upstream and cannot reach this function today. Measured rather than assumed: the Android port of this
  rule added `omni` as a live fix, and copying that reasoning across without checking would have been wrong.
- A stale citation corrected: `LLMModelDiscoveryTests` pointed at `AIPolishSettingsView.swift:977` for the
  picker's label site. That line number was already on unrelated code before this change, and this change
  moves it further, so it now names the symbol.

## Validation

- Full Debug lane: **7333 tests, verdict PASS**, per-bundle sum reconciled against the lane total.
- Two-way controls: emptying the named set, or dropping `lite` or `omni`, turns its own test red.
- Fresh validation record at `docs/audits/2026-09-02-issue-2602-classifier-revalidation.txt` (local, as
  the 2026-05-04 one it supersedes also is); the measurement table above is the durable copy.

## Routed, not fixed here

The discovery probe treats **HTTP 200 as available**, and `gemini-3.5-transcribe` answers 200 with an
empty string. The `transcribe` disqualifier keeps it out of the Recommended heading but not out of the
list, so a user can select it and silently receive their raw dictation back. Different mechanism; recorded
on #2602.

## Added during review

- **A dated snapshot of a named id is that id.** A tier WORD survives its own snapshot for free (`mini` is
  still a token of `gpt-5-mini-2025-08-07`); an exact-name lookup does not, so a dated Luna would have sat
  under "Other" while its alias sat under "Recommended". The disqualifier veto still reads the FULL id, so
  a date cannot launder one.
- **One owner for that rule.** `ProviderModelID.withoutDateSnapshot`. I first wrote a second copy of a rule
  `SettingsChangeTelemetry` has had since #158 — my sweep was scoped to `Sources/EnviousWisprLLM/` and this
  view, so it returned a clean, complete-looking, empty answer. **A claim to that effect in commit
  `1b10945d`'s message is wrong and is corrected here**, not left standing.
  - One deliberate behaviour change: the shared rule requires a real calendar date, which the telemetry
    copy did not. `gpt-4-20259999` now reports `custom` rather than `gpt-4`. The suffix was already
    documented there as public and non-sensitive, so the privacy boundary does not move.
- **`cloudModelAllowlist` knows this generation.** It is deny-by-default, so an unlisted model reports
  `custom` and nothing leaks — but Luna is the model this PR promotes, so it would have become the
  most-selected invisible model. Enumerated from the live lists of all three keys on 2026-09-02 rather
  than from the existing entries: the gap #1770 records for Gemini 3.x had reopened for every generation
  since. Added OpenAI 5.1–5.6 including all three codenames, `gemini-3.8-flash`, `claude-fable-5-1`,
  `claude-opus-5`.

Full Debug lane after all of it: **7336 tests, verdict PASS**, per-bundle sum reconciled.
