### PR TITLE
fix(keybinds): the shortcut box can record a key combination (#2613)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Components/HotkeyRecorderView.swift
@@ -30,15 +30,161 @@ final class KeyCaptureNSView: NSView {
   /// and could be forgotten by the next surface.
   var isRecording = false {
     didSet {
+      // `updateNSView` assigns this on EVERY SwiftUI update pass, not only when it
+      // changes, so an unguarded body would wipe an in-progress capture on any
+      // unrelated redraw. #2613's state below only survives because of this guard.
+      guard isRecording != oldValue else { return }
+      resetCaptureState()
+
       // Stop holding focus the instant recording ends. `acceptsFirstResponder`
       // going false does not resign an existing first-responder status, so without
       // this the view keeps receiving keys until something else takes focus.
-      guard !isRecording, oldValue, let window, window.firstResponder === self else { return }
+      guard !isRecording, let window, window.firstResponder === self else { return }
       window.makeFirstResponder(nil)
     }
   }
 
   override var acceptsFirstResponder: Bool { isRecording }
+
+  /// #2613 — re-take the physically-held snapshot at the moment event delivery is
+  /// actually OWNED, not when the box was armed.
+  ///
+  /// `updateNSView` arms this view and then defers `makeFirstResponder` into a
+  /// `Task`, so there is a real gap in which the box is armed and someone else
+  /// still owns the keyboard. A modifier pressed inside that gap is never seen
+  /// going down, and its release is then read as a press — the same phantom the
+  /// neutral boundary exists to prevent, arriving through a door the arming-time
+  /// read cannot watch. If the phantom is Globe, every later key is refused as a
+  /// Globe chord and the box goes silently dead.
+  ///
+  /// **This covers the FIRST acquisition only, and that is not the whole gap.**
+  /// AppKit does not call this again when the user leaves the app and comes back,
+  /// because the window keeps its stored first responder across losing key status —
+  /// so no responder change happens and nothing here fires. Key events do go
+  /// elsewhere while the window is not key, which is a second window of missed
+  /// transitions with the same phantom outcome. `windowDidBecomeKey` below closes
+  /// that one; neither is sufficient alone.
+  override func becomeFirstResponder() -> Bool {
+    let accepted = super.becomeFirstResponder()
+    if accepted, isRecording { resetCaptureState() }
+    return accepted
+  }
+
+  /// #2613 — the SECOND gap: key events went to another application while this
+  /// window was not key, so any modifier transition in that period was never seen.
+  ///
+  /// Failing sequence without this: click the box, hold Shift, click another app
+  /// while still holding it, release Shift there, come back, press Shift. The
+  /// release was missed, so Shift is still in `held`, and that press is read as a
+  /// release — committing bare Shift on the way DOWN, with the user never having
+  /// finished.
+  ///
+  /// **Re-syncing on RETURN is not the same action as ending a capture on focus
+  /// LOSS, which this plan deliberately left alone (#2624).** That one can cancel
+  /// work the user is in the middle of, and this repo measured it cancelling the
+  /// Quick Add panel 339 ms after opening. This cannot cancel anything: it only
+  /// replaces a stale belief about which keys are down with a fresh reading.
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    NotificationCenter.default.removeObserver(
+      self, name: NSWindow.didBecomeKeyNotification, object: nil)
+    guard let window else { return }
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(windowDidBecomeKey),
+      name: NSWindow.didBecomeKeyNotification,
+      object: window)
+  }
+
+  @objc private func windowDidBecomeKey() {
+    guard isRecording, window?.firstResponder === self else { return }
+    resetCaptureState()
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  // MARK: - #2613 capture state
+  //
+  // Until #2613 this view was stateless between events and forwarded the FIRST one
+  // it saw. Because a bare modifier is a legal shortcut here (the default record key
+  // is a bare right Option, and #1987 added Globe), a modifier press was already a
+  // complete binding — so pressing Control as the first half of Control-Shift-W
+  // saved Control and stopped listening, and no combination could be entered at all.
+  //
+  // `onKeyEvent` now means "this event COMPLETES a binding", not "a key happened".
+  // Restoring unconditional forwarding reintroduces #2613.
+
+  /// Known standalone modifier key codes currently DOWN.
+  ///
+  /// **Direction comes from membership here, never from the event's modifier flag.**
+  /// Left and right Shift are two key codes sharing one `.shift` flag, so the flag
+  /// cannot say which of them moved: releasing left while right is held reports the
+  /// flag as still present. `HotkeyService.handleFlagsChangedValues` uses the flag
+  /// test and carries a documented workaround for exactly that
+  /// (`HotkeyService.swift:1205-1216`); this path does not repeat it.
+  private var held: Set<UInt16> = []
+
+  /// Every key code this capture has ADMITTED. Ambient modifiers rejected by
+  /// `ModifierKeyCodes.flag(for:)` — Caps Lock, Help — never enter, so toggling
+  /// Caps Lock mid-capture cannot change what commits.
+  private var seen: Set<UInt16> = []
+
+  /// A completion has already been forwarded. Idempotence only — it carries no
+  /// policy. Both owners stop recording through a deferred `Task`, and this view
+  /// only learns about it on the next SwiftUI update, so without this a held key's
+  /// auto-repeat can forward a second binding inside that window.
+  private var completed = false
+
+  /// Set at arming when a supported modifier is ALREADY physically down, and
+  /// cleared when every one of them is released.
+  ///
+  /// Without it, `held` starts empty while a key is really down, so that key's
+  /// RELEASE is read as a press and the next physical press is read as a release.
+  /// The phantom then never clears: if it is Globe, every later key takes the
+  /// refusal path below and the box goes silently dead. Waiting for a neutral
+  /// boundary is what makes "absent from `held` means a press" true rather than
+  /// merely usual — and a key already held when the box was clicked could not have
+  /// been part of the shortcut anyway. Founder decision, 2026-09-03.
+  private var awaitingNeutralBoundary = false
+
+  /// The union of every flag a standalone modifier key can set, derived from the
+  /// one mapping in `ModifierKeyCodes` rather than restated, so a key added there
+  /// is covered here with no second edit.
+  private static let trackedModifierFlags: NSEvent.ModifierFlags =
+    ModifierKeyCodes.all.reduce(into: NSEvent.ModifierFlags()) { union, keyCode in
+      union.formUnion(ModifierKeyCodes.flag(for: keyCode) ?? [])
+    }
+
+  /// The one piece of GLOBAL state this view reads, behind a seam.
+  ///
+  /// Not a guard and not a policy switch: it answers "which modifiers are physically
+  /// down right now", which no `NSEvent` handed to a unit test can describe. Without
+  /// the seam a suite could only test the empty-keyboard case, and it would go flaky
+  /// the moment the person running it had a finger on Shift. Production never
+  /// overrides it.
+  var modifierFlagsNow: () -> NSEvent.ModifierFlags = { NSEvent.modifierFlags }
+
+  private func trackedFlagsDown() -> NSEvent.ModifierFlags {
+    modifierFlagsNow().intersection(Self.trackedModifierFlags)
+  }
+
+  private func resetCaptureState() {
+    held = []
+    seen = []
+    completed = false
+    awaitingNeutralBoundary = isRecording && !trackedFlagsDown().isEmpty
+  }
+
+  /// True while the capture is armed but deliberately not listening yet.
+  /// Consumes the event either way: the box is armed, so a key equivalent reaching
+  /// it must not also perform its own action.
+  private func consumedWhileWaitingForNeutralBoundary() -> Bool {
+    guard awaitingNeutralBoundary else { return false }
+    if trackedFlagsDown().isEmpty { awaitingNeutralBoundary = false }
+    return true
+  }
 
   /// Called BEFORE the system handles key equivalents (e.g. Command+Left, Option+Arrow).
   /// Returning true tells AppKit this view handled the event, preventing system consumption.
@@ -52,7 +198,7 @@ final class KeyCaptureNSView: NSView {
   /// and fail to perform its own action.
   override func performKeyEquivalent(with event: NSEvent) -> Bool {
     guard isRecording else { return super.performKeyEquivalent(with: event) }
-    onKeyEvent?(event)
+    forwardIfNonModifierCompletesTheBinding(event)
     return true
   }
 
@@ -62,6 +208,34 @@ final class KeyCaptureNSView: NSView {
       super.keyDown(with: event)
       return
     }
+    forwardIfNonModifierCompletesTheBinding(event)
+  }
+
+  /// The non-modifier arm of #2613's table, shared by `keyDown` and
+  /// `performKeyEquivalent` so the two cannot disagree about what completes.
+  private func forwardIfNonModifierCompletesTheBinding(_ event: NSEvent) {
+    guard !completed else { return }
+    guard !consumedWhileWaitingForNeutralBoundary() else { return }
+
+    // Auto-repeat. `completed` cannot cover this case on its own, because the Globe
+    // refusal below forwards nothing and so leaves `completed` false while the same
+    // physical key keeps repeating.
+    guard !seen.contains(where: { !ModifierKeyCodes.isModifierOnly($0) }) else { return }
+    seen.insert(event.keyCode)
+
+    // A Globe chord cannot be registered — `.function` is not a Carbon modifier, so
+    // `carbonModifiers` drops it and `symbolsForModifiers` never renders it. Saving
+    // one would store, display and fire as the bare key alone: Globe+W would make W
+    // a global hotkey. Refusing is the honest answer, and because W is now in
+    // `seen`, the later Globe release takes the reset arm rather than committing
+    // Globe the user never asked for.
+    //
+    // Keyed on the Globe KEY being held, never on `.function` being present: arrow
+    // keys carry that flag, and `arrowKeysNotAccepted` exists because matching on it
+    // once bound the recorder to an arrow key.
+    guard !held.contains(ModifierKeyCodes.globe) else { return }
+
+    completed = true
     onKeyEvent?(event)
   }
 
@@ -75,22 +249,43 @@ final class KeyCaptureNSView: NSView {
       super.flagsChanged(with: event)
       return
     }
-
-    // Determine which device-independent modifier bits changed compared to the
-    // previous event. NSEvent does not expose a "previous flags" property, so
-    // we rely on the keyCode to identify the specific modifier key that changed
-    // and the direction of the transition from the modifier flags themselves.
-    let currentFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+    guard !completed else { return }
+    guard !consumedWhileWaitingForNeutralBoundary() else { return }
 
     // Map the physical key code to the modifier flag it represents. One shared
     // authority with the dispatch path (#1987): nil means "not a standalone
     // modifier", which is distinguishable from a real flag in a way an empty
-    // OptionSet is not.
-    guard let addedFlag = ModifierKeyCodes.flag(for: event.keyCode) else { return }
+    // OptionSet is not. Ambient modifiers land here — Caps Lock and Help — and are
+    // dropped without entering `seen`, so toggling Caps Lock mid-capture changes
+    // nothing about what commits.
+    guard ModifierKeyCodes.flag(for: event.keyCode) != nil else { return }
 
-    // Only forward the event when the modifier is being pressed (added), not released.
-    if currentFlags.contains(addedFlag) {
+    // PRESS. `held` is authoritative rather than the event's flag, and the neutral
+    // boundary at arming is what makes "absent from `held`" mean a press rather
+    // than the release of a key we never saw go down.
+    guard held.contains(event.keyCode) else {
+      held.insert(event.keyCode)
+      seen.insert(event.keyCode)
+      return
+    }
+
+    // RELEASE.
+    held.remove(event.keyCode)
+
+    // A bare-modifier binding is ONE key, so it commits only if this key is the
+    // only thing this capture ever admitted. #1991 settled that bare modifiers are
+    // legal for every role, so this arm has to keep working — it is the reason the
+    // commit point is the release at all, and #1987's Globe key rides on it.
+    if seen == [event.keyCode] {
+      completed = true
       onKeyEvent?(event)
+      return
+    }
+
+    // Nothing committed and nothing left down: start over, so a user who fumbles
+    // can simply let go and try again without reopening the box.
+    if held.isEmpty {
+      seen = []
     }
   }
 }
