### PR TITLE
fix(dictionary): the Quick Add tab drops its unbuilt demo, and the shortcut it teaches can actually fire (#2497)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/QuickAddTeachingSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/QuickAddTeachingSection.swift
@@ -9,13 +9,25 @@ import SwiftUI
 /// Read-only: it links to Keybinds for the shortcut and explains the menu bar
 /// route; it never touches `QuickAddWiring` or its coordinator.
 ///
-/// **Known gap, tracked on issue #2497: the demo below is a placeholder.**
-/// The real screen recording (highlight a word in a real app → trigger Quick
-/// Add → it lands in the dictionary) still needs to be captured and dropped
-/// in as a bundled resource before this ships to release users — a static
-/// mockup of a video is not the same claim as a real one, and #2497
-/// explicitly says a placeholder can't ship. The three written steps and the
-/// keyboard/menu-bar callouts below are the real, final copy — verified
+/// **No demo frame here, and that is the shipped decision (#2497, founder
+/// 2026-09-02).** The tab originally carried a 16:10 gradient panel captioned
+/// "PREVIEW COMING SOON", holding space for a screen recording that was never
+/// captured; it shipped that way and Codex reopened #2497 against it. Rather
+/// than record the video, the founder cut the panel: the three steps and the
+/// two callouts already carry the whole explanation, and a permanent IOU
+/// drawn in the release build is a worse claim than no picture at all. Do not
+/// reintroduce a placeholder frame — a real recording, or nothing.
+///
+/// **No standalone intro line either, and that is the same decision.** One was
+/// drafted to stand where the frame had been, on the worry that the tab would
+/// otherwise open cold on "1. Highlight a word"; the founder rejected the
+/// premise, because the Dictionary page always opens on Your Words
+/// (`YourWordsView.selectedTab` defaults to `.yourWords`) and this tab is only
+/// ever reached by clicking a rail row that already reads "Quick Add / Add from
+/// any app". Nobody arrives here without having asked for it.
+///
+/// The three written steps and the keyboard/menu-bar callouts are the real,
+/// final copy — verified
 /// against `ShortcutBinding.swift` (default chord) and `MenuBarController.swift`
 /// (the menu item's real title and behavior) rather than composed from memory
 /// (cloud review, PR caught two invented product claims: a default-off
@@ -30,10 +42,7 @@ import SwiftUI
 /// live binding can still lose arbitration to Record or Cancel
 /// (`ShortcutMatcher.quickAddOwnsItsBinding`) — this tab must not advertise a
 /// chord that will not actually fire, so it falls back to pointing at the
-/// menu bar when that happens. The placeholder demo is deliberately NOT
-/// drawn as a play button (the whole area does nothing on click) — a third
-/// round caught that a filled play glyph implies tap-to-watch on something
-/// static.
+/// menu bar when that happens.
 struct QuickAddTeachingSection: View {
   @Environment(\.settingsNavigate) private var navigate
   @Environment(SettingsManager.self) private var settings
@@ -50,17 +59,10 @@ struct QuickAddTeachingSection: View {
       cancelKeyCode: settings.cancelKeyCode, cancelModifiers: settings.cancelModifiers)
   }
 
-  /// "press ⌃⌥W" when the chord is usable, or a shortcut-agnostic fallback
-  /// when it currently is not (conflicts with Record/Cancel, or Quick Add is
-  /// unbound) — never a sentence naming a chord that won't fire.
-  private var triggerPhrase: String {
-    if let shortcutDisplay { return "press \(shortcutDisplay)" }
-    return "use the menu bar"
-  }
-
-  /// Step 2's full sentence, built separately from `triggerPhrase` rather
-  /// than capitalizing a fragment of it — the "or the menu bar" half of the
-  /// sentence only makes sense as an ALTERNATIVE when a shortcut exists.
+  /// Step 2's full sentence, and now the ONLY place the chord is rendered. It
+  /// names the chord only when that chord will actually fire, and otherwise says
+  /// nothing about a shortcut at all — the "or the menu bar" half only makes
+  /// sense as an ALTERNATIVE when one exists.
   private var triggerStepBody: String {
     if let shortcutDisplay {
       return "Press \(shortcutDisplay), or open the EnviousWispr menu and choose the Add item."
@@ -72,55 +74,11 @@ struct QuickAddTeachingSection: View {
     BrandedSection {
       BrandedRow(showDivider: false) {
         VStack(alignment: .leading, spacing: 16) {
-          demoPlaceholder
           steps
           calloutRow
         }
       }
     }
-  }
-
-  private var demoPlaceholder: some View {
-    ZStack {
-      RoundedRectangle(cornerRadius: 12, style: .continuous)
-        .fill(
-          LinearGradient(
-            colors: [Color.stAccentLight, Color.stSectionBg],
-            startPoint: .topLeading, endPoint: .bottomTrailing)
-        )
-        .aspectRatio(16 / 10, contentMode: .fit)
-
-      VStack(spacing: 10) {
-        // NOT a play button (cloud review, PR #2503) — this whole area is
-        // static and unresponsive to a click, and a filled play glyph reads
-        // as "tap to watch" to anyone who sees it. A film-strip glyph shows
-        // "this is video content" without implying it does anything yet.
-        Image(systemName: "film")
-          .font(.system(size: 30, weight: .regular))
-          .foregroundStyle(.stAccent)
-        Text(
-          "Highlight \u{201C}Kubernetes\u{201D} in Slack \u{2192} \(triggerPhrase) \u{2192} it\u{2019}s added."
-        )
-        .font(.stHelper)
-        .foregroundStyle(.stTextSecondary)
-        .multilineTextAlignment(.center)
-        .padding(.horizontal, 24)
-      }
-
-      Text("PREVIEW COMING SOON")
-        .font(.system(size: 11, weight: .bold))
-        .foregroundStyle(.stTextSecondary)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 3)
-        .background(Color.stPageBg.opacity(0.7), in: Capsule())
-        .padding(10)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-    // The three written steps below say the same thing without forcing
-    // VoiceOver to hear it twice; the eventual real video will need its own
-    // accessible description once it replaces this placeholder.
-    .accessibilityHidden(true)
   }
 
   private var steps: some View {

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -48,6 +48,26 @@ enum WhatsNewContent {
       version: "2.4.7"
     ),
 
+    // #2497 follow-up. Repair copy is allowed here and was NOT allowed in the
+    // 2.4.6 entry above, and the protocol draws that line by whether anyone RAN
+    // the version being repaired: Quick Add reached users in 2.4.6, so its keys
+    // moving under them is a change they will feel the moment they reach for the
+    // old ones.
+    //
+    // "could start a recording" rather than "started": the collision is real but
+    // it is not universal. Record ships as bare RIGHT Option, so only a hand that
+    // took the right-hand Option key hit it, and anyone who had rebound Record
+    // never hit it at all. An unearned absolute here would be the same defect
+    // RULE: verify-every-claim-in-an-entry exists to catch.
+    Entry(
+      id: "quick-add-shortcut-moved",
+      icon: "keyboard",
+      title: "Quick Add has a new keyboard shortcut",
+      description:
+        "Quick Add has moved to Control Shift W. Its old keys shared the Option key with the record key, so it could start a recording instead of opening the panel. If you chose your own Quick Add keys, yours are untouched. You can change it in Keybinds settings.",
+      version: "2.4.7"
+    ),
+
     // MARK: - v2.4.6
 
     // Every title and every collapsed line in this group was written or edited by
@@ -66,9 +86,20 @@ enum WhatsNewContent {
     // It names no app as the culprit: naming one dates the entry the moment that
     // app starts publishing a selection.
     //
-    // Control Option W is `ShortcutRole.quickAdd.defaultBinding`
-    // (ShortcutBinding.swift), keyCode 13 with .control and .option. No dashes,
-    // per GR-NO-DASHES.
+    // **THIS ENTRY NAMES NO CHORD, AND THAT IS WHY.** It used to say "press Control
+    // Option W", which is what 2.4.6 really shipped. When that default moved to
+    // Control Shift W (#2497 follow-up, 2026-09-02) the obvious repair looked like
+    // updating this sentence to the new chord — and that is the one thing a version
+    // group may never do. A patch note is a permanent record OF ITS OWN RELEASE and
+    // feeds the published GitHub release body from this same literal
+    // (FACT: whats-new-feeds-github-release-notes), so editing it would have made
+    // 2.4.6 claim it shipped a binding that did not exist until 2.4.7. Cloud review
+    // caught the rewrite.
+    //
+    // A version-neutral phrase is the exit from that bind: it was true for 2.4.6,
+    // it is true now, and it stays true through the next rebind, because the one
+    // thing a reader must not be sent to is a stale chord. The MOVE is announced in
+    // the 2.4.7 group above, which is the group entitled to describe it.
     //
     // **"puts your clipboard back" IS NOT QUALIFIED WITH "exactly as it was", AND
     // THAT IS DELIBERATE.** The restore is conditional, not guaranteed: when the
@@ -93,7 +124,7 @@ enum WhatsNewContent {
       icon: "text.badge.plus",
       title: "Add a custom word to your dictionary with a click of a button",
       description:
-        "Highlight a misheard word anywhere on macOS, press Control Option W, and save the right spelling without opening settings. A small panel ranks that spelling against the words you have already saved, so one Return usually finishes the job. It is also in the menu bar menu, which reads whatever you have highlighted at the moment you open it. Some apps will not tell us what you have selected, such as messaging apps built for iPad and some terminals. There, Quick Add copies your selection, reads it, and puts your clipboard back. Your clipboard history will show both, which we do not try to hide. There is a fraction of a second where a copy you make yourself can be read as the app answering. If that happens the panel shows the wrong word, and that copy of yours is lost when your clipboard is put back. A switch in Clipboard settings turns all of this off, and it turns itself off in common remote desktop and virtual machine apps. The keybind is yours to change in Keybinds settings.",
+        "Highlight a misheard word anywhere on macOS, press your Quick Add keybind, and save the right spelling without opening settings. A small panel ranks that spelling against the words you have already saved, so one Return usually finishes the job. It is also in the menu bar menu, which reads whatever you have highlighted at the moment you open it. Some apps will not tell us what you have selected, such as messaging apps built for iPad and some terminals. There, Quick Add copies your selection, reads it, and puts your clipboard back. Your clipboard history will show both, which we do not try to hide. There is a fraction of a second where a copy you make yourself can be read as the app answering. If that happens the panel shows the wrong word, and that copy of yours is lost when your clipboard is put back. A switch in Clipboard settings turns all of this off, and it turns itself off in common remote desktop and virtual machine apps. The keybind is yours to change in Keybinds settings.",
       version: "2.4.6"
     ),
 

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -53,10 +53,29 @@ extension ShortcutRole {
     case .record: .keyboard(keyCode: ModifierKeyCodes.rightOption, modifiers: [])
     // Escape, bare.
     case .cancel: .keyboard(keyCode: 53, modifiers: [])
-    // Control-Option-W (#2381). A CHORD deliberately: it takes the Carbon path, and the persona
-    // review's hard requirement is that a user who has never heard of this feature never triggers
-    // it by accident. Still reachable with one hand.
-    case .quickAdd: .keyboard(keyCode: 13, modifiers: [.control, .option])
+    // Control-Shift-W. A CHORD deliberately: it takes the Carbon path, and the persona review's
+    // hard requirement is that a user who has never heard of this feature never triggers it by
+    // accident. Still reachable with one hand.
+    //
+    // **SHIFT, not the Option this shipped with in #2381, because Option is RECORD'S OWN KEY.**
+    // Record above is bare Right Option, so the two shipped defaults collided out of the box: the
+    // Option half of Control-Option-W is dispatched by the modifier monitor before the W ever
+    // reaches Carbon (`HotkeyService.handleFlagsChangedValues`), so on the right-hand Option key a
+    // user following our own hint started a push-to-talk recording instead of opening the panel.
+    // `quickAddOwnsItsBinding` saw the collision and correctly refused to advertise the chord, so
+    // every fresh install read "Currently unavailable" on the Quick Add tab (founder report,
+    // 2026-09-02).
+    //
+    // **And not plain Control-W, which is free in Cocoa text fields and taken everywhere else.**
+    // Two measurements, taken 2026-09-02 on the dev machine, and one thing that is merely widely
+    // documented, kept apart on purpose:
+    //   - MEASURED: zsh binds Control-W to `backward-kill-word` (`bindkey | grep '\^W'`).
+    //   - MEASURED: AppKit's own StandardKeyBinding.dict carries no `^W` entry at all, which is why
+    //     the chord looks free from inside a Cocoa text field.
+    //   - NOT VERIFIED HERE, documented elsewhere: readline, vim and emacs each bind it too.
+    // A global hotkey outranks the focused app, so binding Control-W would take word-delete away
+    // from every terminal on the Mac. Adding Shift clears both measured cases.
+    case .quickAdd: .keyboard(keyCode: 13, modifiers: [.control, .shift])
     }
   }
 

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -397,7 +397,24 @@ struct MenuBarControllerTests {
   @Test("A chord Record or Cancel owns is not advertised as Quick Add's")
   func acontestedChordIsNotAdvertised() {
     // The shipped default is uncontested and still shows, so the guard cannot be a blanket nil.
-    #expect(Self.label(13, [.control, .option]) != nil, "the default is nobody else's")
+    //
+    // **ASKED AGAINST THE OTHER TWO SHIPPED DEFAULTS, not against this file's `label` fallbacks,
+    // and that is the whole point of the row.** `label` defaults `record` to key code 49 — Space,
+    // which is not a modifier key at all, so `isBareModifier` is false and the bare-modifier
+    // interception branch above cannot fire. Read at that constant this row asserted "the shipped
+    // chord is nobody else's" against a Record key no install has ever had, and it passed for the
+    // whole time the real pair was broken: Record ships as bare Right Option, Quick Add shipped as
+    // Control-Option-W, and the Option half is Record's (founder report, 2026-09-02, fixed by
+    // moving the default to Control-Shift-W).
+    //
+    // Every value is read from `ShortcutRole` rather than written out, so the row asks about
+    // whatever we currently ship instead of about three numbers that were true when it was typed.
+    #expect(
+      Self.label(
+        ShortcutRole.quickAdd.defaultKeyCode, ShortcutRole.quickAdd.defaultModifiers,
+        record: (ShortcutRole.record.defaultKeyCode, ShortcutRole.record.defaultModifiers),
+        cancel: (ShortcutRole.cancel.defaultKeyCode, ShortcutRole.cancel.defaultModifiers)) != nil,
+      "the three shipped defaults must not contend with each other")
 
     #expect(Self.label(49, [], record: (49, [])) == nil, "Record owns this chord")
     #expect(Self.label(53, [], cancel: (53, [])) == nil, "Cancel owns this chord")

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -387,7 +387,7 @@ struct HotkeyQuickAddShortcutTests {
   func differentChordsDoNotContend() {
     // The paired accepted case. A rule that refused whenever cancel was armed would pass the test
     // above and break Quick Add for every user who never rebound anything.
-    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .option])
+    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift])
     let cancel = ShortcutBinding.keyboard(keyCode: 53, modifiers: [])
 
     #expect(
@@ -398,7 +398,7 @@ struct HotkeyQuickAddShortcutTests {
 
   @Test("A stopped or suspended service holds no Quick Add chord, collision or not")
   func stoppedOrSuspendedHoldsNothing() {
-    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .option])
+    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift])
     let cancel = ShortcutBinding.keyboard(keyCode: 53, modifiers: [])
 
     #expect(

--- a/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
+++ b/Tests/EnviousWisprTests/Services/SettingsDefaultsRoutingTests.swift
@@ -129,7 +129,7 @@ struct SettingsDefaultsRoutingTests {
 
   // MARK: - Quick Add's shortcut (#2381)
 
-  @Test("Quick Add ships on Control-Option-W and belongs to unified defaults")
+  @Test("Quick Add ships on Control-Shift-W and belongs to unified defaults")
   func quickAddShortcutDefaults() {
     let suite = Self.freshSuite()
     let settings = SettingsManager(defaults: suite)
@@ -137,7 +137,7 @@ struct SettingsDefaultsRoutingTests {
     // W (13), not a modifier: the default is deliberately a CHORD, so it takes the Carbon path and
     // nobody who has never heard of the feature reaches it by accident.
     #expect(settings.quickAddKeyCode == 13)
-    #expect(settings.quickAddModifiers == [.control, .option])
+    #expect(settings.quickAddModifiers == [.control, .shift])
     #expect(
       SettingsManager.unifiedDefaultsKeys.filter { $0 == "quickAddKeyCode" }.count == 1,
       "missing from unified keys means it never migrates to the shared suite (#923)")

--- a/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Views/KeybindRowDefaultsTests.swift
@@ -34,7 +34,7 @@ struct KeybindRowDefaultsTests {
     #expect(ShortcutRole.cancel.defaultBinding == .keyboard(keyCode: 53, modifiers: []))
     #expect(
       ShortcutRole.quickAdd.defaultBinding
-        == .keyboard(keyCode: 13, modifiers: [.control, .option]))
+        == .keyboard(keyCode: 13, modifiers: [.control, .shift]))
   }
 
   @Test("Quick Add ships as a CHORD, which is what keeps it out of an unsuspecting user's way")


### PR DESCRIPTION
Closes #2497.

The Dictionary Quick Add tab shipped with a picture of a video that was never made, and taught a keyboard shortcut that could not fire. Both are gone.

## The demo frame

#2497 asked for a screen recording and shipped a 16:10 gradient panel captioned "PREVIEW COMING SOON" in its place. Codex reopened the issue against exactly that, and the file's own docstring already said a placeholder could not ship.

Rather than record the video, the founder cut the panel (2026-09-02): the three numbered steps and the two callouts carry the whole explanation, so the frame was holding space for something nobody needed. A standalone intro line was drafted to stand where the frame had been and was rejected on the same grounds, because the Dictionary page always opens on Your Words and this tab is only reached by clicking a rail row that already reads "Quick Add / Add from any app".

`triggerPhrase` went with the frame. It had exactly one reader: the caption.

## The shortcut could not fire on a fresh install

Record ships as bare Right Option. Quick Add shipped as Control-Option-W. Pressing the Option half reaches `HotkeyService.handleFlagsChangedValues` before the W ever reaches Carbon, so on the right-hand Option key a user following our own hint started a push-to-talk recording instead of opening the panel.

`ShortcutMatcher.quickAddOwnsItsBinding` saw that collision and correctly refused to name the chord, which is why the tab read "Currently unavailable — set one under Keybinds" on every install nobody had rebound.

The default moves to **Control-Shift-W**. Not plain Control-W: measured on the dev machine, zsh binds it to `backward-kill-word`, and a global hotkey outranks the focused app, so that would take word-delete away from every terminal on the Mac. AppKit's StandardKeyBinding.dict carries no `^W` entry, which is why the chord looks free from inside a Cocoa text field and is not.

## Release notes

2.4.6's Quick Add entry named Control Option W, so a reader following it today reaches for Record's key. The first repair rewrote that clause to the new chord, which local `codex review` refused and was right to: a version group is a permanent record of its own release and feeds the published GitHub release body from the same literal, so the edit made 2.4.6 claim a binding that did not exist until 2.4.7.

The 2.4.6 clause is now version-neutral ("press your Quick Add keybind"). The move is announced in the 2.4.7 group, which is the group entitled to describe it. Both were read back through `scripts/ci/render-release-notes.py`, not off the Swift source.

## Why no test caught this

`MenuBarControllerTests.acontestedChordIsNotAdvertised` asserted "the default is nobody else's" through a helper whose `record` fallback is key code 49, which is Space. Space is not a modifier key, so the bare-modifier interception branch could never fire. The row asked about a Record key no install has ever had, and passed for the whole time the real pair was broken.

It now reads all three values from `ShortcutRole`, so it asks about whatever we currently ship and fails if any two shipped defaults ever contend again.

## Known limit, accepted

A user who explicitly stored the old Control-Option-W pair, by pressing Reset on the Quick Add row in 2.4.6, keeps it. No migration ships: the condition for a safe one depends on that user's own Record binding, and getting it wrong overwrites a working shortcut somebody chose, which is a worse failure landing on more people. Those users are not stranded. Their tab says the shortcut is unavailable, and because the default moved, the Reset button now appears on their row and offers the new keys. The 2.4.7 note states it: "If you chose your own Quick Add keys, yours are untouched." Founder decision, 2026-09-02. Tracked as a follow-up.

## Validation

- `scripts/xcode-test.sh` — 7336 tests, Debug lane PASS (three runs, after each edit round).
- `.claude/scripts/check-cited-symbols.py` — 7 symbols resolve, PASSED.
- `scripts/ci/render-release-notes.py --version 2.4.6` and `--version 2.4.7` — both read back as the reader sees them.
- Live UAT on the rebuilt dev app: the tab renders three steps and two callouts with no frame; the shortcut callout reads "⌃⇧ W. Change it under Keybinds."; Dictionary opens on Your Words. Pressing Control-Shift-W logged `Carbon hotkey event: id=4` then `[QuickAdd] opened door=hotkey`.
- Local `codex review` to clean across two rounds.
- `.claude/knowledge/settings-defaults.md` carries the new Quick Add row, per its own RULE: defaults-have-one-source-of-truth. That file is gitignored, so it lands in the main checkout rather than in this PR.
