### PR TITLE
feat(daily-report): cut the fine print from the version and error sections (#2621)

### DIFF
--- a/workers/daily-report/README.md
+++ b/workers/daily-report/README.md
@@ -35,6 +35,49 @@ integer, no decimals. If `total_users` is 0 that day, the whole
 engine/polish section is omitted (no divide-by-zero, no misleading "0%"
 noise on a genuinely empty day).
 
+## Reading the version check and the error section (#2621)
+
+The two lower embeds print numbers and one footnote, nothing that explains method. The founder read
+the earlier shape ("Covering 80.7% of measured dictations across 2 releases", "People counts are
+non-additive", "Ranked against this measure's median week-to-week movement") as noise he could not
+decode, so the explanations live here instead.
+
+**Version check, last 7 days.** Header: the displayed releases, newest first, each with the one fact
+that changes how to read its column: `(out N days)` when it shipped inside the window, `(no data yet)`
+when nothing has been measured on it. A release out the whole week is just its version.
+
+- Which releases appear: the newest published release is ALWAYS shown, whatever its share, then
+  releases are added in descending share of the week's dictations until 80% is covered or four are
+  shown. The footnote `These N versions cover X% of the week's dictations` is the coverage that
+  selection reached; the denominator is every measured dictation, including versions not displayed.
+- Builds before 2.2.0 are never measured. They did not record every reason polished text was
+  rejected, so their AI-polish figure would read a false 100%; the founder chose (2026-07-29) to hide
+  them rather than print a figure known to be wrong beside a caveat.
+- `People` is non-additive: one person can appear under more than one release in a week.
+- `Typical speed` is the median end-to-end time; `Slowest 5%` the 95th percentile.
+- `Auto-paste worked` is the share of paste attempts that landed directly rather than via the
+  clipboard fallback. `Apple polish kept` is the share of Apple Intelligence polish attempts whose
+  output was kept (that provider only, `METRIC_CALCULATIONS.polish_kept`); the split between the safety
+  classifier and other checks is still measured (`classifierDiscards`) and no longer printed. `Failed dictations` counts dictations that ended without a completed transcript, whatever
+  stage failed; it is deliberately not labelled as a transcription-engine figure because the app stamps
+  no-microphone and permission failures with that stage too.
+- `(not compared: …)` on a row means the displayed releases do not share one telemetry contract for
+  that metric, so the numbers are printed but no shift is drawn across them.
+- `Biggest shifts` names the rows whose movement between the two newest releases ranked highest,
+  as "from X to Y" with no verdict. Ranking is against each measure's median week-to-week movement
+  where enough history exists, otherwise by size of change; the sample counts behind each are in
+  `ranking.movers`. A measure that did not move between the two releases is never a mover.
+
+**Errors, yesterday.** One headline: people who hit an error on the release line and newer, and the
+direction against the previous period. The error and problem counts are still measured (`data.events`, `data.rows.length`) and no
+longer printed. No rate is ever shown: Sentry and PostHog join only per install and only partially
+(`sentry-operations.md` RULE: join-sentry-to-posthog-by-install), so dividing one system's people by
+the other's would be arithmetic across two identity systems. `Lost the dictation` and `Worked, but
+worse` are the two severity groups; `delivery not proven` marks a row whose producer cannot confirm
+the text was lost; `NEW` marks a problem first seen in the window. The tail line `Up to N people hit an
+error on builds older than X` is an upper bound because per-release people counts are not additive, and
+it can overlap the headline: one person can hit errors on a current build and an old one.
+
 ## Release list source (the appcast, not GitHub)
 
 The version scorecard needs two facts per release: the version and when it

--- a/workers/daily-report/src/index.js
+++ b/workers/daily-report/src/index.js
@@ -543,7 +543,7 @@ async function postFailureNotice(env, dateStr) {
 
 /** Just "Sentry, yesterday": the day is on the message's content line, and this
  * section always reports the day the rest of the report is about. */
-const SENTRY_TITLE = "Sentry, yesterday";
+const SENTRY_TITLE = "Errors, yesterday";
 
 /** Sentry's window, derived from the ONE resolved report context and nothing
  * else - this file's orchestration rule, applied to a third vendor. Sentry's

--- a/workers/daily-report/src/report-format.js
+++ b/workers/daily-report/src/report-format.js
@@ -41,8 +41,26 @@ const ROW_LABELS = {
   transcription_failed: "Failed dictations",
 };
 
-const pct = (v) => `${(v * 100).toFixed(1)}%`;
-const secs = (v) => `${v.toFixed(2)}s`;
+const pct = (v, decimals = 1) => `${(v * 100).toFixed(decimals)}%`;
+const secs = (v, decimals = 2) => `${v.toFixed(decimals)}s`;
+
+/** Two values of one unit, rendered so the reader can SEE the movement between
+ * them. The ranker decides which rows are movers; a nonzero movement smaller
+ * than the page's usual precision would otherwise print as "0.60s to 0.60s"
+ * under "Biggest shifts" (cloud review on #2622). Rather than the formatter
+ * dropping the mover - a second authority on membership - it adds decimals
+ * until the two differ, up to a bound: past four extra places the movement is
+ * not a shift a reader can act on, and both values print at the bound. */
+function renderPair(unit, from, to) {
+  const fmt = unit === "seconds" ? secs : pct;
+  const base = unit === "seconds" ? 2 : 1;
+  for (let decimals = base; decimals <= base + 4; decimals += 1) {
+    const a = fmt(from, decimals);
+    const b = fmt(to, decimals);
+    if (a !== b || decimals === base + 4) return [a, b];
+  }
+  /* unreachable: the loop returns at the bound */
+}
 // Explicit locale: a Worker's default locale is not something a reader can
 // see, and "9902" against "9,902" is the difference between a glance and a
 // count. Counts are integers; a fractional count would be a producer defect
@@ -138,8 +156,8 @@ function formatShifts(ranking) {
   // in what order, is the ranker's decision alone (it already drops a measure
   // that did not move).
   const parts = ranking.movers.map((m) => {
-    const unit = m.unit === "seconds" ? secs : pct;
-    return `${ROW_LABELS[m.metricKey]} ${unit(m.previousValue)} to ${unit(m.newestValue)}`;
+    const [from, to] = renderPair(m.unit, m.previousValue, m.newestValue);
+    return `${ROW_LABELS[m.metricKey]} ${from} to ${to}`;
   });
   return `Biggest shifts: ${parts.join("; ")}.`;
 }

--- a/workers/daily-report/src/report-format.js
+++ b/workers/daily-report/src/report-format.js
@@ -1,5 +1,5 @@
 /**
- * Version-scorecard presentation (issue #1838 chunk 5).
+ * Version-scorecard presentation (issue #1838 chunk 5, reshaped by #2621).
  *
  * Sole owner of every scorecard sentence the founder reads, and NOTHING else.
  * It imports no metric authority: row order, units, comparability, values,
@@ -10,9 +10,18 @@
  * The report is a SCORECARD, not an alarm. Defect detection is already owned by
  * the twice-daily Sentry triage routines, and the previous threshold-alarm shape
  * is exactly what made this report useless to its one reader. So: no thresholds,
- * no colours, no healthy/unhealthy states, and no better/worse language. Movers
- * are ranked changes, explicitly labelled as not alerts; their job is to guide
- * the eye, not to render a verdict.
+ * no colours, no healthy/unhealthy states, and no better/worse language. The
+ * biggest shifts are named to guide the eye, never to render a verdict.
+ *
+ * #2621: the page carries NUMBERS and nothing that explains method. The founder
+ * read the previous shape as "too much information I can't make heads or tails
+ * of": four lines of method before the first number, two versions packed into
+ * every row, sub-lines under rows, sample counts and a ranking basis under every
+ * mover. Every one of those facts still exists - coverage, the measurement
+ * floor, non-additive people, the polish split, the mover basis - and the
+ * worker README owns their explanation. The page shows one comparison in plain
+ * words. A footnote states coverage in one sentence because it is the one
+ * method fact that changes how much the numbers mean.
  */
 
 const ROW_LABELS = {
@@ -20,25 +29,33 @@ const ROW_LABELS = {
   dictations: "Dictations",
   speed_p50: "Typical speed",
   speed_p95: "Slowest 5%",
-  autopaste_direct: "Auto-paste landed directly",
-  polish_kept: "Polish kept",
+  autopaste_direct: "Auto-paste worked",
+  // Apple Intelligence attempts only (METRIC_CALCULATIONS.polish_kept's
+  // population), so the label must not read as every polish provider.
+  polish_kept: "Apple polish kept",
   // Never "Transcription failed", and never speech-engine reliability: the app
   // stamps EVERY terminal failure with the transcription stage, including
   // no-microphone and permission failures, so that label would send someone
-  // chasing the speech engine for a microphone bug.
-  transcription_failed: "Dictations ending without a completed transcript",
+  // chasing the speech engine for a microphone bug. "Failed dictations" names
+  // the outcome the user had, whatever stage produced it.
+  transcription_failed: "Failed dictations",
 };
 
 const pct = (v) => `${(v * 100).toFixed(1)}%`;
 const secs = (v) => `${v.toFixed(2)}s`;
+// Explicit locale: a Worker's default locale is not something a reader can
+// see, and "9902" against "9,902" is the difference between a glance and a
+// count. Counts are integers; a fractional count would be a producer defect
+// and prints as-is rather than being rounded into a lie.
+const count = (v) => new Intl.NumberFormat("en-US").format(v);
 const render = (value, unit) =>
   value === null || value === undefined
-    ? "not enough data"
+    ? "no data"
     : unit === "seconds"
       ? secs(value)
       : unit === "share"
         ? pct(value)
-        : String(value);
+        : count(value);
 
 function requireNumber(value, label) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -47,111 +64,84 @@ function requireNumber(value, label) {
   return value;
 }
 
+/** One release's name for the header: the version, plus the one fact about it
+ * that changes how to read its column. Under a week old says how many days it
+ * has been out; no data yet says so instead of a column of "no data" being the
+ * only clue. A release out the whole week is just its version. */
+function releaseHeading(release, age) {
+  if (!Number.isInteger(age) || age < 0) {
+    throw new TypeError(`release age must be a non-negative integer, got ${String(age)}`);
+  }
+  if (!release.observed) return `${release.version} (no data yet)`;
+  if (age === 0) return `${release.version} (out today)`;
+  if (age < 7) return `${release.version} (out ${age} ${age === 1 ? "day" : "days"})`;
+  return release.version;
+}
+
 /** One deterministic scorecard section, as an array of lines. */
 export function formatScorecard({ ranking }) {
   if (!ranking || !Array.isArray(ranking.rows) || !(ranking.ages instanceof Map) ||
       !ranking.summary || !Array.isArray(ranking.summary.releases)) {
     throw new TypeError("formatScorecard requires ranking.rows, ranking.ages and ranking.summary");
   }
-  const lines = [];
   // The formatter takes ONLY the ranking. It has no access to the raw selection
   // at all, so a raw tag form, a stale coverage figure or a stale cap flag
   // cannot reach the page - the previous shape merely asked it not to look.
-  const { releases, coverage, capReached, minVersion } = ranking.summary;
+  const { releases, coverage } = ranking.summary;
   requireNumber(coverage, "ranking.summary.coverage");
-  if (typeof minVersion !== "string" || minVersion.length === 0) {
-    throw new TypeError(`ranking.summary.minVersion must be a version string, got ${String(minVersion)}`);
-  }
 
-  lines.push("Version scorecard, last 7 complete Eastern days");
+  const lines = ["Version check, last 7 days"];
   lines.push(
-    `Covering ${pct(coverage)} of measured dictations across ` +
-      `${releases.length} release${releases.length === 1 ? "" : "s"}.`
+    releases
+      .map((r) => {
+        if (!ranking.ages.has(r.version)) {
+          // Never defaulted to zero: a missing age would print a confident
+          // "out 0 days" for a release we simply failed to measure.
+          throw new TypeError(`ranking.ages is missing release ${r.version}`);
+        }
+        return releaseHeading(r, ranking.ages.get(r.version));
+      })
+      .join(" vs ")
   );
-  lines.push("The newest release is always included, whatever its share.");
-  lines.push(
-    `Builds before ${minVersion} are not measured: they did not record every reason ` +
-      "polished text was rejected, so their score would read a false 100%."
-  );
-  if (capReached) lines.push("4-version cap reached before the coverage target.");
-  lines.push("People counts are non-additive: one person can appear under more than one release.");
-
-  for (const r of releases) {
-    if (!ranking.ages.has(r.version)) {
-      // Never defaulted to zero: a missing age would print a confident
-      // "0/7 days publicly available" for a release we simply failed to measure.
-      throw new TypeError(`ranking.ages is missing release ${r.version}`);
-    }
-    lines.push(
-      `${r.version}: ${ranking.ages.get(r.version)}/7 days publicly available` +
-        (r.observed ? "" : ", no production data yet")
-    );
-  }
   lines.push("");
 
   for (const row of ranking.rows) {
-    const cells = row.cells.map((c) => `${c.version} ${render(c.value, row.unit)}`);
-    lines.push(`${ROW_LABELS[row.metricKey]}: ${cells.join("  |  ")}`);
-
-    if (row.metricKey === "dictations") {
-      lines.push(
-        "  " +
-          row.cells
-            .map((c) =>
-              c.shareOfWindow === null
-                ? `${c.version} share unavailable`
-                : `${c.version} ${pct(c.shareOfWindow)} of the measured week`
-            )
-            .join("  |  ")
-      );
-    }
-    if (row.metricKey === "polish_kept") {
-      lines.push(
-        "  " +
-          row.cells
-            .map((c) =>
-              c.classifierDiscards === null
-                ? `${c.version} breakdown unavailable`
-                : `${c.version} ${c.classifierDiscards} by the safety classifier, ` +
-                  `${c.otherDiscards} by other checks`
-            )
-            .join("  |  ")
-      );
-    }
+    // Cells in header order, so the reader never needs a version prefix on
+    // every number: the header names the columns once.
     // A non-comparable row still PRINTS, with the reason in plain words. Hiding
-    // it leaves a silent gap; drawing a comparison across it would be a lie.
-    if (!row.comparable) lines.push(`  not compared, ${row.reason}`);
+    // it leaves a silent gap; drawing a comparison across it would be a lie -
+    // so its cells are separated by a bar, never by "vs".
+    const cells = row.cells.map((c) => render(c.value, row.unit)).join(row.comparable ? " vs " : " | ");
+    const caveat = row.comparable ? "" : ` (not compared: ${row.reason})`;
+    lines.push(`${ROW_LABELS[row.metricKey]}: ${cells}${caveat}`);
   }
 
   lines.push("");
-  lines.push(...formatMovers(ranking));
+  lines.push(formatShifts(ranking));
+  lines.push(
+    `${releases.length === 1 ? "This version covers" : `These ${releases.length} versions cover`} ` +
+      `${pct(coverage)} of measured dictations this week.`
+  );
   return lines;
 }
 
-function formatMovers(ranking) {
-  const lines = ["Ranked changes (these are ranked changes, not alerts):"];
+/** The biggest shifts between the two newest releases, as one sentence. The
+ * ranker decided which rows and in what order; this names them "from X to Y",
+ * which is the whole fact, with no verdict attached. */
+function formatShifts(ranking) {
   if (ranking.movers.length === 0) {
     // Not "nothing changed": with one release, or insufficient history, there
     // was nothing rankable to begin with, which is a different statement.
-    lines.push("  No comparable ranked changes were available.");
-    return lines;
+    return "Biggest shifts: nothing to rank yet.";
   }
-  for (const m of ranking.movers) {
+  // Every mover the ranker handed over is printed: which rows are movers, and
+  // in what order, is the ranker's decision alone (it already drops a measure
+  // that did not move).
+  const parts = ranking.movers.map((m) => {
     const unit = m.unit === "seconds" ? secs : pct;
-    const sign = m.signedDifference >= 0 ? "up" : "down";
-    lines.push(
-      `  ${ROW_LABELS[m.metricKey]}: ${m.newestVersion} ${unit(m.newestValue)} ` +
-        `vs ${m.previousVersion} ${unit(m.previousValue)}, ${sign} ` +
-        `${unit(Math.abs(m.signedDifference))} ` +
-        `(${m.newestSamples} and ${m.previousSamples} samples).`
-    );
-    lines.push(
-      m.basis === "median-historical-movement"
-        ? "    Ranked against this measure's median week-to-week movement."
-        : `    Ranked by size of change only, ${m.fallbackReason}.`
-    );
-  }
-  return lines;
+    return `${ROW_LABELS[m.metricKey]} ${unit(m.previousValue)} to ${unit(m.newestValue)}`;
+  });
+  return `Biggest shifts: ${parts.join("; ")}.`;
 }
 
 /** Plain-language scorecard-unavailable copy, owned here so the integration
@@ -159,7 +149,7 @@ function formatMovers(ranking) {
  * technical: no error text, URL, status code or response body. */
 export function formatScorecardUnavailable() {
   return [
-    "Version scorecard, unavailable today.",
+    "Version check, unavailable today.",
     "Version measurements could not be completed, so this is not a report of zero.",
   ];
 }

--- a/workers/daily-report/src/report-format.js
+++ b/workers/daily-report/src/report-format.js
@@ -99,8 +99,11 @@ function releaseHeading(release, age) {
 /** One deterministic scorecard section, as an array of lines. */
 export function formatScorecard({ ranking }) {
   if (!ranking || !Array.isArray(ranking.rows) || !(ranking.ages instanceof Map) ||
-      !ranking.summary || !Array.isArray(ranking.summary.releases)) {
-    throw new TypeError("formatScorecard requires ranking.rows, ranking.ages and ranking.summary");
+      !ranking.summary || !Array.isArray(ranking.summary.releases) ||
+      !Array.isArray(ranking.movers) || !Number.isInteger(ranking.comparableMeasures)) {
+    throw new TypeError(
+      "formatScorecard requires ranking.rows, ranking.ages, ranking.summary, ranking.movers and ranking.comparableMeasures"
+    );
   }
   // The formatter takes ONLY the ranking. It has no access to the raw selection
   // at all, so a raw tag form, a stale coverage figure or a stale cap flag
@@ -148,9 +151,13 @@ export function formatScorecard({ ranking }) {
  * which is the whole fact, with no verdict attached. */
 function formatShifts(ranking) {
   if (ranking.movers.length === 0) {
-    // Not "nothing changed": with one release, or insufficient history, there
-    // was nothing rankable to begin with, which is a different statement.
-    return "Biggest shifts: nothing to rank yet.";
+    // Two different facts hide behind an empty list (cloud review on #2622):
+    // measures were ranked and none moved, which is a statement about the
+    // product; or nothing was rankable - one release, no comparable contract -
+    // which is a statement about the data. Only the ranker knows which.
+    return ranking.comparableMeasures > 0
+      ? "Biggest shifts: none, nothing moved between these two releases."
+      : "Biggest shifts: nothing to rank yet.";
   }
   // Every mover the ranker handed over is printed: which rows are movers, and
   // in what order, is the ranker's decision alone (it already drops a measure

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -1529,7 +1529,7 @@ export function rankMovers({ measurements, selection }) {
 
   if (displayed.length < 2) {
     // Fewer than two displayed releases: render the grid, invent no comparison.
-    return { movers: [], ages, rows: buildRows(), summary, comparisonPair: null };
+    return { movers: [], comparableMeasures: 0, ages, rows: buildRows(), summary, comparisonPair: null };
   }
 
   const [newest, previous] = displayed;
@@ -1621,7 +1621,11 @@ export function rankMovers({ measurements, selection }) {
   // labelled with the basis used. Founder may overrule.
   const movers = [...normalizedFirst.sort(byScore), ...rawOnly.sort(byScore)].slice(0, 2);
 
-  return { movers, ages, rows: buildRows(), summary,
+  // How many measures were RANKABLE, before the zero-movement drop. The
+  // formatter needs it to tell "nothing moved" from "nothing could be ranked"
+  // (cloud review on #2622): an empty mover list means either, and only the
+  // first is a fact about the product.
+  return { movers, comparableMeasures: candidates.length, ages, rows: buildRows(), summary,
            comparisonPair: [newest.version, previous.version] };
 }
 

--- a/workers/daily-report/src/version-scorecard.js
+++ b/workers/daily-report/src/version-scorecard.js
@@ -1602,8 +1602,14 @@ export function rankMovers({ measurements, selection }) {
   }
 
   const order = Object.keys(METRIC_CALCULATIONS);
-  const normalizedFirst = candidates.filter((c) => c.historicalVariation !== null);
-  const rawOnly = candidates.filter((c) => c.historicalVariation === null);
+  // A measure that did not move is not a mover (#2621 review). Membership is
+  // decided HERE, once: the formatter prints every mover it is handed, so a
+  // zero-movement candidate would print as "1.00s to 1.00s" under "Biggest
+  // shifts", and a formatter that skipped it would be a second authority on
+  // which rows are movers.
+  const moved = candidates.filter((c) => c.rawMovement > 0);
+  const normalizedFirst = moved.filter((c) => c.historicalVariation !== null);
+  const rawOnly = moved.filter((c) => c.historicalVariation === null);
   const byScore = (a, b) =>
     b.score - a.score || order.indexOf(a.metricKey) - order.indexOf(b.metricKey);
   // Normalized candidates always precede raw-fallback ones. The two scores are

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -3249,13 +3249,22 @@ test("scorecard cells format counts with separators and a missing value as 'no d
       () => formatScorecard({ ranking: { ...ranking, ages: new Map([["2.4.6", bad], ["2.4.5", 7]]) } }),
       /release age must be a non-negative integer/, String(bad));
   }
-  // Every mover handed over is printed, in the ranker's order, even when the
-  // two values round to the same string: membership is the ranker's call.
+  // Every mover handed over is printed, in the ranker's order: membership is
+  // the ranker's call. A movement below the page's usual precision gains
+  // decimals until it is VISIBLE, never printing "0.60s to 0.60s" as a shift.
   const near = {
     ...ranking,
-    movers: [{ metricKey: "speed_p50", unit: "seconds", previousValue: 0.6, newestValue: 0.604 }],
+    movers: [{ metricKey: "speed_p50", unit: "seconds", previousValue: 0.6, newestValue: 0.604 },
+             { metricKey: "autopaste_direct", unit: "share", previousValue: 0.977, newestValue: 0.97724 }],
   };
-  assert.ok(formatScorecard({ ranking: near }).includes("Biggest shifts: Typical speed 0.60s to 0.60s."));
+  assert.ok(formatScorecard({ ranking: near }).includes(
+    "Biggest shifts: Typical speed 0.600s to 0.604s; Auto-paste worked 97.70% to 97.72%."));
+  // Bounded: a movement past four extra places prints both at the bound.
+  const tiny = {
+    ...ranking,
+    movers: [{ metricKey: "speed_p50", unit: "seconds", previousValue: 0.6, newestValue: 0.6000001 }],
+  };
+  assert.ok(formatScorecard({ ranking: tiny }).includes("Biggest shifts: Typical speed 0.600000s to 0.600000s."));
 });
 
 test("ranked-change formatting freezes normalized raw-fallback and unavailable copy", async () => {

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -3201,6 +3201,15 @@ test("scorecard formatting freezes coverage release age rows reasons and missing
   assert.match(text, /^Biggest shifts: Slowest 5% 3\.00s to 5\.00s\.$/m);
   assert.ok(!ranking.movers.some((m) => m.metricKey === "speed_p50"),
     "a measure that did not move is not a mover");
+  assert.ok(ranking.comparableMeasures >= 2, "the ranker reports how many measures it could rank");
+  // Every measure identical across the two releases: ranked, none moved, and
+  // the page says so rather than claiming there was nothing to rank.
+  const flatMeasurements = fakeMeasurements({ "2.4.1": Array(8).fill(5), "2.3.2": Array(8).fill(5) });
+  const flatRanking = rankMovers({ measurements: flatMeasurements, selection });
+  assert.deepEqual(flatRanking.movers, []);
+  assert.ok(flatRanking.comparableMeasures > 0);
+  assert.match(formatScorecard({ ranking: flatRanking }).join("\n"),
+    /^Biggest shifts: none, nothing moved between these two releases\.$/m);
   // A non-comparable row separates its cells with a bar, never "vs".
   assert.match(text, /^Failed dictations: 1\.0% \| 1\.0% \(not compared: /m);
   // 2.4.1 and 2.3.2 straddle the typed-code boundary, so that row is not
@@ -3226,6 +3235,7 @@ test("scorecard cells format counts with separators and a missing value as 'no d
     summary: { releases: [{ version: "2.4.6", observed: true }, { version: "2.4.5", observed: true }], coverage: 0.807 },
     movers: [{ metricKey: "speed_p50", unit: "seconds", previousValue: 0.6, newestValue: 0.84 },
              { metricKey: "autopaste_direct", unit: "share", previousValue: 0.977, newestValue: 0.983 }],
+    comparableMeasures: 5,
   };
   const lines = formatScorecard({ ranking });
   assert.deepEqual(lines, [
@@ -3265,6 +3275,17 @@ test("scorecard cells format counts with separators and a missing value as 'no d
     movers: [{ metricKey: "speed_p50", unit: "seconds", previousValue: 0.6, newestValue: 0.6000001 }],
   };
   assert.ok(formatScorecard({ ranking: tiny }).includes("Biggest shifts: Typical speed 0.600000s to 0.600000s."));
+  // An empty mover list means one of two things, and the page must say which:
+  // measures were ranked and none moved, or nothing was rankable at all.
+  const still = { ...ranking, movers: [], comparableMeasures: 5 };
+  assert.ok(formatScorecard({ ranking: still }).includes(
+    "Biggest shifts: none, nothing moved between these two releases."));
+  const unrankable = { ...ranking, movers: [], comparableMeasures: 0 };
+  assert.ok(formatScorecard({ ranking: unrankable }).includes("Biggest shifts: nothing to rank yet."));
+  // The count is REQUIRED: a ranking that omits it cannot be rendered, so a
+  // producer that forgets it fails loud rather than defaulting to one wording.
+  const { comparableMeasures: _omitted, ...without } = ranking;
+  assert.throws(() => formatScorecard({ ranking: without }), /comparableMeasures/);
 });
 
 test("ranked-change formatting freezes normalized raw-fallback and unavailable copy", async () => {

--- a/workers/daily-report/test/report.test.js
+++ b/workers/daily-report/test/report.test.js
@@ -2930,8 +2930,10 @@ test("rankMovers compares the first two selected releases and checks every displ
     assert.equal(row.cells.length, 1, 'one release means one column');
   }
   const oneText = formatScorecard({ ranking: oneRanking }).join('\n');
-  assert.match(oneText, /No comparable ranked changes were available/);
-  assert.match(oneText, /Dictations ending without a completed transcript/);
+  assert.match(oneText, /Biggest shifts: nothing to rank yet\./);
+  assert.match(oneText, /Failed dictations/);
+  assert.match(oneText, new RegExp(
+    `^This version covers ${(oneRanking.summary.coverage * 100).toFixed(1)}% of measured dictations this week\\.$`, "m"));
 
   // Duplicate catalog entries multiply observations and can manufacture enough
   // history to normalise a ranking that should fall back.
@@ -3172,30 +3174,88 @@ test("scorecard formatting freezes coverage release age rows reasons and missing
   const ranking = rankMovers({ measurements, selection });
   const text = formatScorecard({ measurements, selection, ranking }).join("\n");
 
-  assert.match(text, /last 7 complete Eastern days/);
+  assert.match(text, /^Version check, last 7 days$/m);
   assert.ok(!/[\u2013\u2014]/.test(text),
     "user-facing copy must contain no em-dashes or en-dashes");
-  assert.match(text, /84\.8% of measured dictations across 2 releases/,
-    "coverage must name its denominator, not just say 'of use'");
-  assert.match(text, /newest release is always included/);
-  assert.match(text, /4-version cap reached/);
-  assert.match(text, /non-additive/, "people counts must be declared non-additive");
+  assert.match(text, /These 2 versions cover 84\.8% of measured dictations this week\./,
+    "coverage is the one method fact on the page, and it names its denominator");
+  // #2621: the method lines are GONE from the page and owned by the README.
+  for (const finePrint of ["newest release is always included", "cap reached", "non-additive",
+                           "Builds before", "publicly available", "samples)", "median week-to-week",
+                           "by the safety classifier", "of the measured week"]) {
+    assert.ok(!text.includes(finePrint), `fine print must not reach the page: ${finePrint}`);
+  }
   // stamp(3) is 2026-07-26T00:00:00Z, which is 20:00 EASTERN on July 25, so the
   // release was publicly available for July 25-28: FOUR days of window 0. Under
   // the previous UTC flooring this read as three. That difference is the bug.
-  assert.match(text, /2\.4\.1: 4\/7 days publicly available/);
-  assert.match(text, /no production data yet/, "an unobserved release must say so, not show zero");
-  assert.match(text, /Dictations ending without a completed transcript/);
+  // The header carries the age; an unobserved release says so instead of a
+  // column of "no data" being the only clue.
+  assert.match(text, /^2\.4\.1 \(out 4 days\) vs 2\.3\.2 \(no data yet\)$/m);
+  assert.match(text, /^Failed dictations: /m);
   assert.ok(!text.includes("Transcription failed"),
     "must never label the row as speech-engine reliability");
-  assert.match(text, /by the safety classifier/, "classifier split sits under Polish kept");
+  // Cells carry no version prefix: the header names the columns once.
+  assert.match(text, /^People: 10 vs 10$/m);
+  // Typical speed is identical across the two releases, so the RANKER drops
+  // it and the page names only the row that moved. Two-way on one fixture.
+  assert.match(text, /^Biggest shifts: Slowest 5% 3\.00s to 5\.00s\.$/m);
+  assert.ok(!ranking.movers.some((m) => m.metricKey === "speed_p50"),
+    "a measure that did not move is not a mover");
+  // A non-comparable row separates its cells with a bar, never "vs".
+  assert.match(text, /^Failed dictations: 1\.0% \| 1\.0% \(not compared: /m);
   // 2.4.1 and 2.3.2 straddle the typed-code boundary, so that row is not
   // comparable - and must still PRINT, with the reason in plain words.
-  assert.match(text, /not compared, definition changed between these releases/);
-  for (const label of Object.values({ p: "People", d: "Dictations", s: "Typical speed",
-      x: "Slowest 5%", a: "Auto-paste landed directly", k: "Polish kept" })) {
-    assert.ok(text.includes(label), `row ${label} must be present`);
+  assert.match(text, /\(not compared: definition changed between these releases\)/);
+  for (const label of ["People", "Dictations", "Typical speed", "Slowest 5%",
+                       "Auto-paste worked", "Apple polish kept", "Failed dictations"]) {
+    assert.match(text, new RegExp(`^${label.replace("%", "%")}: `, "m"), `row ${label} must be present`);
   }
+});
+
+test("scorecard cells format counts with separators and a missing value as 'no data'", () => {
+  // A synthetic ranking, because the fixture's counts are all under a
+  // thousand and never null. Built by hand rather than through the ranker so
+  // that each cell's rendering is the only thing under test.
+  const ranking = {
+    rows: [
+      { metricKey: "dictations", unit: "count", comparable: true, cells: [{ value: 9902 }, { value: null }] },
+      { metricKey: "speed_p50", unit: "seconds", comparable: true, cells: [{ value: 0.84 }, { value: 0.6 }] },
+      { metricKey: "autopaste_direct", unit: "share", comparable: true, cells: [{ value: 0.983 }, { value: 0.977 }] },
+    ],
+    ages: new Map([["2.4.6", 6], ["2.4.5", 7]]),
+    summary: { releases: [{ version: "2.4.6", observed: true }, { version: "2.4.5", observed: true }], coverage: 0.807 },
+    movers: [{ metricKey: "speed_p50", unit: "seconds", previousValue: 0.6, newestValue: 0.84 },
+             { metricKey: "autopaste_direct", unit: "share", previousValue: 0.977, newestValue: 0.983 }],
+  };
+  const lines = formatScorecard({ ranking });
+  assert.deepEqual(lines, [
+    "Version check, last 7 days",
+    "2.4.6 (out 6 days) vs 2.4.5",
+    "",
+    "Dictations: 9,902 vs no data",
+    "Typical speed: 0.84s vs 0.60s",
+    "Auto-paste worked: 98.3% vs 97.7%",
+    "",
+    "Biggest shifts: Typical speed 0.60s to 0.84s; Auto-paste worked 97.7% to 98.3%.",
+    "These 2 versions cover 80.7% of measured dictations this week.",
+  ]);
+  // Singular day, and a release out today.
+  const young = { ...ranking, ages: new Map([["2.4.6", 1], ["2.4.5", 0]]) };
+  assert.equal(formatScorecard({ ranking: young })[1], "2.4.6 (out 1 day) vs 2.4.5 (out today)");
+  // An age that is not a whole non-negative number is a producer defect, not
+  // "out NaN days".
+  for (const bad of [-1, 1.5, NaN, "3"]) {
+    assert.throws(
+      () => formatScorecard({ ranking: { ...ranking, ages: new Map([["2.4.6", bad], ["2.4.5", 7]]) } }),
+      /release age must be a non-negative integer/, String(bad));
+  }
+  // Every mover handed over is printed, in the ranker's order, even when the
+  // two values round to the same string: membership is the ranker's call.
+  const near = {
+    ...ranking,
+    movers: [{ metricKey: "speed_p50", unit: "seconds", previousValue: 0.6, newestValue: 0.604 }],
+  };
+  assert.ok(formatScorecard({ ranking: near }).includes("Biggest shifts: Typical speed 0.60s to 0.60s."));
 });
 
 test("ranked-change formatting freezes normalized raw-fallback and unavailable copy", async () => {
@@ -3210,20 +3270,17 @@ test("ranked-change formatting freezes normalized raw-fallback and unavailable c
   const ranking = rankMovers({ measurements, selection });
   const text = formatScorecard({ measurements, selection, ranking }).join("\n");
 
-  assert.match(text, /ranked changes, not alerts/,
-    "the section must state plainly that it is not an alarm");
-  assert.match(text, /samples\)/, "every mover must disclose both sample counts");
-  assert.match(text, /median week-to-week movement|size of change only/,
-    "each mover must say which basis ranked it");
+  // One sentence, "from X to Y" per mover, in the ranker's order, no basis, no
+  // sample counts (#2621). Two-way: the sentence names a real mover's numbers.
+  assert.match(text, /^Biggest shifts: [A-Z][^;]+ [0-9.]+(s|%) to [0-9.]+(s|%)(; [^;]+)*\.$/m);
+  assert.ok(!text.includes("samples"), "sample counts are README material, not page material");
 
-  // Prohibited copy: this is a scorecard, not a verdict. The only permitted
-  // occurrence of "alert" is the explicit not-alerts statement.
+  // Prohibited copy: this is a scorecard, not a verdict. No "alert" either -
+  // the page no longer needs to say what it is not.
   for (const banned of ["healthy", "unhealthy", "warning", "regression", "improvement",
-                        "threshold", "better", "worse"]) {
+                        "threshold", "better", "worse", "alert", "up ", "down "]) {
     assert.ok(!text.toLowerCase().includes(banned), `must not use verdict language: ${banned}`);
   }
-  assert.equal((text.toLowerCase().match(/alert/g) || []).length, 1,
-    "the only 'alert' must be the not-alerts statement");
 
   // SOURCE GUARD: the formatter must consume decisions, never re-derive them.
   // Importing a metric authority here would create a second opinion on row
@@ -3291,19 +3348,19 @@ test("a clean run resolves ONE context and posts ONE payload carrying all three 
     assert.equal(payload.content, reportHeader("2026-07-17"));
     assert.equal(payload.embeds.length, 3, "exactly three embeds");
     assert.equal(payload.embeds[0].title, "Adoption");
-    assert.match(payload.embeds[1].title, /^Version scorecard/);
-    assert.equal(payload.embeds[2].title, "Sentry, yesterday");
+    assert.match(payload.embeds[1].title, /^Version check/);
+    assert.equal(payload.embeds[2].title, "Errors, yesterday");
     // Real sections, not the unavailable copy.
     assert.match(payload.embeds[0].description, /Total users: 1 people used the app that day\./);
-    assert.match(payload.embeds[1].description, /2\.4\.1: 7\/7 days publicly available/);
-    assert.match(payload.embeds[1].description, /2\.4\.0: 7\/7 days publicly available/);
+    // Both releases out the whole week: bare versions in the header, no age.
+    assert.match(payload.embeds[1].description, /^2\.4\.1 vs 2\.4\.0$/m);
     // The Sentry section is REAL here, not the unavailable copy: the release
     // line resolves to 2.4.0 from the fixture's own per-release split, and both
     // groups render.
-    assert.match(payload.embeds[2].description, /on 2\.4\.0 and newer/);
-    assert.match(payload.embeds[2].description, /LOST THE DICTATION/);
-    assert.match(payload.embeds[2].description, /7 people {3}microphone capture stalled/);
-    assert.match(payload.embeds[2].description, /STILL WORKED, JUST WORSE/);
+    assert.match(payload.embeds[2].description, /^\d+ (person|people) hit an error on 2\.4\.0 or newer, /m);
+    assert.match(payload.embeds[2].description, /Lost the dictation:/);
+    assert.match(payload.embeds[2].description, /7 people: microphone capture stalled/);
+    assert.match(payload.embeds[2].description, /Worked, but worse:/);
     for (const embed of payload.embeds) {
       assert.doesNotMatch(embed.description, /unavailable today/);
     }
@@ -3450,7 +3507,7 @@ test("an adoption rejection releases its slot and the scorecard still runs and r
     assert.ok(mock.requests.some((u) => u === APPCAST_URL),
       "stage-2 release resolution must still run for the surviving section");
     assert.equal(mock.discordPayloads.length, 1);
-    assert.match(mock.discordPayloads[0].embeds[1].description, /2\.4\.1: 7\/7 days publicly available/);
+    assert.match(mock.discordPayloads[0].embeds[1].description, /^2\.4\.1 vs 2\.4\.0$/m);
   } finally {
     mock.restore();
   }
@@ -3464,7 +3521,7 @@ test("an adoption-only failure posts the scorecard beside an unavailable adoptio
     assert.equal(mock.discordPayloads.length, 1, "one combined report, not one message per section");
     const [adoption, scorecard] = mock.discordPayloads[0].embeds;
     assert.match(adoption.description, /could not be measured, so this is not a report of zero/);
-    assert.match(scorecard.description, /2\.4\.1: 7\/7 days publicly available/);
+    assert.match(scorecard.description, /^2\.4\.1 vs 2\.4\.0$/m);
   } finally {
     mock.restore();
   }
@@ -3506,14 +3563,13 @@ test("every section failing still posts exactly one message, with each marked un
     // Sentry is unaffected by a PostHog 401 and must still render for real.
     // A section that failed BECAUSE a different vendor failed would be a
     // coupling this design does not have.
-    assert.equal(sentry.title, "Sentry, yesterday");
-    // Checked against the unavailable COPY, not the word "unavailable": a
-    // healthy section deliberately contains the sentence "Impact rate
-    // unavailable", so a bare word match would confuse a working section with
-    // a broken one.
+    assert.equal(sentry.title, "Errors, yesterday");
+    // Checked against the unavailable COPY, not the word "unavailable", so a
+    // healthy section that happens to use the word is never confused with a
+    // broken one.
     assert.doesNotMatch(sentry.title, /unavailable today/);
     assert.doesNotMatch(sentry.description, /could not be measured/);
-    assert.match(sentry.description, /on 2\.4\.0 and newer/);
+    assert.match(sentry.description, /^\d+ (person|people) hit an error on 2\.4\.0 or newer, /m);
     // Still a report, still three embeds: the founder learns that nothing was
     // measured, which is not the same as learning that everything was zero.
     assert.equal(mock.discordPayloads[0].embeds.length, 3);
@@ -4103,7 +4159,7 @@ test("only a declared scorecard contract failure can trigger the whole-run path"
     const payload = mock.discordPayloads[0];
     assert.ok("embeds" in payload, "an adoption failure must still produce a combined report");
     assert.match(payload.embeds[0].title, /unavailable today/);
-    assert.match(payload.embeds[1].description, /2\.4\.1: 7\/7 days publicly available/,
+    assert.match(payload.embeds[1].description, /^2\.4\.1 vs 2\.4\.0$/m,
       "the scorecard is real, not discarded by an impostor property");
   } finally {
     mock.restore();
@@ -4175,19 +4231,14 @@ test("builds below the measurement floor are hidden everywhere, not shown with a
   const ranking = rankMovers({ measurements, selection });
   assert.equal(ranking.summary.minVersion, "2.2.0");
   const text = formatScorecard({ ranking }).join("\n");
-  assert.match(text, /Builds before 2\.2\.0 are not measured/);
-  // Those builds DID record filter_tripped; production shows classifier_discard
-  // on them. What they did not record was every fallback reason.
-  assert.match(text, /did not record every reason polished text was rejected/);
-  assert.doesNotMatch(text, /never recorded why/);
+  // #2621: the floor is no longer DISCLOSED on the page; the README owns the
+  // explanation. It still travels on the ranking (asserted above) so a reader
+  // of the data can see it, and the page must not print it or a hole where it
+  // was.
+  assert.doesNotMatch(text, /2\.2\.0|Builds before|undefined/);
   // The floor exists BECAUSE of the polish boundary, so the two must not drift.
   assert.equal(telemetryContractFor("polish_kept", "2.2.0"), "polish-v2-fallback-reason");
   assert.equal(telemetryContractFor("polish_kept", "2.1.9"), null);
-  assert.doesNotMatch(text, /undefined/);
-  assert.throws(
-    () => formatScorecard({ ranking: { ...ranking, summary: { ...ranking.summary, minVersion: undefined } } }),
-    /minVersion must be a version string/
-  );
 });
 
 test("a release published after the reported window is never crowned newest", async () => {

--- a/workers/daily-report/test/sentry-section.test.js
+++ b/workers/daily-report/test/sentry-section.test.js
@@ -562,7 +562,7 @@ test("an issue Sentry returns from OUTSIDE the window is still not badged", asyn
 async function render(overrides, formatOpts = {}) {
   const { fetchFn } = digestFetch(overrides);
   const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
-  return { data, lines: formatSentrySection(data, { title: "Sentry, yesterday", ...formatOpts }) };
+  return { data, lines: formatSentrySection(data, { title: "Errors, yesterday", ...formatOpts }) };
 }
 
 test("the section groups lost from degraded and never prints a rate", async () => {
@@ -573,11 +573,16 @@ test("the section groups lost from degraded and never prints a rate", async () =
     ],
   });
   const text = lines.join("\n");
-  assert.match(text, /LOST THE DICTATION/);
-  assert.match(text, /STILL WORKED, JUST WORSE/);
-  assert.match(text, /7 people {3}microphone capture stalled/);
-  assert.match(text, /1 person {3}paste fell back to the clipboard/);
-  assert.match(text, /Impact rate unavailable/);
+  assert.match(text, /^Lost the dictation:$/m);
+  assert.match(text, /^Worked, but worse:$/m);
+  assert.match(text, /^  7 people: microphone capture stalled$/m);
+  assert.match(text, /^  1 person: paste fell back to the clipboard$/m);
+  // #2621: no rate, and no sentence about why there is no rate - the README
+  // owns that. The headline is people and direction, nothing else.
+  assert.doesNotMatch(text, /Impact rate|identity systems|errors across/);
+  // The headline keeps its DATA SCOPE: the count covers the release line and
+  // newer, and a bare count would read as the whole error population.
+  assert.match(text, /^\d+ (person|people) hit an error on 2\.4\.0 or newer, /m);
   assert.doesNotMatch(text, /\d+(\.\d+)?%/, "the section must never print a percentage");
 });
 
@@ -590,31 +595,31 @@ test("a conservative row says delivery is not proven and a proven one does not",
   });
   const text = lines.join("\n");
   assert.match(text, /transcription helper failed, delivery not proven/);
-  assert.match(text, /2 people {3}microphone capture stalled(\n|$)/);
+  assert.match(text, /2 people: microphone capture stalled(\n|$)/);
 });
 
 test("the crash row reads as a crash exactly once", async () => {
   const { lines } = await render({ problems: [problemRow("EW-1", "", 1, 4, "fatal")] });
   const text = lines.join("\n");
-  assert.match(text, /1 person {3}app crash, delivery not proven/);
+  assert.match(text, /1 person: app crash, delivery not proven/);
   assert.equal(text.match(/delivery not proven/g).length, 1);
 });
 
 test("the people delta is stated in both directions and when flat", async () => {
   const up = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)], people: 13, priorPeople: 12 });
-  assert.match(up.lines.join("\n"), /1 more than the previous period \(12 people\)/);
+  assert.match(up.lines.join("\n"), /^13 people hit an error on 2\.4\.0 or newer, up from 12\.$/m);
 
   const down = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)], people: 10, priorPeople: 12 });
-  assert.match(down.lines.join("\n"), /2 fewer than the previous period/);
+  assert.match(down.lines.join("\n"), /^10 people hit an error on 2\.4\.0 or newer, down from 12\.$/m);
 
   const flat = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)], people: 12, priorPeople: 12 });
-  assert.match(flat.lines.join("\n"), /the same as the previous period/);
+  assert.match(flat.lines.join("\n"), /^12 people hit an error on 2\.4\.0 or newer, the same as last time\.$/m);
 });
 
 test("the old-build tail is reported as an upper bound", async () => {
   const { lines } = await render({ problems: [problemRow("EW-1", "asr_failed", 1, 1)] });
   // Non-additive per-release counts, so it must not claim a distinct-person count.
-  assert.match(lines.join("\n"), /up to 2 people on builds older than 2\.4\.0/);
+  assert.match(lines.join("\n"), /^Up to 2 people hit an error on builds older than 2\.4\.0\.$/m);
 });
 
 test("a truncated release page drops the upper-bound claim it can no longer support", async () => {
@@ -697,7 +702,7 @@ test("zero problems renders an explicit good-news line", async () => {
 });
 
 test("unavailable copy says nothing was measured and leaks nothing technical", () => {
-  const lines = formatSentryUnavailable("Sentry, yesterday");
+  const lines = formatSentryUnavailable("Errors, yesterday");
   assert.equal(lines.length, 2);
   assert.match(lines[1], /not a report of zero/);
   for (const line of lines) {
@@ -714,7 +719,7 @@ test("an over-budget section discloses what it omitted instead of truncating sil
   const many = Array.from({ length: 60 }, (_, i) => problemRow(`EW-${i}`, "audio_capture_stalled", 2, 2));
   const { lines } = await render({ problems: many });
   const text = lines.join("\n");
-  assert.match(text, /more problems are not listed here\. The totals above include them\./);
+  assert.match(text, /more problems are not listed here\. People affected by them are in the total above\./);
   // STRICT. A "near its budget" tolerance is what let a real 24-character
   // overrun pass: the disclosure line was appended after the budget was already
   // spent. The budget governs the DESCRIPTION, so the title is excluded.
@@ -728,14 +733,12 @@ test("a full page of problems is disclosed as a limited breakdown", async () => 
   const { lines } = await render({ problems: many });
   const text = lines.join("\n");
   assert.match(text, /more problems may exist/);
-  // The error total and the visible breakdown are bounded DIFFERENTLY: events
-  // are summed from every returned row, while the list can be cut short again
-  // by the Discord budget. Collapsing both into "those listed above" contradicts
-  // the omission notice printed just above it (Codex review r2).
-  assert.match(text, /the error count covers every problem Sentry returned/);
-  assert.match(text, /the breakdown covers only those listed above/);
-  // 100 DISTINCT issues, so the measured count really is 100 here.
-  assert.match(text, /across 100 or more problems/);
+  // The people total is bounded differently from the list: it comes from an
+  // ungrouped aggregate that is never paginated, while the list can be cut
+  // short by the page and again by the Discord budget. Since #2621 the page
+  // prints no error or problem count, so the line claims only that split.
+  assert.match(text, /People affected by all of them are in the total above; the list above is incomplete\./);
+  assert.doesNotMatch(text, /errors across|or more problems/, "no count is asserted");
 });
 
 test("a truncated page never claims more problems than it can count (#2023)", async () => {
@@ -750,11 +753,12 @@ test("a truncated page never claims more problems than it can count (#2023)", as
 
   assert.equal(data.rows.length, 40, "100 rows over 40 issues must collapse to 40 problems");
   assert.equal(data.truncated, true, "a full page is still treated as possibly incomplete");
-  assert.match(text, /across 40 or more problems/);
-  assert.doesNotMatch(text, /100 or more problems/, "the page size is not a problem count");
-  assert.doesNotMatch(text, /largest 100/, "nor is it a claim about what the breakdown covers");
+  // #2621: no problem count reaches the page at all, so nothing can assert a
+  // number nobody measured. The truncation is still disclosed.
+  assert.doesNotMatch(text, /\d+ or more problems|largest 100/);
+  assert.match(text, /more problems may exist/);
   // The people total is unaffected by truncation and must keep saying so.
-  assert.match(text, /The affected-people total covers all of them/);
+  assert.match(text, /People affected by all of them are in the total above/);
 });
 
 test("a full page issues no second Sentry request", async () => {
@@ -775,7 +779,7 @@ test("the worst realistic section still fits Discord's per-embed limits", async 
     priorPeople: 1,
   });
   const data = await fetchSentrySection(ENV, WINDOW, { ...OPTS, fetchFn });
-  const lines = formatSentrySection(data, { title: "Sentry, last 7 days" });
+  const lines = formatSentrySection(data, { title: "Errors, last 7 days" });
   const [title, ...body] = lines;
   assert.ok(title.length <= DISCORD_LIMITS.embedTitle);
   assert.ok(body.join("\n").length <= DISCORD_LIMITS.embedDescription);
@@ -836,7 +840,7 @@ test("one Sentry issue is one problem even when it returns several rows (#2023)"
   // Exactly one rendered line for that issue, not three.
   const crashLines = lines.filter((l) => l.includes("app crash"));
   assert.equal(crashLines.length, 1, `expected one crash line, got ${JSON.stringify(crashLines)}`);
-  assert.match(lines.join("\n"), /1 person {3}app crash \(EXC_BAD_ACCESS\)/);
+  assert.match(lines.join("\n"), /1 person: app crash \(EXC_BAD_ACCESS\)/);
 });
 
 test("a merged people count says it is a lower bound, an unmerged one does not", async () => {
@@ -852,10 +856,10 @@ test("a merged people count says it is a lower bound, an unmerged one does not",
   });
   const text = lines.join("\n");
 
-  assert.match(text, /at least 3 people {3}app crash \(EXC_BAD_ACCESS\)/);
+  assert.match(text, /at least 3 people: app crash \(EXC_BAD_ACCESS\)/);
   // The two-way control. Without it, a hedge applied to EVERY row would pass the
   // assertion above while quietly making every exact figure look uncertain.
-  assert.match(text, /\n {2}5 people {3}microphone capture stalled/);
+  assert.match(text, /\n {2}5 people: microphone capture stalled/);
   assert.doesNotMatch(text, /at least 5 people/);
 });
 
@@ -998,11 +1002,11 @@ test("two problems that would render identically are separated by their issue id
   const text = lines.join("\n");
   // These fixtures carry no exception type, so both land on the bare "app
   // crash" label and the issue id is the ONLY thing separating them.
-  assert.match(text, /1 person {3}app crash EW-34, delivery not proven/);
-  assert.match(text, /1 person {3}app crash EW-3V, delivery not proven/);
+  assert.match(text, /1 person: app crash EW-34, delivery not proven/);
+  assert.match(text, /1 person: app crash EW-3V, delivery not proven/);
   // The row that does NOT collide keeps its clean label, so the id is a
   // targeted disambiguation rather than noise on every line.
-  assert.match(text, /5 people {3}microphone capture stalled(\n|$)/);
+  assert.match(text, /5 people: microphone capture stalled(\n|$)/);
 });
 
 test("a collision straddling the two groups is still disambiguated", () => {
@@ -1141,25 +1145,25 @@ test("an unusable release line stops after the two stage-one calls", async () =>
   assert.equal(urls.length, 2, "stage two must not run without a resolved floor");
 });
 
-test("the truncated headline says 'at least', and never claims the totals are complete", async () => {
+test("a truncated page never claims the people total includes the omitted rows", async () => {
   // `events` is summed from the returned rows, so on a truncated page it
-  // EXCLUDES everything past the first hundred. Printing it as the total
-  // understates it, and the old disclosure then said the totals included them.
+  // EXCLUDES everything past the first hundred. Since #2621 no error count is
+  // printed, so the only claim left to get wrong is the omission notice's
+  // "includes them", which must not appear when the page was cut.
   const many = Array.from({ length: 100 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
   const { lines } = await render({ problems: many });
   const text = lines.join("\n");
-  assert.match(text, /at least \d+ errors across 100 or more problems/);
-  assert.doesNotMatch(text, /The totals above include them/);
-  assert.match(text, /The affected-people total covers all of them/);
+  assert.doesNotMatch(text, /People affected by them are in the total above/);
+  assert.match(text, /People affected by all of them are in the total above/);
 });
 
-test("an untruncated section still says the totals include the omitted rows", async () => {
+test("an untruncated section still says the people total includes the omitted rows", async () => {
   // Two-way control: the qualifier above must apply ONLY when truncated, or the
   // section would hedge a number it knows exactly.
   const many = Array.from({ length: 60 }, (_, i) => problemRow(`EW-${i}`, "asr_failed", 1, 1));
   const { lines } = await render({ problems: many });
   const text = lines.join("\n");
-  assert.match(text, /The totals above include them/);
+  assert.match(text, /People affected by them are in the total above/);
   assert.doesNotMatch(text, /at least/);
 });
 

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -836,37 +836,29 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
     return finishSection(lines, budget);
   }
 
-  // THE TRUNCATED CASE IS A DIFFERENT SENTENCE, not the same one with a note.
-  // `events` is summed from the returned problem rows, so on a truncated page
-  // it EXCLUDES everything past the first hundred: printing it as the error
-  // total understates it, and the old disclosure then said "the totals above
-  // include them", which was flatly untrue. The PEOPLE figure is unaffected -
-  // it comes from an ungrouped aggregate that is never paginated - so only the
-  // error count and the problem count need qualifying.
-  const errorText = data.truncated
-    ? `at least ${data.events} ${data.events === 1 ? "error" : "errors"}`
-    : `${data.events} ${data.events === 1 ? "error" : "errors"}`;
-  // COUNTED FROM THE ROWS, never from the page size. Before #2023 this said
-  // "100 or more problems", which was sound while one row WAS one problem. Now
-  // that rows collapse by issue, a full 100-row page can yield fewer than 100
-  // unique problems, and a hardcoded 100 would assert a number nobody measured.
-  // `rows.length` is what we actually saw either way; `truncated` only adds the
-  // "or more".
-  const problemText = data.truncated
-    ? `${data.rows.length} or more ${data.rows.length === 1 ? "problem" : "problems"}`
-    : `${data.rows.length} ${data.rows.length === 1 ? "problem" : "problems"}`;
-  lines.push(`${people(data.people)} hit ${errorText} across ${problemText}, on ${data.floor} and newer.`);
-
-  // The action metric. An absolute count rises with usage, so it cannot answer
-  // "is this spreading", which is the entire reason this section exists.
-  const delta = data.people - data.priorPeople;
-  const direction = delta === 0 ? "the same as" : delta > 0 ? `${delta} more than` : `${-delta} fewer than`;
-  lines.push(`That is ${direction} the previous period (${people(data.priorPeople)}).`);
+  // ONE headline: people, and which way it moved (#2621). The PEOPLE figure is
+  // the action metric - an absolute error count rises with usage and cannot
+  // answer "is this spreading" - and it comes from an ungrouped aggregate that
+  // is never paginated, so it needs no truncation qualifier. The error and
+  // problem counts, which did need qualifying, are no longer printed: the
+  // founder read "16 people hit 61 errors across 6 problems" as three numbers
+  // fighting for one sentence. `data.events` and `data.rows.length` still exist
+  // for the truncation logic below.
+  //
   // Never a rate. Sentry and PostHog join only per INSTALL and only partially
   // (sentry-operations.md RULE: join-sentry-to-posthog-by-install), so dividing
   // one system's distinct-user count by the other's would be arithmetic across
-  // two identity systems. Saying so is better than inventing a denominator.
-  lines.push("Impact rate unavailable: error counts and usage counts come from different identity systems.");
+  // two identity systems. The page no longer says so out loud; the README does.
+  const delta = data.people - data.priorPeople;
+  const movement =
+    delta === 0
+      ? "the same as last time"
+      : delta > 0
+        ? `up from ${data.priorPeople}`
+        : `down from ${data.priorPeople}`;
+  // The floor stays in the headline: the people count covers the release
+  // line and newer, and a bare count would read as the whole error population.
+  lines.push(`${people(data.people)} hit an error on ${data.floor} or newer, ${movement}.`);
 
   // TWO ERROR SOURCES PULLING OPPOSITE WAYS MEANS NO BOUND EXISTS, SO PRINT NO
   // NUMBER. The sum OVERSTATES, because per-release people counts are not
@@ -883,13 +875,15 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
   // conclusion this section must never let a reader draw by accident.
   if (data.releasesTruncated) {
     lines.push(
-      `Separately, the release list hit its ${RELEASE_PAGE_LIMIT}-row limit, ` +
+      `The release list hit its ${RELEASE_PAGE_LIMIT}-row limit, ` +
         `so people on builds older than ${data.floor} could not be counted.`
     );
   } else if (data.tailPeople > 0) {
     // "Up to", because these are per-release counts summed across releases and
     // one person can appear under more than one.
-    lines.push(`Separately, up to ${people(data.tailPeople)} on builds older than ${data.floor}.`);
+    // Not "plus" and not "not counted above": one person can hit errors on a
+    // current build AND an old one, so the two populations can overlap.
+    lines.push(`Up to ${people(data.tailPeople)} hit an error on builds older than ${data.floor}.`);
   }
   lines.push("");
 
@@ -921,8 +915,8 @@ export function formatSentrySection(data, { title, budget: requestedBudget = DEF
     (data.truncated ? TRUNCATED_LINE.length + 1 : 0) +
     (data.badgesIncomplete ? BADGES_INCOMPLETE_LINE.length + 1 : 0);
   const state = { budget: budget - reserve, omitted: 0 };
-  appendGroup(lines, "LOST THE DICTATION", lost, state);
-  appendGroup(lines, "STILL WORKED, JUST WORSE", degraded, state);
+  appendGroup(lines, "Lost the dictation:", lost, state);
+  appendGroup(lines, "Worked, but worse:", degraded, state);
 
   if (state.omitted > 0) lines.push(omittedLine(state.omitted, data.truncated));
   if (data.truncated) lines.push(TRUNCATED_LINE);
@@ -973,26 +967,24 @@ const BADGES_INCOMPLETE_LINE =
 /** Deliberately carries NO number. Sentry cut the page at 100 ROWS, and since
  * #2023 those rows collapse by issue, so the page size is no longer the count of
  * problems it covers - "the largest 100" would name a quantity this line cannot
- * support. The headline sentence above already states the measured count and
- * qualifies it with "or more"; this line's job is the CLAIM, which is that the
- * error count and breakdown are bounded by what came back while the people
- * total is not.
+ * support. Since #2621 the headline prints no error or problem count at all, so
+ * this line's whole job is the CLAIM: the list is bounded by what came back
+ * while the people total is not.
  *
  * `BADGES_INCOMPLETE_LINE` above keeps its 100 on purpose: it describes the
  * ISSUES endpoint, whose rows are one-per-issue and are never collapsed, so the
  * page size there really is a problem count. Two different axes, and only this
  * one moved. */
 const TRUNCATED_LINE =
-  "Sentry returned a full page, so more problems may exist. The affected-people total " +
-  "covers all of them; the error count covers every problem Sentry returned, while the " +
-  "breakdown covers only those listed above.";
+  "Sentry returned a full page, so more problems may exist. People affected by all of them " +
+  "are in the total above; the list above is incomplete.";
 
 /** `truncated` changes the CLAIM, not just the wording: when the problem page
  * was cut off, the totals above genuinely do NOT include the omitted rows, so
  * the sentence that says they do must not be printed. */
 const omittedLine = (n, truncated) =>
   `${n} more ${n === 1 ? "problem is" : "problems are"} not listed here.` +
-  (truncated ? "" : " The totals above include them.");
+  (truncated ? "" : " People affected by them are in the total above.");
 
 /** The rendered description length, which is every line EXCEPT the title.
  *
@@ -1094,7 +1086,7 @@ function appendGroup(lines, heading, rows, state) {
     const mixed = others > 0
       ? ` and ${others} other ${others === 1 ? "failure" : "failures"} on the same issue`
       : "";
-    lines.push(`  ${peopleText}   ${row.label}${mixed}${suffix}${row.isNew ? "   NEW" : ""}`);
+    lines.push(`  ${peopleText}: ${row.label}${mixed}${suffix}${row.isNew ? "   NEW" : ""}`);
     if (descriptionLength(lines) > state.budget) {
       lines.pop();
       state.omitted += 1;

--- a/workers/weekly-digest/src/index.js
+++ b/workers/weekly-digest/src/index.js
@@ -646,7 +646,7 @@ async function postFailureNotice(env, label, { fetchFn = fetch } = {}) {
 
 /** This digest always reports the same complete week for every section, so the
  * title needs no date of its own; the range is on the message's content line. */
-const SENTRY_TITLE = "Sentry, last 7 days";
+const SENTRY_TITLE = "Errors, last 7 days";
 
 /** Sentry's window, derived from the ONE resolved week and nothing else.
  *

--- a/workers/weekly-digest/test/digest.test.js
+++ b/workers/weekly-digest/test/digest.test.js
@@ -527,7 +527,7 @@ test("the digest posts five section embeds carrying the brand colour", async () 
   assert.equal(digest.embeds.length, 5);
   assert.deepEqual(digest.embeds.map((e) => e.title), [
     "All website traffic", "Tracked visitor activity", "Downloads", "App usage",
-    "Sentry, last 7 days",
+    "Errors, last 7 days",
   ]);
   for (const embed of digest.embeds) {
     assert.equal(embed.color, 0x7c3aed);
@@ -956,13 +956,12 @@ test("the weekly Sentry section spends the fixed call budget and scopes to the r
     "five fixed Sentry calls, never a per-issue fan-out");
   const [digest] = h.state.posts;
   const sentry = digest.embeds[4];
-  assert.match(sentry.description, /on 2\.4\.0 and newer/);
-  assert.match(sentry.description, /25 people {3}microphone capture stalled/);
-  assert.match(sentry.description, /13 people {3}paste fell back to the clipboard/);
+  assert.match(sentry.description, /25 people: microphone capture stalled/);
+  assert.match(sentry.description, /13 people: paste fell back to the clipboard/);
   // 8 more people than the prior week (38 vs 30).
-  assert.match(sentry.description, /8 more than the previous period \(30 people\)/);
+  assert.match(sentry.description, /^38 people hit an error on 2\.4\.0 or newer, up from 30\.$/m);
   // The tail line: 2.3.1 sits below the resolved 2.4.0 line.
-  assert.match(sentry.description, /up to 2 people on builds older than 2\.4\.0/);
+  assert.match(sentry.description, /^Up to 2 people hit an error on builds older than 2\.4\.0\.$/m);
 });
 
 test("the weekly badge window is the reported week, absolutely, not a relative lookback", async () => {


### PR DESCRIPTION
Closes #2621

## What

The Daily Report's two lower sections, the version scorecard and the Sentry section, print numbers and one footnote, nothing that explains method. Founder's call ("Option A", #2621): cut the fine print, one clean comparison, plain words; the explanations move to the worker README. The weekly digest shares the Sentry formatter and gets the same layout.

Rendered from live data for 2026-09-02 by `live-query-smoke.mjs` (nothing posted):

```
Version check, last 7 days
2.4.6 (out 6 days) vs 2.4.5

People: 135 vs 121
Dictations: 9,902 vs 6,887
Typical speed: 0.85s vs 0.60s
Slowest 5%: 4.72s vs 4.47s
Auto-paste worked: 98.3% vs 97.7%
Apple polish kept: 87.8% vs 89.1%
Failed dictations: 0.5% vs 0.3%

Biggest shifts: Auto-paste worked 97.7% to 98.3%; Typical speed 0.60s to 0.85s.
These 2 versions cover 80.7% of measured dictations this week.

Errors, yesterday
16 people hit an error on 2.4.0 or newer, down from 20.

Lost the dictation:
  11 people: microphone capture stalled
  2 people: saved recording could not be unlocked
  2 people: microphone capture failed

Worked, but worse:
  1 person: paste fell back to the clipboard
  1 person: polish provider failed
  1 person: crash-safety copy could not be armed
```

## What stays

- The no-verdict rule in the version section: no better/worse/healthy/regression/alert language; "Biggest shifts" names "from X to Y" in the ranker's order and nothing more.
- The formatter consumes the ranker's decisions and re-derives none of them (source guard test unchanged). The only presentation-level choice added: a mover whose two values render identically at the printed precision is not named.
- Non-comparable rows still print, with `(not compared: reason)` inline. A missing release age still throws rather than printing "out 0 days".
- The Sentry Discord budget, the omission and truncation disclosures (reworded to claim only what is still on the page), `delivery not proven`, `NEW`, and the old-build tail line.

## Dropped from the page (all still measured, all explained in the README)

Coverage method lines, newest-always-included, the 2.2.0 measurement floor, the non-additive note, per-version share and polish-split sub-lines, mover sample counts and ranking basis; the Sentry error and problem counts and the identity-systems sentence. The release floor stays in the error headline so the count keeps its data scope.

## Validation

- `node --test`: daily-report 268/268, weekly-digest 73/73, sentry-triage 97/97.
- Tests re-frozen to the new wording in all three suites; a new synthetic-ranking test pins thousands separators, `no data`, singular `day`, `out today`, age validation, and that every mover the ranker hands over is printed (the ranker now drops a measure that did not move).
- Local Codex review: 10 findings, 9 adopted, 1 rejected with reason; see the commit body. Lane: Worker. Both workers deploy by hand after merge; the daily one is verified by a dispatched run.