@@ -124,12 +319,28 @@ enum HotkeyCapture {
   /// that flag would require the user to hold Globe while pressing Globe and the
   /// shortcut could never fire. Those come back with empty modifiers; an ordinary
   /// chord keeps its modifiers.
+  ///
+  /// #2613 — a chord's modifiers are narrowed to `ShortcutMatcher.carbonEffectiveModifiers`,
+  /// and the reason is that this function had no reachable chord case until #2613.
+  /// `.deviceIndependentFlagsMask` also carries Caps Lock, Numeric Pad, Help and
+  /// Function, and NEITHER consumer keeps them: `KeySymbols.symbolsForModifiers`
+  /// renders only these four, and `HotkeyService.carbonModifiers` maps only these
+  /// four on the way to `RegisterEventHotKey`. Storing a bit both of them drop
+  /// gives a binding that displays and fires as something other than what is
+  /// saved — a Caps-Lock-contaminated default stops comparing equal to its own
+  /// default, and Globe+W would store as W with an invisible `.function`.
+  ///
+  /// Narrowing HERE rather than at the capture view is deliberate: this is the one
+  /// authority both recording surfaces ask what an event MEANS, so a value the
+  /// view produced and this function disagreed with would be the #1987 drift all
+  /// over again. The set is not redefined here either — `ShortcutMatcher` already
+  /// owns it and already documents why those four are the whole answer.
   static func binding(for event: NSEvent) -> (keyCode: UInt16, modifiers: NSEvent.ModifierFlags) {
     let keyCode = event.keyCode
     if event.type == .flagsChanged && ModifierKeyCodes.isModifierOnly(keyCode) {
       return (keyCode, [])
     }
-    return (keyCode, event.modifierFlags.intersection(.deviceIndependentFlagsMask))
+    return (keyCode, event.modifierFlags.intersection(ShortcutMatcher.carbonEffectiveModifiers))
   }
 }
 

