### PR TITLE
fix(snippets): a multi-line snippet is inserted, not left on the clipboard (#2639)

### DIFF
--- a/Sources/EnviousWisprCore/SnippetStarters.swift
+++ b/Sources/EnviousWisprCore/SnippetStarters.swift
@@ -12,14 +12,16 @@ import Foundation
 /// example, so the catalog is held to the same rules the edit sheet enforces and is checked
 /// against them by its own test rather than by inspection.
 ///
-/// Two constraints the catalog must keep, both mechanically tested:
+/// One constraint the catalog must keep, mechanically tested:
 ///
 /// - **No two starters collide.** `SnippetsManager.validate` refuses a duplicate trigger, so a
 ///   colliding pair would make the seeded file un-editable: every later save re-validates the
 ///   whole list and would fail on a clash the user never created.
-/// - **Every expansion is one line.** A snippet carrying a newline is delivered to the
-///   clipboard rather than typed in place, because in a terminal a newline submits the command.
-///   That is correct behaviour and a poor first impression, so no starter has one.
+///
+/// A second constraint used to sit here — every expansion is one line — and it is gone (#2639).
+/// It existed only because a multi-line expansion was diverted to the clipboard instead of being
+/// inserted. Multi-line expansions now deliver like any other text, so a multi-line starter is
+/// allowed.
 public enum SnippetStarters {
 
   /// The canonical text of one starter, and the reason this is a separate type from `Snippet`:

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -968,8 +968,11 @@ struct KernelFinalizationWiring {
         // A newline pasted into a terminal CAN submit the line before it. That hazard is real,
         // this code does not remove it, and nothing here should be read as claiming otherwise:
         // what decides the outcome is the terminal's bracketed-paste mode, which we neither set
-        // nor observe. `pipeline-mechanics.md` FACT: insertion-repair-runs-after-the-chain says
-        // the same thing for the repair's own payload.
+        // nor observe. The insertion repair has the same limitation for its own payload, and
+        // refuses a newline outright when the caret context is screen-derived
+        // (`CursorInsertionRepair.swift`, the `isScreenDerived` newline guard). That is a
+        // SEPARATE mechanism in a different module, still live, and untouched here — which is
+        // also why the site count below is scoped to the two modules it names.
         //
         // The branch removed here never addressed that hazard either, on two counts:
         //

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -962,129 +962,116 @@ struct KernelFinalizationWiring {
               : ""),
           level: .info, category: "KernelFinalizationWiring")
 
-        // #628. A snippet-bearing payload carrying a NEWLINE never reaches a terminal
-        // automatically. In a terminal a newline can SUBMIT the command, and a multi-line
-        // sign-off snippet would run whatever its first line happens to say.
+        // #2639. Snippet text delivers through the cascade like every other payload, line
+        // breaks included.
         //
-        // `CursorInsertionRepair`'s screen-derived refusal does NOT already cover this, and
-        // checking rather than assuming is what found it: that refusal declines the CONTEXTUAL
-        // repair and still returns the legacy text, newline included, so the payload went out
-        // either way. The behaviour predates snippets — but before snippets a newline in a
-        // terminal payload was rare, and a saved multi-line expansion makes it ordinary. The
-        // feature that made it reachable is the one that has to hold the line.
+        // A newline pasted into a terminal CAN submit the line before it. That hazard is real,
+        // this code does not remove it, and nothing here should be read as claiming otherwise:
+        // what decides the outcome is the terminal's bracketed-paste mode, which we neither set
+        // nor observe. `pipeline-mechanics.md` FACT: insertion-repair-runs-after-the-chain says
+        // the same thing for the repair's own payload.
         //
-        // Clipboard-only rather than a silent drop: the text still exists and is one Cmd+V
-        // away, which is the shape every other refused delivery here already takes.
+        // The branch removed here never addressed that hazard either, on two counts:
         //
-        // A snippet-bearing payload containing a NEWLINE is never auto-pasted. It goes to the
-        // clipboard, always.
+        //   - REACHABILITY. It keyed on `snippetExpansionFired`, so it refused a newline only
+        //     when a snippet produced it. `isNewline` had exactly ONE site across
+        //     `EnviousWisprPipeline` and `EnviousWisprServices` — this one — so a newline
+        //     arriving by any other route already reached a terminal untouched.
+        //   - EQUIVALENCE. Its remedy was clipboard-only, which asks the user to press Cmd+V.
+        //     That posts the same bytes to the same destination with the same bracketed-paste
+        //     outcome as the `cgEvent` tier (`PasteService.swift`, `kVK_ANSI_V`). It relocated
+        //     the risk to the user's hand and called that safety.
         //
-        // This is the third shape of this guard and the first honest one. Enumerating what we
-        // can actually KNOW about a destination closes the question:
-        //   - `caretContext.isScreenDerived` — which IS `terminalEvidence != nil` — says
-        //     terminal.
-        //   - a bundle id in `TerminalSurface` says terminal, without a caret read.
-        //   - everything else says NOTHING. Warp, kitty, Alacritty and WezTerm are terminals in
-        //     neither list, and they hand back an ordinary accessibility caret, so they land in
-        //     the same bucket as a text editor.
+        // So removing it changes no outcome a user could not already reach. A guard that
+        // actually addressed the hazard would have to live where the DESTINATION is resolved —
+        // `TerminalContextResolver` (Services) owns terminal eligibility and the CLI veto — and
+        // would have to apply to every newline, not to the ones a snippet happened to produce.
         //
-        // There is no positive "this app is safe for a newline" signal to ask for. The previous
-        // version claimed to require one and did not: "has a caret, not screen-derived, not a
-        // known terminal" is satisfied exactly by an unrecognised terminal, so the inversion was
-        // wording rather than logic. A danger list has to be complete to be safe, and this one
-        // cannot be.
+        // Founder decision 2026-09-03: a user who saved a multi-line snippet asked for a
+        // multi-line snippet, and a developer pasting a code block into an editor is the
+        // ordinary case rather than an accident to be policed.
         //
-        // So the guard stops trying to tell destinations apart. In a terminal a newline SUBMITS
-        // the line before it, and a multi-line sign-off would run whatever that line says. The
-        // cost of always using the clipboard is that a multi-line snippet needs one Cmd+V; the
-        // cost of the other default is a user's signature executing as a shell command. Nothing
-        // is lost — the text is on the clipboard, which is where every other refused delivery
-        // here puts it.
-        if context.snippetExpansionFired,
-          payloads.legacyText.contains(where: \.isNewline)
-        {
-          ClipboardCleanup.deliveryClaimsBoard()
-          copyToClipboard(text)
-          deliveryOutcome = .clipboardOnly
+        // `snippetExpansionFired` still suppresses `CursorInsertionRepair` above, and that is a
+        // separate decision that stands. The repair changes seam spacing and capitalisation,
+        // which must never edit a saved signature — a fact about the CONTENT of an expansion,
+        // not about how it is delivered.
+        // The legacy payload is what a route falls back to; §6 decides per route
+        // whether the candidate may be committed instead.
+        let pasteText = payloads.legacyText
+        let result = await deliverPaste(
+          PasteDeliveryRequest(
+            legacyText: pasteText,
+            repairedText: payloads.repairedText,
+            caretContext: caretContext,
+            // Asked of the RULES, not enumerated here. Listing the destructive
+            // ones at this call site is how the first version missed
+            // `.droppedTerminalPeriod` — a rule that also removes a character
+            // the user dictated, found by cloud review. `deletesDictatedText`
+            // is an exhaustive switch beside the enum, so a new rule cannot
+            // inherit "not destructive" by being forgotten out here.
+            candidateDeletesDictatedText: payloads.candidateRules.contains {
+              $0.deletesDictatedText
+            },
+            targetApp: context.targetApp,
+            targetElement: context.targetElement,
+            // Same local boolean the outcome fields above were stamped from —
+            // not re-derived from `targetElement` presence, which cannot tell
+            // "retried and recovered" apart from "captured at record-start".
+            targetElementIsRetried: caretCaptureRetried,
+            restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,
+            terminalBudget: terminalBudget))
+        pasteResult = result
+
+        // WHICH payload actually went to the app, which `CURSOR_REPAIR` cannot
+        // say because it is logged before the write happens.
+        //
+        // This is the gap that made the founder's original report
+        // undiagnosable: the repair can decide `lowercased_first`, offer a
+        // candidate, and the route can still commit the LEGACY text because
+        // `payloadAtCommitBoundary` re-reads the caret and refuses when
+        // anything changed. From the log alone those two outcomes were
+        // indistinguishable — both showed `candidate=offered` and the user saw
+        // the capital survive.
+        //
+        // A second line rather than a field on the first, only because the fact
+        // does not exist until after the write. `tier` rides along so the two
+        // can be matched without a timestamp join.
+        // The FULL budget spend, which `CURSOR_REPAIR` structurally cannot show:
+        // that line is written before the paste, and the commit-boundary
+        // re-check runs after the target app is activated. On 2026-08-04 the
+        // repair line reported a healthy 1.6 ms and the breaker tripped anyway,
+        // because the whole overspend lived in the half no line covered.
+        //
+        // Everything before `|recheck|` was already on the repair line; the
+        // suffix is new, and the total is what the cumulative cap is judged
+        // against. That cap is `TerminalResolutionBudget.defaultTotal`, which
+        // owns the current value — do not restate the number here, because a
+        // second copy is what goes stale (it read "100 ms" until 2026-08-05).
+        await AppLogger.shared.log(
+          "CURSOR_COMMIT submitted=\(result.submittedPayload?.rawValue ?? "none") "
+            + "tier=\(result.pasteTierLabel ?? "none") "
+            + "timing=[\(terminalBudget.timingDescription)]",
+          level: .info, category: "KernelFinalizationWiring")
+
+        if case .delivered = result.outcome {
+          // The text that actually LANDED, which is not always the one this
+          // closure passed in: a route may have committed the contextual
+          // candidate. `pasteCompletionRegistry`'s subscriber (#629) watches for
+          // later edits to the pasted text and learns custom words from them, so
+          // announcing the legacy payload after delivering the repaired one
+          // would make our own spacing and casing look like the user correcting
+          // us. Falls back to the legacy payload for `.legacy` and for a
+          // delivered route that reported no payload at all.
+          let deliveredText =
+            result.submittedPayload == .repaired
+            ? (payloads.repairedText ?? pasteText) : pasteText
+          pasteCompletionRegistry?.emit(
+            PasteCompletionEvent(
+              pastedText: deliveredText,
+              destinationBundleID: context.targetApp?.bundleIdentifier))
+          deliveryOutcome = .pasted
         } else {
-          // The legacy payload is what a route falls back to; §6 decides per route
-          // whether the candidate may be committed instead.
-          let pasteText = payloads.legacyText
-          let result = await deliverPaste(
-            PasteDeliveryRequest(
-              legacyText: pasteText,
-              repairedText: payloads.repairedText,
-              caretContext: caretContext,
-              // Asked of the RULES, not enumerated here. Listing the destructive
-              // ones at this call site is how the first version missed
-              // `.droppedTerminalPeriod` — a rule that also removes a character
-              // the user dictated, found by cloud review. `deletesDictatedText`
-              // is an exhaustive switch beside the enum, so a new rule cannot
-              // inherit "not destructive" by being forgotten out here.
-              candidateDeletesDictatedText: payloads.candidateRules.contains {
-                $0.deletesDictatedText
-              },
-              targetApp: context.targetApp,
-              targetElement: context.targetElement,
-              // Same local boolean the outcome fields above were stamped from —
-              // not re-derived from `targetElement` presence, which cannot tell
-              // "retried and recovered" apart from "captured at record-start".
-              targetElementIsRetried: caretCaptureRetried,
-              restoreClipboardAfterPaste: config?.restoreClipboardAfterPaste ?? false,
-              terminalBudget: terminalBudget))
-          pasteResult = result
-
-          // WHICH payload actually went to the app, which `CURSOR_REPAIR` cannot
-          // say because it is logged before the write happens.
-          //
-          // This is the gap that made the founder's original report
-          // undiagnosable: the repair can decide `lowercased_first`, offer a
-          // candidate, and the route can still commit the LEGACY text because
-          // `payloadAtCommitBoundary` re-reads the caret and refuses when
-          // anything changed. From the log alone those two outcomes were
-          // indistinguishable — both showed `candidate=offered` and the user saw
-          // the capital survive.
-          //
-          // A second line rather than a field on the first, only because the fact
-          // does not exist until after the write. `tier` rides along so the two
-          // can be matched without a timestamp join.
-          // The FULL budget spend, which `CURSOR_REPAIR` structurally cannot show:
-          // that line is written before the paste, and the commit-boundary
-          // re-check runs after the target app is activated. On 2026-08-04 the
-          // repair line reported a healthy 1.6 ms and the breaker tripped anyway,
-          // because the whole overspend lived in the half no line covered.
-          //
-          // Everything before `|recheck|` was already on the repair line; the
-          // suffix is new, and the total is what the cumulative cap is judged
-          // against. That cap is `TerminalResolutionBudget.defaultTotal`, which
-          // owns the current value — do not restate the number here, because a
-          // second copy is what goes stale (it read "100 ms" until 2026-08-05).
-          await AppLogger.shared.log(
-            "CURSOR_COMMIT submitted=\(result.submittedPayload?.rawValue ?? "none") "
-              + "tier=\(result.pasteTierLabel ?? "none") "
-              + "timing=[\(terminalBudget.timingDescription)]",
-            level: .info, category: "KernelFinalizationWiring")
-
-          if case .delivered = result.outcome {
-            // The text that actually LANDED, which is not always the one this
-            // closure passed in: a route may have committed the contextual
-            // candidate. `pasteCompletionRegistry`'s subscriber (#629) watches for
-            // later edits to the pasted text and learns custom words from them, so
-            // announcing the legacy payload after delivering the repaired one
-            // would make our own spacing and casing look like the user correcting
-            // us. Falls back to the legacy payload for `.legacy` and for a
-            // delivered route that reported no payload at all.
-            let deliveredText =
-              result.submittedPayload == .repaired
-              ? (payloads.repairedText ?? pasteText) : pasteText
-            pasteCompletionRegistry?.emit(
-              PasteCompletionEvent(
-                pastedText: deliveredText,
-                destinationBundleID: context.targetApp?.bundleIdentifier))
-            deliveryOutcome = .pasted
-          } else {
-            deliveryOutcome = .clipboardOnly
-          }
+          deliveryOutcome = .clipboardOnly
         }
       } else if config?.autoCopyToClipboard == true {
         // #2465: auto-copy never enters `PasteCascadeExecutor`, so it reaches the board without

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -434,6 +434,61 @@ import os
     #expect(recorder.copies == ["hello"], "clipboardOnly must mean it actually copied")
   }
 
+  /// #2639. A multi-line snippet is DELIVERED, not diverted to the clipboard.
+  ///
+  /// The removed #628 guard sent any snippet-bearing payload containing a newline straight to
+  /// `copyToClipboard` without calling the cascade at all, so nothing appeared at the caret and
+  /// the user had to press Cmd+V by hand. Founder decision 2026-09-03: a user who saved a
+  /// multi-line snippet asked for a multi-line snippet.
+  ///
+  /// The fixture is deliberately the exact state the old branch keyed on — auto-paste ON and
+  /// `snippetExpansionFired` TRUE — because a fixture missing either one passes whether or not
+  /// the branch is still there, and would pin nothing.
+  ///
+  /// Both assertions are required for the same reason. "Outcome is `.pasted`" alone does not
+  /// prove the newline survived, and "the clipboard is untouched" alone does not prove the
+  /// cascade ever ran. The pair is what the promise actually is.
+  @Test("#2639 a multi-line snippet reaches the paste cascade with its line breaks intact")
+  func multiLineSnippetIsDeliveredNotDivertedToTheClipboard() async {
+    let recorder = ClipboardRecorder()
+    let requests = PasteRequestRecorder()
+    let context = KernelSessionContext()
+    context.config = .testDefault(autoPasteToActiveApp: true)
+    context.snippetExpansionFired = true
+
+    let signature = "Thanks,\nSaurabh\nEnvious Labs"
+    let wiring = makeWiring(
+      context: context,
+      deliverPaste: { request in
+        requests.record(request.legacyText)
+        return Self.deliveredResult
+      },
+      copyToClipboard: { recorder.record($0) })
+
+    let outcome = await wiring.deliver(signature, .ordinary)
+
+    #expect(outcome == .pasted)
+    #expect(requests.legacyTexts.count == 1, "the cascade is called exactly once")
+
+    // TRAILING whitespace only. The legacy payload always carries a trailing space —
+    // `PasteCascadeExecutor.swift`: "Today's payload, including its trailing space. ALWAYS
+    // present" — which predates snippets and is owned by the insertion repair, not by
+    // anything here. Trimming the tail cannot hide what this test is for: both line breaks
+    // sit in the MIDDLE of the string, so they survive the trim and are compared byte for
+    // byte. Pinning the trailing space instead would make this test fail the day somebody
+    // legitimately changes spacing, on a property it was never about.
+    let received = requests.legacyTexts.first ?? ""
+    let withoutTrailingWhitespace = String(
+      received.reversed().drop(while: \.isWhitespace).reversed())
+    #expect(
+      withoutTrailingWhitespace == signature,
+      "the cascade must receive the snippet text with its line breaks intact")
+
+    #expect(
+      recorder.copies.isEmpty,
+      "nothing may be diverted to the clipboard behind the cascade's back")
+  }
+
   @Test("#1921 A clipboard-only delivery cannot inherit the previous session's language fields")
   func clipboardOnlyDeliveryClearsStaleLanguageFields() async {
     // `outcome` is SHARED and reused across sessions, and everything describing
@@ -1811,6 +1866,15 @@ import os
   private final class ClipboardRecorder {
     private(set) var copies: [String] = []
     func record(_ text: String) { copies.append(text) }
+  }
+
+  /// #2639. What the cascade was actually handed. Records the legacy payload rather than a
+  /// call count, because the question is whether the NEWLINE survived the trip, and a count
+  /// cannot answer that. Takes the String rather than the request: `legacyText` is main-actor
+  /// isolated, so it is read at the call site inside the closure and handed over as a value.
+  private final class PasteRequestRecorder {
+    private(set) var legacyTexts: [String] = []
+    func record(_ legacyText: String) { legacyTexts.append(legacyText) }
   }
 
   // MARK: Fallback metrics gate (#1624, widened #158)

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -470,19 +470,23 @@ import os
     #expect(outcome == .pasted)
     #expect(requests.legacyTexts.count == 1, "the cascade is called exactly once")
 
-    // TRAILING whitespace only. The legacy payload always carries a trailing space —
-    // `PasteCascadeExecutor.swift`: "Today's payload, including its trailing space. ALWAYS
-    // present" — which predates snippets and is owned by the insertion repair, not by
-    // anything here. Trimming the tail cannot hide what this test is for: both line breaks
-    // sit in the MIDDLE of the string, so they survive the trim and are compared byte for
-    // byte. Pinning the trailing space instead would make this test fail the day somebody
-    // legitimately changes spacing, on a property it was never about.
-    let received = requests.legacyTexts.first ?? ""
-    let withoutTrailingWhitespace = String(
-      received.reversed().drop(while: \.isWhitespace).reversed())
+    // Asserted EXACTLY, trailing space included, and the earlier draft of this test trimmed
+    // it away — which is the whole reason to pin it. `CursorInsertionRepair.legacyPayload` is
+    // `text.hasSuffix(" ") ? text : text + " "`, so every delivered payload gains a space it
+    // did not have. That is shared behaviour, not snippet behaviour: single-line snippets
+    // have always carried it. What CHANGED here is that a multi-line snippet used to bypass
+    // the cascade and reach the clipboard byte-exact, and now takes the same path as
+    // everything else, so it gains the space too. A snippet ending in a newline therefore
+    // ends "\n ", a line holding one space — visible in a code block. #2643 owns whether
+    // snippets should be exempt from the trailing space; that is a product question about
+    // ALL snippets, not something to special-case here.
+    //
+    // Pinned rather than trimmed so the day somebody changes this, they change it on purpose
+    // and see this test. A trim would have let the delivered bytes drift silently, which is
+    // exactly what it did before Codex named it.
     #expect(
-      withoutTrailingWhitespace == signature,
-      "the cascade must receive the snippet text with its line breaks intact")
+      requests.legacyTexts == [signature + " "],
+      "the cascade receives the snippet's line breaks intact, plus the shared trailing space")
 
     #expect(
       recorder.copies.isEmpty,

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetStartersTests.swift
@@ -254,18 +254,6 @@ struct SnippetStartersCatalogTests {
     #expect(Set(ids).count == ids.count)
   }
 
