### PR TITLE
fix(polish): give cloud cleanup a budget the real latency fits inside (#2093)

### DIFF
--- a/Sources/EnviousWisprCore/LLMTelemetrySink.swift
+++ b/Sources/EnviousWisprCore/LLMTelemetrySink.swift
@@ -31,17 +31,38 @@ public struct LLMTelemetrySink: Sendable {
   /// account name and the bridged error signature, never the key material.
   public let legacyKeyCleanupFailed: @Sendable (_ error: any Error, _ account: String) -> Void
 
+  /// #2093: a cloud pre-warm request is about to leave → `llm.prewarm_started`.
+  ///
+  /// This exists to MEASURE C4, and it is the only thing that can. The obvious
+  /// proxy — watching `rate_or_quota` fall — moves for reasons we do not control
+  /// (a user's own separate usage, provider policy), so it is a guardrail and
+  /// never the evidence. The ratio that answers "did we stop spending the user's
+  /// quota" is this event over accepted-plus-failed polishes, per provider.
+  ///
+  /// Emitted immediately BEFORE the request is sent and AFTER every key, model
+  /// and construction guard — so it counts requests that actually leave, not
+  /// intentions. Metadata only: provider and model, never key material.
+  public let prewarmStarted: @Sendable (_ provider: String, _ model: String) -> Void
+
+  /// `prewarmStarted` is deliberately NOT defaulted. Only three sites construct
+  /// this type, so requiring it costs almost nothing and makes the compiler,
+  /// rather than a reviewer, catch a `.live` factory that forgets to wire the
+  /// event — the failure mode where the counter silently never fires and the
+  /// change looks unmeasurable rather than broken.
   public init(
     limbFailure: @escaping @Sendable (String, String, String, String, Int?) -> Void,
-    legacyKeyCleanupFailed: @escaping @Sendable (any Error, String) -> Void
+    legacyKeyCleanupFailed: @escaping @Sendable (any Error, String) -> Void,
+    prewarmStarted: @escaping @Sendable (String, String) -> Void
   ) {
     self.limbFailure = limbFailure
     self.legacyKeyCleanupFailed = legacyKeyCleanupFailed
+    self.prewarmStarted = prewarmStarted
   }
 
   /// No-op sink — the default at every construction site except the App composition
   /// root (which injects `.live`). Keeps tests and keyless paths silent.
   public static let noop = LLMTelemetrySink(
     limbFailure: { _, _, _, _, _ in },
-    legacyKeyCleanupFailed: { _, _ in })
+    legacyKeyCleanupFailed: { _, _ in },
+    prewarmStarted: { _, _ in })
 }