--- a/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
+++ b/Tests/EnviousWisprTests/Views/HotkeyRecorderGlobeTests.swift
@@ -40,22 +40,40 @@ import Testing
     )!
   }
 
-  private func makeView() -> (KeyCaptureNSView, () -> [UInt16]) {
+  /// #2613 — the physically-held modifiers a test wants the view to believe in.
+  /// A class, not a value, because the pre-held case has to CHANGE what is down
+  /// after the view has already armed.
+  private final class FlagsBox {
+    var flags: NSEvent.ModifierFlags
+    init(_ flags: NSEvent.ModifierFlags = []) { self.flags = flags }
+  }
+
+  /// #2613 — the whole event, not just its key code, because a chord's assertion is
+  /// about its MODIFIERS and a key-code-only fixture cannot see them.
+  private func keyCodes(_ events: [NSEvent]) -> [UInt16] { events.map(\.keyCode) }
+
+  private func makeView(flags: FlagsBox = FlagsBox()) -> (KeyCaptureNSView, () -> [NSEvent]) {
     let view = KeyCaptureNSView()
+    // #2613 — set BEFORE arming: arming is what reads the physically-held set, so
+    // assigning it afterwards would test the empty-keyboard case whatever was asked
+    // for. Defaulting to none also stops the suite reading the real keyboard, which
+    // would go flaky whenever the person running it had a finger on Shift.
+    view.modifierFlagsNow = { flags.flags }
     // The state under test. Every capture case below describes what happens WHILE
     // the user is recording a shortcut; `isRecording` defaults to false precisely
     // so that a view nobody armed captures nothing.
     view.isRecording = true
-    var captured: [UInt16] = []
-    view.onKeyEvent = { captured.append($0.keyCode) }
+    var captured: [NSEvent] = []
+    view.onKeyEvent = { captured.append($0) }
     return (view, { captured })
   }
 
   /// An un-armed view, for the gate cases below.
-  private func makeIdleView() -> (KeyCaptureNSView, () -> [UInt16]) {
+  private func makeIdleView() -> (KeyCaptureNSView, () -> [NSEvent]) {
     let view = KeyCaptureNSView()
-    var captured: [UInt16] = []
-    view.onKeyEvent = { captured.append($0.keyCode) }
+    view.modifierFlagsNow = { [] }
+    var captured: [NSEvent] = []
+    view.onKeyEvent = { captured.append($0) }
     return (view, { captured })
   }
 
@@ -137,11 +155,11 @@ import Testing
 
     view.isRecording = true
     view.keyDown(with: keyDown(keyCode: 0))
-    #expect(captured() == [0])
+    #expect(keyCodes(captured()) == [0])
 
     view.isRecording = false
     view.keyDown(with: keyDown(keyCode: 1))
-    #expect(captured() == [0], "capture continued after recording ended")
+    #expect(keyCodes(captured()) == [0], "capture continued after recording ended")
   }
 
   /// The one case that needs a real window, and the reason it is worth the cost:
@@ -175,20 +193,35 @@ import Testing
     #expect(window.firstResponder !== view, "the view kept keyboard focus after recording ended")
   }
 
