### PR TITLE
fix(pipeline): only a no-buffer stall files a Sentry error (#1810)

### DIFF
--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -86,16 +86,48 @@ final class HeartPathTelemetryEmitter {
 
   // MARK: - Events
 
-  /// Emit `audio_capture_stalled` once per session. Subsequent calls within
-  /// the same session are dropped silently (dedup).
-  /// Returns true if the event fired (caller may chain terminal-state work).
-  @discardableResult
+  /// Record the first observation of each capture-stall mode per session.
+  /// Subsequent calls for the same mode within the same session are dropped
+  /// silently (dedup).
+  ///
+  /// **Only `.noBuffers` creates an alerting Sentry error (#1810, 2026-09-03).**
+  /// The two zero-sample modes are recorded by the existing
+  /// `deadMicRetireAttempted` breadcrumb and PostHog event after the take stops;
+  /// they get no second breadcrumb here, because that method already fans out
+  /// both sinks from ONE set of computed values and a duplicate would split the
+  /// source of truth.
+  ///
+  /// Why they leave the alerting channel: the standing policy is to alert in
+  /// Sentry only for product-owned faults and to record user and device
+  /// conditions in PostHog. The measured population here is a permanently failed
+  /// microphone, a dropped Bluetooth link, or a hardware mute — none of which we
+  /// own. `.noBuffers` (no buffers arrived at all) is the one shape most likely
+  /// to be ours, so it keeps its error.
+  ///
+  /// **The insert MUST stay above the routing branch.** `noAudioCaptured` reads
+  /// `capturedStallModes` to decide breadcrumb-versus-error, so skipping the
+  /// insert for a downgraded mode would turn a stalled session's
+  /// `no_audio_captured` into a NEW alerting error — moving the noise rather
+  /// than removing it.
+  ///
+  /// Returns nothing: neither production caller read the old `Bool`, and a
+  /// boolean here would now read as "an alert fired", which is no longer true
+  /// for two of the three modes.
   func stallFired(
     ctx: CaptureStallContext,
     isActivelyCapturing: Bool
-  ) -> Bool {
+  ) {
     resetIfNewSession(ctx.sessionID)
-    guard capturedStallModes.insert(ctx.failureMode).inserted else { return false }
+    guard capturedStallModes.insert(ctx.failureMode).inserted else { return }
+
+    // Exhaustive, no `default`: a future failure mode must state its channel
+    // rather than inheriting whichever branch happens to be first.
+    switch ctx.failureMode {
+    case .noBuffers:
+      break
+    case .allZeroFromStart, .becameZeroMidCapture:
+      return
+    }
 
     let extras = SentryAudioExtras.buildCaptureExtras(
       route: ctx.route,
@@ -107,10 +139,15 @@ final class HeartPathTelemetryEmitter {
       failureMode: ctx.failureMode.rawValue,
       stallContext: ctx,
       // #1844: "how long since this user last had a working recording" is
-      // diagnostic on EVERY capture stall, not only a classified zero-signal one,
-      // so it lands on all three failure modes this shared emitter serves. Same
-      // expression the zombie path already uses below; omitted when nil, so a
-      // user with no prior success is not reported as zero.
+      // diagnostic on a capture stall. Since #1810 this payload is built ONLY
+      // for `.noBuffers` — the two zero-sample modes returned above. They are
+      // not left without the measurement: `ms_since_last_good` on
+      // `audio.dead_mic_retire_attempted` reads the SAME `captureTelemetry`.
+      // Same source, NOT the same number — that one is sampled at stop, this one
+      // mid-take, so they differ by the take's own duration and must never be
+      // substituted for each other in a query.
+      // Same expression the zombie path already uses below; omitted when nil, so
+      // a user with no prior success is not reported as zero.
       timeSinceLastSuccessfulRecordingMs:
         captureTelemetry.timeSinceLastSuccessfulRecordingMs(),
       selectedTransport: ctx.selectedTransport,
@@ -127,7 +164,6 @@ final class HeartPathTelemetryEmitter {
       "recording",
       extras
     )
-    return true
   }
 
   /// Emit either a deduped breadcrumb (if a stall already fired for this

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1363,10 +1363,16 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
 
   public func handleCaptureStall(_ ctx: CaptureStallContext) {
     // Two-arm fan-out:
-    //   1. observer.handleCaptureStall — drives the rich Sentry emission
-    //      via `HeartPathTelemetryEmitter.stallFired(ctx:)`.
+    //   1. observer.handleCaptureStall — routes the telemetry via
+    //      `HeartPathTelemetryEmitter.stallFired(ctx:)`. Since #1810
+    //      (2026-09-03) that produces an alerting Sentry error ONLY for
+    //      `stall_window_elapsed`; the two zero-sample shapes are recorded by
+    //      `audio.dead_mic_retire_attempted` and its breadcrumb instead.
     //   2. kernel.externalCaptureStalled — flips the kernel FSM to
     //      `failed(.captureStalled)` so the session actually stops.
+    // **The arms are independent and #1810 changed only arm 1.** Every failure
+    // mode still ends the take, and source retirement still happens on the stop
+    // path; a quieter Sentry channel is not a quieter product.
     // PR-4b.1 dropped the kernel's direct `audioCapture.onCaptureStalled`
     // subscription; PR-4b.2 closes the loop by fanning out from this
     // App-facing entry. Without the kernel call, a real stall would

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -1046,14 +1046,15 @@ final class KernelLifecycleTelemetrySink {
         captureFailureExtra(error: error, failureMode: "prepare_failed"))
     case .captureStalled:
       // r8 (2026-05-25) — NO Sentry/PostHog emission for `.captureStalled`.
-      // The rich `HeartPathTelemetryEmitter.stallFired(ctx:)` (`:91-116`)
-      // already owns this terminal: it is reached via
-      // `KernelHeartPathTelemetryObserver.handleCaptureStall(_:)` (`:94-100`)
+      // `HeartPathTelemetryEmitter.stallFired(ctx:)` already owns this terminal:
+      // it is reached via `KernelHeartPathTelemetryObserver.handleCaptureStall(_:)`
       // from the App-routed `WedgeRecoveryRouter` → driver's
       // `HeartPathTelemetryTarget` conformance, with full
       // `SentryAudioExtras.buildCaptureExtras(...)` payload + per-session
       // dedup. The lifecycle event still fires (kernel state observability
       // is preserved); only the duplicate Sentry captureError is suppressed.
+      // (Line-range citations removed 2026-09-03: they named a range #1810
+      // then moved, and nothing links a comment to the lines it counts.)
       //
       // Codex r8 flagged this as the convergence-escape signal: emitter
       // dedup is `private` to the emitter, so without this skip both paths
@@ -1066,6 +1067,17 @@ final class KernelLifecycleTelemetrySink {
       // the classified event, submitted either through the reactive
       // `WedgeRecoveryRouter` funnel or the kernel's STOP-time telemetry
       // closure (§3.6 N4). The lifecycle event still fires here.
+      //
+      // #1810 (2026-09-03) narrowed what "owns" means and the skip still
+      // stands, so read the reason rather than the conclusion: `stallFired`
+      // now creates an alerting Sentry error ONLY for `stall_window_elapsed`,
+      // and a zero-sample shape reaches NEITHER Sentry channel from it. The
+      // record for those takes is `audio.dead_mic_retire_attempted` plus its
+      // breadcrumb, emitted from the stop path. **Do not "restore" an emission
+      // here on the strength of that silence** — it is the intended end state,
+      // and adding one would put the retired alert back under another name.
+      // Policy: alert in Sentry only for product-owned faults; record user and
+      // device conditions in PostHog.
       break
     case .noAudioCaptured:
       // Build the rich `NoAudioContext` (route, active-capture, source,

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -147,17 +147,19 @@ struct HeartPathTelemetryEmitterTests {
 
   // MARK: - Stall dedup
 
-  @Test("stallFired emits once per session and returns true the first time")
+  @Test("stallFired emits the alerting mode once per session")
   func stallFiresOnce() {
     let recorder = Recorder()
     let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
     let ctx = Self.stallContext(sessionID: 7)
 
-    let firstFired = emitter.stallFired(ctx: ctx, isActivelyCapturing: true)
-    let secondFired = emitter.stallFired(ctx: ctx, isActivelyCapturing: true)
+    // #1810: the method no longer returns a Bool — neither production caller
+    // read it, and "true" would have meant "an alert fired", which stopped
+    // being true for the two zero-sample modes. Assert the SUBJECT (what
+    // reached Sentry), never a marker beside it.
+    emitter.stallFired(ctx: ctx, isActivelyCapturing: true)
+    emitter.stallFired(ctx: ctx, isActivelyCapturing: true)
 
-    #expect(firstFired)
-    #expect(!secondFired)
     #expect(recorder.errors.count == 1)
     let captured = recorder.errors[0]
     #expect(captured.category == .audioCaptureStalled)
@@ -233,6 +235,38 @@ struct HeartPathTelemetryEmitterTests {
     #expect(crumb.message == "No audio captured (deduped)")
     #expect(crumb.data["deduped_from"] as? String == "audio_capture_stalled")
     #expect(crumb.data["capture_session_id"] as? Int == 9)
+  }
+
+  /// #1810 — THE regression the downgrade could silently cause, and the reason
+  /// the `capturedStallModes` insert stays ABOVE the routing branch.
+  ///
+  /// A zero-sample stall now creates no Sentry error, so it is tempting to skip
+  /// the latch for it. `noAudioCaptured` reads that latch to choose breadcrumb
+  /// over error: skip the insert and a stalled session's `no_audio_captured`
+  /// becomes a NEW alerting error, moving the noise instead of removing it. The
+  /// session must end with ZERO errors on both channels.
+  @Test("#1810: a zero-sample stall still latches, so noAudioCaptured stays a breadcrumb")
+  func noAudioDedupsAfterZeroSampleStall() {
+    for mode in [CaptureStallFailureMode.allZeroFromStart, .becameZeroMidCapture] {
+      let recorder = Recorder()
+      let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+      emitter.stallFired(
+        ctx: Self.stallContext(sessionID: 9, failureMode: mode), isActivelyCapturing: true)
+      emitter.noAudioCaptured(ctx: Self.noAudioContext(sessionID: 9))
+
+      #expect(
+        recorder.errors.isEmpty,
+        """
+        \(mode.rawValue): the downgrade leaked into no_audio_captured — the \
+        capturedStallModes insert must stay above the routing branch
+        """)
+      #expect(recorder.breadcrumbs.count == 1)
+      let crumb = recorder.breadcrumbs[0]
+      #expect(crumb.message == "No audio captured (deduped)")
+      #expect(crumb.data["deduped_from"] as? String == "audio_capture_stalled")
+      #expect(crumb.data["capture_session_id"] as? Int == 9)
+    }
   }
 
   @Test("noAudioCaptured dedup breadcrumb for WhisperKit carries WhisperKit-tagged message")
@@ -421,19 +455,68 @@ struct HeartPathTelemetryEmitterTests {
       "stall extras key-set drift: \(actualKeys.symmetricDifference(Self.stallExtraKeys))")
   }
 
-  // MARK: - #1844: elapsed-since-last-good on EVERY stall mode
+  // MARK: - #1810: only the no-buffer mode reaches the alerting channel
   //
-  // `stallFired` is the SHARED stall emitter, so this field lands on all three
-  // failure modes, not only the classified zero-signal pair. That is a wider blast
-  // radius than the coverage finding asked for and is deliberate: the key is
-  // optional and omitted when nil, it breaks no schema, and "how long since this
-  // user last had a working recording" is diagnostic on any capture stall.
+  // Every mode still latches into `capturedStallModes` — that set is what
+  // `noAudioCaptured` reads to choose breadcrumb over error, so a downgrade that
+  // skipped the insert would turn a stalled session's `no_audio_captured` into a
+  // NEW alerting error. `noAudioDedupsAfterZeroSampleStall` below is the guard
+  // for exactly that.
   //
-  // Both tests drive ALL THREE modes, because `capturedStallModes` dedups per mode
-  // within a session — one passing mode cannot stand in for the others.
+  // The zero-sample modes reach NEITHER channel from this method, deliberately:
+  // `deadMicRetireAttempted` already fans out a breadcrumb AND the PostHog event
+  // from one set of computed values, so a second breadcrumb here would split the
+  // source of truth.
 
-  @Test("every stall mode carries elapsed ms when a prior success is known (#1844)")
-  func allStallsCarryElapsedWhenKnown() {
+  @Test("#1810: only stall_window_elapsed reaches Sentry; zero-sample modes reach neither channel")
+  func onlyNoBuffersAlerts() {
+    let modes: [CaptureStallFailureMode] = [
+      .noBuffers, .allZeroFromStart, .becameZeroMidCapture,
+    ]
+    // A fresh emitter per mode so each assertion sees an empty recorder and a
+    // failure names the mode whose routing changed. NOT for dedup reasons:
+    // `capturedStallModes` is keyed BY MODE, so one shared emitter would pass
+    // all three through perfectly well.
+    for mode in modes {
+      let recorder = Recorder()
+      let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
+
+      emitter.stallFired(
+        ctx: Self.stallContext(failureMode: mode), isActivelyCapturing: true)
+
+      switch mode {
+      case .noBuffers:
+        #expect(
+          recorder.errors.count == 1,
+          "\(mode.rawValue) must keep its alerting Sentry error")
+        #expect(
+          recorder.errors[0].extra["capture.failure_mode"] as? String == mode.rawValue)
+        #expect(recorder.breadcrumbs.isEmpty)
+      case .allZeroFromStart, .becameZeroMidCapture:
+        #expect(
+          recorder.errors.isEmpty,
+          "\(mode.rawValue) must not create an alerting Sentry error (#1810)")
+        #expect(
+          recorder.breadcrumbs.isEmpty,
+          """
+          \(mode.rawValue) must not add a SECOND breadcrumb here — \
+          deadMicRetireAttempted already emits one for the same take
+          """)
+      }
+    }
+  }
+
+  // MARK: - #1844: elapsed-since-last-good on the alerting stall
+  //
+  // Scoped to `.noBuffers` since #1810: the two zero-sample modes no longer
+  // build a Sentry payload at all, so there is nothing here to carry the field.
+  // The measurement is NOT lost for them — `audio.dead_mic_retire_attempted`
+  // reads the same `captureTelemetry` for `ms_since_last_good` on every
+  // zero-signal retire. Same source, different sampling instant (stop, not
+  // mid-take), so the two numbers are not interchangeable.
+
+  @Test("the alerting stall carries elapsed ms when a prior success is known (#1844)")
+  func noBufferStallCarriesElapsedWhenKnown() {
     let clock = ManualInstantClock()
     let recorder = Recorder()
     let captureTelemetry = CaptureTelemetryState(currentInstant: { clock.now })
@@ -443,58 +526,39 @@ struct HeartPathTelemetryEmitterTests {
     captureTelemetry.recordSuccessfulRecording(recoveryTransport: "built_in_mic", sessionID: 1)
     clock.advance(by: .milliseconds(4_500))  // fake clock: no real wait
 
-    let modes: [CaptureStallFailureMode] = [
-      .noBuffers, .allZeroFromStart, .becameZeroMidCapture,
-    ]
-    for mode in modes {
-      _ = emitter.stallFired(
-        ctx: Self.stallContext(failureMode: mode), isActivelyCapturing: true)
-    }
+    emitter.stallFired(
+      ctx: Self.stallContext(failureMode: .noBuffers), isActivelyCapturing: true)
 
-    // All three modes genuinely emitted — otherwise a per-mode dedup regression
-    // would leave this test asserting over fewer events than it claims to cover.
-    #expect(recorder.errors.count == modes.count)
-    // Exact enriched key set per MODE, matching the nil test's per-mode sweep, so
-    // a key added or renamed on only one mode's payload cannot hide behind
-    // another mode's.
+    #expect(recorder.errors.count == 1)
+    let extra = recorder.errors[0].extra
     let expectedKeys =
       Self.stallExtraKeys.union(["capture.time_since_last_successful_recording_ms"])
-    for (index, mode) in modes.enumerated() {
-      let extra = recorder.errors[index].extra
-      #expect(
-        extra["capture.time_since_last_successful_recording_ms"] as? Int == 4_500,
-        "mode \(mode.rawValue) lost the elapsed-time field")
-      #expect(extra["capture.failure_mode"] as? String == mode.rawValue)
-      #expect(
-        Set(extra.keys) == expectedKeys,
-        "mode \(mode.rawValue) key drift: \(Set(extra.keys).symmetricDifference(expectedKeys))")
-    }
+    #expect(
+      extra["capture.time_since_last_successful_recording_ms"] as? Int == 4_500,
+      "the alerting stall lost the elapsed-time field")
+    #expect(extra["capture.failure_mode"] as? String == "stall_window_elapsed")
+    #expect(
+      Set(extra.keys) == expectedKeys,
+      "key drift: \(Set(extra.keys).symmetricDifference(expectedKeys))")
   }
 
