### PR TITLE
fix(snippets): a long snippet no longer pushes Save off the edit sheet

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/SnippetEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SnippetEditSheet.swift
@@ -3,16 +3,21 @@ import SwiftUI
 
 /// Add or edit one snippet (#628), to the approved design's sheet.
 ///
-/// The live preview is the reason this sheet is worth its size. The keyword rule is easy to
-/// state and easy to misread, and a user typing a trigger cannot otherwise tell what they will
-/// have to say. Showing "You say" and "You get" as they type answers that without a manual.
+/// The sheet carried a live preview card until #2631. It was the only element in this fixed
+/// 600pt frame with no height bound — its "You get" line rendered every line of the expansion
+/// on purpose, so a multi-paragraph snippet grew the card until Delete, Cancel and Save were
+/// off the bottom and Escape was the only way out. It also restated what sat one row above it:
+/// the keyword is already a pill beside the trigger input, and the expansion is already in the
+/// editor. Removed rather than bounded, and the space went to that editor, which is where a
+/// long snippet is actually written.
 struct SnippetEditSheet: View {
   @Environment(SnippetsCoordinator.self) private var coordinator
   @Environment(\.dismiss) private var dismiss
 
   let draft: SnippetDraft
-  /// Passed in rather than read from the coordinator inside `body`: the preview must show the
-  /// keyword as it was when the sheet opened, so it cannot change under the user mid-edit.
+  /// Passed in rather than read from the coordinator inside `body`: the pill beside the trigger
+  /// input must show the keyword as it was when the sheet opened, so it cannot change under the
+  /// user mid-edit.
   let keyword: String
 
   @State private var trigger = ""
@@ -35,9 +40,7 @@ struct SnippetEditSheet: View {
 
       triggerField
       expansionField
-      preview
 
-      Spacer(minLength: 0)
       footer
     }
     .padding(20)
@@ -79,9 +82,11 @@ struct SnippetEditSheet: View {
   private var expansionField: some View {
     VStack(alignment: .leading, spacing: 6) {
       Text("Expands to").settingsRowLabel()
+      // Takes every point the sheet has left rather than a fixed height. A snippet is routinely
+      // a whole canned message, and the previous 110pt showed about four lines of one.
       TextEditor(text: $expansion)
         .font(.stBody)
-        .frame(height: 110)
+        .frame(minHeight: 110, maxHeight: .infinity)
         .scrollContentBackground(.hidden)
         .padding(6)
         .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 8))
@@ -90,39 +95,6 @@ struct SnippetEditSheet: View {
             .strokeBorder(Color.stAccent.opacity(0.22), lineWidth: 1))
       Text("Pasted exactly as written. AI Polish never rewrites it.").settingsHelperCopy()
     }
-  }
-
-  // MARK: - Preview
-
-  private var preview: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      Text("PREVIEW")
-        .font(.stSectionHeader)
-        .tracking(0.6)
-        .foregroundStyle(.stAccent)
-
-      VStack(alignment: .leading, spacing: 3) {
-        Text("You say").settingsHelperCopy()
-        Text("\(keyword) \(trigger)")
-          .font(.stRowLabel)
-          .foregroundStyle(.stAccent)
-      }
-      Divider().overlay(Color.stDivider)
-      VStack(alignment: .leading, spacing: 3) {
-        Text("You get").settingsHelperCopy()
-        Text(expansion.isEmpty ? " " : expansion)
-          .font(.stRowLabel)
-          .foregroundStyle(.stSuccess)
-          // The expansion's line breaks are its point, so the preview must show them rather
-          // than collapsing them into one line the way the list row deliberately does.
-          .fixedSize(horizontal: false, vertical: true)
-      }
-    }
-    .padding(14)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 10))
-    .overlay(
-      RoundedRectangle(cornerRadius: 10).strokeBorder(Color.stDivider, lineWidth: 1))
   }
 
   // MARK: - Footer

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -53,9 +53,8 @@ The same is true if you say the keyword and nothing after it matches a snippet y
 
 1. Open **Settings** \> **Snippets**.
 2. Click **Add snippet**.
-3. Type the words you will say in **Snippet**, and the text you want pasted in **Expands to**.
-4. Watch the preview. It shows what you will say and what you will get.
-5. Click **Save**.
+3. Type the words you will say in **Snippet**, and the text you want pasted in **Expands to**. Your keyword sits to the left of the **Snippet** box, so you can read the whole phrase you will say.
+4. Click **Save**.
 
 ### Change your keyword
 


### PR DESCRIPTION
Closes #2631

## The user problem

Saving a long snippet made the snippet edit sheet unusable. The founder hit it tonight on a five-paragraph LinkedIn recruiter reply: the PREVIEW card grew with the expansion until Delete, Cancel and Save were off the bottom of the sheet, leaving Escape as the only way out.

## Why it happened

The sheet is a fixed `480 x 600` frame. Every element in its `VStack` had a bounded height except the preview card, whose "You get" `Text` carried `.fixedSize(horizontal: false, vertical: true)` so it rendered every line of the expansion. That was correct for showing line breaks and fatal inside a fixed-height sheet.

## The change

**Removed the card rather than bounding it** (founder call). It restated what sat one row above it:

- "You say" repeated the keyword, which the trigger field already renders as a pill immediately left of its input.
- "You get" repeated the expansion, which the text editor directly above it already shows verbatim.

**The freed space goes to the expansion editor**, from a fixed `110pt` to `minHeight: 110, maxHeight: .infinity`. 110pt showed about four lines, and a snippet is routinely a whole canned message.

**Help centre step 4 told the user to watch the preview**, so it changes here too. The keyword's visibility — the card's one teaching job — moves into step 3.

## Verification

`scripts/xcode-test.sh` — exit 0, **7166 tests in 626 suites passed**, 0 failures, 3 pre-existing known issues.

`codex review --base origin/main` — no actionable defects.

**Live UAT on the dev build, against the founder's own 938-character snippet** (not filler), sheet frame `x=516 y=161 w=480 h=600`, `maxY=761`:

| element | frame | maxY | inside sheet |
|---|---|---|---|
| Delete | x=536 y=714 w=66 h=27 | 741 | yes, 20pt clear |
| Cancel | x=843 y=714 w=68 h=27 | 741 | yes, 20pt clear |
| Save | x=920 y=714 w=56 h=27 | 741 | yes, 20pt clear |

Expansion editor read **326pt** from its AX frame, up from the fixed 110. The snippet now scrolls inside that bounded box instead of pushing the buttons off the sheet.

Absence checked by enumeration rather than by not seeing one: all 13 named elements in the sheet were dumped, and `PREVIEW` / `You say` / `You get` return 0 hits. Positive control on the same dump: `Expands to` returns 1. The one case-insensitive "you say" hit is the trigger hint sentence, ordinary prose.

The store was not touched: `snippets.json` SHA-256 `aff3a989d0…` before and after, byte-identical, closed with Cancel.

## Lane

`Code` primary, `mixed_pr: true` (Content: one help article step).

## Not in scope

Two things the UAT noticed, both pre-existing and neither caused by this change: the only cue that text continues below the editor fold is a thin scrollbar, and the snippet name field opens focused with its text fully selected.