-  @Test("The recorder accepts a Globe press")
-  func acceptsGlobePress() {
+  /// #2613 INVERTED THIS TEST, and the inversion is the fix.
+  ///
+  /// It used to assert that a Globe PRESS commits. That is why no combination could
+  /// ever be entered: a modifier press is a complete binding, so the Control of
+  /// Control-Shift-W saved Control and stopped listening. A press now records the
+  /// key and commits nothing; the case below commits it on the release.
+  @Test("A bare modifier press commits nothing on its own")
+  func aBareModifierPressCommitsNothing() {
     let (view, captured) = makeView()
     view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
-    #expect(captured() == [ModifierKeyCodes.globe])
+    #expect(
+      captured().isEmpty,
+      "committing on the press is what makes a combination impossible to enter")
   }
 
-  /// Without this the recorder would bind on the release too, so a single tap
-  /// would register as two assignments.
-  @Test("The recorder ignores the Globe release")
-  func ignoresGlobeRelease() {
+  /// #2613 INVERTED THIS TEST too. The release used to be dropped; it is now the
+  /// commit point for a bare modifier, which is the only case where nothing earlier
+  /// can tell whether the user meant that key alone.
+  ///
+  /// Globe specifically, because #1987 shipped it and the founder uses it: an
+  /// earlier revision of #2613's design made bare Globe unsettable, and this pair
+  /// is what would have caught that.
+  @Test("The release of a lone modifier commits it")
+  func theReleaseOfALoneModifierCommitsIt() {
     let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
     view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
-    #expect(captured().isEmpty)
+    #expect(keyCodes(captured()) == [ModifierKeyCodes.globe])
+    #expect(HotkeyCapture.binding(for: captured()[0]).modifiers == [])
   }
 
   @Test("A full press then release assigns exactly once")
@@ -196,14 +229,15 @@ import Testing
     let (view, captured) = makeView()
     view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
     view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
-    #expect(captured() == [ModifierKeyCodes.globe])
+    #expect(keyCodes(captured()) == [ModifierKeyCodes.globe])
   }
 
   @Test("Existing modifier keys are still accepted, so capture did not regress")
   func existingModifiersStillAccepted() {
     let (view, captured) = makeView()
     view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: [.option]))
