### PR TITLE
revert: drop the duplicate EG-1 built-in that re-added a removed alias

### DIFF
--- a/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
+++ b/Sources/EnviousWisprPostProcessing/CustomWordsManager.swift
@@ -210,13 +210,6 @@ public final class CustomWordsManager {
         category: .brand
       )),
     BuiltinWord(
-      id: "eg1",
-      word: CustomWord(
-        canonical: "EG-1",
-        aliases: ["E G One", "EG 1", "E G 1"],
-        category: .brand
-      )),
-    BuiltinWord(
       id: "macos",
       word: CustomWord(
         canonical: "macOS",

--- a/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/CustomWordsTransferDocumentTests.swift
@@ -235,16 +235,3 @@ struct CustomWordsTransferDocumentTests {
     #expect(user.ownedByUser() == user)
   }
 }
-
-@MainActor
-@Suite("Built-in custom words", .tags(.productOutcome))
-struct BuiltinCustomWordsTests {
-  @Test(
-    "EG-1 corrects the real split ASR spellings",
-    arguments: ["E G One", "e G One", "EG 1", "E G 1"])
-  func egOneBuiltinCorrectsRealSplitSpellings(_ alias: String) throws {
-    let word = try #require(CustomWordsManager.builtinDefaults.first { $0.id == "eg1" }).word
-    let result = WordCorrector().correct("Use the \(alias) prompt", against: [word])
-    #expect(result.corrected == "Use the EG-1 prompt")
-  }
-}

--- a/scripts/eval/acceptance_gate.py
+++ b/scripts/eval/acceptance_gate.py
@@ -172,7 +172,6 @@ DEFAULT_CUSTOM_VOCAB = [
         ],
     ),
     ("Envious Labs", ["envious laps"]),
-    ("EG-1", ["E G One", "EG 1", "E G 1"]),
     ("macOS", ["mac OS", "Mack OS"]),
     ("iOS", ["I OS", "eye OS"]),
     ("GitHub", ["git hub", "get hub"]),


### PR DESCRIPTION
**Main is red. This restores it.** Reverts 0c4e48f0 (PR #2564).

## What broke

`CustomWordsManager.builtinDefaults` already carried an `id: "eg1"` entry with
`aliases: ["EG 1", "E G 1", "EG-one", "EG1"]`. PR #2564 appended a **second**
entry with the same id and `aliases: ["E G One", "EG 1", "E G 1"]`.

The existing entry's own comment records why the spelled-out forms are absent,
and names the exact sentence that breaks:

> **The spelled-out "one" forms were proposed and REMOVED, measured rather than
> reasoned about.** The fuzzy multi-word pass matches a two-token alias against
> any two-token phrase close enough to it, and English is full of near
> neighbours: "egg one" ate "she cracked an egg on the pan", and "E G one" ate
> "the item is e g on the list". [...] `BuiltinDictionaryCorrectionTests` keeps
> every one of those sentences, so re-adding a spelled-out form fails a test
> rather than shipping.

The guard did exactly what it says. Two failures on main at 28d63ce5:

| Test | Observed |
|---|---|
| `BuiltinDictionaryCorrectionTests` — "ordinary sentences are left alone" | `"the item is e g on the list"` became `"the item is EG-1 the list"` |
| `CustomWordsTransferDocumentTests` — "EG-1 corrects the real split ASR spellings" | all four aliases uncorrected |

One row of nine false-positive sentences failed, and it is the contrived one.
The eight natural neighbours passed: "she cracked an egg on the pan", "do not
beg one of them for it", "he broke a leg on the stairs", "his ego got in the
way", "she hurt her leg badly", "the egg was already cracked", "the meeting is
at one".

The second failure is the more interesting one. #2564's test resolves its
subject with `builtinDefaults.first { $0.id == "eg1" }`, which returns the
FIRST entry — the pre-existing one, with no "E G One" — so it asserted against
a different word than the one it added. A duplicate id makes that lookup
ambiguous by construction, and the test passed pre-merge only because on its
own base there was nothing to collide with.

## Why CI did not catch it

Three things lined up, and none of them is a gap in any single gate:

1. #2564 branched from a base **18 commits behind main**, before the original
   EG-1 entry existed. Two separate array elements, so no textual conflict.
2. Its own post-merge run (0c4e48f0) was **CANCELLED** when #2566 merged
   seconds later.
3. #2566 is website-only, so the next push run classified out both test lanes
   and reported `success` having run neither — `classify: success`,
   `debug-validation: skipped`, `release-validation: skipped`,
   `post-merge-result: success`.

The first full validation after #2564 was the **scheduled** run on the same
sha, which went red. So `28d63ce5` currently shows two Main Post-Merge Check
results with opposite conclusions; the passing one tested nothing.

## Scope

Plain revert of all three files, restoring 8d7db890's known-green behaviour.

`scripts/eval/acceptance_gate.py` carried no EG-1 row before #2564 even though
the built-in existed, so the revert restores that pre-existing mirror drift
rather than introducing it. Filed separately rather than repaired here, to keep
a red-main hotfix minimal.

## About #2557 — it is NOT resolved by this, and is reopened

The underlying report stands: the recognizer sometimes writes EG-1 as separate
letters and nothing corrects it. What this revert re-establishes is the
constraint that a spelled-out "one" alias corrupts ordinary English, so a real
fix needs a mechanism other than a two-token fuzzy alias.

## Validation

`scripts/xcode-test.sh` on this branch: `** TEST SUCCEEDED **`, **7123 tests in
625 suites, 0 failures**, 3 known issues (main's standing three).
`xcodebuild build -scheme EnviousWispr-Dev`: `** BUILD SUCCEEDED **`.

Findings classification: REPRODUCIBLE. Two-way control taken on a separate
merged tree, where removing only the duplicate entry cleared every failure
except #2564's own test, which requires the word it added.

Tier: SMALL | Test: existing suite | Lane: Code