-  @Test("every stall mode omits elapsed ms before the first success (#1844)")
-  func allStallsOmitElapsedBeforeFirstSuccess() {
+  @Test("the alerting stall omits elapsed ms before the first success (#1844)")
+  func noBufferStallOmitsElapsedBeforeFirstSuccess() {
     let recorder = Recorder()
     // Fresh state: no successful recording has ever been recorded.
     let emitter = Self.makeEmitter(backend: .parakeet, recorder: recorder)
 
-    let modes: [CaptureStallFailureMode] = [
-      .noBuffers, .allZeroFromStart, .becameZeroMidCapture,
-    ]
-    for mode in modes {
-      _ = emitter.stallFired(
-        ctx: Self.stallContext(failureMode: mode), isActivelyCapturing: true)
-    }
+    emitter.stallFired(
+      ctx: Self.stallContext(failureMode: .noBuffers), isActivelyCapturing: true)
 
-    #expect(recorder.errors.count == modes.count)
-    for (index, mode) in modes.enumerated() {
-      let extra = recorder.errors[index].extra
-      // ABSENT, not zero and not a placeholder — zero would read as "this user
-      // had a working recording a moment ago," the opposite of the truth.
-      #expect(
-        extra["capture.time_since_last_successful_recording_ms"] == nil,
-        "mode \(mode.rawValue) emitted a placeholder instead of omitting the field")
-      #expect(Set(extra.keys) == Self.stallExtraKeys)
-    }
+    #expect(recorder.errors.count == 1)
+    let extra = recorder.errors[0].extra
+    // ABSENT, not zero and not a placeholder — zero would read as "this user
+    // had a working recording a moment ago," the opposite of the truth.
+    #expect(
+      extra["capture.time_since_last_successful_recording_ms"] == nil,
+      "emitted a placeholder instead of omitting the field")
+    #expect(Set(extra.keys) == Self.stallExtraKeys)
   }
 
   /// Codex code-review gap #1 (noAudio fresh): exact key-set when no prior