-    #expect(captured() == [ModifierKeyCodes.rightOption])
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: []))
+    #expect(keyCodes(captured()) == [ModifierKeyCodes.rightOption])
   }
 
   /// The measured trap on the capture side. Arrow keys carry `.function` in their
@@ -216,6 +250,306 @@ import Testing
     let (view, captured) = makeView()
     view.flagsChanged(with: flagsChanged(keyCode: code, flags: [.function]))
     #expect(captured().isEmpty)
+  }
+
+  // MARK: - #2613 a combination can be recorded at all
+  //
+  // The user report: "whatever I do it only detects the first key that is pressed,
+  // attempting to press shift, option and control at the same time results in the
+  // key being changed to left shift." One case per branch of the capture table, so
+  // the table and this suite cannot drift apart.
+
+  /// The reported bug, as a test. Goes red against the shipped code, which commits
+  /// the Control press and never sees the W.
+  @Test("Holding modifiers and pressing a letter records the whole combination")
+  func aChordRecordsEveryHeldModifier() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftControl, flags: [.control]))
+    view.flagsChanged(
+      with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.control, .shift]))
+    view.keyDown(with: keyDown(keyCode: 13, flags: [.control, .shift], characters: "w"))
+
+    #expect(keyCodes(captured()) == [13], "the letter is what completes a combination")
+    let binding = HotkeyCapture.binding(for: captured()[0])
+    #expect(binding.keyCode == 13)
+    #expect(binding.modifiers == [.control, .shift])
+  }
+
+  /// A combination completes through the key-equivalent arm too. Both arms share one
+  /// implementation precisely so they cannot answer differently, and this is the
+  /// control that says so.
+  @Test("A combination completes through performKeyEquivalent as well as keyDown")
+  func aChordCompletesThroughKeyEquivalent() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftCommand, flags: [.command]))
+    let handled = view.performKeyEquivalent(
+      with: keyDown(keyCode: 13, flags: [.command], characters: "w"))
+
+    #expect(handled)
+    #expect(keyCodes(captured()) == [13])
+    #expect(HotkeyCapture.binding(for: captured()[0]).modifiers == [.command])
+  }
+
+  /// Two modifiers and no letter is not a shortcut, so nothing may commit — and the
+  /// box must recover, because a user who fumbles should be able to let go and try
+  /// again without reopening it.
+  @Test("Two modifiers released with no letter commits nothing, and the box recovers")
+  func twoModifiersWithNoLetterCommitNothingAndRecover() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftControl, flags: [.control]))
+    view.flagsChanged(
+      with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.control, .shift]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.control]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftControl, flags: []))
+    #expect(captured().isEmpty, "two modifiers alone are not a binding")
+
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: [.option]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: []))
+    #expect(
+      keyCodes(captured()) == [ModifierKeyCodes.rightOption],
+      "the box did not recover after an abandoned attempt")
+  }
+
+  /// THE REFUTATION THAT KILLED AN EARLIER DESIGN, kept as a test.
+  ///
+  /// Left and right Shift are two key codes sharing one `.shift` flag. A design that
+  /// decided press-versus-release by asking whether the flag was present classified
+  /// the left release as a press, because the right key was still holding the flag
+  /// up — so left Shift stayed "down" forever and no bare modifier could ever be set
+  /// in that box again. Direction is read from the held set for this reason.
+  @Test("Releasing one Shift while the other is held strands nothing")
+  func releasingOnePairedModifierWhileItsSiblingIsHeldStrandsNothing() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.shift]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightShift, flags: [.shift]))
+    // Left comes up while right still holds the aggregate flag up.
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.shift]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightShift, flags: []))
+    #expect(captured().isEmpty)
+
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: [.option]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: []))
+    #expect(
+      keyCodes(captured()) == [ModifierKeyCodes.rightOption],
+      "a stranded modifier is blocking every later bare-modifier binding")
+  }
+
+  /// A Globe combination cannot be registered, so it must be refused rather than
+  /// stored: `.function` is not a Carbon modifier, so Globe+W would save, display
+  /// and fire as plain W — making W a global hotkey.
+  @Test("Globe held plus a letter commits nothing, and does not later save Globe")
+  func globeHeldPlusALetterCommitsNothing() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+    view.keyDown(with: keyDown(keyCode: 13, flags: [.function], characters: "w"))
+    view.keyDown(with: keyDown(keyCode: 13, flags: [.function], characters: "w"))
+    #expect(captured().isEmpty, "a Globe combination must be refused")
+
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
+    #expect(captured().isEmpty, "the Globe release must not save a Globe nobody asked for")
+
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
+    #expect(
+      keyCodes(captured()) == [ModifierKeyCodes.globe],
+      "a fresh Globe press and release must still bind Globe")
+  }
+
+  /// The refusal keys off the Globe KEY being held, never off `.function` being
+  /// present — arrow keys carry that flag. This is the two-way control for the
+  /// Globe case above, and without it the refusal could be implemented as a flag
+  /// test that silently makes every arrow key unsettable.
+  @Test("An arrow key still completes, because the refusal is about the Globe key")
+  func anArrowKeyStillCompletes() {
+    let (view, captured) = makeView()
+    view.keyDown(with: keyDown(keyCode: 126, flags: [.function], characters: ""))
+    #expect(keyCodes(captured()) == [126])
+  }
+
+  /// Holding a key down long enough for macOS to repeat it must still produce one
+  /// binding. The owners stop recording through a deferred task, so the view cannot
+  /// rely on being disarmed in time.
+  @Test("A repeated key press commits exactly once")
+  func aRepeatedKeyPressCommitsExactlyOnce() {
+    let (view, captured) = makeView()
+    view.keyDown(with: keyDown(keyCode: 13, characters: "w"))
+    view.keyDown(with: keyDown(keyCode: 13, characters: "w"))
+    view.keyDown(with: keyDown(keyCode: 13, characters: "w"))
+    #expect(keyCodes(captured()) == [13])
+  }
+
+  /// Caps Lock is ambient state, not part of the shortcut. It must not commit, must
+  /// not spoil a combination, and must not reach the stored modifiers — where it
+  /// would make a binding stop comparing equal to its own default.
+  @Test("An ambient Caps Lock changes nothing about what commits")
+  func ambientCapsLockChangesNothing() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: 57, flags: [.capsLock]))
+    #expect(captured().isEmpty, "Caps Lock is not a shortcut")
+
+    view.flagsChanged(
+      with: flagsChanged(keyCode: ModifierKeyCodes.leftCommand, flags: [.capsLock, .command]))
+    view.keyDown(with: keyDown(keyCode: 40, flags: [.capsLock, .command], characters: "k"))
+
+    #expect(keyCodes(captured()) == [40])
+    #expect(HotkeyCapture.binding(for: captured()[0]).modifiers == [.command])
+  }
+
+  /// A modifier ALREADY held when the box arms. Founder decision, 2026-09-03: wait
+  /// for a neutral boundary.
+  ///
+  /// Without the wait the held key's RELEASE is read as a press, because the view
+  /// starts with an empty held set, and the phantom never clears — so the next
+  /// physical press is read as a release and commits on the way DOWN. If the
+  /// phantom is Globe, every later key is refused and the box goes silently dead.
+  @Test("A modifier held before arming does not corrupt the capture")
+  func aModifierHeldBeforeArmingDoesNotCorruptTheCapture() {
+    let flags = FlagsBox([.option])
+    let (view, captured) = makeView(flags: flags)
+
+    // The physical release of the key that was already down when the box armed.
+    flags.flags = []
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: []))
+    #expect(captured().isEmpty, "a release we never saw go down is not a press")
+
+    // A real press now, which must NOT be read as a release and commit early.
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: [.option]))
+    #expect(captured().isEmpty, "a bare modifier must not commit on the way down")
+
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.rightOption, flags: []))
+    #expect(keyCodes(captured()) == [ModifierKeyCodes.rightOption])
+  }
+
+  /// The Globe form of the same case, because it is the one whose failure is silent:
+  /// a phantom Globe refuses every later key with no message.
+  @Test("Globe held before arming does not leave the box refusing every key")
+  func globeHeldBeforeArmingDoesNotDeadenTheBox() {
+    let flags = FlagsBox([.function])
+    let (view, captured) = makeView(flags: flags)
+
+    flags.flags = []
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
+    view.keyDown(with: keyDown(keyCode: 13, characters: "w"))
+    #expect(keyCodes(captured()) == [13], "a phantom Globe is refusing ordinary keys")
+  }
+
+  /// Disarming clears every piece of capture state, so a reopened box starts clean
+  /// rather than resuming a half-finished attempt from last time.
+  @Test("Reopening the box starts a clean capture")
+  func reopeningTheBoxStartsACleanCapture() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.shift]))
+    view.isRecording = false
+    view.isRecording = true
+
+    // If `held` had survived, this release would commit left Shift.
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: []))
+    #expect(captured().isEmpty, "capture state leaked across a reopen")
+
+    view.keyDown(with: keyDown(keyCode: 13, characters: "w"))
+    #expect(keyCodes(captured()) == [13])
+  }
+
+  /// A SwiftUI redraw re-assigns `isRecording` with the SAME value on every update
+  /// pass. If that reset the capture, every unrelated redraw would silently discard
+  /// a combination the user was halfway through entering.
+  /// Review caught the FIRST version of this test being vacuous, and the reason is
+  /// worth keeping: it asserted the committed chord carried `.control`, but
+  /// `HotkeyCapture` reconstructs modifiers from the completing event's OWN flags,
+  /// so the assertion passed whether or not the held set had been wiped. The
+  /// expectation was built out of the mechanism under test.
+  ///
+  /// A held GLOBE is observable instead, because nothing can reconstruct it: if the
+  /// state survives, the letter is refused; if it was wiped, the letter commits.
+  @Test("An unchanged isRecording assignment does not discard a capture in progress")
+  func anUnchangedAssignmentDoesNotDiscardACaptureInProgress() {
+    let (view, captured) = makeView()
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: [.function]))
+
+    view.isRecording = true  // what `updateNSView` does on every pass
+    view.keyDown(with: keyDown(keyCode: 13, flags: [.function], characters: "w"))
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
+
+    #expect(captured().isEmpty, "the unchanged assignment erased the held Globe state")
+  }
+
+  /// The gap between arming and OWNING the keyboard, which the arming-time snapshot
+  /// cannot see: `updateNSView` sets `isRecording` and then defers
+  /// `makeFirstResponder` into a `Task`. A modifier pressed inside that gap is never
+  /// seen going down, so its release would be read as a press and leave a phantom.
+  ///
+  /// Needs a real window, because first-responder status is what is under test.
+  @Test("First-responder acquisition refreshes the neutral-boundary snapshot")
+  func focusAcquisitionRefreshesNeutralBoundary() {
+    let flags = FlagsBox()
+    let view = KeyCaptureNSView()
+    view.modifierFlagsNow = { flags.flags }
+    view.isRecording = true
+
+    // Globe goes down after arming and before focus is granted, so the view never
+    // receives the press.
+    flags.flags = [.function]
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+      styleMask: [.titled],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentView = view
+    #expect(window.makeFirstResponder(view))
+
+    var captured: [NSEvent] = []
+    view.onKeyEvent = { captured.append($0) }
+    flags.flags = []
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.globe, flags: []))
+    view.keyDown(with: keyDown(keyCode: 13, characters: "w"))
+
+    #expect(
+      keyCodes(captured) == [13],
+      "a phantom Globe from the arming gap is refusing ordinary keys")
+  }
+
+  /// The SECOND missed-transition gap, and the one `becomeFirstResponder` cannot
+  /// see: the window keeps its stored first responder across losing key status, so
+  /// coming back from another app fires no responder change at all — while key
+  /// events went elsewhere the whole time.
+  ///
+  /// Without the fix this commits bare Shift on a key DOWN, which is the shape the
+  /// whole change exists to remove.
+  @Test("Returning from another app refreshes the snapshot, so a stale key cannot commit early")
+  func returningToTheAppRefreshesTheSnapshot() {
+    let flags = FlagsBox()
+    let view = KeyCaptureNSView()
+    view.modifierFlagsNow = { flags.flags }
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+      styleMask: [.titled],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentView = view
+    view.isRecording = true
+    #expect(window.makeFirstResponder(view))
+
+    var captured: [NSEvent] = []
+    view.onKeyEvent = { captured.append($0) }
+
+    // Shift goes down here, then the user leaves and releases it in the other app.
+    flags.flags = [.shift]
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.shift]))
+    flags.flags = []
+
+    // Back in the app. No responder change happens, only a key-window change.
+    NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+
+    // A real press, which must NOT be read as the release we missed.
+    flags.flags = [.shift]
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: [.shift]))
+    #expect(captured.isEmpty, "a stale held key made a press commit as a release")
+
+    flags.flags = []
+    view.flagsChanged(with: flagsChanged(keyCode: ModifierKeyCodes.leftShift, flags: []))
+    #expect(keyCodes(captured) == [ModifierKeyCodes.leftShift])
   }
 
   // MARK: - #1987 accepted-binding delivery
