### PR TITLE
chore(validation): point the Codex review stubs at the wrapper, not a stale launcher

### DIFF
--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -556,8 +556,8 @@ case "$DECLARED" in
     else
       cat > "$RUN_DIR/codex-prose.txt" <<EOF
 [STUB — caller must overwrite]
-Run: ~/.claude/bin/codex-5.6-sol review --base origin/main > $RUN_DIR/codex-prose.txt
-(fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-prose.txt)
+Run: ~/.claude/bin/codex-run $RUN_DIR/codex-prose.txt review --base origin/main
+(usage-limit fallback: see ~/.claude/knowledge/ai/codex-cli.md — never a bare launcher, never a > redirect)
 Then re-run scripts/validate-pr.sh OR call scripts/attest.sh codex-prose "what I observed"
 EOF
       record_step "codex-prose" 1 "Stage 1 stub — caller must run 'codex review' and overwrite codex-prose.txt + attest"
@@ -579,8 +579,8 @@ esac
 echo "==> Phase 3.4: Codex code-diff review (caller's responsibility; MUST be clean BEFORE the smoke + Live UAT rebuild above — script not auto-invoking)"
 if [ ! -s "$RUN_DIR/codex-review.txt" ] && [ "$DECLARED" = "Code" ]; then
   cat > "$RUN_DIR/codex-review-todo.txt" <<EOF
-Run: ~/.claude/bin/codex-5.6-sol review --base origin/main > $RUN_DIR/codex-review.txt
-(fallback if usage-capped: ~/.claude/bin/codex-5.3-spark review --base origin/main > $RUN_DIR/codex-review.txt)
+Run: ~/.claude/bin/codex-run $RUN_DIR/codex-review.txt review --base origin/main
+(usage-limit fallback: see ~/.claude/knowledge/ai/codex-cli.md — never a bare launcher, never a > redirect)
 EOF
   record_step "codex-review" 1 "Stage 1 stub — caller must run codex review and overwrite codex-review.txt"
 fi


### PR DESCRIPTION
## What

`scripts/validate-pr.sh` writes two instruction stubs into the run directory telling the caller exactly which command to run for the Phase 3.3 prose review and the Phase 3.4 code-diff review. Both named `~/.claude/bin/codex-5.6-sol` with a `> $RUN_DIR/...` redirect.

## Why it was wrong

1. **Stale model.** The primary Codex model became `codex-6-astra` on 2026-09-04 (founder decision). A session obeying the stub silently reviews on the fallback model.
2. **A bare launcher call is denied.** `check-bash-background-pattern.sh` blocks bare `codex exec` / `codex review`; the founder mandate since 2026-07-21 routes every call through `~/.claude/bin/codex-run`, which detects stalls and proves the answer landed.
3. **The `>` redirect is wrong for the wrapper.** `codex-run` takes the outfile as its first argument and writes the transcript itself.

## What changed

Both stubs now emit the `codex-run` form and point at `~/.claude/knowledge/ai/codex-cli.md` for usage-limit fallback, instead of hardcoding a launcher name that goes stale on every model bump.

No behaviour change in the script: these are heredoc bodies written to the run directory as instructions for the caller.

## Lane

`Code` (tracked `scripts/`). Diff is four lines inside two heredocs; no control flow, no new symbols.

## How it was found

A grounded Codex review of the model cutover, asked to enumerate model-selecting sites from the producing code rather than from the list I handed it. This file was outside the list.

## Validation

- `~/.claude/tests/codex-run.test.sh` — 75 passed, 0 failed (includes three new assertions that the default launcher is Astra at medium effort)
- `~/.claude/tests/codex-hook-contract.test.sh` — 94 passed, 0 failed
- `~/.claude/tests/check-bash-background-pattern.test.sh` — 87 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACr9tdPmZ9WMzJ198rCCqc
