### PR TITLE
fix(daily-report): read the release list from our own appcast, not GitHub's rate-limited API (#2619)

### DIFF
--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -42,7 +42,8 @@ shipped. Both come from **our own Sparkle appcast**, `APPCAST_URL` in
 `wrangler.toml` (`https://enviouswispr.com/appcast.xml`): `.github/workflows/release.yml` writes
 an `<item>` on every release, Cloudflare Pages serves the file, and every
 installed app reads it to learn a release exists. No token, no secret, no
-external rate limit, one request per run.
+GitHub API quota. One request on the successful path, with up to three
+attempts on a 429, a 5xx or a transport failure.
 
 It replaced GitHub's releases API on 2026-09-03 (#2619). That API allows 60
 unauthenticated requests an hour **per IP**, a Worker's outbound IP is shared

--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -35,6 +35,30 @@ integer, no decimals. If `total_users` is 0 that day, the whole
 engine/polish section is omitted (no divide-by-zero, no misleading "0%"
 noise on a genuinely empty day).
 
+## Release list source (the appcast, not GitHub)
+
+The version scorecard needs two facts per release: the version and when it
+shipped. Both come from **our own Sparkle appcast**, `APPCAST_URL` in
+`wrangler.toml` (`https://enviouswispr.com/appcast.xml`): `.github/workflows/release.yml` writes
+an `<item>` on every release, Cloudflare Pages serves the file, and every
+installed app reads it to learn a release exists. No token, no secret, no
+external rate limit, one request per run.
+
+It replaced GitHub's releases API on 2026-09-03 (#2619). That API allows 60
+unauthenticated requests an hour **per IP**, a Worker's outbound IP is shared
+with other Cloudflare tenants, and the scorecard went missing five of nine
+mornings while we made one request a day. The `GITHUB_TOKEN` remedy coded in
+#2415 was never installed and would have expired within a year, after which a
+401 fails the whole run.
+
+Two consequences worth knowing: a release counts once the appcast carries it,
+so a GitHub release whose `publish-appcast` job failed is absent until
+`appcast-only` recovery runs (no installed app can see it either); and the
+appcast `pubDate` is taken a step before the GitHub release is published, so a
+build cut within a minute of midnight Eastern is attributed to the earlier day.
+The test suite parses the committed `website/public/appcast.xml` end to end, so
+a format drift in the release job fails at PR time rather than one morning.
+
 ## Correctness guardrail (why this worker trusts nothing on faith)
 
 An early planning-time bug: a naive PostHog query silently truncated at 100
@@ -195,8 +219,8 @@ Three independent signals:
    message is still posted, with "Adoption, unavailable today" in place of the
    figures and the version scorecard intact beside it, and then the worker
    returns non-2xx so the GitHub Actions job goes red. The scorecard behaves
-   the same way in reverse, including when GitHub's release list is
-   unreachable after its retries. If both sections fail you get one message
+   the same way in reverse, including when the appcast (the release list;
+   see § Release list source) is unreachable after its retries. If both sections fail you get one message
    with both marked unavailable — never two messages, and never silence.
 
    `totals` is deliberately the ONE adoption query that never degrades to
@@ -206,8 +230,8 @@ Three independent signals:
 
    **Whole-run failures post a fixed notice and no report at all.** An invalid
    `?date=` override, a dev-ID resolution failure or overflow, and a release
-   -resolution CONTRACT failure (misconfigured `GITHUB_REPO`, auth, malformed
-   response, no eligible stable release) all mean there is nothing honest to
+   -resolution CONTRACT failure (misconfigured `APPCAST_URL`, a non-2xx that is
+   not an outage, a malformed appcast, no eligible stable release) all mean there is nothing honest to
    send: at most one fixed "could not be generated" notice goes to Discord,
    carrying no error text, status code or response body, and the run rejects.
    A dev-ID list that will not resolve is never treated as "no dev accounts".

--- a/workers/daily-report/live-query-smoke.mjs
+++ b/workers/daily-report/live-query-smoke.mjs
@@ -1,5 +1,5 @@
 // Pre-deploy live-query smoke: runs the REAL report against production
-// PostHog and GitHub, prints the exact message that would be sent, and posts
+// PostHog and the appcast, prints the exact message that would be sent, and posts
 // NOTHING to Discord.
 //
 // Usage (with POSTHOG_KEY already injected):