@@ -330,9 +664,15 @@ import Testing
     #expect(box.callbackArguments.first?.1 == [.command, .shift])
   }
 
-  /// An arrow key arrives as a `keyDown` carrying `.function`. It is a legitimate
-  /// chord component, so unlike the capture layer above, acceptance must NOT strip
-  /// it — but it must also not be mistaken for the Globe key.
+  /// An arrow key arrives as a `keyDown` carrying `.function`, and it must not be
+  /// mistaken for the Globe key.
+  ///
+  /// #2613 CHANGED WHAT THIS STORES. The old assertion kept `.function`, on the
+  /// reasoning that acceptance must not strip a legitimate chord component. That
+  /// reasoning was wrong about the consumers: `KeySymbols.symbolsForModifiers`
+  /// never renders `.function` and `HotkeyService.carbonModifiers` never registers
+  /// it, so keeping it stored a bit that could not be seen or fired. The key code
+  /// still identifies the arrow, which is what this test is really about.
   @Test("An arrow key is stored as a chord, not as the Globe key")
   func arrowKeyIsNotTreatedAsGlobe() {
     let box = BindingBox()
@@ -351,7 +691,7 @@ import Testing
     makeRecorder(box).acceptBinding(from: event)
 
     #expect(box.keyCode == 126)
-    #expect(box.modifiers == [.function])
+    #expect(box.modifiers == [], "#2613: a bit neither display nor Carbon keeps must not be stored")
   }
 
   // MARK: - #1987 shared acceptance authority


