### PR TITLE
fix(snippets): the snippet's own ending wins over the recogniser's

### DIFF
--- a/Sources/EnviousWisprCore/Snippet.swift
+++ b/Sources/EnviousWisprCore/Snippet.swift
@@ -16,13 +16,22 @@ public enum SnippetText {
   /// Punctuation dropped from the FRONT of a spoken token before comparison.
   static let leading: Set<Character> = ["(", "[", "{", "\"", "'", "\u{201C}", "\u{2018}"]
 
-  /// Punctuation dropped from the END of a spoken token before comparison. This is also the
-  /// set `SnippetExpander` re-attaches AFTER an expansion, so a full stop that clung to the
-  /// last trigger word survives the substitution. The two uses share this one list on purpose:
-  /// a token stripped here and not re-attached there would silently eat the user's punctuation.
-  public static let trailing: Set<Character> = [
-    ".", ",", "!", "?", ";", ":", ")", "]", "}", "\"", "'", "\u{201D}", "\u{2019}",
-  ]
+  /// Punctuation that CLOSES rather than terminates: a bracket or a quote that can sit AFTER a
+  /// full stop and hide it from anything reading only a token's last character (#2605).
+  public static let closing: Set<Character> = [")", "]", "}", "\"", "'", "\u{201D}", "\u{2019}"]
+
+  /// Punctuation dropped from the END of a spoken token before comparison. `SnippetExpander`
+  /// normally re-attaches the same run after the expansion, so a full stop that clung to the
+  /// last trigger word survives the substitution; a SENTENCE ending is suppressed instead when
+  /// the snippet owns its ending (#2637). The two uses share this one list on purpose: a token
+  /// stripped here and re-attached from a different list there would drift.
+  ///
+  /// Composed from the three ROLES rather than spelled out, so the roles cannot drift apart.
+  /// Before #2605 `closing` was a hand-copied subset of a literal list here, which is how a
+  /// closing quote came to be strippable for matching and invisible to `endsSentence` at the
+  /// same time. Membership is pinned by a literal in `SnippetTextPunctuationSetTests`.
+  public static let trailing: Set<Character> =
+    sentenceEnding.union(closing).union([",", ";", ":"])
 
   /// A spoken token reduced to its comparison form.
   ///
@@ -46,9 +55,45 @@ public enum SnippetText {
   public static let sentenceEnding: Set<Character> = [".", "!", "?"]
 
   /// True when this token ends a sentence.
+  ///
+  /// Reads THROUGH trailing whitespace and closing marks rather than at the final character
+  /// (#2605). `my.\u{201D}` ends a sentence; its last character is the quote. The two callers
+  /// need that for different reasons and both failed the same way: the boundary guard let a
+  /// snippet span a real sentence break, and the trailing-punctuation decision could not see
+  /// that a saved expansion already terminated itself.
+  ///
+  /// Whitespace first, because a saved expansion is deliberately NOT trimmed (`SnippetEditSheet`
+  /// keeps a trailing newline that a user meant), so `Saurabh\n` must answer for `Saurabh`.
   public static func endsSentence(_ token: String) -> Bool {
-    guard let last = token.last else { return false }
+    var s = Substring(token).trimmingWhitespace()
+    while let last = s.last, closing.contains(last) { s = s.dropLast() }
+    guard let last = s.last else { return false }
     return sentenceEnding.contains(last)
+  }
+
+  /// The maximal run of trailing punctuation at the START of `s`.
+  ///
+  /// The mirror of `trailingPunctuation`, which reads from the END of a token. This direction
+  /// exists because `SnippetFinalizer` looks FORWARD from a sentinel into text a model wrote,
+  /// and it must see the WHOLE run before deciding anything — a loop that stops at the first
+  /// non-terminator cannot see a full stop standing behind a bracket.
+  public static func punctuationRunPrefix(of s: Substring) -> Substring {
+    var end = s.startIndex
+    while end < s.endIndex, trailing.contains(s[end]) { end = s.index(after: end) }
+    return s[s.startIndex..<end]
+  }
+
+  /// A trailing-punctuation run with its sentence terminators removed and everything else kept,
+  /// in source order.
+  ///
+  /// **This is the one answer to "a terminator can hide behind a closing mark", and every site
+  /// that decides about a run calls it.** Three separate sites each grew their own version of
+  /// that question and two of them got it wrong in the same way — reading only the last
+  /// character, and stopping at the first closer — so the question is asked in one place now.
+  /// A fourth site of this class is not another patch: it means the per-site handling comes out
+  /// and the run is normalised once, at one point.
+  public static func droppingSentenceEndings(from run: some StringProtocol) -> String {
+    String(run.filter { !sentenceEnding.contains($0) })
   }
 
   /// The leading punctuation run on a token, in source order.

--- a/Sources/EnviousWisprPipeline/SnippetFinalizer.swift
+++ b/Sources/EnviousWisprPipeline/SnippetFinalizer.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import EnviousWisprPostProcessing
 import Foundation
 
@@ -100,9 +101,52 @@ enum SnippetFinalizer {
   ) -> String {
     var out = text
     for record in records {
+      if record.suppressFollowingSentenceEnding {
+        out = removingSentenceEndingsAfter(record.sentinel, in: out)
+      }
       out = out.replacingOccurrences(of: record.sentinel, with: record.expansion)
     }
     return out
+  }
+
+  /// Drop any sentence terminator sitting immediately after a sentinel whose snippet owns its
+  /// ending (#2637).
+  ///
+  /// **The model is the LAST writer, so the expander's decision cannot be enforced upstream of
+  /// it.** `SnippetExpander` removes the recogniser's terminator; polish then receives the
+  /// sentinel and can put one back, and this type substitutes into that output.
+  ///
+  /// A lone sentinel reaching a model is not hypothetical. `LLMPolishStep` bypasses polish at
+  /// three words or fewer, which covers the English case — but that gate is whitespace-based,
+  /// and the sibling gate for unsegmented scripts (ja/zh/th/lo) counts CHARACTERS with a
+  /// minimum of 10 (`LLMPolishStep.swift:437`). A sentinel is 38 characters and clears it every
+  /// time. EG-1 was measured not to add a terminator; the user chooses the provider, so that is
+  /// a fact about one model rather than about the path.
+  ///
+  /// Applied to the deterministic text too, where it is a no-op by construction. That is the
+  /// point: one path cannot drift from the other by having the rule in only one of them.
+  ///
+  /// Scoped to `sentenceEnding`. A comma the model added is the model punctuating a sentence it
+  /// can see, and this leaves it alone, as it leaves brackets and closing quotes alone.
+  ///
+  /// **Reads the WHOLE punctuation run before deciding, never a terminator prefix.** A loop that
+  /// stopped at the first non-terminator left the period in `(EWSNIPccc).` and `"EWSNIPccc".`,
+  /// which is the trailing-period bug back again for a quoted or bracketed snippet. That is the
+  /// same property as `endsSentence` reading only a token's last character and as the expander
+  /// once refusing a mixed run, so all three now ask `SnippetText.droppingSentenceEndings`.
+  private static func removingSentenceEndingsAfter(
+    _ sentinel: String, in text: String
+  ) -> String {
+    var out = ""
+    var rest = Substring(text)
+    while let found = rest.range(of: sentinel) {
+      out += rest[rest.startIndex..<found.upperBound]
+      let after = rest[found.upperBound...]
+      let run = SnippetText.punctuationRunPrefix(of: after)
+      out += SnippetText.droppingSentenceEndings(from: run)
+      rest = after[run.endIndex...]
+    }
+    return out + rest
   }
 
   private static func occurrences(of needle: String, in haystack: String) -> Int {

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -9,10 +9,28 @@ public struct SnippetExpansionRecord: Sendable, Equatable {
   public let sentinel: String
   /// The user's saved text, byte-for-byte. Never sent to a model.
   public let expansion: String
+  /// True when THIS SNIPPET OWNS ITS ENDING (#2637), so `SnippetFinalizer` must strip a
+  /// sentence terminator sitting immediately after the sentinel in whatever polish returns.
+  ///
+  /// It records the DECISION, not whether anything was removed from the recogniser's text: a
+  /// whole-dictation snippet the recogniser left unpunctuated still owns its ending, and the
+  /// model is what puts a terminator there.
+  ///
+  /// **The decision has to TRAVEL, because a whole-dictation expansion CAN reach a model.**
+  /// `LLMPolishStep` bypasses polish at three words or fewer, which is why an English lone
+  /// sentinel never gets there — but that gate is whitespace-segmented, and for an unsegmented
+  /// script (ja/zh/th/lo) the sibling gate counts CHARACTERS with a minimum of 10
+  /// (`LLMPolishStep.swift:437`). A sentinel is 38 characters, so it clears that gate every
+  /// time. Measured EG-1 does not add a terminator, but this is not a claim about one model:
+  /// the user picks the provider, and `SnippetFinalizer` substitutes into whatever comes back.
+  public let suppressFollowingSentenceEnding: Bool
 
-  public init(sentinel: String, expansion: String) {
+  public init(
+    sentinel: String, expansion: String, suppressFollowingSentenceEnding: Bool = false
+  ) {
     self.sentinel = sentinel
     self.expansion = expansion
+    self.suppressFollowingSentenceEnding = suppressFollowingSentenceEnding
   }
 }
 
@@ -41,8 +59,9 @@ public struct SnippetExpansionOutcome: Sendable, Equatable {
 /// - A snippet fires only when the keyword is spoken immediately before its trigger.
 /// - Trigger tokens compare through `SnippetText.normalize` — literal, never fuzzy.
 /// - **Longest match wins** when several triggers match at one position.
-/// - Trailing punctuation clinging to the last trigger word is re-attached AFTER the
-///   substitution, so "…backslash my email address." keeps its full stop.
+/// - Trailing punctuation clinging to the last trigger word is normally re-attached AFTER the
+///   substitution, so "…backslash my email address." keeps its full stop. A SENTENCE ending is
+///   suppressed instead when the snippet owns its ending — see `trailingToRestore` (#2637).
 /// - The keyword is consumed on a hit and left in place on a miss, which is what makes
 ///   "the path is backslash users" come through untouched.
 public struct SnippetExpander: Sendable {
@@ -128,8 +147,15 @@ public struct SnippetExpander: Sendable {
       let sentinel = mintSentinel(
         rawInput: text, expansions: vocabulary.snippets.map(\.expansion), alreadyIssued: issued)
       issued.insert(sentinel)
+      let trailing = Self.trailingToRestore(
+        lastToken: lastToken,
+        expansion: hit.snippet.expansion,
+        isWholeDictation: cursor == 0 && cursor + hit.length == wordIndices.count - 1)
       records.append(
-        SnippetExpansionRecord(sentinel: sentinel, expansion: hit.snippet.expansion))
+        SnippetExpansionRecord(
+          sentinel: sentinel,
+          expansion: hit.snippet.expansion,
+          suppressFollowingSentenceEnding: trailing.suppressed))
 
       // The punctuation the user actually spoke belongs AROUND the pasted text, not swallowed
       // with the trigger. Both ends, and both are load-bearing: the opening mark is stripped
@@ -145,12 +171,52 @@ public struct SnippetExpander: Sendable {
       out +=
         SnippetText.leadingPunctuation(token)
         + SnippetText.leadingPunctuation(firstTriggerToken) + sentinel
-        + SnippetText.trailingPunctuation(lastToken)
+        + trailing.restored
       if let gap = Self.whitespaceAfter(lastWordIndex, in: pieces) { out += gap }
       cursor += hit.length + 1
     }
 
     return SnippetExpansionOutcome(text: out, records: records)
+  }
+
+  /// The trailing punctuation to re-attach after the expansion (#2637).
+  ///
+  /// Re-attaching is the DEFAULT and stays: in `Please contact me at <keyword> my email.` the
+  /// full stop is the user's sentence, not the trigger's, and swallowing it was the original
+  /// defect. What changed is that the recogniser's terminator is suppressed in the two cases
+  /// where the snippet's own text is the authority on how it ends.
+  ///
+  /// Founder, 2026-09-03: "People will add punctuation and formatting to their snippet. We
+  /// would honor that."
+  ///
+  /// - `isWholeDictation` — the keyword is the first word and the last trigger word is the
+  ///   last word, so there is no surrounding sentence for the stop to belong to. Parakeet
+  ///   punctuates a complete utterance, and a dictation that is nothing but a snippet phrase
+  ///   IS one, so `Insert my email.` welded a stop onto an email address on every single use.
+  ///   Measured on the founder's own log, three times at 23:22 on 2026-09-03.
+  /// - the saved text already ends a sentence — otherwise a canned reply ending in `.`
+  ///   arrives as `..`
+  ///
+  /// Scoped to a run that is ENTIRELY sentence-ending. A comma, a closing bracket or a closing
+  /// quote is re-attached exactly as before, because the comma in `<keyword> my email, and let
+  /// me know` belongs to the user's sentence and nothing about the snippet makes it wrong.
+  /// Deliberately NOT widened to "strip any terminator": that would need a claim about every
+  /// mark the recogniser can emit, and this needs a claim about three.
+  /// `suppressed` reports the DECISION and is independent of whether the run contained anything
+  /// to remove, because the model is a second source of terminators and the finalizer needs the
+  /// decision either way.
+  ///
+  /// The run is FILTERED rather than tested wholesale. Refusing a run that is not entirely
+  /// sentence-ending looked conservative and left `.\u{201D}` and `.)` untouched, so a saved
+  /// expansion ending in a full stop still arrived as `..\u{201D}` — the exact outcome this
+  /// exists to prevent, hidden behind one closing mark. Only the terminator goes; commas,
+  /// brackets and closing quotes are re-attached exactly as before.
+  static func trailingToRestore(
+    lastToken: String, expansion: String, isWholeDictation: Bool
+  ) -> (restored: String, suppressed: Bool) {
+    let run = SnippetText.trailingPunctuation(lastToken)
+    guard isWholeDictation || SnippetText.endsSentence(expansion) else { return (run, false) }
+    return (SnippetText.droppingSentenceEndings(from: run), true)
   }
 
   /// A sentinel that appears in NONE of: the raw input, any saved expansion, or the sentinels
@@ -212,8 +278,8 @@ public struct SnippetExpander: Sendable {
           matched = false
           break
         }
-        // Only an INTERIOR boundary blocks: punctuation on the LAST token is the sentence the
-        // trigger legitimately ends, and it is re-attached after the expansion. The keyword's
+        // Only an INTERIOR boundary blocks: punctuation on the LAST token belongs to the
+        // trigger's surrounding context and is decided by `trailingToRestore`. The keyword's
         // own boundary is checked by the CALLER, because the keyword is consumed too and this
         // loop cannot see it — see `consumedTokensSpanASentenceBoundary`.
         if offset < tokens.count - 1, SnippetText.endsSentence(piece.text) {

--- a/Tests/EnviousWisprTests/Pipeline/SnippetFinalizerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/SnippetFinalizerTests.swift
@@ -70,6 +70,120 @@ struct SnippetFinalizerTests {
     expectNoSentinelSurvives(ctx)
   }
 
+  // MARK: - The model is the last writer (#2637)
+
+  private let emailSuppressing = SnippetExpansionRecord(
+    sentinel: "EWSNIPccc", expansion: "sam@example.com", suppressFollowingSentenceEnding: true)
+
+  /// The founder's case, at the step that actually delivers it. The expander already dropped the
+  /// recogniser's terminator, so polish receives the sentinel — and for an unsegmented script it
+  /// reaches a model, because that gate counts characters and a sentinel is 38 of them. Without
+  /// this the fix is undone by the step running after it, and the deterministic text would be
+  /// right while the delivered text stayed wrong.
+  @Test("A period the model added after a suppressing sentinel does not reach the user")
+  func polishAddedTerminatorIsDropped() {
+    var ctx = context(text: "EWSNIPccc", polished: "EWSNIPccc.", records: [emailSuppressing])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.text == "sam@example.com")
+    #expect(ctx.polishedText == "sam@example.com")
+    #expect(ctx.pipelineFellBackToRaw == false)
+    expectNoSentinelSurvives(ctx)
+  }
+
+  /// The control that makes the row above mean something. Same shape, same added period, flag
+  /// off — the period stays, because it is the user's sentence and not the snippet's ending.
+  @Test("Without the flag the same added period is kept")
+  func polishAddedTerminatorIsKeptWithoutTheFlag() {
+    var ctx = context(
+      text: "email me at EWSNIPaaa", polished: "Email me at EWSNIPaaa.", records: [email])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == "Email me at sam@example.com.")
+  }
+
+  /// A saved expansion that ends itself. The doubled stop appears only AFTER substitution, so
+  /// nothing before this step could have caught it.
+  @Test("An expansion that ends a sentence does not gain a second stop from polish")
+  func polishAddedTerminatorAfterASelfTerminatingExpansion() {
+    let signOff = SnippetExpansionRecord(
+      sentinel: "EWSNIPddd", expansion: "Let me know if that works.",
+      suppressFollowingSentenceEnding: true)
+    var ctx = context(
+      text: "tell them EWSNIPddd then send it",
+      polished: "Tell them EWSNIPddd. Then send it.", records: [signOff])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == "Tell them Let me know if that works. Then send it.")
+    expectNoSentinelSurvives(ctx)
+  }
+
+  /// Scoping control. Only a sentence terminator is eaten. A comma is the model punctuating a
+  /// sentence it can see, and this has no business touching it.
+  @Test("A comma after a suppressing sentinel is left alone")
+  func aCommaAfterASuppressingSentinelSurvives() {
+    var ctx = context(
+      text: "EWSNIPccc and more", polished: "EWSNIPccc, and more.",
+      records: [emailSuppressing])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == "sam@example.com, and more.")
+  }
+
+  /// A terminator standing BEHIND a preserved closing mark. Same property as `endsSentence`
+  /// once reading only a token's last character, and as the expander once refusing a mixed run:
+  /// a loop that stops at the first non-terminator never sees the stop. Two members, because a
+  /// row proving one closing mark proves only that mark.
+  @Test("A period behind a closing bracket the model kept is still dropped")
+  func terminatorBehindAClosingBracket() {
+    var ctx = context(
+      text: "(EWSNIPccc)", polished: "(EWSNIPccc).", records: [emailSuppressing])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == "(sam@example.com)")
+    expectNoSentinelSurvives(ctx)
+  }
+
+  @Test("A period behind a closing quote the model kept is still dropped")
+  func terminatorBehindAClosingQuote() {
+    var ctx = context(
+      text: "\u{201C}EWSNIPccc\u{201D}", polished: "\u{201C}EWSNIPccc\u{201D}.",
+      records: [emailSuppressing])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == "\u{201C}sam@example.com\u{201D}")
+  }
+
+  /// The closing mark itself must SURVIVE. A fix that dropped the whole run would pass both rows
+  /// above and silently eat the user's bracket.
+  @Test("The closing mark itself is kept when the period behind it is dropped")
+  func closingMarkSurvivesTheDrop() {
+    var ctx = context(
+      text: "(EWSNIPccc)", polished: "(EWSNIPccc). And more.", records: [emailSuppressing])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.polishedText == "(sam@example.com) And more.")
+  }
+
+  /// The deterministic half is a no-op by construction, and asserting it is what keeps the two
+  /// paths from drifting: the rule runs on both, so neither can be the one that forgot.
+  @Test("The deterministic text is unchanged by the terminator rule")
+  func deterministicTextIsUnaffected() {
+    var ctx = context(text: "EWSNIPccc", polished: nil, records: [emailSuppressing])
+
+    SnippetFinalizer.finalize(&ctx)
+
+    #expect(ctx.text == "sam@example.com")
+    #expect(ctx.polishedText == nil)
+  }
+
   @Test("Several sentinels, all intact, all resolved")
   func severalIntactSentinels() {
     var ctx = context(

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -248,6 +248,194 @@ struct SnippetExpanderTests {
     #expect(out.text == "email me at EWSNIPcomma today")
   }
 
+  // MARK: - The snippet's own ending wins (#2637)
+
+  /// Speaking ONLY the snippet is how a snippet is mostly used — into an empty field, a search
+  /// box, a form. Parakeet punctuates a complete utterance, and a dictation that is nothing but
+  /// the phrase IS one, so the recogniser writes `snippet.` and the reconstruction welded that
+  /// stop onto an email address every single time. Measured on the founder's log, 2026-09-03
+  /// 23:22, three consecutive takes.
+  @Test("A snippet spoken on its own does not get a full stop welded on")
+  func wholeDictationDropsTheRecognisersStop() {
+    let expander = fixedExpander(["EWSNIPalone"])
+    let out = expander.expand(
+      "backslash my email address.",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "EWSNIPalone")
+    #expect(out.records.count == 1)
+    #expect(out.records[0].expansion == "sam@example.com")
+    #expect(out.records[0].suppressFollowingSentenceEnding)
+  }
+
+  /// The two-way control on the test above: with no stop to suppress the output is unchanged,
+  /// so a green there cannot come from the suppression firing on everything.
+  @Test("A snippet spoken on its own with no stop is unchanged")
+  func wholeDictationWithoutAStopIsUnchanged() {
+    let expander = fixedExpander(["EWSNIPalone2"])
+    let out = expander.expand(
+      "backslash my email address",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "EWSNIPalone2")
+    // The flag records the DECISION, not whether anything was removed here. A whole-dictation
+    // snippet the recogniser left unpunctuated still owns its ending, and a model is the other
+    // source of a terminator.
+    #expect(out.records[0].suppressFollowingSentenceEnding)
+  }
+
+  /// Scoping control. Suppression is for the recogniser's TERMINATOR, not for punctuation in
+  /// general, so a comma is re-attached exactly as before even in the whole-dictation case.
+  /// Widening this to "strip whatever clings to the last token" is the change this row refuses.
+  @Test("A comma on a snippet spoken on its own is still re-attached")
+  func wholeDictationKeepsANonTerminator() {
+    let expander = fixedExpander(["EWSNIPcomma2"])
+    let out = expander.expand(
+      "backslash my email address,",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "EWSNIPcomma2,")
+  }
+
+  /// The in-sentence case is the one the re-attachment exists for and it must not regress: this
+  /// full stop is the USER'S sentence, not the trigger's.
+  @Test("A snippet inside a sentence still keeps the sentence's full stop")
+  func inSentenceKeepsTheStop() {
+    let expander = fixedExpander(["EWSNIPmid"])
+    let out = expander.expand(
+      "please contact me at backslash my email address.",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "please contact me at EWSNIPmid.")
+    #expect(!out.records[0].suppressFollowingSentenceEnding)
+  }
+
+  /// Founder, 2026-09-03: "People will add punctuation and formatting to their snippet. We
+  /// would honor that." A canned reply that ends itself must not arrive with a second stop.
+  @Test("A saved expansion that already ends a sentence does not get a second stop")
+  func expansionEndingASentenceSuppressesTheStop() {
+    let expander = fixedExpander(["EWSNIPsig"])
+    let out = expander.expand(
+      "tell them backslash my sign off. Then send it.",
+      using: vocabulary([("my sign off", "Let me know if that works.")]))
+
+    #expect(out.text == "tell them EWSNIPsig Then send it.")
+    #expect(out.records[0].expansion == "Let me know if that works.")
+  }
+
+  /// A saved expansion is deliberately NOT trimmed on save, so a real multi-line snippet ends
+  /// with the newline the user typed. Reading only the final character answers `newline`, which
+  /// is why the whitespace hop is inside `endsSentence` rather than at this call site.
+  @Test("A trailing newline does not hide the expansion's own full stop")
+  func expansionEndingASentenceThenANewline() {
+    let expander = fixedExpander(["EWSNIPnl"])
+    let out = expander.expand(
+      "tell them backslash my sign off. Then send it.",
+      using: vocabulary([("my sign off", "Speak soon.\n")]))
+
+    #expect(out.text == "tell them EWSNIPnl Then send it.")
+  }
+
+  /// An expansion that does NOT end a sentence is the other half of the pair, and without it a
+  /// suppression that fired on every in-sentence expansion would still pass the row above.
+  @Test("An expansion that ends mid-phrase still receives the sentence's stop")
+  func expansionNotEndingASentenceKeepsTheStop() {
+    let expander = fixedExpander(["EWSNIPmid2"])
+    let out = expander.expand(
+      "tell them backslash my sign off. Then send it.",
+      using: vocabulary([("my sign off", "Best,\nSaurabh")]))
+
+    #expect(out.text == "tell them EWSNIPmid2. Then send it.")
+  }
+
+  /// "Whole dictation" has to mean the WHOLE dictation. With two snippets neither one is, so
+  /// both keep their marks — the guard cannot be reading "a snippet fired" and calling it whole.
+  @Test("With two snippets in one utterance neither counts as the whole dictation")
+  func twoSnippetsAreNeitherWhole() {
+    let expander = fixedExpander(["EWSNIPa", "EWSNIPb"])
+    let out = expander.expand(
+      "backslash my email. backslash my cell.",
+      using: vocabulary([("my email", "sam@example.com"), ("my cell", "555-0100")]))
+
+    #expect(out.text == "EWSNIPa. EWSNIPb.")
+    #expect(out.records.count == 2)
+  }
+
+  /// A terminator hidden inside a MIXED run. Testing the run wholesale ("is every character a
+  /// terminator?") looked conservative and left this untouched, so a self-terminating expansion
+  /// still arrived as `..\u{201D}` — the defect this exists to prevent, behind one closing mark.
+  @Test("A full stop followed by a closing quote is suppressed, and the quote is kept")
+  func mixedTrailingRunLosesOnlyTheTerminator() {
+    let expander = fixedExpander(["EWSNIPmix"])
+    let out = expander.expand(
+      "he said \u{201C}backslash my sign off.\u{201D} Then he left.",
+      using: vocabulary([("my sign off", "Let me know if that works.")]))
+
+    #expect(out.text == "he said \u{201C}EWSNIPmix\u{201D} Then he left.")
+    #expect(out.records[0].suppressFollowingSentenceEnding)
+  }
+
+  // MARK: - A sentence boundary hiding behind a closing mark (#2605)
+
+  /// `endsSentence` read only a token's FINAL character, so a stop followed by a closing quote
+  /// was invisible and a snippet could span a real sentence break, eating the first words of
+  /// the next sentence. The quote is what makes this different from the plain boundary rows
+  /// above, so those passing says nothing about this one.
+  @Test("A sentence boundary hidden behind a closing quote blocks the match")
+  func boundaryBehindAClosingQuoteBlocks() {
+    let expander = fixedExpander(["EWSNIPquote"])
+    let out = expander.expand(
+      "he said backslash my.\u{201D} Email address is below",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.text == "he said backslash my.\u{201D} Email address is below")
+    #expect(out.records.isEmpty)
+  }
+
+  /// The same shape with a closing bracket, because the fix hops a SET and a row proving one
+  /// member proves only that member.
+  @Test("A sentence boundary hidden behind a closing bracket blocks the match")
+  func boundaryBehindAClosingBracketBlocks() {
+    let expander = fixedExpander(["EWSNIPparen"])
+    let out = expander.expand(
+      "he said (backslash my.) Email address is below",
+      using: vocabulary([("my email address", "sam@example.com")]))
+
+    #expect(out.records.isEmpty)
+  }
+
+  // MARK: - The punctuation sets themselves
+
+  /// `trailing` is composed from the three roles rather than spelled out, so this pins the
+  /// resulting MEMBERSHIP against a literal. Building the expectation from the same union would
+  /// pass against any definition, including one that dropped a role entirely.
+  @Test("The trailing set is exactly the thirteen marks normalisation strips")
+  func trailingSetMembershipIsPinned() {
+    #expect(
+      SnippetText.trailing == Set<Character>([
+        ".", ",", "!", "?", ";", ":", ")", "]", "}", "\"", "'", "\u{201D}", "\u{2019}",
+      ]))
+    #expect(SnippetText.sentenceEnding.isSubset(of: SnippetText.trailing))
+    #expect(SnippetText.closing.isSubset(of: SnippetText.trailing))
+    #expect(SnippetText.sentenceEnding.isDisjoint(with: SnippetText.closing))
+  }
+
+  @Test("endsSentence reads through trailing closing marks and whitespace")
+  func endsSentenceReadsThroughClosersAndWhitespace() {
+    #expect(SnippetText.endsSentence("done."))
+    #expect(SnippetText.endsSentence("my.\u{201D}"))
+    #expect(SnippetText.endsSentence("email.)"))
+    #expect(SnippetText.endsSentence("done.\"'"))
+    #expect(SnippetText.endsSentence("Speak soon.\n"))
+    #expect(SnippetText.endsSentence("What?  "))
+
+    #expect(!SnippetText.endsSentence("Saurabh"))
+    #expect(!SnippetText.endsSentence("email,"))
+    #expect(!SnippetText.endsSentence("\u{201D}"))
+    #expect(!SnippetText.endsSentence(""))
+    #expect(!SnippetText.endsSentence("   "))
+  }
+
   // MARK: - The disabled path, which is what an ordinary user takes
 
   @Test("An empty store returns the input unchanged and identical")


### PR DESCRIPTION
Closes #2637
Closes #2605

## The user problem

Speaking a snippet **on its own** — into an empty field, a search box, a form — pasted the saved text with a full stop welded on. Every time. An email address, a URL, a signature, a canned reply.

Founder, 2026-09-03: *"I confirmed that it's adding a period to the end of my snippet even though there's no period in my snippet itself. Even when it's a longer snippet."*

## Cause

Parakeet punctuates a complete utterance, and a dictation that is nothing but the trigger phrase IS one, so the recogniser wrote `snippet.` The stop clung to the last trigger token, `SnippetText.normalize` dropped it so the trigger could match, and the reconstruction re-attached it after the sentinel. From the founder's own `app.log`, dev build:

```
23:22:38 [Snippet Expansion] IN:  Insert LinkedIn snippet.
23:22:38 [Snippet Expansion] OUT: EWSNIP1c53fe71f8c4871aa167a1fbc914c4a0.
```

The period is in the expansion step's own output, so this was never AI Polish. Reproduced at 23:22:38, 23:22:44 and 23:22:50, and earlier at 22:57:42 on the email snippet.

## The rule

**The snippet's own ending wins.** Founder decision: *"People will add punctuation and formatting to their snippet. We would honor that."*

Re-attachment stays as the default — in `Please contact me at <keyword> my email address.` the stop is the USER'S sentence, and swallowing it was the original defect that put the re-attachment there. It is suppressed only where the snippet owns its ending:

- the snippet is the whole dictation (keyword is the first word token, last trigger word is the last), so no surrounding sentence owns the stop
- the saved expansion already ends a sentence, else a canned reply ending in `.` arrives as `..`

Scoped to sentence-ending characters. A comma, bracket or closing quote is re-attached exactly as before.

## Enforced twice, and the second time is not optional

Polish is the LAST writer before delivery and `SnippetFinalizer` substitutes into its output, so the decision travels on `SnippetExpansionRecord` and is enforced again at finalization.

**That half was built, removed on a measurement, and restored when the measurement turned out to answer a narrower question.** Recorded in the commit body so nobody repeats the middle step:

1. Cloud review said polish can re-add the terminator. Built the enforcement.
2. **Measured it** rather than assuming, through `scripts/eval/deterministic_runner` (the app's own `RecoveryTextProcessor`, shipped six-step chain, `EGOneServerManager` with shipped launch flags, installed `eg1-1.2-c003`, default English/Parakeet snapshot, temperature 0):

   | input to the chain | polished output |
   |---|---|
   | `tell them EWSNIP2c53… then send it.` | `Tell them EWSNIP2c53… then send it.` |
   | `tell them EWSNIP2c53…. then send it.` | `Tell them EWSNIP2c53…. Then send it.` |
   | `please contact me at EWSNIP3c53….` | `Please contact me at EWSNIP3c53….` |
   | `EWSNIP1c53…` | polish SKIPPED, 3ms, `polishedText` nil |
   | `saurabhav@gmail.com` | polish SKIPPED, 0ms, `polishedText` nil |

   EG-1 adds no terminator, and a lone sentinel never reaches it — `LLMPolishStep.swift:431` `minWordsForPolish = 3`, bypassing at `:500-511` before any provider call. Removed the enforcement.
3. **Review falsified step 2's REACH claim, and it is a real user configuration.** That word gate is whitespace-segmented. Its sibling at `:483-487` handles unsegmented scripts (ja/zh/th/lo) by CHARACTER count, minimum 10 (`:437`). A sentinel is 38 characters, so a whole-dictation snippet clears it every time and DOES reach the model. Restored.

So the enforcement is not there because a model was observed misbehaving. It is there because the path is open and the user chooses the provider.

**Known limit, stated:** only EG-1 was measured. Cloud providers were not, because that is spend. Re-run the probe with `scripts/eval/deterministic_runner` if the question returns.

## One root, found three times, now asked in one place

A sentence terminator can stand BEHIND a closing mark. Three sites had each grown their own answer and two were wrong the same way:

| site | how it was wrong |
|---|---|
| `endsSentence` | read only a token's LAST character, so `my."` was not a boundary (#2605) |
| `trailingToRestore` | refused any run not ENTIRELY sentence-ending, so `.”` kept its stop and a self-terminating expansion arrived as `..”` |
| `removingSentenceEndingsAfter` | stopped at the first non-terminator, so `(EWSNIP…).` and `"EWSNIP…".` kept the period |

Each was found in a separate round and each fix was a patch to the site named. The third finding is the signal. `SnippetText.punctuationRunPrefix` and `SnippetText.droppingSentenceEndings` are now that question, and every site calls them.

**Pre-committed consequence, written before the next round:** a FOURTH finding of this class does not get another fix — the per-site handling comes out and the run is normalised once, at one point.

`SnippetText.trailing` is now composed from its three roles rather than spelled out, because `closing` was a hand-copied subset of that literal. Membership pinned against a literal, not against the union.

## Verification

**Live UAT on the rebuilt dev app, real mic path, real ASR, real polish** — the case the founder reported and its control:

```
01:08:22  [RAW ASR]           Insert my email.
01:08:22  [Snippet Expansion] OUT: EWSNIPf111a01fa2b57fe6fe6d5f09c60db55b      ← no stop
01:08:22  [LLM Polish]        no change

01:08:42  [RAW ASR]           Please contact me and insert my email.
01:08:42  [Snippet Expansion] OUT: Please contact me and EWSNIP217bbfb5e1ab8ddc8c881a6ff8577c30.   ← stop kept
01:08:42  [LLM Polish]        no change
```

**Baseline red, taken before the green.** The two source files reverted to `origin/main` with the new tests kept: 36 tests, 6 failed, 11 issues, 0 compile errors. The observed wrong values are the defect itself:

```
out.text -> "EWSNIPalone."                  expected "EWSNIPalone"
out.text -> "tell them EWSNIPsig. Then …"   expected "… EWSNIPsig Then …"
out.text -> "he said EWSNIPquote is below"  expected the input, unchanged
```

The last is #2605 doing visible damage: on baseline the snippet fired across the sentence break and ate `Email address` out of the following sentence.

The control rows PASSED on baseline and still pass: whole dictation with no stop, a comma on a whole dictation, in-sentence keeping its stop, an expansion that does not end a sentence, two snippets where neither is whole, and the closing mark surviving its dropped period. A suppression that fired indiscriminately would have turned those red.

**Suite:** `scripts/xcode-test.sh` — 7,189 tests in 626 suites passed, 0 failures, 3 pre-existing known issues.

**Review:** four rounds, ending clean. Rounds 2 and 3 each found a real new site of the root above; round 4 confirmed the consolidation.

## Lane

`Code`. No content change — the help article makes no claim about a trailing stop being added, and its line 82 claim is about MATCHING ignoring trailing punctuation, which remains true.