### PR DESCRIPTION
Part of #1810.

## What this changes

`audio_capture_stalled` stops being an alerting Sentry error for the two zero-sample shapes. Only
`stall_window_elapsed` — no audio buffers arriving at all — still files one.

Nothing about dictation changes. Every failure mode still ends the take, still retires the source, and
still shows the user the same sentence. `externalCaptureStalled` is a separate fan-out arm and is
untouched.

## Why

`sentry-operations.md` RULE: sentry-for-bugs-posthog-for-behaviour admits an alerting error only when our
code owns the cause. Measured on release 2.4.6, production, dev-excluded, 14 days:

| Population | Retired takes | Users | Cause owner |
|---|---:|---:|---|
| Bluetooth `became_zero_mid_capture` | 27 | 4 | link drop or hardware mute, indistinguishable by telemetry |
| built-in `all_zero_from_start` | 37 | 9 | unknown; one user contributes 21 |
| Bluetooth `all_zero_from_start` | 19 | 7 | SCO/HFP link state |
| virtual / built-in mid-capture | 14 | 5 | mixed |

**None of those is app-owned.** The clearest case: one user recorded 446 successful built-in dictations
over five weeks with zero silent takes, then the microphone went silent on 2026-08-23 and never returned —
with our app version unchanged on both sides of that date, and their macOS unchanged for a further week.