### PR DESCRIPTION
Closes #2613

## What the user could not do

Set any shortcut that uses more than one key. The box saved the FIRST key event it got, and a bare modifier is a legal shortcut in this app — the default record key is a bare right Option, and #1987 added Globe — so a modifier press was already a complete binding. Pressing Control as the first half of Control-Shift-W saved Control and stopped listening.

> "whatever I do it only detects the first key that is pressed, attempting to press shift, option and control at the same time results in the key being changed to left shift."

All three configurable shortcuts, and both places a shortcut can be set. It bites now because PR #2606 moved the shipped add-a-word shortcut to a combination, so users who already use that chord go looking to change it.

**WHEN A SHORTCUT FIRES IS NOT TOUCHED.** All three roles fire on PRESS today and still do — Quick Add's arm says so in as many words at `HotkeyService.swift:1244`. This changes only the settings box where a shortcut is CHOSEN.

## The change

`KeyCaptureNSView` gains `held` / `seen` / `completed` and forwards to its owner only when an event COMPLETES a binding. A non-modifier key commits a chord with the modifiers held; a lone modifier commits on its RELEASE, which is the only case where nothing earlier can tell the user meant that key alone. `onKeyEvent` narrows from "a key happened" to "a binding is complete". **Neither owner gains a branch**, because the fix lives in the one event source both recording surfaces share — the placement `isRecording`'s own comment already argued for.

