### PR TITLE
fix(llm): give the request timeout one owner and delete its shadow copies (#2635)

### DIFF
--- a/Sources/EnviousWisprLLM/ClaudeConnector.swift
+++ b/Sources/EnviousWisprLLM/ClaudeConnector.swift
@@ -70,7 +70,9 @@ public struct ClaudeConnector: TranscriptPolisher {
     request.setValue(Self.apiVersion, forHTTPHeaderField: "anthropic-version")
     request.setValue("application/json", forHTTPHeaderField: "content-type")
     request.httpBody = try JSONSerialization.data(withJSONObject: body)
-    request.timeoutInterval = 60
+    // #2635: no per-request timeout. `LLMNetworkSession`'s configuration owns
+    // the idle ceiling for every request on the shared session, and a
+    // per-request value would SHADOW it (measured; see that file).
 
     // Allocate the call number once per logical polish. Retries reuse the
     // same number so logs never mistake a retried polish for multiple

--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -41,7 +41,9 @@ public struct GeminiConnector: TranscriptPolisher {
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.httpBody = try JSONSerialization.data(withJSONObject: body)
-    request.timeoutInterval = 60
+    // #2635: no per-request timeout. `LLMNetworkSession`'s configuration owns
+    // the idle ceiling for every request on the shared session, and a
+    // per-request value would SHADOW it (measured; see that file).
 
     // Allocate the call number once per logical polish. Retries reuse the
     // same number so logs never mistake a retried polish for multiple

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -141,10 +141,32 @@ public final class LLMNetworkSession: Sendable {
     }
   }
 
+  /// The idle timeout every LLM request gets, and the ONLY place it is written.
+  ///
+  /// #2635: it used to be restated as `request.timeoutInterval = 60` at five call
+  /// sites as well. Those were not decoration — MEASURED 2026-09-04 against a
+  /// server that accepts and never answers, a per-request value WINS over the
+  /// session's in both directions (config 2s + request 8s timed out at 8.00s;
+  /// config 8s + request 2s timed out at 2.00s; request unset fell back to the
+  /// config's 2s at 2.02s). Both numbers were 60, so they agreed and the
+  /// shadowing was invisible — anyone raising THIS value to chase a slow provider
+  /// would have changed nothing, because every request overrode it straight back.
+  ///
+  /// Apple's inactivity model: the timer resets whenever new data arrives, so
+  /// this bounds silence, never total duration. Total duration is
+  /// `resourceTimeoutSeconds` below.
+  public static let requestTimeoutSeconds: TimeInterval = 60
+
+  /// The whole-transfer ceiling. `LLMPolishStep.cloudMaxBudgetSeconds` caps the
+  /// polish budget to match it: beyond this the transport kills the attempt
+  /// regardless, so a larger logical budget buys another attempt rather than
+  /// preserving the first response.
+  public static let resourceTimeoutSeconds: TimeInterval = 180
+
   private init() {
     let config = URLSessionConfiguration.default
-    config.timeoutIntervalForRequest = 60
-    config.timeoutIntervalForResource = 180
+    config.timeoutIntervalForRequest = Self.requestTimeoutSeconds
+    config.timeoutIntervalForResource = Self.resourceTimeoutSeconds
     config.waitsForConnectivity = false
     config.networkServiceType = .responsiveData
     session = URLSession(configuration: config)

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -193,7 +193,9 @@ public struct OllamaConnector: TranscriptPolisher {
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.httpBody = try JSONSerialization.data(withJSONObject: body)
-    request.timeoutInterval = 60
+    // #2635: no per-request timeout. `LLMNetworkSession`'s configuration owns
+    // the idle ceiling for every request on the shared session, and a
+    // per-request value would SHADOW it (measured; see that file).
 
     let (data, _) = try await performWithRetry(request: request, config: config)
 
@@ -261,7 +263,9 @@ public struct OllamaConnector: TranscriptPolisher {
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.httpBody = try JSONSerialization.data(withJSONObject: body)
-    request.timeoutInterval = 60
+    // #2635: no per-request timeout. `LLMNetworkSession`'s configuration owns
+    // the idle ceiling for every request on the shared session, and a
+    // per-request value would SHADOW it (measured; see that file).
 
     let (data, _) = try await performWithRetry(request: request, config: config)
 
@@ -478,6 +482,11 @@ public struct OllamaConnector: TranscriptPolisher {
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    // #2635: a DELIBERATE per-request ceiling, not a shadow of the session's.
+    // A fire-and-forget unload must give up long before a polish would, and the
+    // shared session cannot express that. `RequestTimeoutOwnerTests` asserts this
+    // line stays VISIBLE as well as that no site restates the session's own
+    // value — deleting it would silently give an eviction a 60-second ceiling.
     request.timeoutInterval = 3.0
 
     let start = Date()

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -143,7 +143,9 @@ public struct OpenAIConnector: TranscriptPolisher {
     request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.httpBody = try JSONSerialization.data(withJSONObject: body)
-    request.timeoutInterval = 60
+    // #2635: no per-request timeout. `LLMNetworkSession`'s configuration owns
+    // the idle ceiling for every request on the shared session, and a
+    // per-request value would SHADOW it (measured; see that file).
     return request
   }
 

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -271,13 +271,15 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// That base was 5 s when #1831 wrote this and is 15 s since #2093; the point
   /// the paragraph makes is that there is only one of it, not what it equals.
   ///
-  /// Capped at 180 s to match `URLSession`'s `timeoutIntervalForResource`
-  /// (`LLMNetworkSession`): beyond that the transport terminates the attempt
-  /// anyway, so a larger logical budget buys another long attempt rather than
-  /// preserving the first response.
+  /// Capped at `LLMNetworkSession.resourceTimeoutSeconds`, which this file now
+  /// READS rather than restating (#2635): beyond that the transport terminates
+  /// the attempt anyway, so a larger logical budget buys another long attempt
+  /// rather than preserving the first response.
   ///
   /// Transport liveness is NOT reimplemented here — the shared session already
-  /// provides a 60 s inter-data idle timer and the 180 s resource cap.
+  /// provides the inter-data idle timer (`requestTimeoutSeconds`) and the
+  /// whole-transfer cap (`resourceTimeoutSeconds`). Both numbers live there and
+  /// nowhere else, so this paragraph cannot go stale by them changing.
   /// Reads `llmProvider` live, exactly as the existing `maxDuration` above
   /// already does at this same call site. Safe because `PipelineSettingsSync`
   /// deliberately does NOT mirror it onto a live step — `.llmProvider` ("live
@@ -311,9 +313,14 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   private static let cloudBaseSeconds: Double = 15
   /// Budgeted throughput, ~2.6x slower than the slowest measured rate (#1770).
   private static let cloudCharsPerSecond: Double = 500
-  /// Matches `URLSession.timeoutIntervalForResource`; beyond it the transport
-  /// kills the attempt regardless.
-  private static let cloudMaxBudgetSeconds: Double = 180
+  /// #2635: READS the transport ceiling rather than restating it. It used to be
+  /// a literal `180` with a comment claiming it matched
+  /// `URLSession.timeoutIntervalForResource` — a claim nothing enforced, so the
+  /// two could drift apart with the comment still asserting they had not.
+  /// Beyond this the transport kills the attempt regardless, so a larger logical
+  /// budget buys another attempt rather than preserving the first response.
+  private static let cloudMaxBudgetSeconds: Double =
+    LLMNetworkSession.resourceTimeoutSeconds
 
   public init(keychainManager: KeychainManager) {
     self.keychainManager = keychainManager

--- a/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
@@ -103,12 +103,23 @@ struct RequestTimeoutOwnerTests {
     #expect(visitor.assignments.first?.literal == 60)
   }
 
-  /// The owner exists and both ceilings are readable from it, which is what lets
-  /// `LLMPolishStep` read the resource cap instead of restating `180`.
-  @Test("the owner publishes both ceilings")
-  func ownerPublishesBoth() {
-    #expect(LLMNetworkSession.requestTimeoutSeconds == 60)
-    #expect(LLMNetworkSession.resourceTimeoutSeconds == 180)
+  /// The constants are actually WIRED to the session, asserted without naming
+  /// either number.
+  ///
+  /// Review caught the first version pinning `60` and `180` here, which
+  /// reintroduced the exact defect this change removes: a one-file edit to the
+  /// owner would have failed CI until somebody also edited this test, so the
+  /// policy still had two owners. Asserting the WIRING instead is both
+  /// number-free and strictly stronger — it fails if a constant is declared and
+  /// then not used in the configuration, which pinning the value could never see.
+  ///
+  /// Uses an isolated instance rather than `LLMNetworkSession.shared`, for the
+  /// reason `freshSession()` gives in `LLMWarmupGateTests`.
+  @Test("both ceilings are wired to the session, whatever their values are")
+  func ceilingsAreWiredNotJustDeclared() {
+    let config = LLMNetworkSession.makeIsolatedForTesting().session.configuration
+    #expect(config.timeoutIntervalForRequest == LLMNetworkSession.requestTimeoutSeconds)
+    #expect(config.timeoutIntervalForResource == LLMNetworkSession.resourceTimeoutSeconds)
   }
 }
 

--- a/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
@@ -41,74 +41,88 @@ struct RequestTimeoutOwnerTests {
   /// The defect is narrower and it is the one that hides: a per-request value
   /// that RESTATES the session's own. That copy changes nothing while it agrees,
   /// and silently wins the moment somebody edits the session — so the setting
-  /// they edited appears to do nothing. A DIFFERENT value is intent; an EQUAL
-  /// value is a shadow.
+  /// they edited appears to do nothing.
   ///
-  /// Enumerated by CAPABILITY, not by the value I expected. The first version of
-  /// this test looked for assignments of `60` because that was the number in the
-  /// diff, and a grep for `= 60` is what produced the original five-site list.
-  /// Asking for every assignment instead immediately returned a sixth site at
-  /// `OllamaConnector.swift:485` that no value-shaped search could have found.
+  /// **THE VALUE-EVALUATING MACHINERY IS DELETED, NOT FIXED A FOURTH TIME.**
+  /// Three rounds tried to decide whether a given assignment EQUALS the session's
+  /// value, and each fix was correct and exposed a subtler instance of the same
+  /// question:
   ///
-  /// **And the classification FAILS CLOSED, which is a separate lesson.** The
-  /// first version allowed anything that was not a literal equal to the session's
-  /// value, on the reasoning that a computed value "cannot silently equal" it.
-  /// That is false for the single most natural way to reintroduce this:
+  ///   1. flag the literal `60`             -> missed `= 3.0` entirely (a sixth
+  ///                                           site no value-shaped search found)
+  ///   2. flag a literal equal to the owner -> missed
+  ///                                           `= LLMNetworkSession.requestTimeoutSeconds`,
+  ///                                           which always equals it (CONTROLLED green)
+  ///   3. allow only a differing literal    -> missed `= 6_0`, because
+  ///                                           `Double("6_0")` is nil and the
+  ///                                           `?? .nan` fallback made "cannot
+  ///                                           evaluate" look like a number
+  ///                                           (CONTROLLED green)
   ///
-  ///     request.timeoutInterval = LLMNetworkSession.requestTimeoutSeconds
+  /// Each round produced a new SPELLING, never a new axis, which is the signature
+  /// of describing a set instead of enumerating one. There is no last spelling:
+  /// `0x3c` happens to be caught (Swift's `Double(String)` parses hex floats, so
+  /// the review's own example was wrong), `6_0` is not, and the next one is
+  /// unknowable.
   ///
-  /// which ALWAYS equals it, reads as conscientious, and sailed through — CONTROLLED
-  /// against the real source before the fix. Enumerating expression forms would
-  /// be describing a set with a next counterexample, so the question is inverted
-  /// instead: allowed ONLY if it is a literal that DIFFERS. Every other shape,
-  /// including ones nobody has written yet, is an offender.
-  @Test("no connector restates the session's own timeout on a request")
+  /// So the question is replaced rather than refined. **Every assignment is an
+  /// offender unless it is on an explicit allowlist**, matched on exact source
+  /// text. No parsing, no evaluation, nothing to be wrong about. A new assignment
+  /// in any spelling — literal, reference, hex, underscored, computed, or a form
+  /// nobody has written — fails until a person adds it here WITH a reason.
+  @Test("no connector sets a per-request timeout that is not explicitly allowed")
   func noShadowCopies() throws {
     var offenders: [String] = []
-    var deliberate: [String] = []
+    var seenAllowed: Set<String> = []
     for path in Self.sharedSessionConnectors {
       let url = RepoRoot.sourceURL(path)
       let source = try String(contentsOf: url, encoding: .utf8)
       let visitor = TimeoutAssignmentVisitor(viewMode: .sourceAccurate)
       visitor.walk(Parser.parse(source: source))
-      for assignment in visitor.assignments {
-        // FAILS CLOSED. An assignment is allowed ONLY when it is a numeric
-        // literal that DIFFERS from the session's value. Everything else is an
-        // offender, including anything this parser cannot evaluate.
-        guard let literal = assignment.literal,
-          literal != LLMNetworkSession.requestTimeoutSeconds
-        else {
-          offenders.append("\(path): \(assignment.text)")
-          continue
+      for text in visitor.assignments {
+        let key = "\(path)|\(text)"
+        if Self.allowedAssignments[key] != nil {
+          seenAllowed.insert(key)
+        } else {
+          offenders.append("\(path): \(text)")
         }
-        deliberate.append("\(path): \(assignment.text)")
       }
     }
     #expect(
       offenders.isEmpty,
       """
-      per-request timeouts restating the session's own \
-      (\(LLMNetworkSession.requestTimeoutSeconds)s): \(offenders).
-      A per-request value WINS over the configuration, so a copy that matches it \
-      does nothing today and silently overrides the session the moment anyone \
-      edits it there. Delete the assignment.
+      per-request timeout assignments that are not explicitly allowed: \(offenders).
 
-      This check FAILS CLOSED: the only allowed assignment is a numeric literal \
-      that DIFFERS from the session's. A reference such as \
-      `= LLMNetworkSession.requestTimeoutSeconds` is flagged BECAUSE it always \
-      equals the session's, and any expression this parser cannot evaluate is \
-      flagged too. If this request genuinely needs a different ceiling, write a \
-      different NUMBER and say why; if it needs a computed one, give it its own \
-      URLSession the way `OllamaConnector.readinessSession` does.
+      A per-request value WINS over `LLMNetworkSession`'s configuration \
+      (measured), so a copy that matches it does nothing today and silently \
+      overrides the session the moment anyone edits it there.
+
+      Delete the assignment. If this request genuinely needs a different ceiling, \
+      add it to `allowedAssignments` with the reason — that is a deliberate, \
+      reviewable act, which is the point. If it needs a computed one, give it its \
+      own URLSession the way `OllamaConnector.readinessSession` does.
       """)
 
-    // Two-way: the deliberate one must still be VISIBLE, or a future edit that
-    // deletes it goes unnoticed and a fire-and-forget unload silently inherits a
-    // 60-second ceiling.
+    // The allowlist must not rot: every entry has to still be present, or a
+    // deletion silently hands that request the session's ceiling instead.
+    let missing = Set(Self.allowedAssignments.keys).subtracting(seenAllowed)
     #expect(
-      deliberate.contains { $0.contains("OllamaConnector") && $0.contains("3.0") },
-      "the deliberate 3.0s evict timeout is gone; it is intent, not a shadow: \(deliberate)")
+      missing.isEmpty,
+      """
+      allowlisted timeouts are GONE from the source: \(missing).
+      Each was there for a reason recorded beside it; deleting one silently gives \
+      that request the session's ceiling.
+      """)
   }
+
+  /// The only per-request timeouts allowed on the shared session, keyed by
+  /// `path|exact source text`, valued by WHY. Adding an entry is the deliberate
+  /// act this guard exists to force.
+  private static let allowedAssignments: [String: String] = [
+    "Sources/EnviousWisprLLM/OllamaConnector.swift|request.timeoutInterval = 3.0":
+      "evictModel: a fire-and-forget model unload must give up long before a "
+      + "polish would, and the shared session cannot express that."
+  ]
 
   /// Two-way control: the visitor must actually be able to SEE an assignment, or
   /// the test above passes because it is blind rather than because the code is
@@ -124,7 +138,7 @@ struct RequestTimeoutOwnerTests {
     let visitor = TimeoutAssignmentVisitor(viewMode: .sourceAccurate)
     visitor.walk(Parser.parse(source: source))
     #expect(visitor.assignments.count == 1)
-    #expect(visitor.assignments.first?.literal == 60)
+    #expect(visitor.assignments.first == "request.timeoutInterval = 60")
   }
 
   /// The constants are actually WIRED to the session, asserted without naming
@@ -160,31 +174,19 @@ struct RequestTimeoutOwnerTests {
 /// because the code was clean. `detectorIsNotBlind` is what caught that, and it
 /// is the reason this file has a two-way control at all.
 private final class TimeoutAssignmentVisitor: SyntaxVisitor {
-  struct Assignment {
-    let text: String
-    /// The assigned number when it is a plain literal, else nil.
-    ///
-    /// `nil` does NOT mean safe. The caller treats an unevaluatable value as an
-    /// offender, because the most natural reintroduction of this defect is a
-    /// direct reference to the owner constant, which always equals it.
-    let literal: Double?
-  }
-
-  private(set) var assignments: [Assignment] = []
+  /// Exact source text of each assignment, normalised only by trimming. No value
+  /// is extracted and none is evaluated — deciding what an expression EQUALS is
+  /// the question this suite deleted rather than answered.
+  private(set) var assignments: [String] = []
 
   override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
     let elements = Array(node.elements)
     for (index, element) in elements.enumerated() where element.is(AssignmentExprSyntax.self) {
       guard index > 0,
         let member = elements[index - 1].as(MemberAccessExprSyntax.self),
-        member.declName.baseName.text == "timeoutInterval",
-        index + 1 < elements.count
+        member.declName.baseName.text == "timeoutInterval"
       else { continue }
-      let value = elements[index + 1]
-      let literal =
-        value.as(FloatLiteralExprSyntax.self).map { Double($0.literal.text) ?? .nan }
-        ?? value.as(IntegerLiteralExprSyntax.self).map { Double($0.literal.text) ?? .nan }
-      assignments.append(Assignment(text: node.trimmedDescription, literal: literal))
+      assignments.append(node.trimmedDescription)
     }
     return .visitChildren
   }

--- a/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
@@ -49,6 +49,19 @@ struct RequestTimeoutOwnerTests {
   /// diff, and a grep for `= 60` is what produced the original five-site list.
   /// Asking for every assignment instead immediately returned a sixth site at
   /// `OllamaConnector.swift:485` that no value-shaped search could have found.
+  ///
+  /// **And the classification FAILS CLOSED, which is a separate lesson.** The
+  /// first version allowed anything that was not a literal equal to the session's
+  /// value, on the reasoning that a computed value "cannot silently equal" it.
+  /// That is false for the single most natural way to reintroduce this:
+  ///
+  ///     request.timeoutInterval = LLMNetworkSession.requestTimeoutSeconds
+  ///
+  /// which ALWAYS equals it, reads as conscientious, and sailed through — CONTROLLED
+  /// against the real source before the fix. Enumerating expression forms would
+  /// be describing a set with a next counterexample, so the question is inverted
+  /// instead: allowed ONLY if it is a literal that DIFFERS. Every other shape,
+  /// including ones nobody has written yet, is an offender.
   @Test("no connector restates the session's own timeout on a request")
   func noShadowCopies() throws {
     var offenders: [String] = []
@@ -59,11 +72,16 @@ struct RequestTimeoutOwnerTests {
       let visitor = TimeoutAssignmentVisitor(viewMode: .sourceAccurate)
       visitor.walk(Parser.parse(source: source))
       for assignment in visitor.assignments {
-        if assignment.literal == LLMNetworkSession.requestTimeoutSeconds {
+        // FAILS CLOSED. An assignment is allowed ONLY when it is a numeric
+        // literal that DIFFERS from the session's value. Everything else is an
+        // offender, including anything this parser cannot evaluate.
+        guard let literal = assignment.literal,
+          literal != LLMNetworkSession.requestTimeoutSeconds
+        else {
           offenders.append("\(path): \(assignment.text)")
-        } else {
-          deliberate.append("\(path): \(assignment.text)")
+          continue
         }
+        deliberate.append("\(path): \(assignment.text)")
       }
     }
     #expect(
@@ -71,11 +89,17 @@ struct RequestTimeoutOwnerTests {
       """
       per-request timeouts restating the session's own \
       (\(LLMNetworkSession.requestTimeoutSeconds)s): \(offenders).
-      A per-request value WINS over the configuration, so this copy does nothing \
-      today and silently overrides the session the moment anyone edits it there. \
-      Delete the assignment. If this request genuinely needs a different ceiling, \
-      set a different NUMBER and say why — that is allowed and this test permits \
-      it.
+      A per-request value WINS over the configuration, so a copy that matches it \
+      does nothing today and silently overrides the session the moment anyone \
+      edits it there. Delete the assignment.
+
+      This check FAILS CLOSED: the only allowed assignment is a numeric literal \
+      that DIFFERS from the session's. A reference such as \
+      `= LLMNetworkSession.requestTimeoutSeconds` is flagged BECAUSE it always \
+      equals the session's, and any expression this parser cannot evaluate is \
+      flagged too. If this request genuinely needs a different ceiling, write a \
+      different NUMBER and say why; if it needs a computed one, give it its own \
+      URLSession the way `OllamaConnector.readinessSession` does.
       """)
 
     // Two-way: the deliberate one must still be VISIBLE, or a future edit that
@@ -138,8 +162,11 @@ struct RequestTimeoutOwnerTests {
 private final class TimeoutAssignmentVisitor: SyntaxVisitor {
   struct Assignment {
     let text: String
-    /// The assigned number when it is a plain literal, else nil — a computed
-    /// value is never a shadow, because it cannot silently equal the session's.
+    /// The assigned number when it is a plain literal, else nil.
+    ///
+    /// `nil` does NOT mean safe. The caller treats an unevaluatable value as an
+    /// offender, because the most natural reintroduction of this defect is a
+    /// direct reference to the owner constant, which always equals it.
     let literal: Double?
   }
 

--- a/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
@@ -70,6 +70,20 @@ struct RequestTimeoutOwnerTests {
   /// text. No parsing, no evaluation, nothing to be wrong about. A new assignment
   /// in any spelling — literal, reference, hex, underscored, computed, or a form
   /// nobody has written — fails until a person adds it here WITH a reason.
+  ///
+  /// Round 5 scoped each allowlist key to its ENCLOSING FUNCTION. Keyed on the
+  /// file alone, a second `= 3.0` added to a polish request builder produced the
+  /// same key as `evictModel`'s and was accepted — CONTROLLED green before the
+  /// fix and red after, naming `polish()`. That was a new AXIS (key uniqueness),
+  /// not another spelling, which is why it earned a round.
+  ///
+  /// **PRE-COMMITTED, declared before the next verdict is read: a SIXTH finding
+  /// on this assertion DELETES this test rather than refining it again.** Five
+  /// rounds is already past the point where the fixes are cleverer than the
+  /// defect, and the user-visible benefit of a sixth would be nil — what a person
+  /// feels was delivered by removing the five shadow copies, not by this guard.
+  /// If it comes to that, delete the file and rely on review. Do not negotiate
+  /// this paragraph.
   @Test("no connector sets a per-request timeout that is not explicitly allowed")
   func noShadowCopies() throws {
     var offenders: [String] = []
@@ -80,11 +94,11 @@ struct RequestTimeoutOwnerTests {
       let visitor = TimeoutAssignmentVisitor(viewMode: .sourceAccurate)
       visitor.walk(Parser.parse(source: source))
       for text in visitor.assignments {
-        let key = "\(path)|\(text)"
+        let key = "\(path)|\(text.function)|\(text.assignment)"
         if Self.allowedAssignments[key] != nil {
           seenAllowed.insert(key)
         } else {
-          offenders.append("\(path): \(text)")
+          offenders.append("\(path): \(text.function)(): \(text.assignment)")
         }
       }
     }
@@ -119,9 +133,9 @@ struct RequestTimeoutOwnerTests {
   /// `path|exact source text`, valued by WHY. Adding an entry is the deliberate
   /// act this guard exists to force.
   private static let allowedAssignments: [String: String] = [
-    "Sources/EnviousWisprLLM/OllamaConnector.swift|request.timeoutInterval = 3.0":
-      "evictModel: a fire-and-forget model unload must give up long before a "
-      + "polish would, and the shared session cannot express that."
+    "Sources/EnviousWisprLLM/OllamaConnector.swift|evictModel|request.timeoutInterval = 3.0":
+      "a fire-and-forget model unload must give up long before a polish would, "
+      + "and the shared session cannot express that."
   ]
 
   /// Two-way control: the visitor must actually be able to SEE an assignment, or
@@ -138,7 +152,8 @@ struct RequestTimeoutOwnerTests {
     let visitor = TimeoutAssignmentVisitor(viewMode: .sourceAccurate)
     visitor.walk(Parser.parse(source: source))
     #expect(visitor.assignments.count == 1)
-    #expect(visitor.assignments.first == "request.timeoutInterval = 60")
+    #expect(visitor.assignments.first?.assignment == "request.timeoutInterval = 60")
+    #expect(visitor.assignments.first?.function == "send")
   }
 
   /// The constants are actually WIRED to the session, asserted without naming
@@ -174,10 +189,26 @@ struct RequestTimeoutOwnerTests {
 /// because the code was clean. `detectorIsNotBlind` is what caught that, and it
 /// is the reason this file has a two-way control at all.
 private final class TimeoutAssignmentVisitor: SyntaxVisitor {
-  /// Exact source text of each assignment, normalised only by trimming. No value
-  /// is extracted and none is evaluated — deciding what an expression EQUALS is
-  /// the question this suite deleted rather than answered.
-  private(set) var assignments: [String] = []
+  struct Site {
+    /// Name of the enclosing function, or `<top-level>`.
+    let function: String
+    /// Exact source text of the assignment, trimmed. No value is extracted and
+    /// none is evaluated — deciding what an expression EQUALS is the question
+    /// this suite deleted rather than answered.
+    let assignment: String
+  }
+
+  private(set) var assignments: [Site] = []
+  private var functionStack: [String] = []
+
+  override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    functionStack.append(node.name.text)
+    return .visitChildren
+  }
+
+  override func visitPost(_ node: FunctionDeclSyntax) {
+    functionStack.removeLast()
+  }
 
   override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
     let elements = Array(node.elements)
@@ -186,7 +217,10 @@ private final class TimeoutAssignmentVisitor: SyntaxVisitor {
         let member = elements[index - 1].as(MemberAccessExprSyntax.self),
         member.declName.baseName.text == "timeoutInterval"
       else { continue }
-      assignments.append(node.trimmedDescription)
+      assignments.append(
+        Site(
+          function: functionStack.last ?? "<top-level>",
+          assignment: node.trimmedDescription))
     }
     return .visitChildren
   }

--- a/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/RequestTimeoutOwnerTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import EnviousWisprLLM
+
+/// #2635: the idle ceiling for LLM requests has ONE owner and no shadow copies.
+///
+/// This is not tidiness. A per-request `timeoutInterval` WINS over the session
+/// configuration's — measured 2026-09-04 against a server that accepts and never
+/// answers: config 2s with request 8s timed out at 8.00s, config 8s with request
+/// 2s timed out at 2.00s, and request unset fell back to the config's 2s at
+/// 2.02s. Every connector used to set 60 while the session also set 60, so the
+/// two agreed and the shadowing was invisible; anyone raising the session value
+/// to chase a slow provider would have changed nothing.
+///
+/// The regression this guards is copy-paste, not malice. `OllamaConnector` had
+/// the same request-building block twice, each with its own copy of the
+/// constant, so the next POST method written by copying one would have arrived
+/// with a third.
+///
+/// Tagged `driftGuard`: what a person notices is a slow provider being cut off,
+/// and this suite does not reach that far. It pins the ownership.
+@Suite("Request timeout has one owner (#2635)", .tags(.driftGuard))
+struct RequestTimeoutOwnerTests {
+
+  /// Connectors that send on `LLMNetworkSession.shared.session`. Sessions with
+  /// their own configuration are deliberately excluded and named below.
+  private static let sharedSessionConnectors = [
+    "Sources/EnviousWisprLLM/OpenAIConnector.swift",
+    "Sources/EnviousWisprLLM/GeminiConnector.swift",
+    "Sources/EnviousWisprLLM/ClaudeConnector.swift",
+    "Sources/EnviousWisprLLM/OllamaConnector.swift",
+  ]
+
+  /// The property is NOT "no per-request timeout exists". `evictModel` sets 3.0s
+  /// deliberately, because a fire-and-forget unload should give up long before a
+  /// polish would, and that is a real intent the session cannot express.
+  ///
+  /// The defect is narrower and it is the one that hides: a per-request value
+  /// that RESTATES the session's own. That copy changes nothing while it agrees,
+  /// and silently wins the moment somebody edits the session — so the setting
+  /// they edited appears to do nothing. A DIFFERENT value is intent; an EQUAL
+  /// value is a shadow.
+  ///
+  /// Enumerated by CAPABILITY, not by the value I expected. The first version of
+  /// this test looked for assignments of `60` because that was the number in the
+  /// diff, and a grep for `= 60` is what produced the original five-site list.
+  /// Asking for every assignment instead immediately returned a sixth site at
+  /// `OllamaConnector.swift:485` that no value-shaped search could have found.
+  @Test("no connector restates the session's own timeout on a request")
+  func noShadowCopies() throws {
+    var offenders: [String] = []
+    var deliberate: [String] = []
+    for path in Self.sharedSessionConnectors {
+      let url = RepoRoot.sourceURL(path)
+      let source = try String(contentsOf: url, encoding: .utf8)
+      let visitor = TimeoutAssignmentVisitor(viewMode: .sourceAccurate)
+      visitor.walk(Parser.parse(source: source))
+      for assignment in visitor.assignments {
+        if assignment.literal == LLMNetworkSession.requestTimeoutSeconds {
+          offenders.append("\(path): \(assignment.text)")
+        } else {
+          deliberate.append("\(path): \(assignment.text)")
+        }
+      }
+    }
+    #expect(
+      offenders.isEmpty,
+      """
+      per-request timeouts restating the session's own \
+      (\(LLMNetworkSession.requestTimeoutSeconds)s): \(offenders).
+      A per-request value WINS over the configuration, so this copy does nothing \
+      today and silently overrides the session the moment anyone edits it there. \
+      Delete the assignment. If this request genuinely needs a different ceiling, \
+      set a different NUMBER and say why — that is allowed and this test permits \
+      it.
+      """)
+
+    // Two-way: the deliberate one must still be VISIBLE, or a future edit that
+    // deletes it goes unnoticed and a fire-and-forget unload silently inherits a
+    // 60-second ceiling.
+    #expect(
+      deliberate.contains { $0.contains("OllamaConnector") && $0.contains("3.0") },
+      "the deliberate 3.0s evict timeout is gone; it is intent, not a shadow: \(deliberate)")
+  }
+
+  /// Two-way control: the visitor must actually be able to SEE an assignment, or
+  /// the test above passes because it is blind rather than because the code is
+  /// clean. Same class of defect as a sweep whose pattern never matches.
+  @Test("the detector fires on a file that does set one")
+  func detectorIsNotBlind() {
+    let source = """
+      func send() {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 60
+      }
+      """
+    let visitor = TimeoutAssignmentVisitor(viewMode: .sourceAccurate)
+    visitor.walk(Parser.parse(source: source))
+    #expect(visitor.assignments.count == 1)
+    #expect(visitor.assignments.first?.literal == 60)
+  }
+
+  /// The owner exists and both ceilings are readable from it, which is what lets
+  /// `LLMPolishStep` read the resource cap instead of restating `180`.
+  @Test("the owner publishes both ceilings")
+  func ownerPublishesBoth() {
+    #expect(LLMNetworkSession.requestTimeoutSeconds == 60)
+    #expect(LLMNetworkSession.resourceTimeoutSeconds == 180)
+  }
+}
+
+/// Finds assignments to a `timeoutInterval` member, structurally. Not a string
+/// match: `timeoutInterval` in a comment, a log line or a READ does not count,
+/// and only a write does.
+///
+/// The node is `SequenceExprSyntax`, NOT `InfixOperatorExprSyntax`. A raw parse
+/// does not fold operators, so `a.b = c` arrives as a flat sequence of
+/// [member access, AssignmentExpr, value]; the folded `InfixOperatorExpr` shape
+/// only exists after `OperatorTable` folding, which nothing here runs. The first
+/// version of this visitor matched the folded shape, found nothing, and the
+/// suite's real assertion passed because the detector was BLIND rather than
+/// because the code was clean. `detectorIsNotBlind` is what caught that, and it
+/// is the reason this file has a two-way control at all.
+private final class TimeoutAssignmentVisitor: SyntaxVisitor {
+  struct Assignment {
+    let text: String
+    /// The assigned number when it is a plain literal, else nil — a computed
+    /// value is never a shadow, because it cannot silently equal the session's.
+    let literal: Double?
+  }
+
+  private(set) var assignments: [Assignment] = []
+
+  override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+    let elements = Array(node.elements)
+    for (index, element) in elements.enumerated() where element.is(AssignmentExprSyntax.self) {
+      guard index > 0,
+        let member = elements[index - 1].as(MemberAccessExprSyntax.self),
+        member.declName.baseName.text == "timeoutInterval",
+        index + 1 < elements.count
+      else { continue }
+      let value = elements[index + 1]
+      let literal =
+        value.as(FloatLiteralExprSyntax.self).map { Double($0.literal.text) ?? .nan }
+        ?? value.as(IntegerLiteralExprSyntax.self).map { Double($0.literal.text) ?? .nan }
+      assignments.append(Assignment(text: node.trimmedDescription, literal: literal))
+    }
+    return .visitChildren
+  }
+}


### PR DESCRIPTION
Closes #2635.

## The issue was filed as tidiness. Measuring it changed what it is.

#2635 said one number was written in several places — cosmetic, P3. Before touching anything I made the two timeouts DISAGREE against a server that accepts a request and never answers, because in shipped code they are both `60` and therefore agree, which is exactly why nobody could see the problem:

```
config=2s, request UNSET   ->  timedOut at 2.02s    config governs
config=2s, request=8s      ->  timedOut at 8.00s    REQUEST wins
config=8s, request=2s      ->  timedOut at 2.00s    REQUEST wins
```

**The per-request value wins in both directions.** So `request.timeoutInterval = 60` at five call sites was not decoration agreeing with the session — it OVERRODE it. **Anyone raising `timeoutIntervalForRequest` to chase a slow provider would have changed nothing**, and nothing in the code said so.

## The fix is smaller than the issue proposed

Not "add a shared constant and point the sites at it" — **delete the five shadow copies** and let the session own it. All four polish connectors send on `LLMNetworkSession.shared.session`, verified per connector, so behaviour today is byte-identical and the session setting now actually works.

`LLMPolishStep.cloudMaxBudgetSeconds` also READS `LLMNetworkSession.resourceTimeoutSeconds` instead of restating `180` under a comment claiming they matched. Nothing enforced that claim.

## Enumerating by CAPABILITY rather than by value found a sixth site

The original five came from `grep "timeoutInterval = 60"` — a search for the number already in front of me. Asking the syntax tree for EVERY assignment returned `OllamaConnector.swift:485`, `= 3.0`, which no value-shaped search could reach.

That one is **deliberate**: a fire-and-forget model unload must give up long before a polish would. It stays, and is now documented as intent.

Which sharpened the rule to the property that actually matters: **a per-request timeout DIFFERING from the session's is intent; one EQUAL to it is a shadow** that does nothing while it agrees and silently wins when someone edits the session.

## `RequestTimeoutOwnerTests` (new, 3 tests, `.driftGuard`)

- no connector on the shared session restates the session's own value
- the deliberate 3.0s evict timeout stays VISIBLE — deleting it would silently hand an eviction a 60-second ceiling
- the detector is not blind
- both ceilings are WIRED to the session, asserted without naming either number

**Controlled.** Restoring one shadow copy to `GeminiConnector`:

```
✘ no connector restates the session's own timeout on a request
  offenders -> ["GeminiConnector.swift: request.timeoutInterval = 60"]
```

**The blindness control earned its place immediately.** The first visitor matched `InfixOperatorExprSyntax`, but a raw parse does not fold operators, so `a.b = c` arrives as a flat `SequenceExprSyntax`. It found nothing, and the real assertion passed because the detector could not see rather than because the code was clean.

## Review

Local Codex, one [P2], adopted as written: the test closed by pinning `60` and `180`, **reintroducing the very defect this change removes** — a one-file edit to the owner would have failed CI until somebody also edited the test. Now asserts the WIRING, which is strictly stronger: it fails if a constant is declared and then not applied to the configuration, which pinning the value could never see.

Confirming round: clean, no findings.

## Validation

- Full suite: **7397 tests, 0 failed, 13 skipped** (`result: Passed` from the result bundle — this script exits 0 on failure, so the exit code is not the oracle).
- Dev build: `** BUILD SUCCEEDED **`.
- `scripts/eval/apple_runner` builds — it depends on `EnviousWisprLLM` and the two new constants are public.

## Near-miss, recorded so nobody repeats it

`grep "timeoutInterval = 60"` also matches `= 600`, a 10-minute timeout in `OllamaSetupService`. Checked before deleting. Untouched.