The cost of filing them as errors: **553 of 2,768 error events in 30 days across 78 users. 20% of
everything Sentry records for us, ~11% of the free monthly quota, our largest issue by 3.4x.** It also
scores as P1 through `timesSeen >= 20` whenever one broken machine retries, which is how a hardware
failure became a recurring GitHub ticket.

This is the second application of the predicate #1446 established for polish failures.

## What is deliberately NOT here

- **No new fleet metric.** One was designed to answer "did we ever abort before our own configured bar",
  then rejected: that invariant is enforced synchronously on `MainActor` with no suspension point, so
  there is no runtime race for telemetry to reveal, and the build-time half already ships
  (`PreRollCeilingTests`, `DeadAirStreamingDetectorTests` — seven tests, verified rather than duplicated).
- **No second breadcrumb.** `deadMicRetireAttempted` already fans out a breadcrumb AND the PostHog event
  from one set of computed values on every zero-signal retire. Adding one here would split the source of
  truth.
- **No change to the user-facing sentence.** Epic #1876 settled that on 2026-07-31.

## The one way this could have backfired

`noAudioCaptured` reads `capturedStallModes` to choose breadcrumb over error. Skipping the latch insert
for a now-silent mode would turn a stalled session's `no_audio_captured` into a NEW alerting error —
moving the noise instead of removing it, with the Sentry volume not even dropping.