**Direction comes from `held`, never from a modifier flag.** Left and right Shift are two key codes sharing one `.shift` flag, so the flag cannot say which moved: releasing left while right is held reports the flag as still present. An earlier revision used the flag, stranded the left key in `held` forever, and no bare modifier could be set again in that box. `handleFlagsChangedValues` uses the same flag test and carries a documented workaround for it (`HotkeyService.swift:1205-1216`); this path does not repeat it.

**Three gaps where `held` could disagree with the keyboard**, each found by a different review pass rather than by design:

1. A modifier already down when the box arms — its release reads as a press. The box now waits for a neutral boundary before listening. Founder decision.
2. Arming happens before the view OWNS the keyboard, because `updateNSView` defers `makeFirstResponder`. `becomeFirstResponder` re-takes the snapshot when delivery begins.
3. Leaving the app and returning fires no responder change at all, because the window keeps its stored first responder — while key events went elsewhere. `windowDidBecomeKey` re-syncs on return. **This is not the focus-loss teardown in #2624**: re-syncing cannot cancel work in progress, which is what made that one dangerous.

**A Globe combination is refused.** `.function` is not a Carbon modifier, so Globe+W would store, display and fire as bare W, making the plain letter a global hotkey. Keyed on the Globe KEY being held, never on the flag — arrow keys carry that flag, which `arrowKeysNotAccepted` exists to remember. The refusal is silent, which is #2627.

**A chord stores only what is displayed and registered.** `HotkeyCapture.binding(for:)` narrows a chord's modifiers to the existing `ShortcutMatcher.carbonEffectiveModifiers`. This function had no reachable chord case until now, and `.deviceIndependentFlagsMask` also carries Caps Lock, Numeric Pad, Help and Function, which neither consumer keeps.

## Evidence

| Check | Result |
|---|---|
| Debug lane | 7379 tests, verdict PASS |
| Release lane | 6742 tests, verdict PASS |
| Suite for this change | 33 tests, 17 new, PASS |
| Live UAT, real app, real key events | 8/8, including a positive control that proves the oracle can see a save |
| **Founder, by hand, real hardware** | **set the add-a-word shortcut to Control-Shift-W and it saved: `keyCode 13`, `modifiersRaw 393216` — Control plus Shift and no hidden bits** |

The founder's manual test is the strongest row there. It confirms the make-or-break premise no unit test could reach: that a real modifier release reaches the recorder in the running app.

Two tests now assert the OPPOSITE of what they did, which is the fix made visible rather than hidden. One test of mine was found VACUOUS in review and rewritten: it asserted a committed chord carried `.control`, but `HotkeyCapture` reconstructs modifiers from the completing event's own flags, so it passed whether or not the state had been wiped.

Mutation recipes: #2626, validated 9/9 runnable. No mutant was run today per `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night, and the one permitted daytime check is unavailable here — the new tests set `modifierFlagsNow`, a seam the parent commit lacks, so the file does not compile there. Recorded in that issue rather than left to look done.

## Process

Plan revision 4, after one coverage round and three review rounds. A pre-committed deletion fired at round 2 and removed state rather than adding a rule. Round 3's finding was escalated rather than designed around.

Related, and deliberately NOT closed by this: #2432 · #2430 · #2607 · #2624 · #2626 · #2627