-  @Test("No starter expansion contains a newline")
-  func everyExpansionIsOneLine() {
-    // A snippet carrying a newline is delivered to the clipboard rather than typed in place.
-    // Correct, and a poor first impression: the example would look like it did nothing.
-    for snippet in SnippetStarters.all {
-      // Computed outside `#expect`: `contains(where:)` is `rethrows`, and the macro expansion
-      // does not carry the `try` the compiler then asks for.
-      let carriesNewline = snippet.expansion.contains(where: \.isNewline)
-      #expect(!carriesNewline, "\(snippet.trigger) would be delivered to the clipboard")
-    }
-  }
-
   @Test("Every trigger survives normalisation as the words it is written as")
   func triggersNormaliseToThemselves() {
     // Written lowercase and unpunctuated on purpose. A trigger that normalised to something

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -68,9 +68,7 @@ The text you save is pasted exactly as you typed it. AI Polish never rewrites it
 
 Line breaks are kept, so a two-line sign-off arrives as two lines.
 
-### Two things worth knowing
-
-**A snippet with a line break goes to your clipboard instead of being typed in.** In a terminal, a line break runs whatever came before it, and we cannot reliably tell every terminal apart from every other app. Rather than guess, a multi-line snippet always waits on your clipboard, ready for Command V. Single-line snippets are never affected and type straight in as normal.
+### One thing worth knowing
 
 **A dictation containing a snippet skips the cursor tidy-up.** Normally, when you dictate into the middle of a sentence you already typed, EnviousWispr fixes the spacing and capital letters where the two halves meet. On a dictation that expanded a snippet, it leaves the text alone instead, so nothing can alter your saved text.
 


### PR DESCRIPTION
Closes #2639

## What the user gets

A snippet containing a line break is now inserted at the cursor like any other dictation. Before this, it was copied to the clipboard with no message, so nothing appeared and the user had to press Cmd+V without being told why. Single-line snippets inserted normally, which made it read as "snippets randomly stop working".

Founder report and decision, 2026-09-03: *"a developer might intentionally want to paste line breaks into a coding software with snippet. who are we to police this behavior?"*

## The evidence it was broken

From `app.log`, seven consecutive "Insert LinkedIn snippet" takes reached `Snippet Expansion OUT` and then finished with **no `PasteService` line and no `Paste cascade` line at all**. The single-line "insert my email" snippet in the same session delivered via `tier=cgevent` every time.

## What was removed

A branch in `KernelFinalizationWiring` keyed on `context.snippetExpansionFired` **and** `payloads.legacyText.contains(where: \.isNewline)`, which called `copyToClipboard` and set `.clipboardOnly` without ever calling the cascade.

Its recorded reason was that in a terminal a newline submits the line before it.

**That hazard is real and this PR does not remove it.** Whether a pasted newline executes is decided by the terminal's bracketed-paste mode, which we neither set nor observe. The branch never addressed it either, on two counts:

- **Reachability.** It required `snippetExpansionFired`, so it refused a newline only when a snippet produced it. `git grep -n "isNewline" origin/main -- Sources/EnviousWisprServices/ Sources/EnviousWisprPipeline/` returns exactly one line — the one removed. A newline arriving any other way already reached a terminal untouched, which the branch's own comment admitted: the payload "went out either way".
- **Equivalence.** Its remedy was clipboard-only, which asks the user to press Cmd+V. That posts the same bytes to the same destination with the same bracketed-paste outcome as the `cgEvent` tier. It relocated the risk to the user's hand and called that safety.

A guard that actually addressed the hazard would have to live where the destination is resolved (`TerminalContextResolver`) and cover **every** newline, not the ones a snippet happened to produce.

**A retracted claim, recorded so nobody re-derives it.** An earlier draft justified the removal with "no delivery route types characters, so the hazard describes synthetic typing". That is wrong — Cmd+V does not make a newline inert, bracketed paste does. One reviewer confirmed it before a second retracted it, which is exactly why it is written down here rather than quietly dropped.

## Live UAT, on the real snippet

Dev build from this branch, pid 60219, rebased on `7f0f7927`.

| Destination | Tier | Result |
|---|---|---|
| TextEdit (`valueSettable=settable`) | `ax_direct` | All 10 lines inserted at the caret, line breaks intact. Verified by reading the document back, not from the log alone. |
| ghostty (`valueSettable=not_settable`) | `cgevent` | All 10 lines **staged at the shell prompt, unexecuted**. No `command not found`, prompt unchanged. Verified by reading the window back through AX. |

**Scope of the terminal result, stated because it bounds the claim:** this measures ghostty with default settings. It does **not** measure a terminal with bracketed paste OFF, and I did not test one. `pipeline-mechanics.md:145` stays true as written.

The tier pair is a free natural control: same payload, same take shape, cascade selecting its route by destination.

## The class, enumerated rather than found one per review round

Two review rounds each returned one member, which is the signal that the self-audit failed rather than that review is working. The third round was gated until the class was enumerated in one pass.

**Class:** artifacts whose correctness depended on a multi-line snippet *bypassing* the cascade.

| Axis | Member | Disposition |
|---|---|---|
| Shipped comments | `SnippetStarters.swift` one-line bullet | Removed |
| Tests justified only by the bypass | `SnippetStartersTests.everyExpansionIsOneLine` | Deleted — a multi-line starter is now allowed |
| User-facing copy | `using-snippets.md` clipboard paragraph | Deleted; the adjacent "line breaks are kept" line retained, still true |
| Cross-platform records | `catalog.db` `snippets` row | Updated after merge |
| Properties true only on the bypass path | trailing space via `CursorInsertionRepair.legacyPayload` | Behaviour unchanged; filed as #2643; the test now pins exact bytes |
| Other `snippetExpansionFired` consumers | repair suppression at `:694` | **Kept** — it is about the CONTENT of an expansion, not delivery |
| Internal design authorities | `issue-628` plan, two sites | Marked SUPERSEDED in place, not rewritten — a plan is a dated provenance record |

The last axis was missing from my own enumeration and came from a refutation pass. My first sweep of `docs/` returned clean and was **blind**: `docs/` is gitignored, so it does not exist in the worktree. Re-run from the main checkout, it found two members.

The confirming round after the full sweep returned no new members.

## Not fixed here, named rather than left silent

`KernelFinalizationWiring.swift` lines 129, 340 and 504 carry the same knowledge-file-reference violation Codex flagged in my own new comment (`code-conventions.md` RULE: no-dotclaude-from-shipped-code). They predate this branch. A sweep across shipped `Sources/` belongs in its own change.

## Validation

`scripts/xcode-test.sh` at this head (rebased on `7f0f7927`): **7181 tests in 627 suites passed**, 3 known issues.

The count moved twice and both moves are accounted for, which is the control that nothing else did:
- 7169 → 7168 when `everyExpansionIsOneLine` was deleted. One test, one fewer.
- 7168 → 7181 on rebasing onto `7f0f7927`, which merged #2093 and brought its own suite with it. Not my change.

Follow-ups: #2643 (snippets do not arrive character for character), #2642 (rule change: a falsified reason belongs in the PR, not left standing in code). #2637 (trailing period) is owned by another session and untouched here.