The insert therefore stays ABOVE the routing branch, and
`#1810: a zero-sample stall still latches, so noAudioCaptured stays a breadcrumb` is the guard. Its
mutation recipe is in #2629.

## Review

Three local Codex diff rounds. The first two returned three findings, all one class: a justification
comment asserting a mechanism I had not checked. The repeat-round gate then required the class to be
enumerated in one pass instead of recovered round by round.

That enumeration covered comments only, which was blind to four other places the same defect lives —
string literals, `@Test` display names, assertion failure messages, and the commit message. Widening it
produced a fifth member the comment sweep could not have seen: the commit message claimed the surviving
alarm "has never fired on a real user" when three releases had been queried. All five fixed. The
confirming round returned an explicit all-clear with no findings.

Sweep artifact: `tmp/1810-claim-sweep.txt` (gitignored, local).

## Testing

- Debug lane green. Verified from the `.xcresult` rather than the console tail: all five changed or added
  tests present and `Passed`, both replaced tests absent, zero non-passing.
- `CaptureErrorTagPromotionFreezeTests` still counts four capture-path sinks; this change removes none.
- Live UAT per the plan: an all-zero take produces the PostHog retire event and **no** new Sentry issue in
  `environment:development`; a normal take is unchanged. A live `.noBuffers` UAT has no harness — nothing
  suppresses callbacks, and the DEBUG zero-fill injector produces buffers — so that route is covered by
  the injected-sink test and the gap is named in #2629.

## Noted, not fixed

Five pre-existing references to knowledge filenames in these same shipped files
(`HeartPathTelemetryEmitter.swift:224`, `KernelLifecycleTelemetrySink.swift:686`,
`KernelDictationDriver.swift:520,734,1539`) predate this change and are left alone as unrelated scope.
The convention that bans them is what caught my own new one during review.

Plan: `docs/feature-requests/issue-1810-2026-09-03-stall-alert-routing.md` (gitignored).
Knowledge updates for `sentry-operations.md`, `analytics-operations.md` and `gotchas-audio.md` are
gitignored too, so they are direct edits in the main checkout and are not in this diff.