--- a/Sources/EnviousWisprLLM/ClaudeConnector.swift
+++ b/Sources/EnviousWisprLLM/ClaudeConnector.swift
@@ -384,7 +384,7 @@ public struct ClaudeConnector: TranscriptPolisher {
         let delay = delays[min(attempt - 1, delays.count - 1)]
         Task {
           await AppLogger.shared.log(
-            "Claude retry \(attempt)/\(maxRetries) after \(delay / 1_000_000_000)s (model=\(config.model))",
+            "Claude retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
             level: .verbose, category: "LLM"
           )
         }

--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -505,7 +505,7 @@ public struct GeminiConnector: TranscriptPolisher {
         let delay = delays[min(attempt - 1, delays.count - 1)]
         Task {
           await AppLogger.shared.log(
-            "Gemini retry \(attempt)/\(maxRetries) after \(delay / 1_000_000_000)s (model=\(config.model))",
+            "Gemini retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
             level: .verbose, category: "LLM"
           )
         }

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -64,11 +64,10 @@ public final class LLMNetworkSession: Sendable {
   ///
   /// ONE lock holding both maps, so the decide-and-claim is a single critical
   /// section. Two recordings can start inside the window, and a check-then-act
-  /// across separate reads would let both warm — the exact shape
-  /// `validation-discipline.md`
-  /// RULE: a-single-threaded-test-cannot-distinguish-atomic-from-check-then-act
-  /// warns about, and a single-threaded test cannot tell the two apart. The
-  /// concurrent test in `LLMWarmupGateTests` races it deliberately.
+  /// across separate reads would let both warm. A single-threaded test cannot
+  /// tell an atomic claim from a check-then-act one, because it cannot open the
+  /// window between the two reads — so the guard for this is structural, in
+  /// `LLMWarmupGateTests`, not a race.
   private struct WarmState {
     var lastSuccess: [String: Date] = [:]
     var inFlight: Set<String> = []

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -124,6 +124,16 @@ public final class LLMNetworkSession: Sendable {
     }
   }
 
+  /// Test seam only: an ISOLATED instance, so a suite never mutates `shared`.
+  ///
+  /// Swift Testing runs tests concurrently by default, and `recordPolishSuccess`
+  /// is called on `shared` from production `LLMPolishStep`, so a suite that
+  /// resets `shared` can race any other test that happens to polish. Review
+  /// finding (2026-09-03) — the first version of `LLMWarmupGateTests` did
+  /// exactly that. This returns a private-init instance whose warm state is its
+  /// own; the URLSession it carries is never used by those tests.
+  static func makeIsolatedForTesting() -> LLMNetworkSession { LLMNetworkSession() }
+
   /// Test seam only: forget all warm state so a suite starts cold.
   func resetWarmStateForTesting() {
     warmState.withLock { state in

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -17,6 +17,121 @@ public final class LLMNetworkSession: Sendable {
   /// subsequent calls without carrying extra state.
   private let callCounter = OSAllocatedUnfairLock<Int>(initialState: 0)
 
+  /// #2093: whether a provider warms at all.
+  ///
+  /// EXHAUSTIVE over `LLMProvider` on purpose, with no `default:` — a provider
+  /// added later must not silently inherit "warms on every recording", which is
+  /// the behaviour this issue exists to remove. `warmupKeychainId(for:)` below
+  /// keeps its `default: nil` because that one answers a different question
+  /// (which key to read) and failing closed there is already correct.
+  enum CloudWarmupPolicy: Equatable {
+    /// Never send a warm-up request for this provider.
+    case never
+    /// Warm only when this `(provider, model)` is not already warm or in flight.
+    case whenCold
+  }
+
+  /// #2093: Gemini stops warming; OpenAI and Claude warm only when cold.
+  ///
+  /// The asymmetry is evidence-led and was a founder decision (2026-09-03). Over
+  /// 60 days `rate_or_quota` — the provider refusing us for quota — was
+  /// 442 events across 4 users, and ALL of them are Gemini. No equivalent signal
+  /// exists for OpenAI or Claude, so removing their warm-up would be a change
+  /// nothing measured. Revisit only with provider-specific request and latency
+  /// evidence.
+  ///
+  /// #266's recorded reason for warming (it warms the provider's model ROUTING,
+  /// not just the transport) is not disputed. Its CONSEQUENCE was removed in the
+  /// same change: that mattered because the cloud budget was 5 s and a cold-start
+  /// spike meant LOSING the polish. At the 15 s base (#2093, `LLMPolishStep`) a
+  /// spike costs latency once instead of costing the answer.
+  static func cloudWarmupPolicy(for provider: LLMProvider) -> CloudWarmupPolicy {
+    switch provider {
+    case .gemini: return .never
+    case .openAI, .claude: return .whenCold
+    // Local providers never had a warm-up: `warmupKeychainId(for:)` returns nil
+    // for them, so this arm is belt-and-braces rather than a behaviour change.
+    case .ollama, .egOne, .appleIntelligence, .none: return .never
+    }
+  }
+
+  /// Warmth window for `.whenCold` providers. Chosen as an ordinary idle
+  /// keep-alive horizon, not a measured constant — the thing being avoided is a
+  /// warm-up on EVERY recording, and any window of minutes achieves that.
+  static let warmWindowSeconds: TimeInterval = 300
+
+  /// Atomic `(provider, model)` warm state.
+  ///
+  /// ONE lock holding both maps, so the decide-and-claim is a single critical
+  /// section. Two recordings can start inside the window, and a check-then-act
+  /// across separate reads would let both warm — the exact shape
+  /// `validation-discipline.md`
+  /// RULE: a-single-threaded-test-cannot-distinguish-atomic-from-check-then-act
+  /// warns about, and a single-threaded test cannot tell the two apart. The
+  /// concurrent test in `LLMWarmupGateTests` races it deliberately.
+  private struct WarmState {
+    var lastSuccess: [String: Date] = [:]
+    var inFlight: Set<String> = []
+  }
+
+  private let warmState = OSAllocatedUnfairLock<WarmState>(initialState: WarmState())
+
+  private static func warmKey(_ provider: LLMProvider, _ model: String) -> String {
+    "\(provider.rawValue)|\(model)"
+  }
+
+  /// Decides and CLAIMS in one critical section. Returns true only for the caller
+  /// that may send; that caller owns clearing the in-flight marker.
+  func claimWarmupSlot(provider: LLMProvider, model: String, now: Date) -> Bool {
+    let key = Self.warmKey(provider, model)
+    return warmState.withLock { state in
+      if state.inFlight.contains(key) { return false }
+      if let last = state.lastSuccess[key],
+        now.timeIntervalSince(last) < Self.warmWindowSeconds
+      {
+        return false
+      }
+      state.inFlight.insert(key)
+      return true
+    }
+  }
+
+  func releaseWarmupSlot(provider: LLMProvider, model: String, succeededAt: Date?) {
+    let key = Self.warmKey(provider, model)
+    warmState.withLock { state in
+      state.inFlight.remove(key)
+      if let succeededAt { state.lastSuccess[key] = succeededAt }
+    }
+  }
+
+  /// #2093: a REAL polish was accepted, so this `(provider, model)` is warm and
+  /// the next take inside the window needs no warm-up request.
+  ///
+  /// This exists because `LLMNetworkSession` can observe its own warm-up and has
+  /// no other way to learn that a genuine polish succeeded — the first draft of
+  /// this change described "mark warm after an accepted polish" as a state with
+  /// no producer, which review caught. `LLMPolishStep` is the producer.
+  ///
+  /// The trigger is a COMPLETED ROUND TRIP, not a good answer. Warmth is a
+  /// property of the transport and the provider's model routing, so a polish
+  /// whose text we then discard on validation still leaves the route warm. A
+  /// throw, a timeout or an empty response exits before the call site and
+  /// records nothing: attempted is not completed.
+  public func recordPolishSuccess(provider: LLMProvider, model: String, at date: Date = Date()) {
+    guard Self.cloudWarmupPolicy(for: provider) == .whenCold, !model.isEmpty else { return }
+    warmState.withLock { state in
+      state.lastSuccess[Self.warmKey(provider, model)] = date
+    }
+  }
+
+  /// Test seam only: forget all warm state so a suite starts cold.
+  func resetWarmStateForTesting() {
+    warmState.withLock { state in
+      state.lastSuccess.removeAll()
+      state.inFlight.removeAll()
+    }
+  }
+
   private init() {
     let config = URLSessionConfiguration.default
     config.timeoutIntervalForRequest = 60
@@ -37,9 +152,23 @@ public final class LLMNetworkSession: Sendable {
   /// Pre-warm the LLM backend with a real lightweight inference request.
   /// Warms both the transport layer (QUIC/TLS) AND the provider's model routing.
   /// Silently ignores errors — pre-warming is best-effort.
+  ///
+  /// #2093: this is no longer unconditional. It costs one provider request on the
+  /// USER'S OWN key, and it used to fire on every launch, every foreground and
+  /// every recording start. Gemini now returns immediately (`cloudWarmupPolicy`), and
+  /// OpenAI/Claude send only when this `(provider, model)` is neither warm nor
+  /// already in flight. Callers are unchanged and still call it freely — the
+  /// decision lives here, with the state that informs it, rather than being
+  /// duplicated at the three call sites.
   public func preWarmModel(
     provider: LLMProvider, model: String, keychainManager: KeychainManager
   ) {
+    // #2093: FIRST, before key lookup, request construction, state mutation or
+    // telemetry. A Gemini caller must leave this function having touched
+    // nothing — that is what makes "removing Gemini's warm-up cannot affect
+    // OpenAI or Claude" checkable rather than asserted, since all three enter
+    // here. `LLMWarmupGateTests` pins the ordering.
+    guard Self.cloudWarmupPolicy(for: provider) == .whenCold else { return }
     guard let keychainId = Self.warmupKeychainId(for: provider) else { return }
     guard !model.isEmpty else { return }
 
@@ -53,12 +182,22 @@ public final class LLMNetworkSession: Sendable {
       )
     else { return }
 
+    // #2093: decide and CLAIM atomically. Everything above this line is a pure
+    // eligibility check; this is the only place that can commit us to sending.
+    guard claimWarmupSlot(provider: provider, model: model, now: Date()) else { return }
+
     // #1177 (Telemetry Bible Phase 8): A6 reads the LLM module's telemetry sink off
     // the `keychainManager` it already receives (carried there because the LLM module
     // has no telemetry dependency — KeychainManager is the App-injected seam). The
     // sink is `Sendable`, so it crosses into the detached task cleanly.
-    Task.detached { [session, sink = keychainManager.telemetrySink] in
+    Task.detached { [self, session, sink = keychainManager.telemetrySink] in
       let start = CFAbsoluteTimeGetCurrent()
+      // #2093: counted here — past every guard, immediately before the request
+      // leaves — so the metric counts requests that actually go out rather than
+      // intentions. This is the only measurement of whether the warm-up gate
+      // works; `rate_or_quota` is a guardrail and moves for reasons we do not
+      // control.
+      sink.prewarmStarted(provider.rawValue, model)
       do {
         let (data, response) = try await session.data(for: request)
         let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
@@ -84,6 +223,13 @@ public final class LLMNetworkSession: Sendable {
         // returns it), so it would otherwise log "completed" and never report the
         // failure — mirror the A5 evict 2xx/non-2xx split. A missing status code
         // (n/a) is NOT treated as a failure (that path already lacks a real signal).
+        // #2093: release the in-flight marker on EVERY terminal outcome, and
+        // record warmth ONLY on a 2xx. A non-2xx warm-up proves the route is
+        // reachable and nothing else — treating it as warm would suppress the
+        // next real warm-up on the strength of a failure.
+        let warmedAt: Date? =
+          if let code = statusCode, (200...299).contains(code) { Date() } else { nil }
+        releaseWarmupSlot(provider: provider, model: model, succeededAt: warmedAt)
         if let code = statusCode, !(200...299).contains(code) {
           // `#if DEBUG` at the CALL SITE, not just inside `AppLogger` (cloud
           // review, PR #2072). `AppLogger.log` takes a `String`, so the
@@ -104,6 +250,9 @@ public final class LLMNetworkSession: Sendable {
             "llm_prewarm", "prewarm", "failed", "\(provider.rawValue)_http_\(code)", ms)
         }
       } catch {
+        // #2093: terminal too — free the slot so a later take can retry, and
+        // record NO warmth.
+        releaseWarmupSlot(provider: provider, model: model, succeededAt: nil)
         let ms = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
         await AppLogger.shared.log(
           "preWarm failed provider=\(provider.rawValue) model=\(model) duration_ms=\(ms) error=\(String(describing: error))",

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -3,8 +3,23 @@ import Foundation
 /// Shared retry infrastructure for LLM connectors.
 /// Centralizes retry-eligibility logic so all connectors use the same rules.
 enum LLMRetryPolicy {
-  /// Default retry delays: 1s, then 3s.
-  static let defaultDelays: [UInt64] = [1_000_000_000, 3_000_000_000]
+  /// Default retry delays: 200ms, then 400ms.
+  ///
+  /// #2093: was 1s then 3s. Those sleeps are spent INSIDE the polish step's own
+  /// budget, so on the old 5 s cloud base two retries burned 4 of the 5 seconds
+  /// doing nothing — one transient 5xx made a short dictation's timeout
+  /// arithmetically certain, and the user was then told "timed out" rather than
+  /// what actually happened. The failure was rebranded by our own backoff.
+  ///
+  /// 200ms x attempt matches FluidVoice's shipped `retryDelayMs` (open source,
+  /// same providers, same BYOK-direct architecture). Worst case is now 0.6 s of
+  /// sleep inside the 15 s cloud budget instead of 4 s inside 5 s.
+  ///
+  /// KNOWN LIMIT, deliberately not fixed here: these sleeps are still charged to
+  /// the caller's budget rather than deducted from a remaining-time ledger. The
+  /// ledger is the fuller fix and is its own change; this one removes the
+  /// arithmetic certainty without adding a mechanism.
+  static let defaultDelays: [UInt64] = [200_000_000, 400_000_000]
   static let defaultMaxRetries = 2
 
   /// Determine if an error is transient and worth retrying.

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -19,6 +19,11 @@ enum LLMRetryPolicy {
   /// the caller's budget rather than deducted from a remaining-time ledger. The
   /// ledger is the fuller fix and is its own change; this one removes the
   /// arithmetic certainty without adding a mechanism.
+  /// REACH, stated because the issue's non-goals said local providers were not
+  /// touched: that was about BUDGETS. All four connectors — including Ollama —
+  /// default to these delays, so Ollama's backoff shrinks too. Intended and
+  /// beneficial (more of its unchanged 15 s budget goes to real attempts), not
+  /// an accident.
   static let defaultDelays: [UInt64] = [200_000_000, 400_000_000]
   static let defaultMaxRetries = 2
 

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -618,7 +618,7 @@ public struct OllamaConnector: TranscriptPolisher {
         let delay = delays[min(attempt - 1, delays.count - 1)]
         Task {
           await AppLogger.shared.log(
-            "Ollama retry \(attempt)/\(maxRetries) after \(delay / 1_000_000_000)s (model=\(config.model))",
+            "Ollama retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
             level: .verbose, category: "LLM"
           )
         }

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -167,7 +167,7 @@ public struct OpenAIConnector: TranscriptPolisher {
         let delay = delays[min(attempt - 1, delays.count - 1)]
         Task {
           await AppLogger.shared.log(
-            "OpenAI retry \(attempt)/\(maxRetries) after \(delay / 1_000_000_000)s (model=\(config.model))",
+            "OpenAI retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
             level: .verbose, category: "LLM"
           )
         }

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -320,9 +320,8 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
     // something the data says it did not cause. Measured across 121 production
     // timeouts: median dictation 106 characters, 26 of 54 Gemini cases under 100,
     // smallest 18. The dictation was almost never long; the provider did not
-    // answer inside the budget. `grounding-discipline.md`
-    // RULE: public-claims-need-binding-evidence — a user-facing sentence is a
-    // claim, and this one was refuted by our own telemetry.
+    // answer inside the budget. A user-facing sentence is a claim like any
+    // other, and this one was refuted by our own telemetry.
     case .timedOut:
       return "\(name) did not answer in time. Your original text was pasted unchanged."
     case .unknown:

--- a/Sources/EnviousWisprLLM/PolishFailureReason.swift
+++ b/Sources/EnviousWisprLLM/PolishFailureReason.swift
@@ -316,8 +316,15 @@ public enum PolishFailureReason: String, Sendable, Equatable, CaseIterable {
       return "a configuration problem stopped it. Your original text was pasted unchanged."
     case .emptyResponse:
       return "\(name) returned no cleanup text. Try again."
+    // #2093: was "the dictation took too long", which blamed the user's input for
+    // something the data says it did not cause. Measured across 121 production
+    // timeouts: median dictation 106 characters, 26 of 54 Gemini cases under 100,
+    // smallest 18. The dictation was almost never long; the provider did not
+    // answer inside the budget. `grounding-discipline.md`
+    // RULE: public-claims-need-binding-evidence — a user-facing sentence is a
+    // claim, and this one was refuted by our own telemetry.
     case .timedOut:
-      return "the dictation took too long. Your original text was pasted unchanged."
+      return "\(name) did not answer in time. Your original text was pasted unchanged."
     case .unknown:
       return "an unexpected error stopped it. Your original text was pasted unchanged."
     case .outputTruncated:

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -182,9 +182,10 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// (#1770 corrected an older claim on this line that "cloud providers respond
   /// in <2s so 5s is generous": false for Gemini on the measured long
   /// dictations (11,324 chars took 6.12s, 66,896 took 50.65s), and #158 already
-  /// measured a 9.16s Claude call. Gemini now
-  /// scales via `maxDuration(for:)` below; the rest keep fixed budgets, and
-  /// OpenAI/Claude are #1833.)
+  /// measured a 9.16s Claude call. Gemini and, since #2093, OpenAI scale via
+  /// `maxDuration(for:)` below; the rest keep fixed budgets. #2093 closes the
+  /// OpenAI half of #1833; the Claude half stays open by choice, since #158
+  /// measured that provider directly.)
   /// Local models (Ollama 12B) generate ~18 tok/s and need 10-15s for long dictations.
   /// Apple Intelligence runs on-device with variable latency depending on model size.
   public var maxDuration: Duration {
@@ -209,7 +210,26 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     // rather than inventing a new number, with real headroom over the
     // worst real value measured across every offered model so far.
     case .claude: return .seconds(15)
-    case .openAI, .gemini, .none: return .seconds(5)
+    // #2093: raised from 5 s. The 5 s base was never measured against the live
+    // distribution — it was the original backstop, and #1770 fixed only the LONG
+    // tail above it. Production, 30 days, SUCCESSFUL Gemini polishes: 263 under
+    // 1 s, 197 at 1-2 s, 41 at 2-3 s, 23 at 3-4 s, 9 at 4-5 s. The distribution
+    // thins and never stops, so a 5 s cut sits INSIDE it and took 54 polishes
+    // from 7 users in that window (`ENVIOUSWISPR-32`). 15 s is not a new number:
+    // it is the `.claude` value directly above, whose own receipt records a real
+    // 9.16 s call, and it clears every successful cloud polish we have ever
+    // recorded (max 5.3 s) by ~3x.
+    //
+    // This budget IS a real bound — measured, not assumed. `withThrowingTimeout`
+    // returns the caller at the budget on every shape we ship, including Gemini's
+    // SSE `bytes(for:)` stream and this runner's `@MainActor` executor bridge
+    // (four-arm probe against stalling localhost servers, 2026-09-03). An earlier
+    // draft of #2093 claimed the opposite and was wrong.
+    case .openAI, .gemini: return .seconds(15)
+    // No provider selected: polish never runs, so this value is unreachable in
+    // practice. Left at 5 s deliberately rather than swept along with the two
+    // above, which would imply a measurement that does not exist for it.
+    case .none: return .seconds(5)
     }
   }
 
@@ -233,8 +253,11 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// chars/second leaves ~2.6x margin on the variable part alone. Headroom
   /// lands at 6x / 6x / 4.5x / 2.7x across the table above.
   ///
-  /// `base` is 5 s, preserving today's short-dictation failure speed almost
-  /// exactly (110 chars -> 5.22 s).
+  /// `base` was 5 s, chosen to preserve the then-current short-dictation failure
+  /// speed (110 chars -> 5.22 s). **#2093 raised it to 15 s**: preserving that
+  /// speed was preserving the defect, because the failures are concentrated on
+  /// SHORT dictations — measured median 106 chars, 26 of 54 under 100 — so the
+  /// base, not the per-character term, is what was cutting them off.
   ///
   /// #1831 removed the 60 s deep base along with the Deep-reasoning toggle that
   /// was its only trigger. The measurement that justified it is kept because it
@@ -267,20 +290,27 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// for every Gemini request, so a torn read cannot produce a budget/request
   /// mismatch on this axis. `llmProvider` and `llmModel` retain the invariant
   /// above.
+  /// #2093: OpenAI joins Gemini on the scaled form. It was on a FIXED 5 s while
+  /// Gemini scaled, which is the gap #1833 tracks — a long OpenAI dictation had
+  /// the same truncation #1770 fixed for Gemini, with no receipt saying 5 s was
+  /// right for it. Claude keeps its fixed 15 s: #158's receipt measured that
+  /// provider directly, and widening it here would be a change nothing measured.
   public func maxDuration(for context: TextProcessingContext) -> Duration {
-    guard llmProvider == .gemini else { return maxDuration }
+    guard llmProvider == .gemini || llmProvider == .openAI else { return maxDuration }
     let scaled =
-      Self.geminiBaseSeconds + Double(context.text.count) / Self.geminiCharsPerSecond
-    return .seconds(min(Self.geminiMaxBudgetSeconds, scaled))
+      Self.cloudBaseSeconds + Double(context.text.count) / Self.cloudCharsPerSecond
+    return .seconds(min(Self.cloudMaxBudgetSeconds, scaled))
   }
 
-  /// Preserves today's 5 s short-dictation failure speed.
-  private static let geminiBaseSeconds: Double = 5
-  /// Budgeted throughput, ~2.6x slower than the slowest measured rate.
-  private static let geminiCharsPerSecond: Double = 500
+  /// #2093: 5 -> 15. Rationale and the production distribution behind it live at
+  /// the `.openAI, .gemini` arm of `maxDuration` above; not restated here so the
+  /// two cannot drift apart.
+  private static let cloudBaseSeconds: Double = 15
+  /// Budgeted throughput, ~2.6x slower than the slowest measured rate (#1770).
+  private static let cloudCharsPerSecond: Double = 500
   /// Matches `URLSession.timeoutIntervalForResource`; beyond it the transport
   /// kills the attempt regardless.
-  private static let geminiMaxBudgetSeconds: Double = 180
+  private static let cloudMaxBudgetSeconds: Double = 180
 
   public init(keychainManager: KeychainManager) {
     self.keychainManager = keychainManager
@@ -823,6 +853,19 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       mode: plan.mode,
       provider: provider, model: model
     )
+
+    // #2093: the round trip completed, so this (provider, model) is warm and the
+    // next take inside the window needs no warm-up request. Without this call
+    // the gate in `LLMNetworkSession` could only ever be satisfied by a warm-up
+    // warming itself, which is the state-with-no-producer review caught.
+    //
+    // Placed on the COMPLETED round trip, deliberately, not on a "good" answer:
+    // warmth is a property of the transport and the provider's model routing, so
+    // a validator discard a few lines below still counts — the connection and the
+    // route were exercised. Every path that did NOT complete a round trip (throw,
+    // timeout, empty response) exits before here and records nothing.
+    // `recordPolishSuccess` itself ignores providers whose policy is `.never`.
+    LLMNetworkSession.shared.recordPolishSuccess(provider: provider, model: model)
 
     var ctx = context
     ctx.polishedText = validatedText

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -199,8 +199,10 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     case .appleIntelligence: return .seconds(10)
     // #158 pre-merge latency receipt (30 real calls, Haiku + Sonnet 4.6,
     // short/medium/long): observed max 7.47s (Sonnet, long bucket), with
-    // two Haiku calls over 4.6s. The shared 5 s backstop below would
-    // truncate that real tail. The picker offers every live-discovered
+    // two Haiku calls over 4.6s. The shared backstop below was 5 s when this
+    // receipt was written and would have truncated that real tail; #2093 raised
+    // the openAI/gemini arm to this same 15 s, so the contrast is now with the
+    // 10 s that the paragraph below rejects, not with 5 s. The picker offers every live-discovered
     // model, including several Opus tiers the bucketed receipt never
     // measured — the separate all-models sweep recorded a real successful
     // claude-opus-4-5-20251101 call at 9.16s (Codex r10), which would leave
@@ -233,8 +235,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     }
   }
 
-  /// Gemini's budget scales with the transcript; every other provider keeps its
-  /// fixed one (#1770).
+  /// Gemini (#1770) and OpenAI (#2093) scale their budget with the transcript;
+  /// every other provider keeps a fixed one.
   ///
   /// A fixed 5 s was timing out long dictations. Measured live against
   /// real dictations, Gemini in fast mode: 1,709 chars -> 1.33 s, 4,605 -> 2.69 s,
@@ -264,9 +266,10 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// is evidence, not dead code: deep mode spent a measured 42.2-42.4 s
   /// thinking BEFORE the first byte, a fixed cost rather than a per-character
   /// one. No caller can request that shape any more — the capability table now
-  /// holds one value per model, each of them the toggle's OFF value — so 5 s is
-  /// what every Gemini request has always been budgeted at in the shipped
-  /// default configuration.
+  /// holds one value per model, each of them the toggle's OFF value — so there
+  /// is ONE base for every Gemini request in the shipped default configuration.
+  /// That base was 5 s when #1831 wrote this and is 15 s since #2093; the point
+  /// the paragraph makes is that there is only one of it, not what it equals.
   ///
   /// Capped at 180 s to match `URLSession`'s `timeoutIntervalForResource`
   /// (`LLMNetworkSession`): beyond that the transport terminates the attempt

--- a/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
+++ b/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
@@ -31,6 +31,16 @@ extension LLMTelemetrySink {
       errorCategory: errorCategory, durationMs: durationMs)
   }
 
+  /// #2093: the pre-warm counter's production home. Same injectable shape as the
+  /// two reporters above so a test asserts the effect without a process global.
+  package typealias PrewarmStartedReporter = @MainActor (
+    _ provider: String, _ model: String
+  ) -> Void
+
+  package static let defaultPrewarmStartedReporter: PrewarmStartedReporter = { provider, model in
+    TelemetryService.shared.prewarmStarted(provider: provider, model: model)
+  }
+
   package static let defaultHandledErrorReporter: HandledErrorReporter = {
     error, category, stage, extra, fingerprintDetail in
     SentryBreadcrumb.captureError(
@@ -47,7 +57,8 @@ extension LLMTelemetrySink {
   /// telemetry lost to an immediate quit is acceptable; a limb never blocks the heart.
   package static func makeLive(
     limbFailureReporter: @escaping LimbFailureReporter = defaultLimbFailureReporter,
-    handledErrorReporter: @escaping HandledErrorReporter = defaultHandledErrorReporter
+    handledErrorReporter: @escaping HandledErrorReporter = defaultHandledErrorReporter,
+    prewarmStartedReporter: @escaping PrewarmStartedReporter = defaultPrewarmStartedReporter
   ) -> LLMTelemetrySink {
     LLMTelemetrySink(
       limbFailure: { limb, operation, result, errorCategory, durationMs in
@@ -70,6 +81,13 @@ extension LLMTelemetrySink {
             handledErrorReporter(
               SentryCaptureBoundaryError.normalizingLegacyKeyCleanupFailure(error),
               .legacyKeyCleanupFailed, "keychain", ["account": account], account)
+          }
+        }
+      },
+      prewarmStarted: { provider, model in
+        DispatchQueue.main.async {
+          MainActor.assumeIsolated {
+            prewarmStartedReporter(provider, model)
           }
         }
       })

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -909,12 +909,12 @@ public final class TelemetryService {
   /// request is sent — so it counts requests that actually leave, not intentions.
   ///
   /// `model` is RAW, matching `llm.polish_completed` / `llm.polish_failed`. That
-  /// is deliberate and required: `observability-operations.md`
-  /// RULE: telemetry-observes-resolved-value-deny-by-default carries a founder
-  /// decision (2026-08-15) that runtime polish events keep the raw model, because
-  /// bucketing makes "which model is failing" unanswerable and an allowlist goes
-  /// stale monthly. A reviewer seeing only the SETTINGS guard files this as a
-  /// privacy P0; it is not one. Metadata only — never key material.
+  /// is deliberate and required by a founder decision (2026-08-15): runtime
+  /// polish events keep the raw model, because bucketing makes "which model is
+  /// failing" unanswerable and a static allowlist goes stale monthly. The
+  /// deny-by-default projection applies to SETTINGS telemetry, not here — a
+  /// reviewer seeing only that guard files this as a privacy P0, and it is not
+  /// one. Metadata only, never key material.
   public func prewarmStarted(provider: String, model: String) {
     let props: [String: Any] = ["provider": provider, "model": model]
     #if DEBUG

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -897,9 +897,19 @@ public final class TelemetryService {
   /// per dictation charged to the user's quota — and `rate_or_quota` became the
   /// largest cloud polish failure we have (442 events / 4 users / 60 days).
   /// #2093 removes Gemini's warm-up entirely and gates OpenAI/Claude on cold.
-  /// The ratio that says whether that worked is this event over
-  /// (`llm.polish_completed` + `llm.polish_failed`) per cloud user-day, split by
-  /// provider. It reads ~1.0 today by construction and should fall.
+  /// Two ratios say whether that worked, and NEITHER has a 1.0 baseline — an
+  /// earlier draft claimed one "by construction" and that was wrong. Warm-ups
+  /// also fire at launch and at foreground (`AppLifecycleCoordinator`), which
+  /// produce a numerator with no take behind them, and a take ending in
+  /// `llm.polish_skipped` produces one with no denominator event. Both push the
+  /// old value ABOVE 1. So state each ratio and measure it, never assume it:
+  ///   - per attempted polish: this event over
+  ///     (`llm.polish_completed` + `llm.polish_failed`)
+  ///   - per eligible take: this event over
+  ///     (`llm.polish_completed` + `llm.polish_failed` + `llm.polish_skipped`)
+  /// Both per cloud user-day, split by provider, and both should FALL at the
+  /// release that ships #2093. The fall is the evidence; the absolute level
+  /// before it is not a number anyone has taken.
   ///
   /// Watching `rate_or_quota` fall instead would NOT be evidence: it moves with
   /// the user's own separate API usage and with provider policy, neither of

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -890,6 +890,42 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("limb.failure_observed", properties: props)
   }
 
+  /// #2093: a cloud pre-warm request is leaving, on the user's own API key.
+  ///
+  /// THE DENOMINATOR IS THE POINT. Before #2093 we warmed on every launch, every
+  /// foreground and every recording start, which is one extra provider request
+  /// per dictation charged to the user's quota — and `rate_or_quota` became the
+  /// largest cloud polish failure we have (442 events / 4 users / 60 days).
+  /// #2093 removes Gemini's warm-up entirely and gates OpenAI/Claude on cold.
+  /// The ratio that says whether that worked is this event over
+  /// (`llm.polish_completed` + `llm.polish_failed`) per cloud user-day, split by
+  /// provider. It reads ~1.0 today by construction and should fall.
+  ///
+  /// Watching `rate_or_quota` fall instead would NOT be evidence: it moves with
+  /// the user's own separate API usage and with provider policy, neither of
+  /// which this change controls. Guardrail, never the measurement.
+  ///
+  /// Emitted after every key/model/construction guard, immediately before the
+  /// request is sent — so it counts requests that actually leave, not intentions.
+  ///
+  /// `model` is RAW, matching `llm.polish_completed` / `llm.polish_failed`. That
+  /// is deliberate and required: `observability-operations.md`
+  /// RULE: telemetry-observes-resolved-value-deny-by-default carries a founder
+  /// decision (2026-08-15) that runtime polish events keep the raw model, because
+  /// bucketing makes "which model is failing" unanswerable and an allowlist goes
+  /// stale monthly. A reviewer seeing only the SETTINGS guard files this as a
+  /// privacy P0; it is not one. Metadata only — never key material.
+  public func prewarmStarted(provider: String, model: String) {
+    let props: [String: Any] = ["provider": provider, "model": model]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "llm.prewarm_started",
+          stringProps: ["provider": provider, "model": model]))
+    #endif
+    PostHogSDK.shared.capture("llm.prewarm_started", properties: props)
+  }
+
   /// #1408: the microphone died (or the duration cap fired) while a recording was
   /// in flight. Fires on EVERY such interruption that reaches a recording exit —
   /// salvaged or not — so `dictation.completed`'s salvage count has a denominator.

--- a/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
@@ -14,7 +14,8 @@ private final class CleanupSinkSpy: @unchecked Sendable {
     LLMTelemetrySink(
       limbFailure: { _, _, _, _, _ in },
       legacyKeyCleanupFailed: { _, account in self.lock.withLock { self._accounts.append(account) }
-      })
+      },
+      prewarmStarted: { _, _ in })
   }
 }
 

--- a/Tests/EnviousWisprTests/LLM/LLMRetryPolicyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMRetryPolicyTests.swift
@@ -8,9 +8,27 @@ struct LLMRetryPolicyTests {
 
   // MARK: - Constants
 
-  @Test("default delays are 1s and 3s")
+  @Test("default delays are 200ms and 400ms")
   func defaultDelays() {
-    #expect(LLMRetryPolicy.defaultDelays == [1_000_000_000, 3_000_000_000])
+    #expect(LLMRetryPolicy.defaultDelays == [200_000_000, 400_000_000])
+  }
+
+  /// #2093: the durable claim is not the two literals above — it is that the
+  /// SLEEPS cannot eat the budget they run inside. They are spent within the
+  /// polish step's own deadline, so at 1s+3s a single transient 5xx made a short
+  /// cloud dictation's timeout arithmetically certain on the old 5s base, and
+  /// the user was told "timed out" instead of the real reason.
+  ///
+  /// Stated as a RELATION against the smallest cloud budget rather than as a
+  /// third copy of the numbers, so it stays true if the delays are retuned and
+  /// goes red if anyone reintroduces multi-second backoff.
+  @Test("all retry sleeps together stay well inside the smallest cloud budget")
+  func retrySleepsFitInsideTheBudget() {
+    let totalSleepNanos = LLMRetryPolicy.defaultDelays.reduce(0, +)
+    let totalSleepSeconds = Double(totalSleepNanos) / 1_000_000_000
+    #expect(totalSleepSeconds < 1.0)
+    // The smallest cloud budget any dictation can get is the 15s base (#2093).
+    #expect(totalSleepSeconds < 15.0 * 0.1)
   }
 
   @Test("default max retries is 2")

--- a/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
@@ -1,0 +1,260 @@
+import EnviousWisprCore
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+import os
+
+@testable import EnviousWisprLLM
+
+/// #2093: the cloud pre-warm no longer fires on every recording.
+///
+/// It costs one provider request on the USER'S OWN key, and it used to fire on
+/// every launch, every foreground and every recording start. Over 60 days
+/// `rate_or_quota` — the provider refusing us for quota — was the largest cloud
+/// polish failure we had (442 events / 4 users), and every one was Gemini.
+///
+/// Tagged `driftGuard` rather than `productOutcome` on purpose. What a person
+/// notices is "my cleanup got refused", and this suite does not reach that far:
+/// it pins the decision, the state machine and its atomicity. Claiming product
+/// coverage here would inflate the split `TestInventoryFreezeTests` reports.
+@Suite("Cloud pre-warm gate (#2093)", .tags(.driftGuard))
+struct LLMWarmupGateTests {
+
+  private func freshSession() -> LLMNetworkSession {
+    let s = LLMNetworkSession.shared
+    s.resetWarmStateForTesting()
+    return s
+  }
+
+  // MARK: - The decision
+
+  /// EXHAUSTIVE over `LLMProvider`. The production switch has no `default:`, so
+  /// adding a provider breaks the build until someone decides; this asserts the
+  /// decision that shipped, one row per case, so a future edit that flips a
+  /// provider back to warming-always fails here rather than in production
+  /// quota telemetry weeks later.
+  @Test(
+    "every provider's warm-up policy is the one #2093 decided",
+    arguments: [
+      (LLMProvider.gemini, LLMNetworkSession.CloudWarmupPolicy.never),
+      (LLMProvider.openAI, .whenCold),
+      (LLMProvider.claude, .whenCold),
+      (LLMProvider.ollama, .never),
+      (LLMProvider.egOne, .never),
+      (LLMProvider.appleIntelligence, .never),
+      (LLMProvider.none, .never),
+    ])
+  func cloudWarmupPolicyPerProvider(provider: LLMProvider, expected: LLMNetworkSession.CloudWarmupPolicy) {
+    #expect(LLMNetworkSession.cloudWarmupPolicy(for: provider) == expected)
+  }
+
+  /// The regression this issue exists to prevent, stated as its own row: Gemini
+  /// must never warm, whatever else changes.
+  @Test("Gemini never warms")
+  func geminiNeverWarms() {
+    #expect(LLMNetworkSession.cloudWarmupPolicy(for: .gemini) == .never)
+  }
+
+  // MARK: - Gemini touches nothing
+
+  /// `preWarmModel` is the shared door all three cloud providers enter, so
+  /// "removing Gemini cannot affect OpenAI or Claude" is not free — it depends
+  /// on the Gemini guard running BEFORE any state is touched.
+  ///
+  /// Observable proof rather than a reading of the source: after a Gemini call,
+  /// the slot is still claimable, which is only true if no in-flight marker was
+  /// left behind. A guard placed after the claim would fail this.
+  @Test("a Gemini pre-warm leaves no in-flight marker behind")
+  func geminiLeavesNoState() {
+    let session = freshSession()
+    session.preWarmModel(
+      provider: .gemini, model: "gemini-3.6-flash", keychainManager: KeychainManager())
+    #expect(session.claimWarmupSlot(provider: .gemini, model: "gemini-3.6-flash", now: Date()))
+  }
+
+  // MARK: - The cold window
+
+  @Test("a cold (provider, model) may warm; a warm one may not")
+  func coldWindow() {
+    let session = freshSession()
+    let now = Date()
+
+    #expect(session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: now))
+    session.releaseWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", succeededAt: now)
+
+    // Inside the window: no second warm-up.
+    let justInside = now.addingTimeInterval(LLMNetworkSession.warmWindowSeconds - 1)
+    #expect(!session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: justInside))
+
+    // Outside it: cold again. Injected clock, never a real sleep
+    // (`swift-patterns.md` RULE: tests-no-real-time-scheduling-precision).
+    let justOutside = now.addingTimeInterval(LLMNetworkSession.warmWindowSeconds + 1)
+    #expect(session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: justOutside))
+  }
+
+  /// Warmth is keyed on the PAIR. Switching model inside the window is a
+  /// different route and must be treated as cold, or the first dictation after a
+  /// model change silently loses the warm-up it was supposed to get.
+  @Test("warmth is per (provider, model), not per provider")
+  func warmthIsPerPair() {
+    let session = freshSession()
+    let now = Date()
+    #expect(session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: now))
+    session.releaseWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", succeededAt: now)
+
+    #expect(session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-mini", now: now))
+    #expect(session.claimWarmupSlot(provider: .claude, model: "gpt-5.4-nano", now: now))
+  }
+
+  /// A non-2xx warm-up proves the route is reachable and nothing else. Recording
+  /// warmth on it would suppress the next real attempt on the strength of a
+  /// failure — the arm that quietly makes a broken provider look warm forever.
+  @Test("a failed warm-up frees the slot and records no warmth")
+  func failedWarmupRecordsNothing() {
+    let session = freshSession()
+    let now = Date()
+    #expect(session.claimWarmupSlot(provider: .claude, model: "claude-haiku-4-5", now: now))
+    session.releaseWarmupSlot(provider: .claude, model: "claude-haiku-4-5", succeededAt: nil)
+    // Immediately claimable again: not warm, not stuck in flight.
+    #expect(session.claimWarmupSlot(provider: .claude, model: "claude-haiku-4-5", now: now))
+  }
+
+  // MARK: - The real-polish producer
+
+  @Test("an accepted polish marks the pair warm")
+  func acceptedPolishMarksWarm() {
+    let session = freshSession()
+    let now = Date()
+    session.recordPolishSuccess(provider: .openAI, model: "gpt-5.4-nano", at: now)
+    #expect(!session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: now))
+  }
+
+  /// Gemini has no warm state to hold, so the producer must be inert for it.
+  /// Asserted rather than assumed: a future edit that drops the policy guard
+  /// inside `recordPolishSuccess` would start accumulating state nothing reads.
+  @Test("recording a Gemini polish changes nothing")
+  func geminiPolishRecordsNothing() {
+    let session = freshSession()
+    let now = Date()
+    session.recordPolishSuccess(provider: .gemini, model: "gemini-3.6-flash", at: now)
+    #expect(session.claimWarmupSlot(provider: .gemini, model: "gemini-3.6-flash", now: now))
+  }
+
+  @Test("an empty model name records nothing")
+  func emptyModelRecordsNothing() {
+    let session = freshSession()
+    let now = Date()
+    session.recordPolishSuccess(provider: .openAI, model: "", at: now)
+    #expect(session.claimWarmupSlot(provider: .openAI, model: "", now: now))
+  }
+
+  // MARK: - Atomicity
+
+  /// The decide-and-claim must be ONE critical section.
+  ///
+  /// A check-then-act across two reads passes every test above, because a
+  /// single-threaded test cannot open the window between them
+  /// (`validation-discipline.md`
+  /// RULE: a-single-threaded-test-cannot-distinguish-atomic-from-check-then-act).
+  /// **This test was VACUOUS on its first writing and the control caught it.**
+  /// A `withTaskGroup` of 64 children finished in 0.001s and passed against a
+  /// deliberately broken check-then-act implementation, because `claimWarmupSlot`
+  /// never suspends: each child ran start-to-finish before the next was
+  /// scheduled, so the window between the check and the act was never opened.
+  /// A concurrency test that cannot interleave is decoration.
+  ///
+  /// **AND THE SECOND ATTEMPT FAILED THE CONTROL TOO.** Rewritten to use
+  /// `DispatchQueue.concurrentPerform` — real OS threads — across 400 trials of
+  /// 32 racers, it STILL passed against the broken split-lock version, in 6ms.
+  /// The critical section is two dictionary lookups; the window between a split
+  /// check and act is on the order of nanoseconds, and real threads do not
+  /// reliably land inside it.
+  ///
+  /// **So this test is NOT the guard for atomicity, and must not be read as
+  /// one.** It is a smoke test: it exercises the claim under genuine parallelism
+  /// and would catch a gross regression such as removing the lock entirely. The
+  /// property "decide and claim happen in ONE critical section" is pinned
+  /// STRUCTURALLY by `claimIsASingleCriticalSection` below, because that is a
+  /// question about the code's shape and the machine can answer it exactly —
+  /// where a timing test can only ever answer "I did not happen to see it".
+  @Test("concurrent claims under real threads yield one winner (smoke, not the guard)")
+  func concurrentClaimsProduceOneWinner() {
+    let session = freshSession()
+    for trial in 0..<400 {
+      session.resetWarmStateForTesting()
+      let model = "gpt-5.4-nano-\(trial)"
+      let now = Date()
+      let winners = OSAllocatedUnfairLock<Int>(initialState: 0)
+      DispatchQueue.concurrentPerform(iterations: 32) { _ in
+        if session.claimWarmupSlot(provider: .openAI, model: model, now: now) {
+          winners.withLock { $0 += 1 }
+        }
+      }
+      let count = winners.withLock { $0 }
+      #expect(count == 1, "trial \(trial) produced \(count) winners")
+      if count != 1 { return }
+    }
+  }
+
+  /// THE ACTUAL ATOMICITY GUARD.
+  ///
+  /// Two review rounds and two failed controls established that this property
+  /// cannot be demonstrated by racing: the window is nanoseconds wide and a
+  /// timing test that never opens it reports green against broken code. So ask
+  /// the machine about the SHAPE instead, which it can answer exactly.
+  ///
+  /// `claimWarmupSlot` must take the lock EXACTLY ONCE. Two acquisitions is the
+  /// check-then-act bug, and it is invisible in every behavioural test.
+  /// Parsed, never grepped — `swift-patterns.md`
+  /// RULE: scan-swift-source-with-swiftparser-never-a-hand-rolled-lexer.
+  @Test("the claim decides and commits inside ONE critical section")
+  func claimIsASingleCriticalSection() throws {
+    let url = RepoRoot.sourceURL("Sources/EnviousWisprLLM/LLMNetworkSession.swift")
+    let tree = Parser.parse(source: try String(contentsOf: url, encoding: .utf8))
+    let visitor = LockCountVisitor(functionName: "claimWarmupSlot", viewMode: .sourceAccurate)
+    visitor.walk(tree)
+
+    #expect(visitor.functionFound, "claimWarmupSlot not found — did it get renamed?")
+    #expect(
+      visitor.lockCallCount == 1,
+      """
+      claimWarmupSlot takes the lock \(visitor.lockCallCount) times, expected exactly 1.
+      More than one acquisition means the decision and the claim are separable, which is       the check-then-act race. No behavioural test in this suite can see it — that was       measured twice, so this assertion is the only thing standing between us and it.
+      """)
+  }
+}
+
+/// Counts `withLock` calls inside one named function.
+private final class LockCountVisitor: SyntaxVisitor {
+  private let functionName: String
+  private(set) var functionFound = false
+  private(set) var lockCallCount = 0
+  private var depth = 0
+
+  init(functionName: String, viewMode: SyntaxTreeViewMode) {
+    self.functionName = functionName
+    super.init(viewMode: viewMode)
+  }
+
+  override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard node.name.text == functionName else { return .visitChildren }
+    functionFound = true
+    depth += 1
+    return .visitChildren
+  }
+
+  override func visitPost(_ node: FunctionDeclSyntax) {
+    if node.name.text == functionName { depth -= 1 }
+  }
+
+  override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+    guard depth > 0 else { return .visitChildren }
+    if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+      member.declName.baseName.text == "withLock"
+    {
+      lockCallCount += 1
+    }
+    return .visitChildren
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
@@ -21,8 +21,15 @@ import os
 @Suite("Cloud pre-warm gate (#2093)", .tags(.driftGuard))
 struct LLMWarmupGateTests {
 
+  /// An ISOLATED instance per test, never `LLMNetworkSession.shared`.
+  ///
+  /// Review finding (2026-09-03): the first version reset the shared singleton.
+  /// Swift Testing runs tests concurrently, and production `LLMPolishStep` calls
+  /// `recordPolishSuccess` on `shared`, so resetting it here could race any
+  /// other suite that polishes — nondeterministic failures and state leaking out
+  /// of this file. Nothing in this suite needs the real shared session.
   private func freshSession() -> LLMNetworkSession {
-    let s = LLMNetworkSession.shared
+    let s = LLMNetworkSession.makeIsolatedForTesting()
     s.resetWarmStateForTesting()
     return s
   }

--- a/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
@@ -94,8 +94,8 @@ struct LLMWarmupGateTests {
     let justInside = now.addingTimeInterval(LLMNetworkSession.warmWindowSeconds - 1)
     #expect(!session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: justInside))
 
-    // Outside it: cold again. Injected clock, never a real sleep
-    // (`swift-patterns.md` RULE: tests-no-real-time-scheduling-precision).
+    // Outside it: cold again. Injected clock, never a real sleep — this suite
+    // must not depend on scheduling precision.
     let justOutside = now.addingTimeInterval(LLMNetworkSession.warmWindowSeconds + 1)
     #expect(session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: justOutside))
   }
@@ -161,9 +161,7 @@ struct LLMWarmupGateTests {
   /// The decide-and-claim must be ONE critical section.
   ///
   /// A check-then-act across two reads passes every test above, because a
-  /// single-threaded test cannot open the window between them
-  /// (`validation-discipline.md`
-  /// RULE: a-single-threaded-test-cannot-distinguish-atomic-from-check-then-act).
+  /// single-threaded test cannot open the window between them.
   /// **This test was VACUOUS on its first writing and the control caught it.**
   /// A `withTaskGroup` of 64 children finished in 0.001s and passed against a
   /// deliberately broken check-then-act implementation, because `claimWarmupSlot`
@@ -178,13 +176,16 @@ struct LLMWarmupGateTests {
   /// check and act is on the order of nanoseconds, and real threads do not
   /// reliably land inside it.
   ///
-  /// **So this test is NOT the guard for atomicity, and must not be read as
-  /// one.** It is a smoke test: it exercises the claim under genuine parallelism
-  /// and would catch a gross regression such as removing the lock entirely. The
-  /// property "decide and claim happen in ONE critical section" is pinned
-  /// STRUCTURALLY by `claimIsASingleCriticalSection` below, because that is a
-  /// question about the code's shape and the machine can answer it exactly —
-  /// where a timing test can only ever answer "I did not happen to see it".
+  /// **What it does and does not catch, both measured — the honest version is
+  /// narrower than "useless" and narrower than "a guard".** It MISSED the tight
+  /// split, where two `withLock` calls sit adjacent and the window is a few
+  /// nanoseconds. It CAUGHT the helper-boundary split, where the check moves
+  /// into its own lock-taking function: that window spans a call boundary, and
+  /// the race produced 2 winners immediately.
+  ///
+  /// So: a real test of a real property, blind to the tightest shape. The
+  /// structural guard below is what covers that one, and the two together are
+  /// why both are kept.
   @Test("concurrent claims under real threads yield one winner (smoke, not the guard)")
   func concurrentClaimsProduceOneWinner() {
     let session = freshSession()
@@ -206,38 +207,57 @@ struct LLMWarmupGateTests {
 
   /// THE ACTUAL ATOMICITY GUARD.
   ///
-  /// Two review rounds and two failed controls established that this property
-  /// cannot be demonstrated by racing: the window is nanoseconds wide and a
-  /// timing test that never opens it reports green against broken code. So ask
-  /// the machine about the SHAPE instead, which it can answer exactly.
+  /// Two failed controls established that this property cannot be demonstrated
+  /// by racing: the window is nanoseconds wide, and a timing test that never
+  /// opens it reports green against broken code. So ask the machine about the
+  /// SHAPE instead, which it can answer exactly.
   ///
-  /// `claimWarmupSlot` must take the lock EXACTLY ONCE. Two acquisitions is the
-  /// check-then-act bug, and it is invisible in every behavioural test.
-  /// Parsed, never grepped — `swift-patterns.md`
-  /// RULE: scan-swift-source-with-swiftparser-never-a-hand-rolled-lexer.
+  /// **The first version of this guard counted lock acquisitions and review was
+  /// right that a count is a PROXY.** One `withLock` says nothing about what is
+  /// inside it: a refactor could move the CHECK into a lock-taking helper and
+  /// leave one `withLock` around the insert, recreating the exact race while
+  /// this test still passed. So assert the property itself — every read and
+  /// write of the warm state happens INSIDE the one critical section, and both
+  /// halves of the decision are in there together.
   @Test("the claim decides and commits inside ONE critical section")
   func claimIsASingleCriticalSection() throws {
     let url = RepoRoot.sourceURL("Sources/EnviousWisprLLM/LLMNetworkSession.swift")
     let tree = Parser.parse(source: try String(contentsOf: url, encoding: .utf8))
-    let visitor = LockCountVisitor(functionName: "claimWarmupSlot", viewMode: .sourceAccurate)
+    let visitor = CriticalSectionVisitor(functionName: "claimWarmupSlot", viewMode: .sourceAccurate)
     visitor.walk(tree)
 
     #expect(visitor.functionFound, "claimWarmupSlot not found — did it get renamed?")
     #expect(
       visitor.lockCallCount == 1,
+      "claimWarmupSlot takes the lock \(visitor.lockCallCount) times, expected exactly 1")
+    #expect(
+      visitor.stateTouchesOutsideLock.isEmpty,
       """
-      claimWarmupSlot takes the lock \(visitor.lockCallCount) times, expected exactly 1.
-      More than one acquisition means the decision and the claim are separable, which is       the check-then-act race. No behavioural test in this suite can see it — that was       measured twice, so this assertion is the only thing standing between us and it.
+      warm state touched OUTSIDE the critical section: \(visitor.stateTouchesOutsideLock).
+      Every read and write must be inside the single lock, or the decision and the       claim are separable and two callers can both warm.
+      """)
+    #expect(
+      visitor.stateNamesInsideLock == ["inFlight", "lastSuccess"],
+      """
+      the critical section touches \(visitor.stateNamesInsideLock.sorted()); it must       contain BOTH the in-flight check and the last-success check, or half the       decision has moved out of the lock.
       """)
   }
 }
 
-/// Counts `withLock` calls inside one named function.
-private final class LockCountVisitor: SyntaxVisitor {
+/// Verifies that a named function touches its guarded state only inside a single
+/// `withLock` closure — the property, not the proxy.
+private final class CriticalSectionVisitor: SyntaxVisitor {
+  private static let stateNames: Set<String> = ["inFlight", "lastSuccess"]
+
   private let functionName: String
   private(set) var functionFound = false
   private(set) var lockCallCount = 0
-  private var depth = 0
+  private(set) var stateTouchesOutsideLock: [String] = []
+  private(set) var stateNamesInsideLock: Set<String> = []
+
+  private var functionRange: Range<AbsolutePosition>?
+  private var lockRanges: [Range<AbsolutePosition>] = []
+  private var tokensSeen: [(String, AbsolutePosition)] = []
 
   init(functionName: String, viewMode: SyntaxTreeViewMode) {
     self.functionName = functionName
@@ -247,21 +267,38 @@ private final class LockCountVisitor: SyntaxVisitor {
   override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     guard node.name.text == functionName else { return .visitChildren }
     functionFound = true
-    depth += 1
+    functionRange = node.position..<node.endPosition
     return .visitChildren
   }
 
-  override func visitPost(_ node: FunctionDeclSyntax) {
-    if node.name.text == functionName { depth -= 1 }
-  }
-
   override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-    guard depth > 0 else { return .visitChildren }
+    guard let fnRange = functionRange, fnRange.contains(node.position) else {
+      return .visitChildren
+    }
     if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
       member.declName.baseName.text == "withLock"
     {
       lockCallCount += 1
+      lockRanges.append(node.position..<node.endPosition)
     }
     return .visitChildren
+  }
+
+  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    if Self.stateNames.contains(token.text) {
+      tokensSeen.append((token.text, token.position))
+    }
+    return .skipChildren
+  }
+
+  override func visitPost(_ node: SourceFileSyntax) {
+    guard let fnRange = functionRange else { return }
+    for (name, pos) in tokensSeen where fnRange.contains(pos) {
+      if lockRanges.contains(where: { $0.contains(pos) }) {
+        stateNamesInsideLock.insert(name)
+      } else {
+        stateTouchesOutsideLock.append(name)
+      }
+    }
   }
 }

--- a/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
@@ -176,16 +176,18 @@ struct LLMWarmupGateTests {
   /// check and act is on the order of nanoseconds, and real threads do not
   /// reliably land inside it.
   ///
-  /// **What it does and does not catch, both measured — the honest version is
-  /// narrower than "useless" and narrower than "a guard".** It MISSED the tight
-  /// split, where two `withLock` calls sit adjacent and the window is a few
-  /// nanoseconds. It CAUGHT the helper-boundary split, where the check moves
-  /// into its own lock-taking function: that window spans a call boundary, and
-  /// the race produced 2 winners immediately.
+  /// **What it does and does not catch, measured against three splits, and the
+  /// discriminator is WHICH operation moves — not how wide the window is.** It
+  /// catches a split that separates the IN-FLIGHT read from the in-flight write
+  /// across a call boundary: 2 winners immediately. It misses that same split
+  /// when the two sit adjacent, a few nanoseconds apart. And it misses a split
+  /// that moves only the WARMTH read out — measured 2026-09-03, one winner,
+  /// green — because `inFlight` is still read and written under one lock there,
+  /// so nothing races even though the decision is no longer atomic.
   ///
-  /// So: a real test of a real property, blind to the tightest shape. The
-  /// structural guard below is what covers that one, and the two together are
-  /// why both are kept.
+  /// That last case is the one worth carrying: a real race test reports a real
+  /// green against code whose guarantee is already broken. Only the structural
+  /// guard below sees it.
   @Test("concurrent claims under real threads yield one winner (smoke, not the guard)")
   func concurrentClaimsProduceOneWinner() {
     let session = freshSession()
@@ -205,20 +207,23 @@ struct LLMWarmupGateTests {
     }
   }
 
-  /// THE ACTUAL ATOMICITY GUARD.
+  /// **Two review rounds have now landed on this one assertion, so it asserts
+  /// the whole property rather than another clause.** Round 2: the first
+  /// version counted lock acquisitions, and a count says nothing about what is
+  /// inside one. Round 3: counting the NAMES inside the lock is the same defect
+  /// one level in — `inFlight` and `lastSuccess` can both appear inside the
+  /// closure while `inFlight.insert` has moved out to a separately locking
+  /// helper, which is check-then-act again with every name assertion green.
   ///
-  /// Two failed controls established that this property cannot be demonstrated
-  /// by racing: the window is nanoseconds wide, and a timing test that never
-  /// opens it reports green against broken code. So ask the machine about the
-  /// SHAPE instead, which it can answer exactly.
+  /// So the unit is the OPERATION, not the name. All three of the decision's
+  /// parts must sit inside ONE `withLock` closure: the in-flight read, the
+  /// warmth read, and the in-flight write.
   ///
-  /// **The first version of this guard counted lock acquisitions and review was
-  /// right that a count is a PROXY.** One `withLock` says nothing about what is
-  /// inside it: a refactor could move the CHECK into a lock-taking helper and
-  /// leave one `withLock` around the insert, recreating the exact race while
-  /// this test still passed. So assert the property itself — every read and
-  /// write of the warm state happens INSIDE the one critical section, and both
-  /// halves of the decision are in there together.
+  /// Controlled 2026-09-03 against both splits, each applied to the real source
+  /// and each red HERE and nowhere else in the suite: moving the in-flight
+  /// check-and-write into a lock-taking helper while both reads stay in the
+  /// original closure, and moving the WARMTH READ into one. The race test above
+  /// stayed green on both. Recipes in #2632.
   @Test("the claim decides and commits inside ONE critical section")
   func claimIsASingleCriticalSection() throws {
     let url = RepoRoot.sourceURL("Sources/EnviousWisprLLM/LLMNetworkSession.swift")
@@ -234,30 +239,52 @@ struct LLMWarmupGateTests {
       visitor.stateTouchesOutsideLock.isEmpty,
       """
       warm state touched OUTSIDE the critical section: \(visitor.stateTouchesOutsideLock).
-      Every read and write must be inside the single lock, or the decision and the       claim are separable and two callers can both warm.
+      Every read and write must be inside the single lock, or the decision and the \
+      claim are separable and two callers can both warm.
       """)
     #expect(
-      visitor.stateNamesInsideLock == ["inFlight", "lastSuccess"],
+      visitor.sectionsHoldingTheWholeDecision == 1,
       """
-      the critical section touches \(visitor.stateNamesInsideLock.sorted()); it must       contain BOTH the in-flight check and the last-success check, or half the       decision has moved out of the lock.
+      no single critical section performs the whole decision. Sections found: \
+      \(visitor.operationsPerSection.map { $0.sorted() }). \
+      One `withLock` closure must contain ALL of \
+      \(CriticalSectionVisitor.wholeDecision.sorted()) — the in-flight read, the \
+      warmth read and the in-flight write together. Splitting any one of them into \
+      a separately locking helper reopens the race with every name still present.
       """)
   }
 }
 
-/// Verifies that a named function touches its guarded state only inside a single
-/// `withLock` closure — the property, not the proxy.
+/// Verifies that a named function performs its whole guarded decision inside a
+/// single `withLock` closure.
+///
+/// The unit is the OPERATION (`inFlight.contains`, `lastSuccess[]`,
+/// `inFlight.insert`), never the bare property name. A name-based check passes
+/// against a version that reads both names inside the lock and writes one of
+/// them outside it, which is exactly the race being guarded.
 private final class CriticalSectionVisitor: SyntaxVisitor {
   private static let stateNames: Set<String> = ["inFlight", "lastSuccess"]
+
+  /// Every operation the decision is made of. A section holding all three has
+  /// decided and committed without releasing the lock.
+  static let wholeDecision: Set<String> = [
+    "inFlight.contains", "inFlight.insert", "lastSuccess[]",
+  ]
 
   private let functionName: String
   private(set) var functionFound = false
   private(set) var lockCallCount = 0
   private(set) var stateTouchesOutsideLock: [String] = []
-  private(set) var stateNamesInsideLock: Set<String> = []
+  private(set) var operationsPerSection: [Set<String>] = []
+
+  var sectionsHoldingTheWholeDecision: Int {
+    operationsPerSection.filter { Self.wholeDecision.isSubset(of: $0) }.count
+  }
 
   private var functionRange: Range<AbsolutePosition>?
   private var lockRanges: [Range<AbsolutePosition>] = []
   private var tokensSeen: [(String, AbsolutePosition)] = []
+  private var operationsSeen: [(String, AbsolutePosition)] = []
 
   init(functionName: String, viewMode: SyntaxTreeViewMode) {
     self.functionName = functionName
@@ -275,11 +302,24 @@ private final class CriticalSectionVisitor: SyntaxVisitor {
     guard let fnRange = functionRange, fnRange.contains(node.position) else {
       return .visitChildren
     }
-    if let member = node.calledExpression.as(MemberAccessExprSyntax.self),
-      member.declName.baseName.text == "withLock"
-    {
-      lockCallCount += 1
-      lockRanges.append(node.position..<node.endPosition)
+    if let member = node.calledExpression.as(MemberAccessExprSyntax.self) {
+      let method = member.declName.baseName.text
+      if method == "withLock" {
+        lockCallCount += 1
+        lockRanges.append(node.position..<node.endPosition)
+      } else if let owner = Self.stateName(of: member.base) {
+        operationsSeen.append(("\(owner).\(method)", node.position))
+      }
+    }
+    return .visitChildren
+  }
+
+  override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
+    guard let fnRange = functionRange, fnRange.contains(node.position) else {
+      return .visitChildren
+    }
+    if let owner = Self.stateName(of: node.calledExpression) {
+      operationsSeen.append(("\(owner)[]", node.position))
     }
     return .visitChildren
   }
@@ -294,11 +334,29 @@ private final class CriticalSectionVisitor: SyntaxVisitor {
   override func visitPost(_ node: SourceFileSyntax) {
     guard let fnRange = functionRange else { return }
     for (name, pos) in tokensSeen where fnRange.contains(pos) {
-      if lockRanges.contains(where: { $0.contains(pos) }) {
-        stateNamesInsideLock.insert(name)
-      } else {
+      if !lockRanges.contains(where: { $0.contains(pos) }) {
         stateTouchesOutsideLock.append(name)
       }
     }
+    operationsPerSection = lockRanges.map { range in
+      Set(operationsSeen.filter { range.contains($0.1) }.map(\.0))
+    }
+  }
+
+  /// The guarded property an expression is rooted at, if any — `state.inFlight`
+  /// and a bare `inFlight` both answer `inFlight`.
+  private static func stateName(of expr: ExprSyntax?) -> String? {
+    guard let expr else { return nil }
+    if let member = expr.as(MemberAccessExprSyntax.self),
+      stateNames.contains(member.declName.baseName.text)
+    {
+      return member.declName.baseName.text
+    }
+    if let ref = expr.as(DeclReferenceExprSyntax.self),
+      stateNames.contains(ref.baseName.text)
+    {
+      return ref.baseName.text
+    }
+    return nil
   }
 }

--- a/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
@@ -19,7 +19,11 @@ import Testing
         limbFailure: { limb, _, _, _, _ in self.lock.withLock { self._limbs.append(limb) } },
         legacyKeyCleanupFailed: { _, account in
           self.lock.withLock { self._cleanups.append(account) }
-        })
+        },
+        // #2093: this spy does not assert pre-warm counting; that lives in
+        // LLMWarmupGateTests. Required rather than defaulted at the type so a
+        // production factory cannot silently forget to wire it.
+        prewarmStarted: { _, _ in })
     }
   }
 

--- a/Tests/EnviousWisprTests/LLM/PolishFailureReasonTests.swift
+++ b/Tests/EnviousWisprTests/LLM/PolishFailureReasonTests.swift
@@ -180,7 +180,7 @@ struct PolishFailureReasonTests {
     // repeating the lead-in (no "AI cleanup skipped: AI cleanup took too long").
     #expect(
       PolishFailureReason.timedOut.composedMessage(provider: .openAI)
-        == "AI cleanup skipped: the dictation took too long. Your original text was pasted unchanged."
+        == "AI cleanup skipped: OpenAI did not answer in time. Your original text was pasted unchanged."
     )
     #expect(
       PolishFailureReason.badRequest.composedMessage(provider: .openAI)

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -218,10 +218,12 @@ struct HeartPathIntegrationTests {
       asrManager: asrManager,
       pasteSink: pasteSink,
       polisher: FixedPolisher(polished: "Hello, world. This is a test."),
-      // The real `.openAI` polish budget is 5s. A 6s discriminator throws
-      // TimeoutError for it before the polisher body runs — deterministic, no
+      // #2093: the real `.openAI` budget moved 5s -> 15s + 1s per 500 chars, so
+      // the old 6s discriminator stopped firing and this test would have proved
+      // the opposite of its name. The discriminator must stay ABOVE the real
+      // budget for this fixture: 26 chars -> 15.052s, so 16s. Deterministic, no
       // wall clock, no sleep.
-      textProcessingRunner: finalizerRunner(throwBelowSeconds: 6)
+      textProcessingRunner: finalizerRunner(throwBelowSeconds: 16)
     )
 
     let result = try await harness.run()
@@ -230,13 +232,13 @@ struct HeartPathIntegrationTests {
     #expect(result.outcome.transcript?.text == "hello world this is a test")
     #expect(result.outcome.transcript?.polishedText == nil)
     #expect(result.outcome.transcript?.displayText == "hello world this is a test")
-    // The real step's `.openAI` budget is 5s; the fake executor throws for any
-    // budget below 6s, so polish times out deterministically with no wall clock.
-    // The live path maps a timeout to its own user-facing copy, distinct from
-    // the generic failure message above.
+    // The real step's `.openAI` budget is 15.052s for this fixture (#2093); the
+    // fake executor throws for any budget below 16s, so polish times out
+    // deterministically with no wall clock. The live path maps a timeout to its
+    // own user-facing copy, distinct from the generic failure message above.
     #expect(
       result.outcome.polishError
-        == "AI cleanup skipped: the dictation took too long. Your original text was pasted unchanged."
+        == "AI cleanup skipped: OpenAI did not answer in time. Your original text was pasted unchanged."
     )
     #expect(pasteSink.pastedTexts == ["hello world this is a test "])
   }
@@ -259,8 +261,13 @@ private struct HeartPathHarnessResult {
 /// degrades to raw ASR text — a false failure unrelated to the test's
 /// intent. `throwBelowSeconds: 0.0` never throws (every step runs);
 /// `throwBelowSeconds: 0.1` discriminates a 50ms slow-step budget from the
-/// 5s default so the `polishTimeoutFallsBackToRawASR` test can exercise the
+/// cloud default so the `polishTimeoutFallsBackToRawASR` test can exercise the
 /// real timeout-degradation path deterministically.
+///
+/// #2093: any discriminator here is COUPLED to the real cloud budget. When that
+/// moved 5s -> 15s the 6s value silently stopped triggering, turning a
+/// timeout-path test into a happy-path one that still passed its name. If the
+/// budget moves again, these numbers move with it.
 @MainActor
 private func finalizerRunner(throwBelowSeconds: Double = 0.0) -> TextProcessingRunner {
   TextProcessingRunner(

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -257,7 +257,7 @@ private struct HeartPathHarnessResult {
 ///
 /// #794 (2026-05-19): the default `TextProcessingRunner()` delegates to the
 /// real `withThrowingTimeout`, which races a wall clock. On a contended CI
-/// runner a polish step's 5s budget can expire and the runner silently
+/// runner a polish step's real budget can expire and the runner silently
 /// degrades to raw ASR text — a false failure unrelated to the test's
 /// intent. `throwBelowSeconds: 0.0` never throws (every step runs);
 /// `throwBelowSeconds: 0.1` discriminates a 50ms slow-step budget from the
@@ -329,7 +329,7 @@ private final class HeartPathHarness {
     }
 
     let polishStep = LLMPolishStep(keychainManager: KeychainManager())
-    // `.openAI` only selects the 5 s budget and enables the step; the injected
+    // `.openAI` only selects that provider's budget and enables the step; the injected
     // polisher replaces the connector entirely, so no key or network is used.
     polishStep.llmProvider = .openAI
     if let polisher {

--- a/Tests/EnviousWisprTests/Pipeline/LLMPolishBudgetScalingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/LLMPolishBudgetScalingTests.swift
@@ -7,12 +7,19 @@ import Testing
 @testable import EnviousWisprPipeline
 
 /// #1770: the polish deadline scales with the transcript for Gemini.
+/// #2093: the base moved 5s -> 15s and OpenAI joined the scaled form.
 ///
 /// A flat 5 s was timing out the measured long dictations (11,324 chars at
-/// 6.12 s, 66,896 at 50.65 s; the last case under budget was 4,605 at 2.69 s) — measured live, a 10-minute dictation polishes in 6.12 s and the
-/// longest transcript we have recorded in 50.65 s. A flat LARGER number was
-/// rejected because it would slow the common case (p50 is 8 seconds of speech)
-/// down to rescue the 0.1% tail.
+/// 6.12 s, 66,896 at 50.65 s; the last case under budget was 4,605 at 2.69 s).
+///
+/// #1770 rejected a flat LARGER number on the ground that it would slow the
+/// common case to rescue the 0.1% tail. **#2093 raised the base anyway, because
+/// that reasoning did not survive its own evidence:** the failures are not in a
+/// long tail at all. Median dictation at a production timeout is 106 characters
+/// and 26 of 54 are under 100, so the BASE was cutting off the common case, not
+/// protecting it. Raising it costs nothing on a healthy call — the budget is a
+/// ceiling, not a delay — and only lengthens the wait when the provider was
+/// never going to answer.
 ///
 /// One table-driven test rather than "long > short": that weaker assertion
 /// would pass with the base, the divisor or the ceiling wrong.
@@ -20,7 +27,7 @@ import Testing
 /// #1831 removed the second (60 s) base along with the Deep-reasoning toggle
 /// that was its only trigger, so every Gemini request now shares one base.
 @MainActor
-@Suite("Gemini polish budget scales with transcript length (#1770)")
+@Suite("Cloud polish budget scales with transcript length (#1770, #2093)")
 struct LLMPolishBudgetScalingTests {
 
   private func step(model: String, provider: LLMProvider = .gemini) -> LLMPolishStep {
@@ -38,17 +45,40 @@ struct LLMPolishBudgetScalingTests {
   }
 
   /// Exact expected values, not display rounding: `base + chars / 500`.
-  @Test("base 5s plus one second per 500 characters")
+  ///
+  /// #2093 swept the RANGE the value really takes rather than testing at one
+  /// nominal length: 0 and 1 are the degenerate ends a `count`-derived term can
+  /// get wrong, and 106 is the MEASURED median dictation length at a production
+  /// timeout — the case the whole issue is about, which no earlier row covered.
+  @Test("base 15s plus one second per 500 characters, across the real range")
   func budgetScalesWithLength() {
     let s = step(model: "gemini-3.6-flash")
-    // ~20 words. Preserves today's short-dictation failure speed almost exactly.
-    #expect(budget(s, chars: 110) == .seconds(5 + 110.0 / 500))
+    // Degenerate ends.
+    #expect(budget(s, chars: 0) == .seconds(15))
+    #expect(budget(s, chars: 1) == .seconds(15 + 1.0 / 500))
+    // The measured median dictation at a production timeout (#2093).
+    #expect(budget(s, chars: 106) == .seconds(15 + 106.0 / 500))
+    // ~20 words.
+    #expect(budget(s, chars: 110) == .seconds(15 + 110.0 / 500))
     // p99 of real dictations.
-    #expect(budget(s, chars: 1709) == .seconds(5 + 1709.0 / 500))
-    // A 10-minute dictation — 6.12s measured, so 4.5x headroom.
-    #expect(budget(s, chars: 11324) == .seconds(5 + 11324.0 / 500))
-    // The longest transcript ever recorded — 50.65s measured, 2.7x headroom.
-    #expect(budget(s, chars: 66896) == .seconds(5 + 66896.0 / 500))
+    #expect(budget(s, chars: 1709) == .seconds(15 + 1709.0 / 500))
+    // A 10-minute dictation — 6.12s measured.
+    #expect(budget(s, chars: 11324) == .seconds(15 + 11324.0 / 500))
+    // The longest transcript ever recorded — 50.65s measured.
+    #expect(budget(s, chars: 66896) == .seconds(15 + 66896.0 / 500))
+  }
+
+  /// #2093: OpenAI now scales identically to Gemini, closing the OpenAI half of
+  /// #1833. Asserted at the same lengths so a divergence between the two cloud
+  /// providers cannot hide behind a different test shape.
+  @Test("OpenAI scales identically to Gemini (#2093)")
+  func openAIScalesLikeGemini() {
+    let openAI = step(model: "gpt-5.4-mini", provider: .openAI)
+    let gemini = step(model: "gemini-3.6-flash")
+    for chars in [0, 1, 106, 110, 1709, 11324, 66896] {
+      #expect(budget(openAI, chars: chars) == .seconds(15 + Double(chars) / 500))
+      #expect(budget(openAI, chars: chars) == budget(gemini, chars: chars))
+    }
   }
 
   /// Beyond this the transport terminates the attempt anyway, so a larger
@@ -77,19 +107,18 @@ struct LLMPolishBudgetScalingTests {
   func unlistedModelGetsTheSameBase() {
     let listed = step(model: "gemini-3.6-flash")
     let unlisted = step(model: "gemini-4.0-flash-imaginary")
-    #expect(budget(unlisted, chars: 110) == .seconds(5 + 110.0 / 500))
+    #expect(budget(unlisted, chars: 110) == .seconds(15 + 110.0 / 500))
     #expect(budget(unlisted, chars: 110) == budget(listed, chars: 110))
   }
 
-  /// Only Gemini scales. OpenAI and Claude keep their fixed budgets; widening
-  /// them without measuring their streaming behaviour is #1833.
-  @Test("other providers keep their fixed budgets regardless of length")
+  /// #2093: the set that scales is now {gemini, openAI}. Claude keeps its FIXED
+  /// 15s deliberately — #158 measured that provider directly (9.16s worst real
+  /// call), so widening it here would be a change nothing measured. This is the
+  /// remaining half of #1833.
+  @Test("non-scaling providers keep their fixed budgets regardless of length")
   func otherProvidersUnchanged() {
-    let openAI = step(model: "gpt-4o-mini", provider: .openAI)
-    #expect(budget(openAI, chars: 110) == .seconds(5))
-    #expect(budget(openAI, chars: 66896) == .seconds(5))
-
     let claude = step(model: "claude-haiku-4-5", provider: .claude)
+    #expect(budget(claude, chars: 110) == .seconds(15))
     #expect(budget(claude, chars: 66896) == .seconds(15))
 
     let ollama = step(model: "llama3.2", provider: .ollama)

--- a/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TextProcessingRunnerCaptureTests.swift
@@ -439,9 +439,19 @@ struct TextProcessingRunnerCaptureTests {
   func polishTimeout() async throws {
     let spy = CaptureSpy()
     let records = RecordSpy()
-    // Polish step's cloud budget is 5s; throwing below 6s injects a TimeoutError
-    // for it (the executor short-circuits before calling the polisher).
-    let executor = FakeTimeoutExecutor(throwBelowSeconds: 6.0)
+    // The polish step's cloud budget is 15s + 1s per 500 chars (#2093), which is
+    // 15.154s for this 77-character fixture; throwing below 16s injects a
+    // TimeoutError for it (the executor short-circuits before calling the
+    // polisher).
+    //
+    // #2093: this was 6.0, tuned to the old 5s budget. When the budget moved to
+    // 15s the discriminator silently stopped firing — the fake polisher's
+    // `requestFailed` ran instead and the test asserted `bad_request` against a
+    // name that says `timed_out`. It went RED, which is the good outcome, but the
+    // coupling is invisible from the assertion: **any discriminator here is tied
+    // to the real cloud budget and must move with it.** Same trap in
+    // `HeartPathIntegrationTests.polishTimeoutFallsBackToRawASR`.
+    let executor = FakeTimeoutExecutor(throwBelowSeconds: 16.0)
     let runner = TextProcessingRunner(
       telemetry: .init(
         captureError: spy.sink, recordPolishFailed: records.sink,


### PR DESCRIPTION
Closes #2093.

## What a person gets

Cloud AI cleanup stops being cut off mid-answer, and we stop spending their API quota on a request nobody asked for.

## What was actually wrong

Not what the issue assumed. Measured, in order:

- **Not length.** The median dictation that timed out was **106 characters**; 26 of 54 were under 100.
- **Not an outage.** One provider server error in 60 days, and the failures show no cross-user clustering in time.
- **Not a version regression.** `llm.polish_failed` first shipped in v2.4.0, so every earlier zero is the instrument missing, not the problem being absent.

It was a **fixed 5-second wall sitting inside a live latency distribution**. Successful Gemini polishes over 30 production days: 263 under 1s, 197 at 1-2s, 41 at 2-3s, 23 at 3-4s, 9 at 4-5s. The distribution thins and never stops, so a cut at 5s sits *inside* it and took 54 polishes from 7 users in that window (`ENVIOUSWISPR-32`). Competitors calling the same APIs directly use 30s, 120s, or no limit at all.

## The change

| What | Where |
|---|---|
| Cloud base budget 5s -> 15s; OpenAI joins Gemini's length scaling | `LLMPolishStep.swift` |
| Retry delays 1s/3s -> 200ms/400ms (reaches all four connectors) | `LLMRetryPolicy.swift` |
| Gemini never pre-warms; OpenAI/Claude only when cold, claimed atomically | `LLMNetworkSession.swift` |
| `recordPolishSuccess` — the producer that marks a route warm | `LLMPolishStep.swift` |
| New event `llm.prewarm_started` (provider, model) | telemetry sink + `TelemetryService.swift` |
| The timeout notice stops blaming the dictation | `PolishFailureReason.swift` |

15s is not a new number: it is the `.claude` value directly above it, whose own receipt records a real 9.16s call. It clears every successful cloud polish we have ever recorded (max 5.3s) by roughly 3x.

## The plan's centrepiece was false, and the test is what proved it

Revision 1 claimed our timeout wrapper does not bound the caller, and proposed rewriting every connector. **The founder required the measurement during planning rather than after.** Real `URLSession` against two stalling local HTTP servers, budget 1.0s:

```
1. data(for:)      stall before headers         TimeoutError at 1.01s
2. data(for:)      stall mid-stream             TimeoutError at 1.01s
3. bytes(for:)+SSE stall mid-stream             TimeoutError at 1.06s
4. bytes(for:) via the @MainActor bridge (ours) TimeoutError at 1.01s
```

Cancellation already unwinds at the budget on every shape we ship. That deleted the connector rewrite, the budget handoff, the parity tests and the LARGE tier, and reduced this to four values in four files. The original "proof" had used a closure that deliberately ignores cancellation.

## Review

Three local Codex rounds (`gpt-5.6-sol`, medium), then a class enumeration rather than a fourth round of whack-a-mole.

- **r1:** tests reset a process-global singleton; retry logs printed integer seconds, so 200ms read "after 0s".
- **r2:** six `.claude/` references in shipped code; the atomicity guard asserted a PROXY (a lock count).
- **r3:** the warm-up metric claimed a ~1.0 baseline it does not have; the atomicity guard asserted the wrong unit *again* (names, not operations).

**One root, not six:** every finding is an artifact I added or changed and never swept against the authority governing its KIND. r3 revealed a third direction the enumeration lacked — an **unchanged** statement that this change makes false — so the final sweep ran from the producing code (every comment line in every touched file, minus this branch's added lines) and found five stale claims about the old 5s budget.

**Pre-committed before reading this PR's review:** a fourth finding on that one atomicity assertion **deletes** the structural guard rather than refining it again.

## Validation

- Full suite: **7392 test cases, all accepted, Debug lane PASS**. Read from the output text — `scripts/xcode-test.sh` prints `** TEST FAILED **` and still exits 0.
- Dev build: `** BUILD SUCCEEDED **`.
- `check-cited-symbols.py`: PASSED, 32 symbols.
- Both atomicity mutants controlled against real source: each red on that one test and nothing else.
- Test hardening: **#2632**, 13 mutation rows, 13/13 runnable.

## Known limits, stated

- **Three follow-ups filed, not fixed here:** #2633 (a 60-second app freeze being recorded as a polish timeout — a blocked main actor reproduces it exactly at budget+block), #2634 (one user's local model at 0 successes in 183 attempts), #2635 (one request ceiling written in seven places).
- Retry sleeps are still charged to the polish budget. Bounded now (<1s total against a 15s floor) rather than removed.
- Claude keeps its fixed 15s: #158 measured that provider directly, and widening it here would be a change nothing measured.