@@ -24,7 +24,7 @@ const CAPTURED_WEBHOOK = "https://smoke.invalid/never-posted";
 const env = {
   POSTHOG_PROJECT_ID: "354235",
   POSTHOG_PERSONAL_API_KEY: process.env.POSTHOG_KEY,
-  GITHUB_REPO: "saurabhav88/EnviousWispr",
+  APPCAST_URL: "https://enviouswispr.com/appcast.xml",
   DISCORD_WEBHOOK_URL: CAPTURED_WEBHOOK,
   SENTRY_ORG: "envious-labs-llc",
   SENTRY_PROJECT_ID: "4511097112428544",
@@ -53,8 +53,8 @@ globalThis.fetch = async (url, init) => {
   requests.push(
     target.startsWith("https://us.posthog.com")
       ? `posthog:${JSON.parse(init.body).name}`
-      : target.startsWith("https://api.github.com")
-        ? "github:releases"
+      : target === env.APPCAST_URL
+        ? "appcast"
         : target.startsWith("https://us.sentry.io")
           ? `sentry:${new URL(target).pathname}`
           : target
@@ -91,7 +91,7 @@ if (captured) {
   }
 }
 
-// A missing or unavailable section means PostHog, GitHub or a calculation did
+// A missing or unavailable section means PostHog, the appcast or a calculation did
 // not answer DURING this smoke run - the exact thing a pre-deploy check exists
 // to prove did not happen. Printing "Smoke OK" regardless would let a real
 // degradation pass silently, so this fails loud and lets the caller decide

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -22,7 +22,7 @@
  * with the literal SQL its freeze test must hash.
  *
  * Privacy: this module handles version strings and counts. It never logs or
- * returns a GitHub response body.
+ * returns an appcast document.
  */
 
 import { hogql, rowsToObjects } from "../../shared/posthog.js";
@@ -40,9 +40,8 @@ export class ReleaseResolutionError extends Error {
   }
 }
 
-const GITHUB_API = "https://api.github.com";
 const USER_AGENT = "EnviousWispr-Daily-Report";
-const GITHUB_MAX_ATTEMPTS = 3;
+const APPCAST_MAX_ATTEMPTS = 3;
 
 // Approved product policy, deliberately NOT caller-overridable parameters: a
 // later caller must not be able to quietly widen coverage or show more releases
@@ -77,28 +76,25 @@ const SCORECARD_MIN_VERSION = POLISH_FALLBACK_REASON_FROM;
 export function isScorecardEligible(version) {
   return version !== null && compareVersions(version, SCORECARD_MIN_VERSION) >= 0;
 }
-// Constrained to GitHub's own slug charset, not merely "no slashes or spaces".
-// A looser pattern let "owner/repo?per_page=1", "../repo" and "owner/.." through
-// into a URL, where they mean something entirely different from a repo name.
-const REPO_SLUG = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const isSafeRepoSegment = (seg) => seg !== "." && seg !== "..";
 const SEMVER = /^v?(\d+)\.(\d+)\.(\d+)$/;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const GITHUB_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/;
+const UTC_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/;
 
 /** Strict UTC timestamp parser, the single owner for every publication date.
  *
  * `new Date(...)` is far too permissive to validate with: "0" becomes the year
  * 2000, "July 24, 2026" parses in local time, and "2026-02-30" silently rolls
  * forward to March 2nd. Any of those would be accepted as a publication date and
- * could reorder the displayed release set. Requires GitHub's exact wire form,
- * then re-checks the calendar components so a rolled-over date is refused rather
- * than reinterpreted. Returns null on anything else. */
-function parseGitHubTimestamp(value) {
+ * could reorder the displayed release set. Requires the exact wire form
+ * `YYYY-MM-DDTHH:MM:SSZ` - what normalizeAppcastPubDate emits and what every
+ * selector test writes by hand - then re-checks the calendar components so a
+ * rolled-over date is refused rather than reinterpreted. Returns null on
+ * anything else. */
+function parseUtcTimestamp(value) {
   if (typeof value !== "string") return null;
-  const m = GITHUB_TIMESTAMP.exec(value);
+  const m = UTC_TIMESTAMP.exec(value);
   if (!m) return null;
   const [, y, mo, d, h, mi, sec] = m.map(Number);
   const ms = Date.UTC(y, mo - 1, d, h, mi, sec);
@@ -131,7 +127,8 @@ function assertDenseArray(value, label) {
   }
 }
 
-/** GitHub tags are `v2.4.1`; telemetry `app_version` is `2.4.1`. Returns null
+/** The appcast carries `2.4.1`, git tags `v2.4.1`, telemetry `app_version`
+ * `2.4.1`; the optional `v` keeps every shape canonical. Returns null
  * for anything that is not a plain three-part semantic version, so a malformed
  * tag is REFUSED rather than silently selected around. */
 export function normalizeReleaseVersion(value) {
@@ -162,177 +159,225 @@ export function compareVersions(a, b) {
   return a1 - b1 || a2 - b2 || a3 - b3;
 }
 
-/** THREE outcomes, because "transient" was hiding two different things (#2411).
- *
- * A 403 is temporary ONLY when GitHub says the rate limit is exhausted; treating
- * every forbidden response as temporary would retry a genuine permission or
- * configuration failure and then report it as a blip. That part is unchanged.
- *
- * What changed is that a rate limit is no longer RETRIED. Its window resets at
- * the top of an hour and a Worker cannot wait that long, so the two extra
- * requests spend more of an already-exhausted budget and fail anyway - three
- * attempts inside a few milliseconds is arithmetically one attempt against
- * anything with a recovery time. It stays TEMPORARY, so the section still
- * degrades rather than killing the run; only the retry is dropped.
- *
- * Returns "retry" | "rate-limited" | "fatal".
- */
-function classifyGitHubStatus(res) {
-  const status = res.status;
-  if (status >= 500) return "retry";
-  if (status === 429) return "rate-limited";
-  if (status !== 403) return "fatal";
-  // A SECONDARY RATE LIMIT CAN ARRIVE AS 403 WITH `x-ratelimit-remaining`
-  // NONZERO (#2415 review r3). Keying only on that header called it FATAL, which
-  // is the worst outcome available here: fatal means `wholeRun`, so the founder
-  // loses the entire report - not just the scorecard - over a condition that
-  // resolves in seconds, and the `Retry-After` recovery never runs.
-  //
-  // `Retry-After` is the precise discriminator rather than a widening: GitHub
-  // sends it for rate limiting and NOT for a genuine permission failure, so a
-  // 403 carrying it is the server saying "slow down", and a 403 without it is
-  // still "you may not" and still fatal. Presence is what is tested, not
-  // usability - an unparseable value degrades to reported-and-not-retried, never
-  // to killing the run.
-  if (typeof res.headers?.get?.("retry-after") === "string") return "rate-limited";
-  return res.headers?.get?.("x-ratelimit-remaining") === "0" ? "rate-limited" : "fatal";
-}
+/** Backoff between RETRYABLE attempts against the appcast. Sums to the same
+ * two-second ceiling the GitHub lookup had (#2415): a daily report's release
+ * lookup may block a request somebody is waiting on for about that long, and
+ * nothing measured 2000 - it is a ceiling chosen to be small. */
+const APPCAST_RETRY_DELAYS_MS = [500, 1500];
 
-/** A `Retry-After` we can actually honour, in MILLISECONDS, or null.
+/** THE RELEASE LIST IS OUR OWN APPCAST, NOT GITHUB'S API (#2619).
  *
- * **A SECONDARY RATE LIMIT IS NOT THE SAME ANIMAL AS THE HOURLY ONE (#2415 review
- * r2).** The primary limit resets at the top of an hour and no request can wait
- * for it, which is why this change stopped retrying. GitHub's SECONDARY limit is
- * different: it carries `Retry-After`, and the value can be a second or two - a
- * wait we can afford, and the only case where a rate limit is recoverable inside
- * one request. Refusing it threw away a recovery the server had explicitly
- * offered.
+ * The scorecard needs two facts per release: the version and when it was
+ * published. `.github/workflows/release.yml` writes both into `website/public/appcast.xml` on
+ * every release, Cloudflare Pages serves it, and every installed app reads it
+ * to learn a release exists. It has no external rate limit and needs no secret.
  *
- * Two ways this returns null, and they are different situations rather than one:
- * the header is ABSENT or unparseable, and the wait is LONGER than the budget.
- * The caller reports which, because "GitHub did not say" and "GitHub said 900
- * seconds" send a reader to different places.
+ * GitHub's releases API had both problems. Unauthenticated it allows 60 requests
+ * an hour PER IP, a Worker's outbound traffic leaves from a shared egress pool,
+ * so strangers spent our ceiling and five of nine mornings lost the scorecard
+ * (run history in #2619). We made ONE request a day; there was nothing to
+ * throttle. The coded `GITHUB_TOKEN` remedy (#2415) needed a founder-created
+ * token that expires within a year, after which a 401 classifies FATAL and the
+ * whole report stops. Reading what we already publish removes the limit, the
+ * secret and the expiry at once.
  *
- * Integer seconds only. `Retry-After` also has an HTTP-date form; GitHub sends
- * seconds here, and a date we half-parsed would be a guess wearing a
- * measurement's clothes. An unrecognised value is reported as unusable, never
- * silently treated as absent. */
-function retryAfterMs(res) {
-  const raw = res.headers?.get?.("retry-after");
-  if (typeof raw !== "string" || !/^\d+$/.test(raw.trim())) return null;
-  const ms = Number(raw.trim()) * 1000;
-  // `>= 0`, not `> 0`. **`Retry-After: 0` IS A VALID DELTA-SECONDS VALUE** and it
-  // means "you may retry immediately" (#2415 review r4). Rejecting it threw away
-  // the CHEAPEST recovery available - no wait at all - and reported the section
-  // unavailable instead. The negative branch is unreachable given the `^\d+$`
-  // above and is kept as a floor, not as live logic.
-  if (!Number.isSafeInteger(ms) || ms < 0) return null;
-  return ms;
-}
+ * Membership follows the appcast. A release that reached GitHub but whose
+ * appcast publication failed (`publish-appcast` is a separately failable job)
+ * is absent here until `appcast-only` recovery runs - and no installed app can
+ * see it either, so the scorecard is describing what users could get. */
+// The WHOLE document must be one Sparkle RSS element (optional XML
+// declaration, then `<rss` declaring the Sparkle namespace, closed at the end),
+// not merely contain one - an HTML page that quotes an appcast fragment is not
+// the appcast. Item tags are counted open against close against matched: an
+// unbalanced `<item>` would otherwise be skipped by the non-greedy match while
+// its neighbours succeed, and a skipped item is a release that silently
+// vanishes (#2619 review r2).
+const APPCAST_ROOT =
+  /^\s*(?:<\?xml\b[\s\S]*?\?>\s*)?<rss\b(?=[^>]*\bxmlns:sparkle\s*=\s*(["'])http:\/\/www\.andymatuschak\.org\/xml-namespaces\/sparkle\1)[^>]*>[\s\S]*<\/rss>\s*$/;
+const APPCAST_RSS_OPEN = /<rss\b/g;
+const APPCAST_RSS_CLOSE = /<\/rss>/g;
+const APPCAST_ITEM = /<item\b[^>]*>([\s\S]*?)<\/item>/g;
+const APPCAST_ITEM_OPEN = /<item\b[^>]*>/g;
+const APPCAST_ITEM_CLOSE = /<\/item>/g;
+const APPCAST_VERSION = /<sparkle:shortVersionString>([^<]*)<\/sparkle:shortVersionString>/g;
+const APPCAST_PUBDATE = /<pubDate>([^<]*)<\/pubDate>/g;
 
-/** How long until the rate-limit window resets, in SECONDS FROM NOW.
- *
- * Deliberately not a formatted instant. The first version returned
- * `new Date(ms).toISOString()` and the suite's source guardrail refused it -
- * correctly, because that guard exists to keep `parseGitHubTimestamp` the ONLY
- * date authority in this file, and a second one would drift. Seconds-from-now
- * needs no date construction, and it is the more useful number in a log anyway:
- * an operator reading the failure wants "how long", not a timestamp to subtract.
- *
- * `x-ratelimit-reset` is unix SECONDS. Absent, unparseable, or already past
- * yields null rather than a guess - an invented reset is worse than an unknown
- * one, because the next reader plans around it. */
-function rateLimitResetInSeconds(res, nowFn = Date.now) {
-  const raw = res.headers?.get?.("x-ratelimit-reset");
-  if (typeof raw !== "string" || !/^\d+$/.test(raw)) return null;
-  const resetSec = Number(raw);
-  if (!Number.isSafeInteger(resetSec) || resetSec <= 0) return null;
-  const delta = resetSec - Math.floor(nowFn() / 1000);
-  return delta > 0 ? delta : null;
-}
+/** `.github/workflows/release.yml` writes `<pubDate>$(date -R)</pubDate>`: RFC 2822 as GNU and BSD
+ * `date -R` print it, `Fri, 28 Aug 2026 18:45:54 +0000`. Releases cut locally
+ * before July 2026 carry `-0400` (24 of the 49 entries on 2026-09-03), so the
+ * offset is parsed and applied, never assumed to be zero - four hours is enough
+ * to move a midnight-adjacent release across an Eastern day. Anything outside
+ * this exact shape is refused. */
+const APPCAST_PUBDATE_FORM =
+  /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) ([+-])(\d{2})(\d{2})$/;
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-/** ONE waiting budget for this lookup, and everything that waits derives from it.
+/** Strict appcast `pubDate` normaliser: returns the UTC wire form
+ * `YYYY-MM-DDTHH:MM:SSZ` that parseUtcTimestamp owns, or null.
  *
- * The delays below and the `Retry-After` ceiling started as three separate
- * numbers I had chosen and nothing had measured (#2415 review r1, my own
- * question). Reducing them to one leaves one thing to justify: **how long may a
- * daily report's release lookup block a request somebody is waiting on.** The
- * ping workflow's `curl` sets no `--max-time` and the job budget is hours, so the
- * real constraint is that a human reading a failed run should not be waiting on
- * arithmetic - 2 seconds is beneath notice beside the PostHog, Sentry and Discord
- * work the same run already does.
+ * Emits a STRING rather than milliseconds on purpose: parseUtcTimestamp stays
+ * the single millisecond authority, every downstream reader keeps the shape it
+ * has, and the suite's date guard registers this function as the one other
+ * place `new Date(` may appear. The components must survive a round trip so a
+ * rolled-over date is refused, not reinterpreted.
  *
- * Stated so the next reader can disagree with the number rather than reverse-
- * engineer it: nothing measured 2000. It is a ceiling chosen to be small.
- */
-const GITHUB_MAX_WAIT_MS = 2000;
-
-/** Backoff between RETRYABLE attempts. Was `0`, which made the retry loop three
- * requests inside a few milliseconds - the shape of a retry with none of the
- * effect. Sums to exactly the budget above. */
-const GITHUB_RETRY_DELAYS_MS = [500, 1500];
-
-/** OPTIONAL authentication, matching what `workers/weekly-digest` already does
- * (`src/index.js`, its `fetchGitHubDownloads`).
- *
- * A token is not needed to READ a public repo - authorization was never the
- * question. It is what raises the RATE LIMIT: unauthenticated GitHub allows 60
- * requests an hour PER IP (measured, `x-ratelimit-limit: 60`), and a Cloudflare
- * Worker's outbound requests leave from a shared egress pool, so that ceiling is
- * shared with every other tenant on the same address. Our own usage is one
- * request a day, so nothing about our call rate reaches it.
- *
- * `wrangler.toml` claimed this lookup "needs no token and no secret - the same
- * unauthenticated pattern workers/weekly-digest already uses". The second half
- * was false: the sibling has had this header since it was written. Corrected
- * there rather than deleted.
- *
- * INERT until the secret exists, which is deliberate. This is the code half of
- * #2411; installing `GITHUB_TOKEN` is a separate, founder-owned action, and the
- * diagnostic added in this same change is what will say whether it is needed. */
-function githubHeaders(env) {
-  const headers = { "User-Agent": USER_AGENT, Accept: "application/vnd.github+json" };
-  const token = env?.GITHUB_TOKEN;
-  // A blank or whitespace-only secret is ABSENT, not a credential. Sending
-  // `Authorization: token ` makes GitHub answer 401, which classifies fatal and
-  // would turn a missing secret into a whole-run failure - the loud-but-wrong
-  // direction, from a value nobody meant to set.
-  if (typeof token === "string" && token.trim() !== "") {
-    headers.Authorization = `token ${token.trim()}`;
-  }
-  return headers;
-}
-
-/** Fetches published, non-draft, non-prerelease releases. Newest is decided by
- * `published_at`, never by the API's array order (which is creation order and
- * can disagree after a re-publish). */
-async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep, nowFn = Date.now } = {}) {
-  // Checked BEFORE any request: configuration is not a blip, and must never
-  // consume retries or look transient. Validated as a real owner/repo slug
-  // rather than merely truthy - a value like "EnviousWispr" would otherwise
-  // build a URL that 404s and read as a genuine API failure.
-  const repo = env?.GITHUB_REPO;
+ * The weekday name is shape-checked and NOT cross-checked against the date.
+ * The committed appcast's 1.7.0 entry reads `Tue, 25 Mar 2026`, and that day was
+ * a Wednesday (measured 2026-09-03, 1 of 49 entries): a hand-edited value from
+ * the pre-CI era. A cross-check would turn that historical typo into a
+ * whole-run failure every morning, for a field nothing downstream reads. */
+export function normalizeAppcastPubDate(value) {
+  if (typeof value !== "string") return null;
+  const m = APPCAST_PUBDATE_FORM.exec(value.trim());
+  if (!m) return null;
+  const [, , dd, mon, yyyy, hh, mi, ss, sign, offH, offM] = m;
+  const [d, y, h, min, sec, oh, om] = [dd, yyyy, hh, mi, ss, offH, offM].map(Number);
+  const mo = MONTHS.indexOf(mon);
+  const localMs = Date.UTC(y, mo, d, h, min, sec);
+  if (!Number.isFinite(localMs)) return null;
+  // ONE Date object, reused: the suite's guard allows a registered parser a
+  // single construction. It first carries the literal components for the
+  // round-trip check, then is moved onto the UTC instant for serialisation.
+  const stamp = new Date(localMs);
+  // A date that normalises to a DIFFERENT calendar date was impossible.
   if (
-    typeof repo !== "string" ||
-    !REPO_SLUG.test(repo) ||
-    !repo.split("/").every(isSafeRepoSegment)
+    stamp.getUTCFullYear() !== y || stamp.getUTCMonth() !== mo || stamp.getUTCDate() !== d ||
+    stamp.getUTCHours() !== h || stamp.getUTCMinutes() !== min || stamp.getUTCSeconds() !== sec
+  ) {
+    return null;
+  }
+  if (oh > 23 || om > 59) return null;
+  const offsetMs = (sign === "-" ? -1 : 1) * (oh * 60 + om) * 60 * 1000;
+  stamp.setTime(localMs - offsetMs);
+  const pad = (n, width = 2) => String(n).padStart(width, "0");
+  return (
+    `${pad(stamp.getUTCFullYear(), 4)}-${pad(stamp.getUTCMonth() + 1)}-${pad(stamp.getUTCDate())}` +
+    `T${pad(stamp.getUTCHours())}:${pad(stamp.getUTCMinutes())}:${pad(stamp.getUTCSeconds())}Z`
+  );
+}
+
+/** The single captured group of the ONE occurrence of `re` in `text`, or null
+ * when the element is absent or repeated. An item carrying two dates or two
+ * versions is ambiguous, and "first wins" would pick silently. */
+function exactlyOne(re, text) {
+  const matches = [...text.matchAll(re)];
+  return matches.length === 1 ? matches[0][1].trim() : null;
+}
+
+/** Keeps a quoted document value readable in a message a human will scan. */
+const brief = (s) => (s.length > 80 ? `${s.slice(0, 80)}…` : s);
+
+/** Extracts `{ version, publishedAt }` from an appcast document.
+ *
+ * Every branch fails LOUD. Silently skipping a malformed item is the whole
+ * hazard: a newest release with a missing date would simply vanish and the
+ * SECOND-newest would be crowned, changing the entire displayed set with
+ * nothing reporting a problem. The root check is what stops a 200 that is not
+ * the appcast - an HTML page from a wrong path, say - from reading as "no
+ * releases": that is a broken source, and a contract failure names it. */
+function parseAppcast(text) {
+  if (
+    typeof text !== "string" ||
+    !APPCAST_ROOT.test(text) ||
+    [...text.matchAll(APPCAST_RSS_OPEN)].length !== 1 ||
+    [...text.matchAll(APPCAST_RSS_CLOSE)].length !== 1
+  ) {
+    throw new ReleaseResolutionError("appcast response is not a Sparkle RSS document", {
+      transient: false,
+    });
+  }
+  const items = [...text.matchAll(APPCAST_ITEM)];
+  const itemOpens = [...text.matchAll(APPCAST_ITEM_OPEN)].length;
+  const itemCloses = [...text.matchAll(APPCAST_ITEM_CLOSE)].length;
+  if (items.length !== itemOpens || items.length !== itemCloses) {
+    throw new ReleaseResolutionError("appcast contains malformed item structure", {
+      transient: false,
+    });
+  }
+  const parsed = [];
+  const seen = new Set();
+  for (const [, item] of items) {
+    const rawVersion = exactlyOne(APPCAST_VERSION, item);
+    if (rawVersion === null) {
+      throw new ReleaseResolutionError(
+        "appcast item must carry exactly one sparkle:shortVersionString",
+        { transient: false }
+      );
+    }
+    const version = normalizeReleaseVersion(rawVersion);
+    if (version === null) {
+      throw new ReleaseResolutionError(`malformed appcast version: ${brief(rawVersion)}`, {
+        transient: false,
+      });
+    }
+    const rawDate = exactlyOne(APPCAST_PUBDATE, item);
+    if (rawDate === null) {
+      throw new ReleaseResolutionError(`appcast item ${version} must carry exactly one pubDate`, {
+        transient: false,
+      });
+    }
+    const publishedAt = normalizeAppcastPubDate(rawDate);
+    if (publishedAt === null) {
+      throw new ReleaseResolutionError(
+        `malformed pubDate on appcast item ${version}: ${brief(rawDate)}`,
+        { transient: false }
+      );
+    }
+    if (seen.has(version)) {
+      // Two items for one version make "newest" ambiguous.
+      throw new ReleaseResolutionError(`duplicate release version: ${version}`, {
+        transient: false,
+      });
+    }
+    seen.add(version);
+    parsed.push({ version, publishedAt });
+  }
+  if (parsed.length === 0) {
+    throw new ReleaseResolutionError("appcast has no items", { transient: false });
+  }
+  return parsed;
+}
+
+/** The appcast location, validated as an absolute https URL carrying no
+ * credentials. Returned as the exact string the env carried, so the request
+ * URL is observable in tests as configured rather than as re-serialised. */
+function appcastUrl(env) {
+  const raw = env?.APPCAST_URL;
+  let parsed = null;
+  if (typeof raw === "string" && raw !== "" && raw.trim() === raw) {
+    try {
+      parsed = new URL(raw);
+    } catch (_) {
+      parsed = null;
+    }
+  }
+  if (
+    parsed === null ||
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== ""
   ) {
     throw new ReleaseResolutionError(
-      `GITHUB_REPO must be "owner/repo", got: ${String(repo)}`,
+      `APPCAST_URL must be an absolute https URL, got: ${String(raw)}`,
       { transient: false }
     );
   }
+  return raw;
+}
+
+/** Fetches the appcast and returns every release it lists. Newest is decided by
+ * `pubDate`, never by document order: the committed appcast lists 1.3.0 first. */
+async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep } = {}) {
+  // Checked BEFORE any request: configuration is not a blip, and must never
+  // consume retries or look transient.
+  const url = appcastUrl(env);
 
   let lastStatus = null;
-  // ONCE, not per attempt. A server that keeps answering "wait one second" would
-  // otherwise be obeyed for as many attempts as the loop has, turning a bounded
-  // budget into a multiple of it.
-  let honouredRetryAfter = false;
-  for (let attempt = 1; attempt <= GITHUB_MAX_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= APPCAST_MAX_ATTEMPTS; attempt += 1) {
     let res;
     try {
-      res = await fetchFn(`${GITHUB_API}/repos/${repo}/releases`, {
-        headers: githubHeaders(env),
+      res = await fetchFn(url, {
+        headers: { "User-Agent": USER_AGENT, Accept: "application/xml" },
       });
     } catch (_) {
       // A network-level rejection (DNS, reset, abort) never produces a response
@@ -341,74 +386,30 @@ async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep, n
       // the scorecard section degrades on. Deliberately does not surface the
       // original error: it can carry a URL or body.
       lastStatus = "network error";
-      if (attempt < GITHUB_MAX_ATTEMPTS) {
-        await sleepFn(GITHUB_RETRY_DELAYS_MS[attempt - 1]);
+      if (attempt < APPCAST_MAX_ATTEMPTS) {
+        await sleepFn(APPCAST_RETRY_DELAYS_MS[attempt - 1]);
         continue;
       }
       break;
     }
 
     if (res.ok) {
-      // Every branch below fails LOUD. Silently filtering a malformed release
-      // is the whole hazard: a newest release with a missing publish date would
-      // simply disappear and the SECOND-newest would be crowned, changing the
-      // entire displayed set with nothing reporting a problem.
-      let body;
+      let text;
       try {
-        body = await res.json();
+        text = await res.text();
       } catch (_) {
-        throw new ReleaseResolutionError("GitHub releases response was not valid JSON", {
-          transient: false,
-        });
+        // A body that fails to READ is a connection reset mid-stream, the same
+        // transport failure as a rejected fetch, and takes the same bounded
+        // retry (#2619 review r2). Only a body that reads and is not an appcast
+        // is a contract failure.
+        lastStatus = "network error";
+        if (attempt < APPCAST_MAX_ATTEMPTS) {
+          await sleepFn(APPCAST_RETRY_DELAYS_MS[attempt - 1]);
+          continue;
+        }
+        break;
       }
-      assertDenseArray(body, "GitHub releases response");
-
-      const parsed = [];
-      const seen = new Set();
-      for (const r of body) {
-        if (r === null || typeof r !== "object" || Array.isArray(r)) {
-          throw new ReleaseResolutionError("GitHub releases entry was not an object", {
-            transient: false,
-          });
-        }
-        if (typeof r.draft !== "boolean" || typeof r.prerelease !== "boolean") {
-          throw new ReleaseResolutionError(
-            `GitHub release ${String(r.tag_name)} has non-boolean draft/prerelease flags`,
-            { transient: false }
-          );
-        }
-        // Drafts and prereleases are legitimately EXCLUDED, not errors.
-        if (r.draft || r.prerelease) continue;
-
-        if (typeof r.tag_name !== "string" || typeof r.published_at !== "string") {
-          throw new ReleaseResolutionError(
-            `release tag_name and published_at must be strings: ${String(r.tag_name)}`,
-            { transient: false }
-          );
-        }
-        const version = normalizeReleaseVersion(r.tag_name);
-        if (version === null) {
-          throw new ReleaseResolutionError(`malformed release tag: ${r.tag_name}`, {
-            transient: false,
-          });
-        }
-        const publishedMs = parseGitHubTimestamp(r.published_at);
-        if (publishedMs === null) {
-          throw new ReleaseResolutionError(
-            `missing or malformed published_at on release ${version}`,
-            { transient: false }
-          );
-        }
-        if (seen.has(version)) {
-          // Two tags normalising to one version makes "newest" ambiguous.
-          throw new ReleaseResolutionError(`duplicate release version: ${version}`, {
-            transient: false,
-          });
-        }
-        seen.add(version);
-        parsed.push({ version, publishedAt: r.published_at });
-      }
-      return parsed;
+      return parseAppcast(text);
     }
 
     lastStatus = res.status;
@@ -422,53 +423,21 @@ async function fetchPublishedReleases(env, { fetchFn = fetch, sleepFn = sleep, n
       }
     }
 
-    const disposition = classifyGitHubStatus(res);
-    if (disposition === "fatal") {
-      throw new ReleaseResolutionError(`GitHub releases request failed: HTTP ${lastStatus}`, {
+    // Two classes only. Our own site never rate-limits us the way GitHub did,
+    // so the Retry-After and reset-window machinery left with the API. A 5xx or
+    // a 429 is the edge having a moment and is retried on the bounded budget;
+    // anything else non-2xx - a 404 on our own appcast is a broken site, not a
+    // blip - is a contract failure after ONE attempt, as a 404 always was.
+    if (!(res.status >= 500 || res.status === 429)) {
+      throw new ReleaseResolutionError(`appcast request failed: HTTP ${lastStatus}`, {
         transient: false,
       });
     }
-    if (disposition === "rate-limited") {
-      // A SHORT `Retry-After` IS A RECOVERY THE SERVER OFFERED, so take it once
-      // (#2415 review r2). Only once, and only inside the budget: this is the
-      // secondary-limit case, where the wait is seconds. The primary hourly limit
-      // carries no such header and still fails immediately, which is the whole
-      // point of not retrying it.
-      const waitMs = retryAfterMs(res);
-      if (waitMs !== null && waitMs <= GITHUB_MAX_WAIT_MS && !honouredRetryAfter) {
-        honouredRetryAfter = true;
-        lastStatus = res.status;
-        await sleepFn(waitMs);
-        continue;
-      }
-      // Reported at once rather than after two more refusals. The reset instant
-      // is the fact that decides what to do about it, so it is in the message
-      // and not only in a header nobody will see.
-      const resetIn = rateLimitResetInSeconds(res, nowFn);
-      // Three facts, each of which sends a reader somewhere different: the
-      // status, when the window reopens, and whether the server offered a wait
-      // we could not afford. A `Retry-After` that was present and too long is
-      // NOT the same situation as one that was absent - the first says GitHub
-      // knows and we declined, the second says nobody knows.
-      const declined =
-        waitMs !== null && waitMs > GITHUB_MAX_WAIT_MS
-          ? `, Retry-After ${waitMs / 1000}s exceeds the ${GITHUB_MAX_WAIT_MS / 1000}s budget`
-          : honouredRetryAfter
-            ? ", already waited once on Retry-After"
-            : "";
-      throw new ReleaseResolutionError(
-        `GitHub releases rate-limited: HTTP ${lastStatus}` +
-          (resetIn === null ? ", reset not reported" : `, resets in ${resetIn}s`) +
-          declined +
-          " (not retried: the window is far longer than a request can wait)",
-        { transient: true }
-      );
-    }
-    if (attempt < GITHUB_MAX_ATTEMPTS) await sleepFn(GITHUB_RETRY_DELAYS_MS[attempt - 1]);
+    if (attempt < APPCAST_MAX_ATTEMPTS) await sleepFn(APPCAST_RETRY_DELAYS_MS[attempt - 1]);
   }
 
   throw new ReleaseResolutionError(
-    `GitHub releases unavailable after ${GITHUB_MAX_ATTEMPTS} attempts: HTTP ${lastStatus}`,
+    `appcast unavailable after ${APPCAST_MAX_ATTEMPTS} attempts: HTTP ${lastStatus}`,
     { transient: true }
   );
 }
@@ -537,7 +506,7 @@ export function selectReleases(publishedReleases, usageRows) {
         transient: false,
       });
     }
-    const publishedMs = parseGitHubTimestamp(r.publishedAt);
+    const publishedMs = parseUtcTimestamp(r.publishedAt);
     if (publishedMs === null) {
       throw new ReleaseResolutionError(`malformed publishedAt on ${version}`, {
         transient: false,
@@ -631,7 +600,7 @@ export function selectReleases(publishedReleases, usageRows) {
  * that would silently restore the version-blind behaviour this issue exists to
  * remove, and it would do so invisibly. */
 export async function resolveReleases(env, usageRows, opts = {}) {
-  // REQUIRED, not defaulted. GitHub returns every published release including
+  // REQUIRED, not defaulted. The appcast lists every published release including
   // ones published AFTER the window being reported: a build shipped at 08:00
   // would be crowned newest in the 09:12 report covering yesterday, and a
   // backfill would crown a release that did not exist during the reported week
@@ -650,7 +619,7 @@ export async function resolveReleases(env, usageRows, opts = {}) {
   // Published DURING the window is fine - it has partial data and its age line
   // says so. Published at or after the window end cannot have any.
   const withinWindow = published.filter((r) => {
-    const ms = parseGitHubTimestamp(r.publishedAt);
+    const ms = parseUtcTimestamp(r.publishedAt);
     if (ms === null) return true; // malformed dates fail loudly in selectReleases
     return easternDayOf(ms).dayMs < anchorMs;
   });
@@ -1003,7 +972,7 @@ function parseAdditiveRows(rows, windowEndExclusiveMs) {
 
 const EASTERN_DAY = /^(\d{4})-(\d{2})-(\d{2})$/;
 
-/** Strict Eastern calendar-day parser, matching parseGitHubTimestamp's rigour:
+/** Strict Eastern calendar-day parser, matching parseUtcTimestamp's rigour:
  * a permissive `new Date` would accept "2026-02-30" and roll it to March 2nd,
  * which would silently move a day into the wrong window. */
 function parseEasternDay(value) {
@@ -1451,7 +1420,7 @@ export function rankMovers({ measurements, selection }) {
         transient: false,
       });
     }
-    const ms = parseGitHubTimestamp(r.publishedAt);
+    const ms = parseUtcTimestamp(r.publishedAt);
     if (ms === null) {
       throw new ReleaseResolutionError(`${label} entry has a malformed publishedAt`, {
         transient: false,
@@ -1660,7 +1629,7 @@ export function rankMovers({ measurements, selection }) {
  *
  * It is FALSE for everything the section can survive as a missing section: a
  * query failure, a truncated response, a measurement or ranking fault, or an
- * exhausted TRANSIENT GitHub failure. Collapsing the two directions would
+ * exhausted TRANSIENT appcast failure. Collapsing the two directions would
  * either lose the adoption half to a blip, or let a misconfigured worker
  * report "scorecard temporarily unavailable" every morning for months.
  */

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -192,6 +192,10 @@ const APPCAST_RETRY_DELAYS_MS = [500, 1500];
 // unbalanced `<item>` would otherwise be skipped by the non-greedy match while
 // its neighbours succeed, and a skipped item is a release that silently
 // vanishes (#2619 review r2).
+// These regexes parse the ONE document shape `.github/workflows/release.yml`
+// writes, not XML in general: no comments, CDATA, attributes on the two
+// elements read, or entity escapes occur in it, and a drift toward any of them
+// fails LOUD here and in the suite's real-file control, never silently.
 const APPCAST_ROOT =
   /^\s*(?:<\?xml\b[\s\S]*?\?>\s*)?<rss\b(?=[^>]*\bxmlns:sparkle\s*=\s*(["'])http:\/\/www\.andymatuschak\.org\/xml-namespaces\/sparkle\1)[^>]*>[\s\S]*<\/rss>\s*$/;
 const APPCAST_RSS_OPEN = /<rss\b/g;

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -20,6 +20,7 @@ import {
   compareVersions,
   selectReleases,
   resolveReleases,
+  normalizeAppcastPubDate,
   telemetryContractFor,
   decideComparability,
   COMPARABILITY_REASONS,
@@ -1115,12 +1116,33 @@ const SCORECARD_NON_ADDITIVE_ROWS = [
   [0, "2.4.1", 2, 12, 60, 60, 1.2, 2.4],
   [0, "2.4.0", 2, 9, 40, 40, 1.3, 2.9],
 ];
-const PUBLISHED_RELEASES = [
-  { tag_name: "v2.4.1", published_at: "2026-07-10T12:00:00Z", draft: false, prerelease: false },
-  { tag_name: "v2.4.0", published_at: "2026-06-28T12:00:00Z", draft: false, prerelease: false },
-];
-
-const GITHUB_HOST = "https://api.github.com";
+/** One appcast `<item>` in exactly the shape release.yml writes. */
+function item(version, pubDate) {
+  return `      <item>
+        <title>Version ${version}</title>
+        <pubDate>${pubDate}</pubDate>
+        <sparkle:version>${version}</sparkle:version>
+        <sparkle:shortVersionString>${version}</sparkle:shortVersionString>
+        <enclosure url="https://enviouswispr.com/downloads/EnviousWispr-${version}.dmg" length="1" type="application/octet-stream" sparkle:edSignature="x" />
+      </item>`;
+}
+/** A whole appcast document around the given items. */
+function appcastXml(items) {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>EnviousWispr Updates</title>
+${items.join("\n")}
+  </channel>
+</rss>
+`;
+}
+const APPCAST_URL = "https://enviouswispr.com/appcast.xml";
+// Deliberately NOT in publication order: document order must never decide.
+const PUBLISHED_APPCAST = appcastXml([
+  item("2.4.0", "Sun, 28 Jun 2026 12:00:00 +0000"),
+  item("2.4.1", "Fri, 10 Jul 2026 12:00:00 +0000"),
+]);
 const SENTRY_HOST = "https://us.sentry.io";
 
 /** Answers the five Sentry calls the digest section makes (#1965).
@@ -1183,12 +1205,13 @@ function sentryAnswer(target) {
   });
 }
 
-function githubResponse(status, body) {
+function appcastResponse(status, xml, { onCancel } = {}) {
   return {
     ok: status >= 200 && status < 300,
     status,
     headers: { get: () => null },
-    json: async () => body,
+    text: async () => xml,
+    body: onCancel ? { cancel: async () => onCancel() } : undefined,
   };
 }
 
@@ -1197,7 +1220,7 @@ function githubResponse(status, body) {
  * post) succeed, and lets the caller redirect any one of them. `seen` records
  * every PostHog query name in order; `requests` records every outbound call so
  * a test can count what actually left the worker. Returns a restore fn. */
-function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord, sentry } = {}) {
+function mockPostHog({ failQuery, failWith, appcast, discordStatus, onDiscord, sentry } = {}) {
   const realFetch = globalThis.fetch;
   const seen = [];
   const requests = [];
@@ -1237,10 +1260,10 @@ function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord, se
   };
 
   async function answer(target, init) {
-    if (target.startsWith(GITHUB_HOST)) {
-      if (github instanceof Error) throw github;
-      if (typeof github === "number") return githubResponse(github, null);
-      return githubResponse(200, github ?? PUBLISHED_RELEASES);
+    if (target === APPCAST_URL) {
+      if (appcast instanceof Error) throw appcast;
+      if (typeof appcast === "number") return appcastResponse(appcast, "");
+      return appcastResponse(200, appcast ?? PUBLISHED_APPCAST);
     }
     if (target.startsWith(SENTRY_HOST)) {
       if (sentry instanceof Error) throw sentry;
@@ -1302,7 +1325,7 @@ function mockPostHog({ failQuery, failWith, github, discordStatus, onDiscord, se
 const TEST_ENV = {
   POSTHOG_PROJECT_ID: "x",
   POSTHOG_PERSONAL_API_KEY: "k",
-  GITHUB_REPO: "saurabhav88/EnviousWispr",
+  APPCAST_URL,
   DISCORD_WEBHOOK_URL: "https://discord.example/webhook",
   // #1965. Present in the base env so a "clean run" test exercises the Sentry
   // section for real. An env WITHOUT these is a legitimate deployment state
@@ -1711,22 +1734,6 @@ test("worst-case explicit fetch count stays under Cloudflare's 50-subrequest cap
 // coverage. Comparability depends solely on declared contracts, never on which
 // event codes happen to appear.
 
-function ghResponse(status, body, { headers = {}, onCancel } = {}) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    headers: { get: (k) => headers[k.toLowerCase()] ?? null },
-    json: async () => body,
-    body: onCancel ? { cancel: async () => onCancel() } : undefined,
-  };
-}
-const release = (tag, publishedAt, extra = {}) => ({
-  tag_name: tag,
-  published_at: publishedAt,
-  draft: false,
-  prerelease: false,
-  ...extra,
-});
 const usage = (v, n) => ({ app_version: v, dictations: n });
 /** A sparse array whose PROTOTYPE supplies the missing index. `i in arr` walks
  * the prototype and reads true, so this looks dense while owning no element -
@@ -1739,7 +1746,7 @@ function protoBackedSparse(length, protoValue) {
   return arr;
 }
 
-test("normalizeReleaseVersion: maps a GitHub tag to a telemetry version", () => {
+test("normalizeReleaseVersion: maps a git tag or an appcast version to a telemetry version", () => {
   for (const [input, expected] of [
     ["v2.4.1", "2.4.1"],
     ["2.4.1", "2.4.1"],
@@ -1806,7 +1813,9 @@ test("malformed tags, versions and usage rows are refused, never silently absorb
   // the sort is not observably wrong today - both agree on every input that
   // survives validation - so no behavioural test can catch it. It is still a
   // second authority that would drift, which is exactly what a source guard is
-  // for. Permitted occurrences are inside parseGitHubTimestamp only.
+  // for. Permitted occurrences are inside the registered strict parsers only:
+  // parseUtcTimestamp owns milliseconds, normalizeAppcastPubDate feeds it the
+  // wire form and is the one other place a Date may be constructed.
   const fs = await import("node:fs");
   const scSrc = fs.readFileSync(new URL("../src/version-scorecard.js", import.meta.url), "utf8");
   // Every `new Date(` must sit inside a declared STRICT parser. Counting
@@ -1815,7 +1824,7 @@ test("malformed tags, versions and usage rows are refused, never silently absorb
   // does not track closing braces, so a loose call placed AFTER a parser's body
   // gets attributed to that already-closed parser. This extracts each parser's
   // bounded body, then requires zero operational uses anywhere else.
-  const STRICT_PARSERS = ["parseGitHubTimestamp", "parseEasternDay", "easternDayOf"];
+  const STRICT_PARSERS = ["parseUtcTimestamp", "normalizeAppcastPubDate", "parseEasternDay", "easternDayOf"];
   const operational = (text) =>
     text.split("\n").filter((l) => l.includes("new Date(") && !l.trimStart().startsWith("*")).length;
 
@@ -1889,464 +1898,223 @@ test("malformed tags, versions and usage rows are refused, never silently absorb
   }
 });
 
-test("resolveReleases: GITHUB_TOKEN is optional, and a blank one is ABSENT not a credential", async () => {
-  // #2411. A token is not needed to READ a public repo - it is what raises the
-  // rate limit from 60 requests an hour per shared IP to 5,000. Inert until the
-  // secret exists, which is the point: installing it is a separate action.
-  const sent = async (env) => {
-    let headers = null;
-    await resolveReleases(env, [usage("2.4.1", 1)], {
-      windowEndExclusive: "2026-07-29",
-      fetchFn: async (_url, init) => {
-        headers = init.headers;
-        return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
-      },
-      sleepFn: async () => {},
-    });
-    return headers;
-  };
-
-  const none = await sent({ GITHUB_REPO: "o/r" });
-  assert.equal(none.Authorization, undefined, "no secret means no Authorization header");
-  assert.equal(none["User-Agent"], "EnviousWispr-Daily-Report", "the UA is unconditional");
-
-  const withToken = await sent({ GITHUB_REPO: "o/r", GITHUB_TOKEN: "ghp_example" });
-  assert.equal(withToken.Authorization, "token ghp_example");
-
-  // The rejected twin, and it is the one that would hurt: `Authorization: token `
-  // makes GitHub answer 401, which classifies FATAL and fails the whole run. An
-  // unset secret must never turn into a loud failure by way of an empty string.
-  for (const blank of ["", "   ", "\n"]) {
-    const h = await sent({ GITHUB_REPO: "o/r", GITHUB_TOKEN: blank });
-    assert.equal(h.Authorization, undefined, `a blank token (${JSON.stringify(blank)}) is absent`);
-  }
-  // A token with surrounding whitespace is a real secret someone pasted with a
-  // trailing newline - trimmed, not refused.
-  const padded = await sent({ GITHUB_REPO: "o/r", GITHUB_TOKEN: "  ghp_padded\n" });
-  assert.equal(padded.Authorization, "token ghp_padded");
-});
-
-test("resolveReleases: uses GITHUB_REPO + User-Agent, drops draft/prerelease, newest by published_at", async () => {
-  let seenUrl = null;
-  let seenUA = null;
-  const body = [
-    // Deliberately NOT in published_at order - array order must not decide.
-    release("v2.3.2", "2026-07-10T10:00:00Z"),
-    release("v2.4.1", "2026-07-24T17:00:00Z"),
-    release("v9.9.9", "2026-07-28T00:00:00Z", { draft: true }),
-    release("v8.8.8", "2026-07-27T00:00:00Z", { prerelease: true }),
-    release("v2.4.0", "2026-07-18T21:00:00Z"),
-  ];
-  const out = await resolveReleases(
-    { GITHUB_REPO: "saurabhav88/EnviousWispr" },
-    [usage("2.4.1", 100)],
-    {
-      windowEndExclusive: "2026-07-29",
-        fetchFn: async (url, init) => {
-        seenUrl = url;
-        seenUA = init.headers["User-Agent"];
-        return ghResponse(200, body);
-      },
-      sleepFn: async () => {},
-    }
-  );
-  assert.ok(seenUrl.includes("/repos/saurabhav88/EnviousWispr/releases"), seenUrl);
-  assert.equal(seenUA, "EnviousWispr-Daily-Report");
-  assert.equal(out.releases[0].version, "2.4.1", "newest by published_at must lead");
-  const shown = out.releases.map((r) => r.version);
-  assert.ok(!shown.includes("9.9.9"), "draft must be excluded");
-  assert.ok(!shown.includes("8.8.8"), "prerelease must be excluded");
-});
-
-test("resolveReleases: bad configuration and malformed release data fail loud, never silently", async () => {
-  // Configuration is checked before any request, and validated as a real
-  // owner/repo slug - "EnviousWispr" alone would build a URL that 404s and read
-  // as a genuine API failure.
-  // URL syntax and path traversal are not repository names: each of these
-  // previously built a request URL that meant something else entirely.
-  for (const repo of [undefined, "", "   ", "EnviousWispr", "owner/repo/extra", "owner /repo",
-                      "owner/repo?per_page=1", "owner#fragment/repo", "../repo", "owner/..",
-                      "./repo", "owner/.", 42, null, {}]) {
+test("resolveReleases: APPCAST_URL is validated before any request, and a bad one is a contract failure", async () => {
+  // Configuration is not a blip, and must never consume retries or look
+  // transient. Parsed as a real absolute https URL: a relative path, an http
+  // scheme, or embedded credentials each build a request that fails in a way
+  // that would read as an outage.
+  for (const url of [undefined, "", "   ", "appcast.xml", "/appcast.xml",
+                     "http://enviouswispr.com/appcast.xml",
+                     "https://user:pw@enviouswispr.com/appcast.xml", "ftp://x/y",
+                     " https://enviouswispr.com/appcast.xml", "https://enviouswispr.com/appcast.xml\n",
+                     42, null, {}]) {
     let called = false;
     await assert.rejects(
       () =>
-        resolveReleases(repo === undefined ? {} : { GITHUB_REPO: repo }, [], {
+        resolveReleases(url === undefined ? {} : { APPCAST_URL: url }, [], {
           windowEndExclusive: "2026-07-29",
-        fetchFn: async () => { called = true; return ghResponse(200, []); },
+          fetchFn: async () => { called = true; return appcastResponse(200, PUBLISHED_APPCAST); },
         }),
       (err) => err instanceof ReleaseResolutionError && err.transient === false,
-      `repo ${JSON.stringify(repo)}`
+      `url ${JSON.stringify(url)}`
     );
-    assert.equal(called, false, `config error for ${JSON.stringify(repo)} must not make a request`);
+    assert.equal(called, false, `config error for ${JSON.stringify(url)} must not make a request`);
   }
+});
 
+test("resolveReleases: fetches APPCAST_URL exactly as configured, newest by pubDate never by document order", async () => {
+  let seenUrl = null;
+  let seenHeaders = null;
+  const xml = appcastXml([
+    // Deliberately NOT in publication order - the committed appcast lists 1.3.0
+    // first - so document order must not decide.
+    item("2.3.2", "Fri, 10 Jul 2026 10:00:00 +0000"),
+    item("2.4.1", "Fri, 24 Jul 2026 17:00:00 +0000"),
+    item("2.4.0", "Sat, 18 Jul 2026 21:00:00 +0000"),
+  ]);
+  const out = await resolveReleases({ APPCAST_URL }, [usage("2.4.1", 100)], {
+    windowEndExclusive: "2026-07-29",
+    fetchFn: async (url, init) => {
+      seenUrl = url;
+      seenHeaders = init.headers;
+      return appcastResponse(200, xml);
+    },
+  });
+  // OBSERVED, not assumed: a hard-coded URL would still pass a count check
+  // while reading somebody else's release history.
+  assert.equal(seenUrl, APPCAST_URL);
+  assert.equal(seenHeaders["User-Agent"], "EnviousWispr-Daily-Report");
+  assert.equal(seenHeaders.Authorization, undefined, "no credential is ever sent to our own site");
+  assert.equal(out.releases[0].version, "2.4.1", "newest by pubDate must lead");
+  for (const v of ["2.3.2", "2.4.0", "2.4.1"]) {
+    assert.ok(out.releaseCatalog.some((r) => r.version === v), `${v} is in the catalog`);
+  }
+});
+
+test("normalizeAppcastPubDate: applies the offset, tolerates a wrong weekday name, and refuses anything off the date -R shape", () => {
+  // Real forms from the committed appcast, both offsets. The -0400 entries are
+  // releases cut locally before July 2026; a parser that assumed UTC would
+  // shift them four hours and could move one across an Eastern day.
+  assert.equal(normalizeAppcastPubDate("Fri, 28 Aug 2026 18:45:54 +0000"), "2026-08-28T18:45:54Z");
+  assert.equal(normalizeAppcastPubDate("Mon, 02 Mar 2026 14:55:59 +0000"), "2026-03-02T14:55:59Z");
+  assert.equal(normalizeAppcastPubDate("Wed, 20 May 2026 23:40:54 -0400"), "2026-05-21T03:40:54Z",
+    "a negative offset late in the evening lands on the next UTC day");
+  assert.equal(normalizeAppcastPubDate("Thu, 01 Jan 2026 00:30:00 +0100"), "2025-12-31T23:30:00Z",
+    "a positive offset can cross a year boundary");
+  assert.equal(normalizeAppcastPubDate("\n  Fri, 28 Aug 2026 18:45:54 +0000\n  "), "2026-08-28T18:45:54Z",
+    "element whitespace is not part of the value");
+  // The committed 1.7.0 entry, verbatim: 25 Mar 2026 was a Wednesday. The
+  // weekday is a shape token only; cross-checking it would fail the whole run
+  // on a historical typo in a field nothing downstream reads.
+  assert.equal(normalizeAppcastPubDate("Tue, 25 Mar 2026 21:34:52 -0400"), "2026-03-26T01:34:52Z");
+  for (const bad of [
+    "Fri, 28 Aug 2026 18:45:54",       // no offset
+    "Friday, 28 Aug 2026 18:45:54 +0000", // not a date -R weekday token
+    "Fri, 28 Aug 2026 18:45:54 GMT",   // named zone
+    "Tue, 31 Feb 2026 00:00:00 +0000", // rolls over to March
+    "Fri, 28 Aug 2026 24:00:00 +0000", // rolls over to the next day
+    "Fri, 28 Aug 2026 18:45:54 +2500", // offset hours out of range
+    "Fri, 28 Aug 2026 18:45:54 +0060", // offset minutes out of range
+    "Fri, 8 Aug 2026 18:45:54 +0000",  // date -R always pads the day
+    "2026-08-28T18:45:54Z",            // the wire form is not a pubDate
+    "July 24, 2026",
+    "", null, undefined, 42,
+  ]) {
+    assert.equal(normalizeAppcastPubDate(bad), null, JSON.stringify(bad));
+  }
+});
+
+test("resolveReleases: a malformed appcast fails loud, never silently", async () => {
   // A malformed NEWEST release must never be silently filtered out: dropping it
   // crowns the second-newest and changes the entire displayed set with nothing
-  // reporting a problem.
-  const env = { GITHUB_REPO: "o/r" };
-  const bodies = [
-    [release("v9.9.9", null), release("v2.4.1", "2026-07-24T00:00:00Z")],
-    [release("v9.9.9", "not-a-date"), release("v2.4.1", "2026-07-24T00:00:00Z")],
-    [release("v9.9.9", "2026-07-29T00:00:00Z", { draft: "yes" })],
-    [release("bad-tag", "2026-07-29T00:00:00Z")],
-    ["not-an-object"],
-    [null],
-    [release("v2.4.1", "2026-07-24T00:00:00Z"), release("2.4.1", "2026-07-25T00:00:00Z")],
-    { not: "an array" },
-    [release("v2.4.1", "July 24, 2026")],
-    [release("v2.4.1", "2026-02-30T00:00:00Z")],
-    [release("v2.4.1", "0")],
-    new Array(1),
-    protoBackedSparse(1, release("v2.4.1", "2026-07-24T00:00:00Z")),
+  // reporting a problem. Every malformed item below is dated after the good one.
+  const good = item("2.4.1", "Fri, 24 Jul 2026 00:00:00 +0000");
+  const later = "Sat, 25 Jul 2026 00:00:00 +0000";
+  const docs = [
+    ["an HTML page answered with 200", "<!doctype html><html><body>Not found</body></html>"],
+    ["rss without the sparkle namespace", `<rss version="2.0"><channel>${good}</channel></rss>`],
+    ["an empty body", ""],
+    ["no items", appcastXml([])],
+    ["an item without a version", appcastXml([`<item><pubDate>${later}</pubDate></item>`, good])],
+    ["an item with two versions", appcastXml([
+      item("9.9.9", later).replace("</item>",
+        "<sparkle:shortVersionString>9.9.8</sparkle:shortVersionString></item>"), good])],
+    ["an item without a pubDate", appcastXml([
+      "<item><sparkle:shortVersionString>9.9.9</sparkle:shortVersionString></item>", good])],
+    ["an item with two pubDates", appcastXml([
+      item("9.9.9", later).replace("</item>", `<pubDate>${later}</pubDate></item>`), good])],
+    ["a malformed version", appcastXml([item("9.9", later), good])],
+    ["a malformed pubDate", appcastXml([item("9.9.9", "July 25, 2026"), good])],
+    ["a duplicate version", appcastXml([good, item("2.4.1", later)])],
+    ["a duplicate version spelled with a v", appcastXml([good, item("v2.4.1", later)])],
+    // STRUCTURE, not only content (#2619 review r2): a page quoting an appcast
+    // is not the appcast, and an unbalanced item must not be skipped while its
+    // neighbours parse - a skipped item is a release that silently vanishes.
+    ["an HTML page embedding a real appcast", `<html><body>${appcastXml([good])}</body></html>`],
+    ["two rss documents concatenated", appcastXml([good]) + appcastXml([good])],
+    ["the wrong sparkle namespace", appcastXml([good]).replace(
+      "http://www.andymatuschak.org/xml-namespaces/sparkle", "urn:not-sparkle")],
+    ["an unclosed item beside a good one", appcastXml([good]).replace("</channel>", "<item></channel>")],
+    ["a stray item close beside a good one", appcastXml([good]).replace("</channel>", "</item></channel>")],
+    ["an item nested in an item", appcastXml([good.replace("</item>", `${item("9.9.9", later)}</item>`)])],
   ];
-  for (const body of bodies) {
+  for (const [label, xml] of docs) {
     await assert.rejects(
-      () => resolveReleases(env, [usage("2.4.1", 1)], {
+      () => resolveReleases({ APPCAST_URL }, [usage("2.4.1", 1)], {
         windowEndExclusive: "2026-07-29",
-        fetchFn: async () => ghResponse(200, body),
-        sleepFn: async () => {},
+        fetchFn: async () => appcastResponse(200, xml),
       }),
       (err) => err instanceof ReleaseResolutionError && err.transient === false,
-      `body ${JSON.stringify(body)}`
+      label
     );
   }
-
-  // Invalid JSON is a contract failure, not a transient blip.
-  await assert.rejects(
-    () => resolveReleases(env, [], {
-      windowEndExclusive: "2026-07-29",
-        fetchFn: async () => ({ ok: true, status: 200, headers: { get: () => null },
-        json: async () => { throw new SyntaxError("bad json"); } }),
-      sleepFn: async () => {},
-    }),
-    (err) => err instanceof ReleaseResolutionError && err.transient === false
-  );
-});
-
-test("resolveReleases: a RETRYABLE failure takes 3 attempts with real backoff between them", async () => {
-  // A network-level rejection produces no response to inspect, so without
-  // explicit handling it escapes unretried AND unclassified.
-  let netAttempts = 0;
-  const netSleeps = [];
-  await assert.rejects(
-    () =>
-      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-        windowEndExclusive: "2026-07-29",
-        fetchFn: async () => {
-          netAttempts += 1;
-          throw new TypeError("network failure");
-        },
-        sleepFn: async (ms) => netSleeps.push(ms),
-      }),
-    (err) => err instanceof ReleaseResolutionError && err.transient === true,
-    "network rejection"
-  );
-  assert.equal(netAttempts, 3, "a network rejection must retry to exactly 3 attempts");
-  // THE DELAYS MUST BE REAL AND GROWING (#2411). They were `0`, which is the
-  // shape of a retry with none of the effect: three requests inside a few
-  // milliseconds is arithmetically one attempt against anything with a recovery
-  // time. Asserting the VALUES, not merely that sleep was called - a call with 0
-  // is exactly the defect.
-  assert.deepEqual(netSleeps, [500, 1500], "network retries must back off");
-
-  let attempts = 0;
-  const sleeps = [];
-  await assert.rejects(
-    () =>
-      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-        windowEndExclusive: "2026-07-29",
-        fetchFn: async () => {
-          attempts += 1;
-          return ghResponse(503, null, { headers: {} });
-        },
-        sleepFn: async (ms) => sleeps.push(ms),
-      }),
-    (err) => err instanceof ReleaseResolutionError && err.transient === true,
-    "status 503"
-  );
-  assert.equal(attempts, 3, "a 5xx must make exactly 3 attempts");
-  assert.deepEqual(sleeps, [500, 1500], "5xx retries must back off");
-});
-
-test("a rate limit's 500 body says WHY, and never claims a retry loop that did not run", async () => {
-  // #2415 review r1. The section prefix used to read "exhausted its retries",
-  // true while every temporary failure was retried three times - and false the
-  // moment a rate limit started failing after ONE attempt, which is what this
-  // same change did. The body a human reads is the only place that shows.
-  const mock = mockPostHog({ github: 429 });
-  try {
-    const res = await trigger("&date=2026-07-17");
-    assert.equal(res.status, 500);
-    const body = await res.text();
-    assert.match(body, /rate-limited/, "the body names the mechanism");
-    assert.doesNotMatch(body, /exhausted its retries/,
-      "and does not claim a retry loop that never ran");
-    assert.equal(mock.requests.filter((u) => u.startsWith(GITHUB_HOST)).length, 1,
-      "one attempt, because retrying a rate limit cannot help");
-    // Still only the SECTION: a rate limit must not cost the adoption numbers.
-    assert.equal(mock.discordPayloads.length, 1);
-    const [adoption, scorecard] = mock.discordPayloads[0].embeds;
-    assert.match(adoption.description, /Total users:/);
-    assert.match(scorecard.title, /unavailable today/);
-  } finally {
-    mock.restore();
-  }
-});
-
-test("resolveReleases: a SHORT Retry-After is honoured once; a long one is declined out loud", async () => {
-  // #2415 review r2. The primary hourly limit resets at the top of an hour and
-  // no request can wait for it - that is why this change stopped retrying. The
-  // SECONDARY limit is a different animal: it carries `Retry-After`, the value
-  // can be a second, and refusing it threw away a recovery the server offered.
-  const NOW_MS = 1_787_670_000_000;
-  const nowFn = () => NOW_MS;
-  const resetAt = String(Math.floor(NOW_MS / 1000) + 1800);
-
-  // 1. A one-second secondary limit RECOVERS, and the request succeeds.
-  let calls = 0;
-  const sleeps = [];
-  const out = await resolveReleases({ GITHUB_REPO: "o/r" }, [usage("2.4.1", 1)], {
+  // And the two-way control: the same good item alone resolves.
+  const out = await resolveReleases({ APPCAST_URL }, [usage("2.4.1", 1)], {
     windowEndExclusive: "2026-07-29",
-    fetchFn: async () => {
-      calls += 1;
-      if (calls === 1) return ghResponse(429, null, { headers: { "retry-after": "1" } });
-      return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
-    },
-    sleepFn: async (ms) => sleeps.push(ms),
-    nowFn,
+    fetchFn: async () => appcastResponse(200, appcastXml([good])),
   });
-  assert.equal(calls, 2, "the offered wait is taken and the request retried");
-  assert.deepEqual(sleeps, [1000], "it waits exactly what the server asked for");
-  assert.ok(out.releases.length > 0, "and the lookup succeeds");
-
-  // 2. ONCE, not per attempt. A server that keeps answering "wait one second"
-  // would otherwise turn a bounded budget into a multiple of it.
-  let repeat = 0;
-  const repeatSleeps = [];
-  await assert.rejects(
-    () =>
-      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-        windowEndExclusive: "2026-07-29",
-        fetchFn: async () => {
-          repeat += 1;
-          return ghResponse(429, null, { headers: { "retry-after": "1", "x-ratelimit-reset": resetAt } });
-        },
-        sleepFn: async (ms) => repeatSleeps.push(ms),
-        nowFn,
-      }),
-    (err) =>
-      err instanceof ReleaseResolutionError &&
-      err.transient === true &&
-      /already waited once on Retry-After/.test(err.message),
-    "a repeated Retry-After is obeyed once"
-  );
-  assert.equal(repeat, 2, "two requests: the original and the one honoured wait");
-  assert.deepEqual(repeatSleeps, [1000]);
-
-  // 3. A wait longer than the budget is DECLINED, and the message says so.
-  // "GitHub said 900 seconds" and "GitHub did not say" send a reader to
-  // different places, so they must not collapse into one sentence.
-  let longCalls = 0;
-  await assert.rejects(
-    () =>
-      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-        windowEndExclusive: "2026-07-29",
-        fetchFn: async () => {
-          longCalls += 1;
-          return ghResponse(429, null, { headers: { "retry-after": "900", "x-ratelimit-reset": resetAt } });
-        },
-        sleepFn: async () => {},
-        nowFn,
-      }),
-    (err) =>
-      err instanceof ReleaseResolutionError &&
-      /Retry-After 900s exceeds the 2s budget/.test(err.message),
-    "a long Retry-After is named, not silently ignored"
-  );
-  assert.equal(longCalls, 1, "and it is not waited on");
-
-  // 4. `Retry-After` also has an HTTP-date form. GitHub sends seconds here, and
-  // a date we half-parsed would be a guess wearing a measurement's clothes - so
-  // it reads as no usable wait rather than as a number.
-  let dateCalls = 0;
-  await assert.rejects(
-    () =>
-      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-        windowEndExclusive: "2026-07-29",
-        fetchFn: async () => {
-          dateCalls += 1;
-          return ghResponse(429, null, {
-            headers: { "retry-after": "Wed, 21 Oct 2026 07:28:00 GMT", "x-ratelimit-reset": resetAt },
-          });
-        },
-        sleepFn: async () => {},
-        nowFn,
-      }),
-    (err) => err instanceof ReleaseResolutionError && err.transient === true,
-    "an HTTP-date Retry-After is not parsed as a number"
-  );
-  assert.equal(dateCalls, 1, "an unusable Retry-After is not waited on");
-
-  // 5. A FRACTIONAL value, and this row exists because a mutant found that
-  // nothing else needed the digit check: an HTTP-date already dies at
-  // `Number.isSafeInteger`, so dropping the regex changed nothing observable
-  // there - two mechanisms covering one outcome. `1.5` is the input where the
-  // regex does unique work: without it, `Number("1.5") * 1000` is a safe integer
-  // and a fractional header would be honoured as a real wait.
-  let fracCalls = 0;
-  await assert.rejects(
-    () =>
-      resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-        windowEndExclusive: "2026-07-29",
-        fetchFn: async () => {
-          fracCalls += 1;
-          return ghResponse(429, null, {
-            headers: { "retry-after": "1.5", "x-ratelimit-reset": resetAt },
-          });
-        },
-        sleepFn: async () => {},
-        nowFn,
-      }),
-    (err) => err instanceof ReleaseResolutionError && err.transient === true,
-    "a fractional Retry-After is not a wait we honour"
-  );
-  assert.equal(fracCalls, 1, "a fractional Retry-After is not waited on");
-
-  // 6. A SECONDARY LIMIT CAN ARRIVE AS 403 WITH `x-ratelimit-remaining` NONZERO
-  // (#2415 review r3). Keying only on that header called it FATAL - and fatal
-  // means `wholeRun`, so the founder loses the ENTIRE report over a condition
-  // that resolves in seconds. Strictly worse than the defect this PR started on.
-  let secCalls = 0;
-  const secSleeps = [];
-  const secOut = await resolveReleases({ GITHUB_REPO: "o/r" }, [usage("2.4.1", 1)], {
-    windowEndExclusive: "2026-07-29",
-    fetchFn: async () => {
-      secCalls += 1;
-      if (secCalls === 1) {
-        return ghResponse(403, null, {
-          headers: { "retry-after": "1", "x-ratelimit-remaining": "57" },
-        });
-      }
-      return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
-    },
-    sleepFn: async (ms) => secSleeps.push(ms),
-    nowFn,
-  });
-  assert.equal(secCalls, 2, "a 403 carrying Retry-After is a rate limit, and recovers");
-  assert.deepEqual(secSleeps, [1000]);
-  assert.ok(secOut.releases.length > 0);
-
-  // 7. `Retry-After: 0` is a VALID delta-seconds value meaning "retry now"
-  // (#2415 review r4). A `> 0` test rejected it and threw away the cheapest
-  // recovery there is - no wait at all - reporting the section unavailable
-  // instead. The row asserts the retry happens AND that the wait is zero, since
-  // "recovered" alone would also be true of a version that slept a default.
-  let zeroCalls = 0;
-  const zeroSleeps = [];
-  const zeroOut = await resolveReleases({ GITHUB_REPO: "o/r" }, [usage("2.4.1", 1)], {
-    windowEndExclusive: "2026-07-29",
-    fetchFn: async () => {
-      zeroCalls += 1;
-      if (zeroCalls === 1) return ghResponse(429, null, { headers: { "retry-after": "0" } });
-      return ghResponse(200, [release("v2.4.1", "2026-07-24T00:00:00Z")]);
-    },
-    sleepFn: async (ms) => zeroSleeps.push(ms),
-    nowFn,
-  });
-  assert.equal(zeroCalls, 2, "Retry-After: 0 is honoured, not discarded");
-  assert.deepEqual(zeroSleeps, [0], "and it waits for exactly no time");
-  assert.ok(zeroOut.releases.length > 0);
+  assert.equal(out.releases[0].version, "2.4.1");
 });
 
-test("resolveReleases: a RATE LIMIT is temporary but NOT retried, and says when it resets", async () => {
-  // #2411. This used to retry three times like any other transient status. The
-  // window resets at the top of an hour and a request cannot wait that long, so
-  // the two extra attempts only spend more of an already-exhausted budget and
-  // fail anyway. It stays TEMPORARY - the section degrades, the run survives -
-  // and only the retry is dropped.
-  const NOW_MS = 1_787_670_000_000;
-  const nowFn = () => NOW_MS;
-  const resetAt = String(Math.floor(NOW_MS / 1000) + 1800);
-
-  for (const [label, status, headers] of [
-    ["primary limit", 403, { "x-ratelimit-remaining": "0", "x-ratelimit-reset": resetAt }],
-    ["secondary limit", 429, { "x-ratelimit-reset": resetAt }],
+test("resolveReleases: network, 5xx and 429 take 3 attempts with real backoff, then are TRANSIENT", async () => {
+  for (const [label, answer, detail] of [
+    ["network rejection", () => { throw new Error("ECONNRESET"); }, /network error/],
+    // A body that fails to READ is a reset mid-stream: transport, not contract.
+    ["body read failure", () => ({ ok: true, status: 200, text: async () => { throw new Error("stream reset"); } }),
+      /network error/],
+    ["503", () => appcastResponse(503, ""), /HTTP 503/],
+    ["429", () => appcastResponse(429, ""), /HTTP 429/],
   ]) {
     let attempts = 0;
     const sleeps = [];
     await assert.rejects(
-      () =>
-        resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-          windowEndExclusive: "2026-07-29",
-          fetchFn: async () => {
-            attempts += 1;
-            return ghResponse(status, null, { headers });
-          },
-          sleepFn: async (ms) => sleeps.push(ms),
-          nowFn,
-        }),
+      () => resolveReleases({ APPCAST_URL }, [], {
+        windowEndExclusive: "2026-07-29",
+        fetchFn: async () => { attempts += 1; return answer(); },
+        sleepFn: async (ms) => { sleeps.push(ms); },
+      }),
       (err) =>
-        err instanceof ReleaseResolutionError &&
-        err.transient === true &&
-        /rate-limited/.test(err.message) &&
-        /resets in 1800s/.test(err.message),
+        err instanceof ReleaseResolutionError && err.transient === true &&
+        /appcast unavailable after 3 attempts/.test(err.message) && detail.test(err.message),
       label
     );
-    assert.equal(attempts, 1, `${label} must not retry`);
-    assert.deepEqual(sleeps, [], `${label} must not sleep`);
+    assert.equal(attempts, 3, `${label}: three attempts`);
+    assert.deepEqual(sleeps, [500, 1500], `${label}: real backoff between attempts, none after the last`);
   }
-
-  // A reset we cannot read is reported as unknown, never guessed: the next
-  // reader plans around whatever this says.
-  for (const [label, headers] of [
-    ["absent", { "x-ratelimit-remaining": "0" }],
-    ["not a number", { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "soon" }],
-    ["already past", { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "1" }],
-  ]) {
-    await assert.rejects(
-      () =>
-        resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-          windowEndExclusive: "2026-07-29",
-          fetchFn: async () => ghResponse(403, null, { headers }),
-          sleepFn: async () => {},
-          nowFn,
-        }),
-      (err) =>
-        err instanceof ReleaseResolutionError &&
-        err.transient === true &&
-        /reset not reported/.test(err.message),
-      `reset ${label}`
-    );
-  }
+  // Recovery on a later attempt still returns the list - the retry has an effect.
+  let n = 0;
+  const out = await resolveReleases({ APPCAST_URL }, [usage("2.4.1", 1)], {
+    windowEndExclusive: "2026-07-29",
+    fetchFn: async () => { n += 1; return n < 3 ? appcastResponse(503, "") : appcastResponse(200, PUBLISHED_APPCAST); },
+    sleepFn: async () => {},
+  });
+  assert.equal(out.releases[0].version, "2.4.1");
+  assert.equal(n, 3);
 });
 
-test("resolveReleases: a non-transient 4xx fails loud after ONE attempt", async () => {
-  for (const [status, headers] of [
-    [404, {}],
-    // A forbidden response that is NOT rate-limit exhaustion is a real failure,
-    // not a blip - retrying it would report a permission problem as temporary.
-    // THE REJECTED TWIN of the Retry-After widening (#2415 review r3): a 403
-    // WITHOUT that header is still "you may not", not "slow down". GitHub does
-    // not send Retry-After for a permission failure, which is what makes the
-    // header a discriminator rather than a loosening.
-    [403, { "x-ratelimit-remaining": "57" }],
-  ]) {
+test("resolveReleases: any other non-2xx is a CONTRACT failure after ONE attempt, and the body is drained", async () => {
+  // A 404 on our own appcast is a broken site, not a blip; retrying it spends
+  // the budget on an answer that will not change, and calling it transient would
+  // let a broken deploy read as "temporarily unavailable" every morning.
+  for (const status of [400, 401, 403, 404, 410]) {
     let attempts = 0;
+    let cancelled = 0;
     await assert.rejects(
-      () =>
-        resolveReleases({ GITHUB_REPO: "o/r" }, [], {
-          windowEndExclusive: "2026-07-29",
+      () => resolveReleases({ APPCAST_URL }, [], {
+        windowEndExclusive: "2026-07-29",
         fetchFn: async () => {
-            attempts += 1;
-            return ghResponse(status, null, { headers });
-          },
-          sleepFn: async () => {},
-        }),
-      (err) => err instanceof ReleaseResolutionError && err.transient === false,
+          attempts += 1;
+          return appcastResponse(status, "", { onCancel: () => { cancelled += 1; } });
+        },
+        sleepFn: async () => { throw new Error("must not sleep on a contract failure"); },
+      }),
+      (err) => err instanceof ReleaseResolutionError && err.transient === false &&
+        err.message.includes(`HTTP ${status}`),
       `status ${status}`
     );
     assert.equal(attempts, 1, `status ${status} must not retry`);
+    assert.equal(cancelled, 1, `status ${status} drains the body before throwing`);
   }
+});
+
+test("the committed appcast parses end to end, every item, and the newest shipped release leads", async () => {
+  // The real producer's real output, read from the repo rather than restated:
+  // a format drift in release.yml's appcast entry fails here at PR time, before
+  // it can reach the worker as a whole-run failure one morning.
+  const xml = readFileSync(new URL("../../../website/public/appcast.xml", import.meta.url), "utf8");
+  const items = (xml.match(/<item\b/g) || []).length;
+  assert.ok(items >= 49, `expected at least the 49 releases shipped by 2026-09-03, found ${items}`);
+  const versions = [...xml.matchAll(/<sparkle:shortVersionString>([^<]*)</g)].map((m) => m[1]);
+  const newest = versions.reduce((a, b) => (compareVersions(a, b) >= 0 ? a : b));
+  const out = await resolveReleases({ APPCAST_URL }, [usage(newest, 1)], {
+    windowEndExclusive: "2099-01-01",
+    fetchFn: async () => appcastResponse(200, xml),
+  });
+  assert.equal(out.releases[0].version, newest);
+  // Both offsets survive: 2.3.0 shipped locally (-0400), 2.4.6 from CI (+0000).
+  assert.ok(out.releaseCatalog.some((r) => r.version === "2.4.6"));
+  assert.ok(out.releaseCatalog.some((r) => r.version === "2.3.0"));
+  assert.ok(!out.releaseCatalog.some((r) => r.version === "1.3.0"), "below the measurement floor");
 });
 
 test("selectReleases: newest is always included at 1% share, then fills by descending share to 80%", () => {
@@ -3551,18 +3319,20 @@ test("a clean run's seventeen requests go to the expected queries, repository, S
 
     assert.equal(mock.requests.length, 17);
     const posthog = mock.requests.filter((u) => u.includes("posthog.com"));
-    const github = mock.requests.filter((u) => u.startsWith(GITHUB_HOST));
+    const appcast = mock.requests.filter((u) => u === APPCAST_URL);
     const sentry = mock.requests.filter((u) => u.startsWith(SENTRY_HOST));
     const discord = mock.requests.filter((u) => u === TEST_ENV.DISCORD_WEBHOOK_URL);
     assert.equal(posthog.length, 10, "1 dev-ID + 7 adoption + 2 scorecard");
-    assert.equal(github.length, 1, "the release list is fetched exactly once");
+    assert.equal(appcast.length, 1, "the release list is fetched exactly once");
     assert.equal(sentry.length, SENTRY_CALLS_PER_DIGEST, "the fixed Sentry budget, never a per-issue fan-out");
     assert.equal(discord.length, 1, "one delivery");
-    assert.equal(posthog.length + github.length + sentry.length + discord.length, mock.requests.length,
+    assert.equal(posthog.length + appcast.length + sentry.length + discord.length, mock.requests.length,
       "no unaccounted outbound request");
-    // GITHUB_REPO is OBSERVED, not assumed: a hard-coded repository would still
-    // pass a count check while reading somebody else's release history.
-    assert.equal(github[0], `${GITHUB_HOST}/repos/${TEST_ENV.GITHUB_REPO}/releases`);
+    // APPCAST_URL is OBSERVED, not assumed: a hard-coded URL would still pass a
+    // count check while reading somebody else's release history. And it is our
+    // own site - nothing goes to GitHub any more (#2619).
+    assert.equal(appcast[0], TEST_ENV.APPCAST_URL);
+    assert.ok(!mock.requests.some((u) => u.includes("github.com")), "no request reaches GitHub");
     assert.equal(mock.seen.filter((n) => n === "dev_ids").length, 1);
     assert.equal(mock.seen.filter((n) => n.startsWith("scorecard_")).length, 2);
   } finally {
@@ -3673,7 +3443,7 @@ test("an adoption rejection releases its slot and the scorecard still runs and r
     await assert.rejects(() => runReport(TEST_ENV, "2026-07-17", { hogqlOpts: { sleepFn: async () => {} } }));
     assert.ok(mock.seen.includes("scorecard_additive"), "the scorecard's queries must still run");
     assert.ok(mock.seen.includes("scorecard_non_additive"));
-    assert.ok(mock.requests.some((u) => u.startsWith(GITHUB_HOST)),
+    assert.ok(mock.requests.some((u) => u === APPCAST_URL),
       "stage-2 release resolution must still run for the surviving section");
     assert.equal(mock.discordPayloads.length, 1);
     assert.match(mock.discordPayloads[0].embeds[1].description, /2\.4\.1: 7\/7 days publicly available/);
@@ -3754,7 +3524,7 @@ test("every section failing still posts exactly one message, with each marked un
 });
 
 test("exhausted TRANSIENT release resolution loses only the scorecard, and never falls back to telemetry versions", async () => {
-  const mock = mockPostHog({ github: 503 });
+  const mock = mockPostHog({ appcast: 503 });
   try {
     const res = await trigger("&date=2026-07-17");
     assert.equal(res.status, 500);
@@ -3773,12 +3543,12 @@ test("exhausted TRANSIENT release resolution loses only the scorecard, and never
     assert.doesNotMatch(body, /exhausted its retries/,
       "the prefix does not assert a retry loop it does not control");
     assert.match(body, /HTTP 503/, "and it now carries the status that caused it");
-    assert.equal(mock.requests.filter((u) => u.startsWith(GITHUB_HOST)).length, 3,
+    assert.equal(mock.requests.filter((u) => u === APPCAST_URL).length, 3,
       "three attempts, then give up");
     assert.equal(mock.discordPayloads.length, 1);
     const [adoption, scorecard] = mock.discordPayloads[0].embeds;
     assert.match(adoption.description, /Total users: 1 people used the app that day\./,
-      "a GitHub outage costs the scorecard, never adoption");
+      "an appcast outage costs the scorecard, never adoption");
     assert.match(scorecard.title, /unavailable today/);
     // The versions ARE in the telemetry we already hold. Printing them anyway
     // would silently restore the version-blind report this issue removed.
@@ -3791,8 +3561,8 @@ test("exhausted TRANSIENT release resolution loses only the scorecard, and never
 
 test("a release-resolution CONTRACT failure fails the whole run and never posts a normal report", async () => {
   for (const [label, opts, env] of [
-    ["a 404 from the release list", { github: 404 }, TEST_ENV],
-    ["an unusable GITHUB_REPO", {}, { ...TEST_ENV, GITHUB_REPO: "EnviousWispr" }],
+    ["a 404 from the appcast", { appcast: 404 }, TEST_ENV],
+    ["an unusable APPCAST_URL", {}, { ...TEST_ENV, APPCAST_URL: "appcast.xml" }],
   ]) {
     const mock = mockPostHog(opts);
     try {
@@ -3807,7 +3577,7 @@ test("a release-resolution CONTRACT failure fails the whole run and never posts 
       assert.equal(mock.discordPayloads.length, 1, label);
       assert.ok(!("embeds" in mock.discordPayloads[0]), `${label}: no combined report`);
       assert.match(mock.discordPayloads[0].content, /could not be generated/);
-      assert.doesNotMatch(mock.discordPayloads[0].content, /404|GITHUB_REPO|http/i,
+      assert.doesNotMatch(mock.discordPayloads[0].content, /404|APPCAST_URL|http/i,
         "the notice discloses no technical detail");
     } finally {
       mock.restore();
@@ -3828,7 +3598,7 @@ test("a shared-preflight failure starts NEITHER section", async () => {
         `${label}: must be refused AS a bad override, not by an incidental
          downstream crash - a report for a day nobody asked for is the failure`);
       assert.equal(mock.seen.length, 0, `${label}: no PostHog query may start`);
-      assert.ok(!mock.requests.some((u) => u.startsWith(GITHUB_HOST)), `${label}: no GitHub call`);
+      assert.ok(!mock.requests.some((u) => u === APPCAST_URL), `${label}: no appcast call`);
       assert.equal(mock.discordPayloads.length, 1, `${label}: one fixed notice`);
       assert.ok(!("embeds" in mock.discordPayloads[0]), `${label}: never a partial report`);
     } finally {
@@ -4417,22 +4187,22 @@ test("builds below the measurement floor are hidden everywhere, not shown with a
 });
 
 test("a release published after the reported window is never crowned newest", async () => {
-  // GitHub returns every published release, including ones published AFTER the
-  // window being reported. A build shipped at 08:00 would otherwise be crowned
+  // The appcast lists every published release, including ones published AFTER
+  // the window being reported. A build shipped at 08:00 would otherwise be crowned
   // newest in the 09:12 report covering yesterday, and a backfill would crown a
   // release that did not exist during the reported week at all - both printing
   // "0/7 days publicly available, no production data yet" for the build
   // supposedly most worth watching, while displacing one that has real data.
-  const body = [
-    release("v2.4.0", "2026-07-18T21:00:00Z"),
-    release("v2.4.1", "2026-07-24T17:00:00Z"),
-    release("v2.5.0", "2026-07-29T08:00:00Z"), // published the morning of the run
-  ];
+  const body = appcastXml([
+    item("2.4.0", "Sat, 18 Jul 2026 21:00:00 +0000"),
+    item("2.4.1", "Fri, 24 Jul 2026 17:00:00 +0000"),
+    item("2.5.0", "Wed, 29 Jul 2026 08:00:00 +0000"), // published the morning of the run
+  ]);
   const opts = {
-    fetchFn: async () => ghResponse(200, body),
+    fetchFn: async () => appcastResponse(200, body),
     sleepFn: async () => {},
   };
-  const env = { GITHUB_REPO: "saurabhav88/EnviousWispr" };
+  const env = { APPCAST_URL };
   const usageRows = [usage("2.4.1", 100), usage("2.4.0", 60)];
 
   const excluded = await resolveReleases(env, usageRows,
@@ -4456,6 +4226,21 @@ test("a release published after the reported window is never crowned newest", as
   const backfill = await resolveReleases(env, [usage("2.4.0", 60)],
     { ...opts, windowEndExclusive: "2026-07-19" });
   assert.deepEqual(backfill.releases.map((r) => r.version), ["2.4.0"]);
+
+  // BOUNDARY CONTROL (#2619 grounded review). The appcast's pubDate is taken a
+  // step before GitHub publishes the release, 30 to 70 seconds earlier. A build
+  // whose pubDate is 23:59:30 Eastern on the 28th would have carried a GitHub
+  // published_at of 00:00:xx on the 29th. Membership follows the appcast, so
+  // the 28th's own report (window end 29th) includes it, and that is the
+  // documented, accepted difference - not a bug in the window filter.
+  const midnight = appcastXml([
+    item("2.4.1", "Fri, 24 Jul 2026 17:00:00 +0000"),
+    item("2.5.0", "Tue, 28 Jul 2026 23:59:30 -0400"), // 03:59:30Z on the 29th
+  ]);
+  const edge = await resolveReleases(env, usageRows,
+    { ...opts, fetchFn: async () => appcastResponse(200, midnight), windowEndExclusive: "2026-07-29" });
+  assert.equal(edge.releases[0].version, "2.5.0",
+    "a pubDate before Eastern midnight belongs to that day, whatever GitHub's clock said");
 
   // The anchor is REQUIRED, never defaulted to "no filter": a forgotten caller
   // would silently restore the defect this closes.

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -2037,20 +2037,23 @@ test("resolveReleases: a malformed appcast fails loud, never silently", async ()
 });
 
 test("resolveReleases: network, 5xx and 429 take 3 attempts with real backoff, then are TRANSIENT", async () => {
-  for (const [label, answer, detail] of [
-    ["network rejection", () => { throw new Error("ECONNRESET"); }, /network error/],
+  for (const [label, answer, detail, drains] of [
+    ["network rejection", () => { throw new Error("ECONNRESET"); }, /network error/, 0],
     // A body that fails to READ is a reset mid-stream: transport, not contract.
     ["body read failure", () => ({ ok: true, status: 200, text: async () => { throw new Error("stream reset"); } }),
-      /network error/],
-    ["503", () => appcastResponse(503, ""), /HTTP 503/],
-    ["429", () => appcastResponse(429, ""), /HTTP 429/],
+      /network error/, 0],
+    // Every retryable response carries a body, so the drain-before-retry path
+    // is exercised here and not only on the contract-failure side.
+    ["503", (onCancel) => appcastResponse(503, "", { onCancel }), /HTTP 503/, 3],
+    ["429", (onCancel) => appcastResponse(429, "", { onCancel }), /HTTP 429/, 3],
   ]) {
     let attempts = 0;
+    let cancelled = 0;
     const sleeps = [];
     await assert.rejects(
       () => resolveReleases({ APPCAST_URL }, [], {
         windowEndExclusive: "2026-07-29",
-        fetchFn: async () => { attempts += 1; return answer(); },
+        fetchFn: async () => { attempts += 1; return answer(() => { cancelled += 1; }); },
         sleepFn: async (ms) => { sleeps.push(ms); },
       }),
       (err) =>
@@ -2059,6 +2062,7 @@ test("resolveReleases: network, 5xx and 429 take 3 attempts with real backoff, t
       label
     );
     assert.equal(attempts, 3, `${label}: three attempts`);
+    assert.equal(cancelled, drains, `${label}: every failed body is drained before the retry`);
     assert.deepEqual(sleeps, [500, 1500], `${label}: real backoff between attempts, none after the last`);
   }
   // Recovery on a later attempt still returns the list - the retry has an effect.

--- a/workers/daily-report/wrangler.toml
+++ b/workers/daily-report/wrangler.toml
@@ -9,16 +9,13 @@ compatibility_date = "2026-07-09"
 
 [vars]
 POSTHOG_PROJECT_ID = "354235"
-# The version scorecard's release lookup. Public repo, so no token is needed to
-# READ it; a token is what raises the RATE LIMIT, and the lookup sends one when
-# GITHUB_TOKEN is present (#2411).
-#
-# The line this replaces said the lookup needs no secret, "the same
-# unauthenticated pattern workers/weekly-digest already uses". The second half
-# was false - that worker has sent an optional Authorization header since it was
-# written - and the sentence is why nobody looked at the limit for five days of
-# failures.
-GITHUB_REPO = "saurabhav88/EnviousWispr"
+# The version scorecard's release list: OUR OWN Sparkle appcast, written by
+# release.yml on every release and served by our Pages site. No token, no
+# secret, no external rate limit (#2619). It replaced GitHub's releases API,
+# whose unauthenticated 60-per-hour ceiling is PER IP and a Worker's outbound
+# IP is shared with other tenants, so strangers spent our budget and the
+# scorecard went missing five of nine mornings.
+APPCAST_URL = "https://enviouswispr.com/appcast.xml"
 # Sentry section (#1965). Identifiers only, no credential.
 SENTRY_ORG = "envious-labs-llc"
 SENTRY_PROJECT_ID = "4511097112428544"
@@ -30,13 +27,6 @@ SENTRY_PROJECT_SLUG = "enviouswispr"
 #   TRIGGER_SECRET            - gates the public `fetch` trigger; the GitHub Action sends it as
 #                               the `x-trigger-secret` header (the workers.dev URL is public, so
 #                               the trigger fails closed without it)
-#   GITHUB_TOKEN              - OPTIONAL (#2411). Absent, the release lookup is
-#     unauthenticated and shares a 60-request-per-hour ceiling with every other
-#     tenant on the Worker's outbound IP; present, the ceiling is 5,000. Read
-#     access to a PUBLIC repo needs no scopes at all, so a fine-grained token
-#     with none is correct here. The lookup degrades to an unavailable scorecard
-#     either way and never fails the run, so this is a reliability setting rather
-#     than a requirement.
 #   SENTRY_AUTH_TOKEN         - reads the Sentry section's aggregates (#1965).
 #     GCP secret `sentry-workers-readonly-token`, scoped to exactly
 #     `event:read` + `org:read`. Install the SAME token on all three Sentry


### PR DESCRIPTION
Closes #2619

## What

The Daily Report's version scorecard now reads the release list from **our own Sparkle appcast** (`https://enviouswispr.com/appcast.xml`) instead of `api.github.com/repos/<repo>/releases`. Zero requests to GitHub from this worker; no token, no secret, no external rate limit.

## Why

Five of the last nine scheduled runs lost the scorecard to `GitHub releases rate-limited: HTTP 403, resets in 2387s` (runs 33760928526, 33635517141, 33254671117, 33194037277, 32975028986). The worker makes **one** request a day. The limit it hits is GitHub's unauthenticated 60-per-hour ceiling **per IP**, and a Cloudflare Worker's outbound IP is shared with other tenants, so strangers spend our budget. The `GITHUB_TOKEN` path from #2415 was never installed (`wrangler secret list` on 2026-09-03 shows no such secret) and a fine-grained token expires within a year, after which a 401 classifies FATAL and the whole report stops.

The appcast is written by `.github/workflows/release.yml` on every release, served by our Pages site, and is the file every installed app reads. Measured 2026-09-03: GitHub lists 49 published releases (0 drafts, 0 prereleases), the appcast has 49 items, the sets are identical.

## How

- `fetchPublishedReleases` fetches `APPCAST_URL` (new `wrangler.toml` var, replaces `GITHUB_REPO`) and parses each `<item>`'s `sparkle:shortVersionString` and `pubDate`.
- `normalizeAppcastPubDate` is a strict parser for the exact RFC 2822 subset `date -R` prints, with the numeric offset applied (24 of 49 committed entries carry `-0400` from pre-CI local releases). It emits the existing `YYYY-MM-DDTHH:MM:SSZ` wire form, so `parseUtcTimestamp` (renamed from `parseGitHubTimestamp`) stays the single millisecond authority and every downstream consumer is untouched. The weekday name is shape-checked only: the committed 1.7.0 entry names a Tuesday for a Wednesday, which the real-file control test caught.
- Whole-document structure is required (one `<rss>` with the Sparkle namespace, balanced `<item>` tags), so an HTML page or a fragment can never read as "no releases".
- Transport: network, body-read failure, 5xx and 429 retry on the same `[500, 1500]` ms budget and then degrade the section (transient, run red, report still delivered). Any other non-2xx or a malformed document is a contract failure, as before. Deleted: `Retry-After`, reset-window, rate-limit classification and optional-token code.

One intentional behavioural delta, stated in the plan: a release counts when the **appcast** carries it. A GitHub release whose `publish-appcast` job failed is absent until `appcast-only` recovery runs, which is also when installed apps can first see it.

## Validation

- `node --test` in `workers/daily-report`: 267 tests, 267 pass (baseline 268; seven GitHub-specific tests replaced by eight appcast tests plus a boundary control).
- Live pre-deploy smoke (`live-query-smoke.mjs`, posts nothing): 17 outbound requests, exactly one labelled `appcast`, zero to GitHub, full scorecard rendered from the real appcast for 2026-09-02.
- Codex grounded review r1: PROCEED-WITH-REVISIONS (plan text, applied). r2 on the diff: two actionable findings, both adopted (whole-document structure check; body-read failure retried as transport).
- Lane: Worker. This worker deploys by hand after merge (README § Deploy); deploy and a dispatched `Daily Report` run with a date override follow the merge, and #2619 closes on the green run.

**Not in scope:** `workers/weekly-digest` also reads GitHub unauthenticated, for per-asset download counts the appcast does not carry. Same shared-IP exposure, different fix.
