### PR TITLE
feat(paste): count how many copies of a dictation land, and the bench that found why the web gate misses (#2652)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -31,6 +31,45 @@ import Foundation
 @MainActor
 public enum KernelDictationDriverFactory {
 
+  /// The delivery policy every production dictation runs under (#2652).
+  ///
+  /// **Release is a literal baseline with no path to anything else.** The bake-off's
+  /// other policies do not exist in a release binary — their enum cases are compiled
+  /// out — so this is not a switch a user could flip, an environment variable they could
+  /// set, or a string an artifact scan could find.
+  ///
+  /// Resolved ONCE, lazily, and held for the process lifetime. Resolving per delivery
+  /// would let a variant change mid-run and make a scored row describe two policies;
+  /// resolving once means the harness's "relaunch to change variant" rule is enforced by
+  /// construction rather than by the harness remembering to.
+  ///
+  /// A rejection is LOGGED rather than swallowed. A bake-off that quietly ran the
+  /// baseline while the harness believed it was measuring V2 would produce a scorecard
+  /// full of confident rows about a policy that never ran, and nothing downstream could
+  /// tell. That is the one failure the whole control plane exists to prevent.
+  static let pasteDeliveryPolicy: PasteDeliveryPolicy = {
+    #if DEBUG
+      let resolved = PasteDeliveryPolicy.resolve(environment: ProcessInfo.processInfo.environment)
+      PasteCascadeExecutor.bakeoffRunID = resolved.runID
+      if let rejection = resolved.rejection {
+        Task {
+          await AppLogger.shared.log(
+            "PASTE_BAKEOFF_CONTROL rejected: \(rejection)", level: .info,
+            category: "PipelineTiming")
+        }
+      } else if !resolved.policy.isBaseline, let runID = resolved.runID {
+        Task { [id = resolved.policy.id] in
+          await AppLogger.shared.log(
+            "PASTE_BAKEOFF_CONTROL run_id=\(runID) variant=\(id)", level: .info,
+            category: "PipelineTiming")
+        }
+      }
+      return resolved.policy
+    #else
+      return .baseline
+    #endif
+  }()
+
   /// Heart-path infrastructure-error sink. Defaults to the global
   /// `SentryBreadcrumb.captureError` so production behavior is byte-identical;
   /// tests inject a per-instance spy/no-op closure so a pipeline-under-test
@@ -300,6 +339,17 @@ public enum KernelDictationDriverFactory {
   /// Build the driver stack for the Parakeet engine and arm both observation
   /// arms before returning. Live App caller in `EnviousWisprApp`.
   package static func makeForParakeet(inputs: ParakeetInputs) -> KernelDictationDriver {
+    // Resolve the delivery policy HERE, while the driver is being built, not lazily on
+    // the first paste. A `static let` is lazy, so without this touch the control line
+    // that proves which policy a process resolved would not appear until a dictation had
+    // already been delivered — and the harness that waits for it before running any
+    // trial would time out on a perfectly healthy launch. Measured 2026-09-04: the
+    // environment variables reached the process and the line still never came.
+    //
+    // Resolving at construction also makes "immutable for the process lifetime" true at
+    // the moment the harness checks it, rather than true eventually.
+    _ = Self.pasteDeliveryPolicy
+
     // PR-6 (#827): concrete adapter construction is owned by
     // `KernelAdapterFactory` (the single construction site). This file no
     // longer names a concrete adapter type in code (EngineIdentityFreezeTests
@@ -331,6 +381,17 @@ public enum KernelDictationDriverFactory {
   /// invariant inverts to `makeForWhisperKitHasExactlyOneProductionCaller`
   /// (locked in the same architecture freeze file).
   package static func makeForWhisperKit(inputs: WhisperKitInputs) -> KernelDictationDriver {
+    // Resolve the delivery policy HERE, while the driver is being built, not lazily on
+    // the first paste. A `static let` is lazy, so without this touch the control line
+    // that proves which policy a process resolved would not appear until a dictation had
+    // already been delivered — and the harness that waits for it before running any
+    // trial would time out on a perfectly healthy launch. Measured 2026-09-04: the
+    // environment variables reached the process and the line still never came.
+    //
+    // Resolving at construction also makes "immutable for the process lifetime" true at
+    // the moment the harness checks it, rather than true eventually.
+    _ = Self.pasteDeliveryPolicy
+
     // PR-5 Rung 4.5 (#827): plumb the audio-capture session-id source to the
     // adapter so it can snapshot at `beginSession` (race-safe for delayed LID
     // perf signposts like `t_clipboard_write`).
@@ -494,7 +555,8 @@ public enum KernelDictationDriverFactory {
       // omission; this is the production wiring, so here it is passed
       // explicitly. Same shape as the required seam two hundred lines above.
       deliverPaste: { request in
-        await PasteCascadeExecutor(pasteboard: .general).deliver(request)
+        await PasteCascadeExecutor(pasteboard: .general, policy: Self.pasteDeliveryPolicy)
+          .deliver(request)
       },
       pasteCompletionRegistry: pasteCompletionRegistry,
       // #950 — share the SAME telemetry state the kernel stamps so the metrics

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -555,8 +555,39 @@ public enum KernelDictationDriverFactory {
       // omission; this is the production wiring, so here it is passed
       // explicitly. Same shape as the required seam two hundred lines above.
       deliverPaste: { request in
-        await PasteCascadeExecutor(pasteboard: .general, policy: Self.pasteDeliveryPolicy)
-          .deliver(request)
+        // #2652. SNAPSHOT the take id BEFORE the await. `KernelTelemetryState.takeID` is mutable
+        // and reset per accepted session, so reading it after the observation's settle window
+        // could attribute this delivery's copies to the NEXT dictation.
+        let takeIDAtDelivery = telemetryState.takeID
+        let result = await PasteCascadeExecutor(
+          pasteboard: .general, policy: Self.pasteDeliveryPolicy
+        ).deliver(request)
+        // Scheduled AFTER delivery has returned and its latency is finalised, so the
+        // observation's own work cannot land inside a delivery metric. It reports and returns
+        // nothing: there is no caller decision to make on a measurement.
+        if let takeIDAtDelivery {
+          PasteCopiesObserver.schedule(
+            evidence: result.copiesEvidence,
+            targetBundleID: request.targetApp?.bundleIdentifier,
+            gate: .shared
+          ) { observation in
+            // The measurement is finished before this hop, so nothing accessibility-related runs
+            // on the main actor. Only the reporting does, because `TelemetryService` is
+            // main-actor isolated.
+            Task { @MainActor in
+              TelemetryService.shared.pasteCopiesObserved(
+                takeID: takeIDAtDelivery,
+                copiesEstimate: observation.estimate.rawValue,
+                status: observation.status.rawValue,
+                detectorVersion: observation.detectorVersion,
+                settleMs: PasteCopiesObserver.settleMilliseconds,
+                tier: result.pasteTierLabel,
+                targetApp: request.targetApp?.bundleIdentifier,
+                tier1ReachedSetter: result.copiesEvidence != nil)
+            }
+          }
+        }
+        return result
       },
       pasteCompletionRegistry: pasteCompletionRegistry,
       // #950 — share the SAME telemetry state the kernel stamps so the metrics

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -583,7 +583,7 @@ public enum KernelDictationDriverFactory {
                 settleMs: PasteCopiesObserver.settleMilliseconds,
                 tier: result.pasteTierLabel,
                 targetApp: request.targetApp?.bundleIdentifier,
-                tier1ReachedSetter: result.copiesEvidence != nil)
+                tier1ReachedSetter: result.copiesSetterReached)
             }
           }
         }

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -76,6 +76,35 @@ internal enum PasteDeliveryOutcome: Equatable, Sendable {
   )
 }
 
+/// Everything the copies observation needs, and nothing it could write with (#2652).
+///
+/// `@unchecked Sendable` for the `AXUIElement`, matching the house precedent at
+/// `PasteService.logElementDiagnostics`, which captures one with `nonisolated(unsafe)` to run its
+/// reads off the caller's thread.
+///
+/// `submittedLengths` holds EVERY attempt's UTF-16 length, never the winner's alone. Routes choose
+/// their payload separately, so when the attempts disagree there is no single length the
+/// arithmetic can be about and the observation must decline rather than pick one.
+package struct PasteCopiesEvidence: @unchecked Sendable {
+  package let element: AXUIElement
+  package let before: PasteService.CopiesBeforeImage
+  package let submittedLengths: [Int]
+
+  package init(
+    element: AXUIElement, before: PasteService.CopiesBeforeImage, submittedLengths: [Int]
+  ) {
+    self.element = element
+    self.before = before
+    self.submittedLengths = submittedLengths
+  }
+
+  /// The one length the observation may use, or nil when the attempts disagree.
+  package var unambiguousSubmittedLength: Int? {
+    let distinct = Set(submittedLengths)
+    return distinct.count == 1 ? distinct.first : nil
+  }
+}
+
 /// Result of a paste delivery operation.
 internal struct PasteDeliveryResult {
   let tier: PasteTier
@@ -89,6 +118,9 @@ internal struct PasteDeliveryResult {
   /// answers as one token. Nil when Tier 1 delivered.
   var axDeclineReason: String?
   var axSettability: String?
+  /// #2652. Non-nil only where Tier 1 reached its setter, so the before-image exists without any
+  /// read having been added for it. Nil is reported as `no_before_image`, never as one copy.
+  var copiesEvidence: PasteCopiesEvidence?
 
   var pasteTierLabel: String {
     if case .clipboardOnlyAccessibilityDenied = outcome {
@@ -531,21 +563,14 @@ internal final class PasteCascadeExecutor {
       // AFTER delivery — see `resumeAncestorChainTrace`.
       var webGateTrace: PasteService.AXWebAreaAncestryTrace?
 
-      // The before-image the copies detector is judged against (#2652). Read HERE,
-      // before any writer runs, because after the first write there is no longer a
-      // before to read and the count alone cannot say how many copies made it.
-      var copiesCountBefore: Int?
-      var copiesSelectionLengthBefore = 0
-      // The UTF-16 length actually handed to the winning writer. Recorded AT the
-      // submission rather than re-derived at the end: `repairedText` is optional and
-      // which of the two strings went out is decided inside the write, so re-deriving
-      // it here would be a second opinion about a question already answered.
-      var copiesSubmittedLength: Int?
-      if !policy.isBaseline, let element = request.targetElement {
-        copiesCountBefore = PasteService.characterCount(of: element)
-        copiesSelectionLengthBefore = PasteService.selectedTextLength(of: element) ?? 0
-      }
     #endif
+
+    // #2652. The before-image comes ONLY from reads Tier 1 already performs, and the lengths from
+    // the attempts themselves. Nothing here reads the destination: an added pre-write AX round trip
+    // would land on the delivery path, against a destination whose slow round trip is the suspected
+    // cause of the very defect being measured.
+    var copiesBeforeImage: PasteService.CopiesBeforeImage?
+    var copiesSubmittedLengths: [Int] = []
     let skipTier1ForWebContent: Bool = {
       #if DEBUG
         guard policy.writer == .webCmdV, let element = request.targetElement else { return false }
@@ -570,12 +595,13 @@ internal final class PasteCascadeExecutor {
         element: element,
         requireFocusedElementMatch: request.targetElementIsRetried,
         boundMessagingTimeout: policy.boundTier1MessagingTimeout)
-      #if DEBUG
-        if let attempted = insert.writeCall.attemptedText {
+      copiesBeforeImage = insert.copiesBeforeImage
+      if let attempted = insert.writeCall.attemptedText {
+        copiesSubmittedLengths.append(attempted.utf16.count)
+        #if DEBUG
           submissionLedger.append(submissionToken(tier: .axDirect, text: attempted))
-          copiesSubmittedLength = attempted.utf16.count
-        }
-      #endif
+        #endif
+      }
       let disposition = dispositionForAXDirect(insert, writerPolicy: policy.writer)
       submittedKind = insert.submitted
       axDeclineReason = insert.declineReason
@@ -657,9 +683,9 @@ internal final class PasteCascadeExecutor {
             ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
             : { ClipboardCleanup.deliveryClaimsBoard(); return nil }()
           submittedKind = payload.kind
+          copiesSubmittedLengths.append(payload.text.utf16.count)
           #if DEBUG
             submissionLedger.append(submissionToken(tier: .cgEvent, text: payload.text))
-            copiesSubmittedLength = payload.text.utf16.count
           #endif
           let dispatchResult = PasteService.pasteToActiveApp(
             payload.text, to: self.pasteboard)
@@ -667,17 +693,6 @@ internal final class PasteCascadeExecutor {
           switch dispatchResult {
           case .dispatched:
             tier = .cgEvent
-            #if DEBUG
-              // V6 ONLY: stage the reported defect on purpose, so the copies detector
-              // below has a positive control. Every Mac we own delivers exactly one
-              // copy, so without this the detector could be wired to a constant and
-              // three hundred `once` readings would look like proof.
-              if policy.writer == .deliberateDouble {
-                submissionLedger.append(submissionToken(tier: .cgEvent, text: payload.text))
-                copiesSubmittedLength = payload.text.utf16.count
-                _ = PasteService.pasteToActiveApp(payload.text, to: self.pasteboard)
-              }
-            #endif
           case .cgEventCreationFailed(let accessibilityTrusted, _):
             cgEventFailureAccessibilityTrusted = accessibilityTrusted
             tierFailures["cgevent"] = "creation_failed (ax_trusted=\(accessibilityTrusted))"
@@ -727,9 +742,9 @@ internal final class PasteCascadeExecutor {
           ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
           : { ClipboardCleanup.deliveryClaimsBoard(); return nil }()
         submittedKind = payload.kind
+        copiesSubmittedLengths.append(payload.text.utf16.count)
         #if DEBUG
           submissionLedger.append(submissionToken(tier: .appleScript, text: payload.text))
-          copiesSubmittedLength = payload.text.utf16.count
         #endif
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
           payload.text, to: self.pasteboard)
@@ -810,9 +825,9 @@ internal final class PasteCascadeExecutor {
           requireCaretUnchanged: request.targetElementIsRetried,
           terminalBudget: request.terminalBudget)
         submittedKind = payload.kind
+        copiesSubmittedLengths.append(payload.text.utf16.count)
         #if DEBUG
           submissionLedger.append(submissionToken(tier: .menuPaste, text: payload.text))
-          copiesSubmittedLength = payload.text.utf16.count
         #endif
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
           payload.text, to: self.pasteboard)
@@ -938,35 +953,6 @@ internal final class PasteCascadeExecutor {
         // The gate evidence rides on the DELIVERY line rather than on a line of its own.
         // Two independently scheduled log lines have to be joined by timestamp, and a
         // mis-join produces a confident wrong tabulation with nothing to show for it.
-        // HOW MANY COPIES ARRIVED, measured from lengths and never from the text.
-        //
-        // Read after a settle window because the destination has not finished applying
-        // the write when the cascade returns — the same lag that makes the Tier 1
-        // verification answer `noMutation` on a write that landed. Reading immediately
-        // would reproduce the defect inside its own detector.
-        var copiesEvidence = " copies=not_measured"
-        if let element = request.targetElement, let before = copiesCountBefore,
-          tier != .clipboardOnly
-        {
-          try? await Task.sleep(for: .milliseconds(400))
-          let after = PasteService.characterCount(of: element)
-          let copies = PasteService.copiesDelivered(
-            countAfter: after,
-            countBefore: before,
-            selectionLengthBefore: copiesSelectionLengthBefore,
-            insertedLength: copiesSubmittedLength ?? 0)
-          // The raw readings ride along while this is being proved. `unknown` has three
-          // causes that demand different answers — the field will not report a count, the
-          // destination rewrote the text so the arithmetic cannot hold, or a real double —
-          // and a bare `unknown` cannot tell them apart.
-          copiesEvidence =
-            " copies=\(copies.map(String.init) ?? "unknown")"
-            + " copies_raw=before:\(before)"
-            + ",sel:\(copiesSelectionLengthBefore)"
-            + ",sent:\(copiesSubmittedLength.map(String.init) ?? "nil")"
-            + ",after:\(after.map(String.init) ?? "unreadable")"
-        }
-
         var gateEvidence = ""
         if let trace = webGateTrace {
           let extended = PasteService.resumeAncestorChainTrace(trace, maxExamined: 60)
@@ -976,11 +962,11 @@ internal final class PasteCascadeExecutor {
             + " roles=\(extended.roles.joined(separator: ">"))"
             + " target=\(targetDiagnostics)"
         }
-        Task { [runID = Self.bakeoffRunID, variant = policy.id, gateEvidence, copiesEvidence] in
+        Task { [runID = Self.bakeoffRunID, variant = policy.id, gateEvidence] in
           await AppLogger.shared.log(
             "PASTE_BAKEOFF_TRIAL run_id=\(runID ?? "none") variant=\(variant) "
               + "tier=\(tier.rawValue) app=\(bundleId) attempts=\(attempts) "
-              + "ledger=\(ledger) duration=\(durationMs)ms" + copiesEvidence + gateEvidence,
+              + "ledger=\(ledger) duration=\(durationMs)ms" + gateEvidence,
             level: .info, category: "PipelineTiming"
           )
         }
@@ -1021,9 +1007,19 @@ internal final class PasteCascadeExecutor {
       axDeclineReason: axDeclineReason?.rawValue,
       axSettability: axSettability?.telemetryValue)
 
-    return PasteDeliveryResult(
+    // #2652. Evidence only where Tier 1 reached its setter AND the delivery put something in a
+    // field. A `clipboardOnly` delivery submitted nothing to the destination, so there is nothing
+    // to have arrived once or twice; it is reported as `no_before_image`, never as one copy.
+    var result = PasteDeliveryResult(
       tier: tier, durationMs: durationMs, outcome: outcome, submittedPayload: submittedKind,
       axDeclineReason: axDeclineReason?.rawValue, axSettability: axSettability?.telemetryValue)
+    if let before = copiesBeforeImage, let element = request.targetElement,
+      tier != .clipboardOnly, !copiesSubmittedLengths.isEmpty
+    {
+      result.copiesEvidence = PasteCopiesEvidence(
+        element: element, before: before, submittedLengths: copiesSubmittedLengths)
+    }
+    return result
   }
 
   /// #729 Tier 2c menu-paste probe outcome. Drives `paste.focus_class`.

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -121,6 +121,8 @@ internal struct PasteDeliveryResult {
   /// #2652. Non-nil only where Tier 1 reached its setter, so the before-image exists without any
   /// read having been added for it. Nil is reported as `no_before_image`, never as one copy.
   var copiesEvidence: PasteCopiesEvidence?
+  /// #2652. Whether the Tier 1 accessibility SETTER ran. Narrower than "evidence exists".
+  var copiesSetterReached = false
 
   var pasteTierLabel: String {
     if case .clipboardOnlyAccessibilityDenied = outcome {
@@ -571,6 +573,10 @@ internal final class PasteCascadeExecutor {
     // cause of the very defect being measured.
     var copiesBeforeImage: PasteService.CopiesBeforeImage?
     var copiesSubmittedLengths: [Int] = []
+    /// Whether the Tier 1 SETTER ran, which is a narrower claim than "Tier 1 was attempted"
+    /// and narrower again than "a before-image exists". Read from `writeCall`, never inferred
+    /// from the presence of evidence.
+    var copiesSetterReached = false
     let skipTier1ForWebContent: Bool = {
       #if DEBUG
         guard policy.writer == .webCmdV, let element = request.targetElement else { return false }
@@ -596,6 +602,8 @@ internal final class PasteCascadeExecutor {
         requireFocusedElementMatch: request.targetElementIsRetried,
         boundMessagingTimeout: policy.boundTier1MessagingTimeout)
       copiesBeforeImage = insert.copiesBeforeImage
+      if case .succeeded = insert.writeCall { copiesSetterReached = true }
+      if case .failed = insert.writeCall { copiesSetterReached = true }
       if let attempted = insert.writeCall.attemptedText {
         copiesSubmittedLengths.append(attempted.utf16.count)
         #if DEBUG
@@ -1007,17 +1015,28 @@ internal final class PasteCascadeExecutor {
       axDeclineReason: axDeclineReason?.rawValue,
       axSettability: axSettability?.telemetryValue)
 
-    // #2652. Evidence only where Tier 1 reached its setter AND the delivery put something in a
-    // field. A `clipboardOnly` delivery submitted nothing to the destination, so there is nothing
-    // to have arrived once or twice; it is reported as `no_before_image`, never as one copy.
+    // #2652. Evidence wherever a before-image exists AND something was actually submitted to the
+    // destination.
+    //
+    // Review finding, 2026-09-04: this used to also require `tier != .clipboardOnly`, which
+    // discarded the measurement on the two paths where it is most useful. A Tier 1 write that
+    // returned `.unverifiable` leaves the tier at `clipboardOnly` even though the setter
+    // SUCCEEDED and the text may be in the document; a setter that returned an error hands
+    // delivery to a fallback that then succeeds. Both are measurable and both were being
+    // reported as `no_before_image`.
+    //
+    // The submitted-lengths check is what still excludes a genuine nothing-happened: a decline
+    // before any writer ran leaves that array empty, so there is no delivery to have arrived once
+    // or twice.
     var result = PasteDeliveryResult(
       tier: tier, durationMs: durationMs, outcome: outcome, submittedPayload: submittedKind,
       axDeclineReason: axDeclineReason?.rawValue, axSettability: axSettability?.telemetryValue)
     if let before = copiesBeforeImage, let element = request.targetElement,
-      tier != .clipboardOnly, !copiesSubmittedLengths.isEmpty
+      !copiesSubmittedLengths.isEmpty
     {
       result.copiesEvidence = PasteCopiesEvidence(
         element: element, before: before, submittedLengths: copiesSubmittedLengths)
+      result.copiesSetterReached = copiesSetterReached
     }
     return result
   }

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -3,6 +3,10 @@ import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
 
+#if DEBUG
+  import CryptoKit
+#endif
+
 /// Input for a paste delivery operation. Captures session-scoped target info.
 @MainActor
 internal struct PasteDeliveryRequest {
@@ -232,6 +236,30 @@ internal func dispositionForAXDirect(
   }
 }
 
+/// Policy-aware disposition (#2652).
+///
+/// Under the shipped baseline this is the function above, unchanged. Under the V2 arm a
+/// setter that RETURNED SUCCESS ends the cascade whatever verification concluded, which
+/// is the arm's whole hypothesis: `.noMutation` after a successful write is exactly the
+/// state the reporter's duplicate came from, and the reading may simply be stale.
+///
+/// The V2 branch keys on `writeCall`, never on `outcome`, because `.noMutation` is
+/// returned both for "we declined before touching it" and for "the write ran and
+/// provably did nothing" — and only the second may stop the cascade. Stopping on the
+/// first would refuse the fallback for every Electron app that never accepts the write,
+/// which is the coverage loss this bake-off exists to detect rather than to cause.
+internal func dispositionForAXDirect(
+  _ result: PasteService.AXInsertResult,
+  writerPolicy: PasteDeliveryPolicy.WriterPolicy
+) -> AXDirectDisposition {
+  #if DEBUG
+    if writerPolicy == .axOneWriter, case .succeeded = result.writeCall {
+      return result.outcome == .verified ? .delivered : .stopUnverified
+    }
+  #endif
+  return dispositionForAXDirect(result.outcome)
+}
+
 extension PasteFocusClassification {
   /// Whether a key-based paste (Tier 2 Cmd+V / Tier 2b AppleScript) should be
   /// attempted. True for `.textField` and `.missing`; false for `.nonText`.
@@ -331,9 +359,45 @@ internal final class PasteCascadeExecutor {
     pasteboard === NSPasteboard.general
   }
 
-  internal init(pasteboard: NSPasteboard) {
+  /// Which delivery policy this cascade runs (#2652).
+  ///
+  /// Required and undefaulted for the same reason `pasteboard` is: a capability reached
+  /// through a defaulted argument leaves no call-site token, so no sweep can enumerate
+  /// who is using it. There is exactly one production construction site, so requiring it
+  /// costs one line there and buys a grep that cannot miss a future one.
+  private let policy: PasteDeliveryPolicy
+
+  internal init(pasteboard: NSPasteboard, policy: PasteDeliveryPolicy) {
     self.pasteboard = pasteboard
+    self.policy = policy
   }
+
+  #if DEBUG
+    /// The harness run this process belongs to, set once at bootstrap beside the policy.
+    ///
+    /// Nil in every ordinary DEBUG session. A scored row whose run id does not match the
+    /// one the harness launched with is `invalid` rather than attributed to the wrong
+    /// run — the cheapest defence against scoring a stale line from a previous process.
+    nonisolated(unsafe) static var bakeoffRunID: String?
+
+    /// One entry per ACTUAL writer call, in the order the calls were made (#2652).
+    ///
+    /// The bake-off's cursor-context veto asks whether a variant changed the bytes we
+    /// submit. Nothing in the shipped code could answer that: the result records a
+    /// payload KIND (`legacy` / `repaired`), never the bytes, and two variants can agree
+    /// on the kind while disagreeing on the string. So the ledger records the route, the
+    /// UTF-8 byte count, and a digest of the exact string handed to that call.
+    ///
+    /// **No raw text, and this may never be widened.** It is DEBUG-only and lands in the
+    /// operator's own `app.log`, which is for local troubleshooting. A digest of a short
+    /// dictated sentence is guessable, so promoting this to Sentry or PostHog would cross
+    /// the privacy boundary that says user content never reaches Envious Labs.
+    private func submissionToken(tier: PasteTier, text: String) -> String {
+      let bytes = Data(text.utf8)
+      let digest = SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+      return "\(tier.rawValue):\(bytes.count):\(digest.prefix(16))"
+    }
+  #endif
 
   func deliver(_ request: PasteDeliveryRequest) async -> PasteDeliveryResult {
     let pasteStart = CFAbsoluteTimeGetCurrent()
@@ -447,7 +511,32 @@ internal final class PasteCascadeExecutor {
     // gets the text — Tier 3 puts it on the clipboard and shows the existing
     // "press Cmd+V" notice — but we never place it twice on their behalf.
     var axAllowsRetry = true
-    if classification == .textField, !isChromiumOmnibox, let element = request.targetElement {
+    #if DEBUG
+      // One entry per actual writer call, in call order. See `submissionToken`.
+      var submissionLedger: [String] = []
+    #endif
+
+    // #2652 V1/V5: refuse Tier 1 when the target is POSITIVELY inside web content.
+    //
+    // Both confirmed doubled takes landed in WebKit-backed fields, and the one delivery
+    // that took the direct route cleanly on the same machine was Safari's address bar,
+    // which is native chrome rather than page content. The discriminator already ships —
+    // the ancestor walk that `addressBarFamily` uses — and it fails closed, so an
+    // unreadable chain is NOT treated as web content and keeps baseline behaviour. That
+    // asymmetry is deliberate: this arm is a claim about page content, not about AX
+    // uncertainty in general.
+    let skipTier1ForWebContent: Bool = {
+      #if DEBUG
+        guard policy.writer == .webCmdV, let element = request.targetElement else { return false }
+        return PasteService.ancestorChainVerifiedFreeOfWebArea(element) == .containsWebArea
+      #else
+        return false
+      #endif
+    }()
+
+    if classification == .textField, !isChromiumOmnibox, !skipTier1ForWebContent,
+      let element = request.targetElement
+    {
       tiersAttempted.append(.axDirect)
       // The payload choice happens INSIDE the write, against the range read in
       // the same breath as the write itself (plan §6). Nothing is chosen here.
@@ -456,8 +545,14 @@ internal final class PasteCascadeExecutor {
         repaired: request.repairedText,
         context: request.caretContext,
         element: element,
-        requireFocusedElementMatch: request.targetElementIsRetried)
-      let disposition = dispositionForAXDirect(insert.outcome)
+        requireFocusedElementMatch: request.targetElementIsRetried,
+        boundMessagingTimeout: policy.boundTier1MessagingTimeout)
+      #if DEBUG
+        if let attempted = insert.writeCall.attemptedText {
+          submissionLedger.append(submissionToken(tier: .axDirect, text: attempted))
+        }
+      #endif
+      let disposition = dispositionForAXDirect(insert, writerPolicy: policy.writer)
       submittedKind = insert.submitted
       axDeclineReason = insert.declineReason
       axSettability = insert.settability
@@ -538,6 +633,9 @@ internal final class PasteCascadeExecutor {
             ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
             : { ClipboardCleanup.deliveryClaimsBoard(); return nil }()
           submittedKind = payload.kind
+          #if DEBUG
+            submissionLedger.append(submissionToken(tier: .cgEvent, text: payload.text))
+          #endif
           let dispatchResult = PasteService.pasteToActiveApp(
             payload.text, to: self.pasteboard)
           submittedClipboardChangeCount = dispatchResult.changeCount
@@ -593,6 +691,9 @@ internal final class PasteCascadeExecutor {
           ? ClipboardCleanup.snapshotForDelivery(from: pasteboard)
           : { ClipboardCleanup.deliveryClaimsBoard(); return nil }()
         submittedKind = payload.kind
+        #if DEBUG
+          submissionLedger.append(submissionToken(tier: .appleScript, text: payload.text))
+        #endif
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
           payload.text, to: self.pasteboard)
         submittedClipboardChangeCount = changeCount
@@ -672,6 +773,9 @@ internal final class PasteCascadeExecutor {
           requireCaretUnchanged: request.targetElementIsRetried,
           terminalBudget: request.terminalBudget)
         submittedKind = payload.kind
+        #if DEBUG
+          submissionLedger.append(submissionToken(tier: .menuPaste, text: payload.text))
+        #endif
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
           payload.text, to: self.pasteboard)
         submittedClipboardChangeCount = changeCount
@@ -784,6 +888,25 @@ internal final class PasteCascadeExecutor {
         level: .info, category: "PipelineTiming"
       )
     }
+
+    // #2652 bake-off evidence. DEBUG-only and emitted only under a forced variant, so a
+    // release build's log format is byte-identical to what it was before this existed —
+    // the scored comparison needs no release-observable, and adding one would widen the
+    // blast radius of a measurement to every user.
+    #if DEBUG
+      if !policy.isBaseline {
+        let attempts = tiersAttempted.map(\.rawValue).joined(separator: ">")
+        let ledger = submissionLedger.joined(separator: "|")
+        Task { [runID = Self.bakeoffRunID, variant = policy.id] in
+          await AppLogger.shared.log(
+            "PASTE_BAKEOFF_TRIAL run_id=\(runID ?? "none") variant=\(variant) "
+              + "tier=\(tier.rawValue) app=\(bundleId) attempts=\(attempts) "
+              + "ledger=\(ledger) duration=\(durationMs)ms",
+            level: .info, category: "PipelineTiming"
+          )
+        }
+      }
+    #endif
 
     // Construct typed outcome. `cgEventCreationFailed` takes priority over
     // `clipboardOnly` when both would be true — CGEvent failure is a more

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -89,13 +89,18 @@ package struct PasteCopiesEvidence: @unchecked Sendable {
   package let element: AXUIElement
   package let before: PasteService.CopiesBeforeImage
   package let submittedLengths: [Int]
+  /// Whether the Tier 1 SETTER ran. Decides whether the before-image's SELECTION LENGTH is
+  /// still describing the field the fallback wrote into — see `PasteCopiesObserver`.
+  package let setterReached: Bool
 
   package init(
-    element: AXUIElement, before: PasteService.CopiesBeforeImage, submittedLengths: [Int]
+    element: AXUIElement, before: PasteService.CopiesBeforeImage, submittedLengths: [Int],
+    setterReached: Bool
   ) {
     self.element = element
     self.before = before
     self.submittedLengths = submittedLengths
+    self.setterReached = setterReached
   }
 
   /// The one length the observation may use, or nil when the attempts disagree.
@@ -1035,7 +1040,8 @@ internal final class PasteCascadeExecutor {
       !copiesSubmittedLengths.isEmpty
     {
       result.copiesEvidence = PasteCopiesEvidence(
-        element: element, before: before, submittedLengths: copiesSubmittedLengths)
+        element: element, before: before, submittedLengths: copiesSubmittedLengths,
+        setterReached: copiesSetterReached)
       result.copiesSetterReached = copiesSetterReached
     }
     return result

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -525,10 +525,18 @@ internal final class PasteCascadeExecutor {
     // unreadable chain is NOT treated as web content and keeps baseline behaviour. That
     // asymmetry is deliberate: this arm is a claim about page content, not about AX
     // uncertainty in general.
+    #if DEBUG
+      // Why this gate decided what it decided (#2652). Captured here, reported at the
+      // emit site below, because the remaining ancestor distance may only be measured
+      // AFTER delivery — see `resumeAncestorChainTrace`.
+      var webGateTrace: PasteService.AXWebAreaAncestryTrace?
+    #endif
     let skipTier1ForWebContent: Bool = {
       #if DEBUG
         guard policy.writer == .webCmdV, let element = request.targetElement else { return false }
-        return PasteService.ancestorChainVerifiedFreeOfWebArea(element) == .containsWebArea
+        let trace = PasteService.ancestorChainTrace(element)
+        webGateTrace = trace
+        return trace.result == .containsWebArea
       #else
         return false
       #endif
@@ -897,11 +905,23 @@ internal final class PasteCascadeExecutor {
       if !policy.isBaseline {
         let attempts = tiersAttempted.map(\.rawValue).joined(separator: ">")
         let ledger = submissionLedger.joined(separator: "|")
-        Task { [runID = Self.bakeoffRunID, variant = policy.id] in
+        // The gate evidence rides on the DELIVERY line rather than on a line of its own.
+        // Two independently scheduled log lines have to be joined by timestamp, and a
+        // mis-join produces a confident wrong tabulation with nothing to show for it.
+        var gateEvidence = ""
+        if let trace = webGateTrace {
+          let extended = PasteService.resumeAncestorChainTrace(trace, maxExamined: 60)
+          gateEvidence =
+            " gate=\(trace.result):\(trace.depthExamined):\(trace.stopReason.rawValue)"
+            + " ext=\(extended.result):\(extended.depthExamined):\(extended.stopReason.rawValue)"
+            + " roles=\(extended.roles.joined(separator: ">"))"
+            + " target=\(targetDiagnostics)"
+        }
+        Task { [runID = Self.bakeoffRunID, variant = policy.id, gateEvidence] in
           await AppLogger.shared.log(
             "PASTE_BAKEOFF_TRIAL run_id=\(runID ?? "none") variant=\(variant) "
               + "tier=\(tier.rawValue) app=\(bundleId) attempts=\(attempts) "
-              + "ledger=\(ledger) duration=\(durationMs)ms",
+              + "ledger=\(ledger) duration=\(durationMs)ms" + gateEvidence,
             level: .info, category: "PipelineTiming"
           )
         }

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -89,18 +89,20 @@ package struct PasteCopiesEvidence: @unchecked Sendable {
   package let element: AXUIElement
   package let before: PasteService.CopiesBeforeImage
   package let submittedLengths: [Int]
-  /// Whether the Tier 1 SETTER ran. Decides whether the before-image's SELECTION LENGTH is
-  /// still describing the field the fallback wrote into — see `PasteCopiesObserver`.
-  package let setterReached: Bool
+  /// Whether any route AFTER Tier 1 ran. Every one of them ACTIVATES the destination first,
+  /// and activation is what can clear a selection — so this, not "did the setter run", is what
+  /// decides whether the before-image's SELECTION LENGTH still describes the field that was
+  /// written into. See `PasteCopiesObserver.selectionStillDescribesTheField`.
+  package let fallbackRan: Bool
 
   package init(
     element: AXUIElement, before: PasteService.CopiesBeforeImage, submittedLengths: [Int],
-    setterReached: Bool
+    fallbackRan: Bool
   ) {
     self.element = element
     self.before = before
     self.submittedLengths = submittedLengths
-    self.setterReached = setterReached
+    self.fallbackRan = fallbackRan
   }
 
   /// The one length the observation may use, or nil when the attempts disagree.
@@ -1039,9 +1041,11 @@ internal final class PasteCascadeExecutor {
     if let before = copiesBeforeImage, let element = request.targetElement,
       !copiesSubmittedLengths.isEmpty
     {
+      // Derived from `tiersAttempted` — the producing code — rather than from any belief about
+      // which paths reach a fallback.
       result.copiesEvidence = PasteCopiesEvidence(
         element: element, before: before, submittedLengths: copiesSubmittedLengths,
-        setterReached: copiesSetterReached)
+        fallbackRan: tiersAttempted.contains { $0 != .axDirect })
       result.copiesSetterReached = copiesSetterReached
     }
     return result

--- a/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
+++ b/Sources/EnviousWisprPipeline/PasteCascadeExecutor.swift
@@ -530,6 +530,21 @@ internal final class PasteCascadeExecutor {
       // emit site below, because the remaining ancestor distance may only be measured
       // AFTER delivery — see `resumeAncestorChainTrace`.
       var webGateTrace: PasteService.AXWebAreaAncestryTrace?
+
+      // The before-image the copies detector is judged against (#2652). Read HERE,
+      // before any writer runs, because after the first write there is no longer a
+      // before to read and the count alone cannot say how many copies made it.
+      var copiesCountBefore: Int?
+      var copiesSelectionLengthBefore = 0
+      // The UTF-16 length actually handed to the winning writer. Recorded AT the
+      // submission rather than re-derived at the end: `repairedText` is optional and
+      // which of the two strings went out is decided inside the write, so re-deriving
+      // it here would be a second opinion about a question already answered.
+      var copiesSubmittedLength: Int?
+      if !policy.isBaseline, let element = request.targetElement {
+        copiesCountBefore = PasteService.characterCount(of: element)
+        copiesSelectionLengthBefore = PasteService.selectedTextLength(of: element) ?? 0
+      }
     #endif
     let skipTier1ForWebContent: Bool = {
       #if DEBUG
@@ -558,6 +573,7 @@ internal final class PasteCascadeExecutor {
       #if DEBUG
         if let attempted = insert.writeCall.attemptedText {
           submissionLedger.append(submissionToken(tier: .axDirect, text: attempted))
+          copiesSubmittedLength = attempted.utf16.count
         }
       #endif
       let disposition = dispositionForAXDirect(insert, writerPolicy: policy.writer)
@@ -643,6 +659,7 @@ internal final class PasteCascadeExecutor {
           submittedKind = payload.kind
           #if DEBUG
             submissionLedger.append(submissionToken(tier: .cgEvent, text: payload.text))
+            copiesSubmittedLength = payload.text.utf16.count
           #endif
           let dispatchResult = PasteService.pasteToActiveApp(
             payload.text, to: self.pasteboard)
@@ -650,6 +667,17 @@ internal final class PasteCascadeExecutor {
           switch dispatchResult {
           case .dispatched:
             tier = .cgEvent
+            #if DEBUG
+              // V6 ONLY: stage the reported defect on purpose, so the copies detector
+              // below has a positive control. Every Mac we own delivers exactly one
+              // copy, so without this the detector could be wired to a constant and
+              // three hundred `once` readings would look like proof.
+              if policy.writer == .deliberateDouble {
+                submissionLedger.append(submissionToken(tier: .cgEvent, text: payload.text))
+                copiesSubmittedLength = payload.text.utf16.count
+                _ = PasteService.pasteToActiveApp(payload.text, to: self.pasteboard)
+              }
+            #endif
           case .cgEventCreationFailed(let accessibilityTrusted, _):
             cgEventFailureAccessibilityTrusted = accessibilityTrusted
             tierFailures["cgevent"] = "creation_failed (ax_trusted=\(accessibilityTrusted))"
@@ -701,6 +729,7 @@ internal final class PasteCascadeExecutor {
         submittedKind = payload.kind
         #if DEBUG
           submissionLedger.append(submissionToken(tier: .appleScript, text: payload.text))
+          copiesSubmittedLength = payload.text.utf16.count
         #endif
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
           payload.text, to: self.pasteboard)
@@ -783,6 +812,7 @@ internal final class PasteCascadeExecutor {
         submittedKind = payload.kind
         #if DEBUG
           submissionLedger.append(submissionToken(tier: .menuPaste, text: payload.text))
+          copiesSubmittedLength = payload.text.utf16.count
         #endif
         let changeCount = PasteService.copyToClipboardReturningChangeCount(
           payload.text, to: self.pasteboard)
@@ -908,6 +938,35 @@ internal final class PasteCascadeExecutor {
         // The gate evidence rides on the DELIVERY line rather than on a line of its own.
         // Two independently scheduled log lines have to be joined by timestamp, and a
         // mis-join produces a confident wrong tabulation with nothing to show for it.
+        // HOW MANY COPIES ARRIVED, measured from lengths and never from the text.
+        //
+        // Read after a settle window because the destination has not finished applying
+        // the write when the cascade returns — the same lag that makes the Tier 1
+        // verification answer `noMutation` on a write that landed. Reading immediately
+        // would reproduce the defect inside its own detector.
+        var copiesEvidence = " copies=not_measured"
+        if let element = request.targetElement, let before = copiesCountBefore,
+          tier != .clipboardOnly
+        {
+          try? await Task.sleep(for: .milliseconds(400))
+          let after = PasteService.characterCount(of: element)
+          let copies = PasteService.copiesDelivered(
+            countAfter: after,
+            countBefore: before,
+            selectionLengthBefore: copiesSelectionLengthBefore,
+            insertedLength: copiesSubmittedLength ?? 0)
+          // The raw readings ride along while this is being proved. `unknown` has three
+          // causes that demand different answers — the field will not report a count, the
+          // destination rewrote the text so the arithmetic cannot hold, or a real double —
+          // and a bare `unknown` cannot tell them apart.
+          copiesEvidence =
+            " copies=\(copies.map(String.init) ?? "unknown")"
+            + " copies_raw=before:\(before)"
+            + ",sel:\(copiesSelectionLengthBefore)"
+            + ",sent:\(copiesSubmittedLength.map(String.init) ?? "nil")"
+            + ",after:\(after.map(String.init) ?? "unreadable")"
+        }
+
         var gateEvidence = ""
         if let trace = webGateTrace {
           let extended = PasteService.resumeAncestorChainTrace(trace, maxExamined: 60)
@@ -917,11 +976,11 @@ internal final class PasteCascadeExecutor {
             + " roles=\(extended.roles.joined(separator: ">"))"
             + " target=\(targetDiagnostics)"
         }
-        Task { [runID = Self.bakeoffRunID, variant = policy.id, gateEvidence] in
+        Task { [runID = Self.bakeoffRunID, variant = policy.id, gateEvidence, copiesEvidence] in
           await AppLogger.shared.log(
             "PASTE_BAKEOFF_TRIAL run_id=\(runID ?? "none") variant=\(variant) "
               + "tier=\(tier.rawValue) app=\(bundleId) attempts=\(attempts) "
-              + "ledger=\(ledger) duration=\(durationMs)ms" + gateEvidence,
+              + "ledger=\(ledger) duration=\(durationMs)ms" + copiesEvidence + gateEvidence,
             level: .info, category: "PipelineTiming"
           )
         }

--- a/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
+++ b/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
@@ -1,0 +1,186 @@
+import ApplicationServices
+import EnviousWisprServices
+import Foundation
+
+// MARK: - How many copies landed (#2652)
+//
+// `paste.completed` fires once whether one copy or two copies of a dictation arrive, so the
+// reported double-paste defect is invisible fleet-wide: one user reported it and we cannot say
+// whether he is one of one or one of thousands. This observes the destination AFTER delivery has
+// returned and reports an estimate.
+//
+// **It reports and it can write nothing.** Nothing in this file's reachable call graph contains an
+// accessibility content setter, a pasteboard mutation, simulated input, or a call into the paste
+// cascade. That is the property the whole change exists to preserve, and it is checked by reading
+// this file rather than argued from what the caller did not inject — a raw `AXUIElement` can be
+// handed straight to `AXUIElementSetAttributeValue`, as `PasteService.insertViaAccessibility` does,
+// so withholding an executor would prove nothing on its own.
+
+/// What the observation concluded about how much the field grew.
+package enum PasteCopiesEstimate: String, Sendable {
+  case one
+  case two
+  /// The observation RAN and produced no band.
+  case unknown
+}
+
+/// Why the observation concluded what it did. A closed set: a new member cannot be added without
+/// the compiler naming every site that switches on it.
+package enum PasteCopiesStatus: String, Sendable {
+  case measured
+  /// The read succeeded and the evidence does not support classification — the arithmetic fit no
+  /// band, or the attempted writers submitted different payload lengths.
+  case unclassified
+  /// The AX read failed, timed out, or the element is gone.
+  case elementUnreadable = "element_unreadable"
+  /// Tier 1 never reached its setter, so there is no before-image. **Never one copy.**
+  case noBeforeImage = "no_before_image"
+  /// An observation was already outstanding.
+  case probeBusy = "probe_busy"
+  /// This destination answered too slowly earlier in the session.
+  case processDisabled = "process_disabled"
+}
+
+package struct PasteCopiesObservation: Sendable, Equatable {
+  package let estimate: PasteCopiesEstimate
+  package let status: PasteCopiesStatus
+  package let detectorVersion: Int
+}
+
+/// One outstanding observation at a time, and a per-destination kill switch.
+///
+/// An actor gives serialisation for free, but serialisation is QUEUING and queuing is the wrong
+/// answer: a second delivery arriving during a settle window must be refused and reported as
+/// `probe_busy`, never held behind the first. So the claim is a fast call that returns immediately,
+/// and the waiting happens outside it.
+package actor PasteCopiesGate {
+  package static let shared = PasteCopiesGate()
+
+  private var busy = false
+  private var disabled: Set<String> = []
+
+  package init() {}
+
+  /// Nil means claimed. A status means refused, and that status is what gets reported.
+  package func claim(bundleID: String?) -> PasteCopiesStatus? {
+    if let bundleID, disabled.contains(bundleID) { return .processDisabled }
+    if busy { return .probeBusy }
+    busy = true
+    return nil
+  }
+
+  package func release() { busy = false }
+
+  /// Stop observing this destination for the rest of the session.
+  ///
+  /// The suspected population is destinations whose accessibility round trip is slow, so the
+  /// instrument must not keep asking one. Bounding by elapsed time rather than by
+  /// `AXUIElementSetMessagingTimeout` is deliberate: that call mutates the ELEMENT handle, which
+  /// the delivery path also holds, and an instrument may not change the behaviour of the thing it
+  /// measures.
+  package func disable(bundleID: String?) {
+    guard let bundleID else { return }
+    disabled.insert(bundleID)
+  }
+
+  package func isDisabled(_ bundleID: String?) -> Bool {
+    guard let bundleID else { return false }
+    return disabled.contains(bundleID)
+  }
+}
+
+package enum PasteCopiesObserver {
+  /// How long the destination is given to finish applying the write.
+  ///
+  /// **Proved on THIS machine, where the second write is the one that lands.** It is not proved on
+  /// the affected population, whose working explanation is that the FIRST write lands late; a
+  /// second copy arriving after this window leaves a one-copy estimate at observation time. The
+  /// constant travels with every event as `detector_version`, so a later widening is
+  /// distinguishable in the data instead of silently rewriting history.
+  package static let settleMilliseconds = 400
+
+  /// A read slower than this retires the destination for the session.
+  package static let slowReadMilliseconds = 1000
+
+  package static let detectorVersion = 1
+
+  /// Observe, then hand the result to `report`. Never returns it: there is no caller decision to
+  /// make on a measurement, and giving one a value to branch on is how an instrument acquires
+  /// authority it should not have.
+  ///
+  /// `report` is REQUIRED rather than defaulted, so a test cannot inherit the production sink by
+  /// omission — the same discipline as the delivery seams in `KernelDictationDriverFactory`.
+  package static func schedule(
+    evidence: PasteCopiesEvidence?,
+    targetBundleID: String?,
+    gate: PasteCopiesGate,
+    report: @escaping @Sendable (PasteCopiesObservation) -> Void
+  ) {
+    guard let evidence else {
+      report(
+        PasteCopiesObservation(
+          estimate: .unknown, status: .noBeforeImage, detectorVersion: detectorVersion))
+      return
+    }
+    Task.detached(priority: .utility) {
+      if let refusal = await gate.claim(bundleID: targetBundleID) {
+        report(
+          PasteCopiesObservation(
+            estimate: .unknown, status: refusal, detectorVersion: detectorVersion))
+        return
+      }
+      let observation = await observe(
+        evidence: evidence, targetBundleID: targetBundleID, gate: gate)
+      await gate.release()
+      report(observation)
+    }
+  }
+
+  /// The measurement itself. Reads two numbers and does arithmetic; writes nothing.
+  private static func observe(
+    evidence: PasteCopiesEvidence,
+    targetBundleID: String?,
+    gate: PasteCopiesGate
+  ) async -> PasteCopiesObservation {
+    guard let submitted = evidence.unambiguousSubmittedLength else {
+      // The routes disagreed about what they submitted, so no single length is what the field
+      // grew BY. Declining is the whole point: picking the last writer's length would produce a
+      // confident number about a question nobody asked.
+      return PasteCopiesObservation(
+        estimate: .unknown, status: .unclassified, detectorVersion: detectorVersion)
+    }
+
+    try? await Task.sleep(for: .milliseconds(settleMilliseconds))
+
+    let started = DispatchTime.now()
+    let after = PasteService.characterCount(of: evidence.element)
+    let elapsedMs = Int(
+      (DispatchTime.now().uptimeNanoseconds &- started.uptimeNanoseconds) / 1_000_000)
+    if elapsedMs >= slowReadMilliseconds {
+      await gate.disable(bundleID: targetBundleID)
+    }
+
+    guard let after else {
+      return PasteCopiesObservation(
+        estimate: .unknown, status: .elementUnreadable, detectorVersion: detectorVersion)
+    }
+
+    let copies = PasteService.copiesDelivered(
+      countAfter: after,
+      countBefore: evidence.before.count,
+      selectionLengthBefore: evidence.before.selectionLength,
+      insertedLength: submitted)
+
+    switch copies {
+    case 1:
+      return PasteCopiesObservation(
+        estimate: .one, status: .measured, detectorVersion: detectorVersion)
+    case 2:
+      return PasteCopiesObservation(
+        estimate: .two, status: .measured, detectorVersion: detectorVersion)
+    default:
+      return PasteCopiesObservation(
+        estimate: .unknown, status: .unclassified, detectorVersion: detectorVersion)
+    }
+  }
+}

--- a/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
+++ b/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
@@ -136,6 +136,15 @@ package enum PasteCopiesObserver {
     }
   }
 
+  /// Whether the before-image's selection length still describes the field the delivery wrote
+  /// into. Pure, so the rule can be tested without a live element.
+  package static func selectionStillDescribesTheField(
+    setterReached: Bool, selectionLength: Int
+  ) -> Bool {
+    if setterReached { return true }
+    return selectionLength == 0
+  }
+
   /// The measurement itself. Reads two numbers and does arithmetic; writes nothing.
   private static func observe(
     evidence: PasteCopiesEvidence,
@@ -146,6 +155,29 @@ package enum PasteCopiesObserver {
       // The routes disagreed about what they submitted, so no single length is what the field
       // grew BY. Declining is the whole point: picking the last writer's length would produce a
       // confident number about a question nobody asked.
+      return PasteCopiesObservation(
+        estimate: .unknown, status: .unclassified, detectorVersion: detectorVersion)
+    }
+
+    // A BEFORE-IMAGE THAT SURVIVED A DECLINE MAY DESCRIBE A DIFFERENT SELECTION.
+    //
+    // Review finding, 2026-09-04, and it was introduced by the fix one commit earlier: carrying
+    // the before-image through a Tier 1 decline means the delivery that followed was the
+    // FALLBACK, and the fallback activates the destination first. Activation is explicitly
+    // allowed to change the selection.
+    //
+    // The failure is one-directional and it is the direction that matters. A selection that is
+    // LOST means the field never shrank, so it grew by a whole payload more than expected — a
+    // 100-character field with 27 selected, losing its selection and receiving one 27-character
+    // paste, reaches 127 where one copy was expected at 100, and reads as TWO. A false `two` is
+    // the one error this instrument must never make.
+    //
+    // A caret with nothing selected cannot lose a selection, so the arithmetic still holds
+    // there. Activation CREATING a selection fails the other way — the field ends shorter than
+    // expected and lands in no band — which is `unclassified`, the safe answer.
+    if !selectionStillDescribesTheField(
+      setterReached: evidence.setterReached, selectionLength: evidence.before.selectionLength)
+    {
       return PasteCopiesObservation(
         estimate: .unknown, status: .unclassified, detectorVersion: detectorVersion)
     }

--- a/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
+++ b/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
@@ -138,10 +138,19 @@ package enum PasteCopiesObserver {
 
   /// Whether the before-image's selection length still describes the field the delivery wrote
   /// into. Pure, so the rule can be tested without a live element.
+  /// **The discriminator is ACTIVATION, not the setter.** Three review rounds each found a new
+  /// case where "did the Tier 1 setter run" trusted a selection it should not have: a setter that
+  /// failed, and a setter that returned `.noMutation`, both hand delivery to a fallback. Reaching
+  /// the setter never proved it replaced the selection.
+  ///
+  /// Every route after Tier 1 activates the destination first, and activation is what can clear a
+  /// selection. So the question is whether ANY of them ran, which `tiersAttempted` answers
+  /// directly. The `.unverifiable` case keeps its measurement, correctly: the cascade STOPS there
+  /// rather than paste again, so nothing activated and the selection still stands.
   package static func selectionStillDescribesTheField(
-    setterReached: Bool, selectionLength: Int
+    fallbackRan: Bool, selectionLength: Int
   ) -> Bool {
-    if setterReached { return true }
+    if !fallbackRan { return true }
     return selectionLength == 0
   }
 
@@ -176,7 +185,7 @@ package enum PasteCopiesObserver {
     // there. Activation CREATING a selection fails the other way — the field ends shorter than
     // expected and lands in no band — which is `unclassified`, the safe answer.
     if !selectionStillDescribesTheField(
-      setterReached: evidence.setterReached, selectionLength: evidence.before.selectionLength)
+      fallbackRan: evidence.fallbackRan, selectionLength: evidence.before.selectionLength)
     {
       return PasteCopiesObservation(
         estimate: .unknown, status: .unclassified, detectorVersion: detectorVersion)

--- a/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
+++ b/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
@@ -1,4 +1,5 @@
 import ApplicationServices
+import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
 
@@ -195,31 +196,26 @@ package enum PasteCopiesObserver {
 
     // A WEDGED DESTINATION MUST NOT TAKE THE GATE WITH IT.
     //
-    // Cloud review, PR #2660: timing the read cannot bound it. `AXUIElementCopyAttributeValue`
-    // is a synchronous call into a foreign process, and if that process never answers, control
-    // never reaches the elapsed-time check OR `gate.release()`. The single-slot gate would then
-    // stay claimed for the rest of the session and EVERY later delivery — into healthy
-    // applications — would report `probe_busy`. One wedged app would silently retire the whole
-    // instrument.
+    // Cloud review, PR #2660, twice. `AXUIElementCopyAttributeValue` is a synchronous call into
+    // a foreign process; if that process never answers, nothing downstream of it runs — not the
+    // elapsed-time check, and not `gate.release()`. The single-slot gate would stay claimed for
+    // the rest of the session and EVERY later delivery, into healthy applications, would report
+    // `probe_busy`. One wedged app would silently retire the whole instrument, and the dashboard
+    // would look like a busy user rather than a broken one.
     //
-    // So the read races a deadline. Losing the race releases the gate and retires that
-    // destination; the wedged read is abandoned to finish or not on its own thread. That leaks
-    // at most one thread per destination, and the destination is disabled immediately after, so
-    // it cannot leak a second. Bounding with `AXUIElementSetMessagingTimeout` is still refused:
-    // it mutates the ELEMENT handle the delivery path also holds.
-    // `nonisolated(unsafe)` for the element crossing into the task group, the same spelling
-    // `PasteService.logElementDiagnostics` uses to run its AX reads off the caller's thread.
+    // **A task group does not bound it either, which is the part that is not obvious.** The
+    // group's scope AWAITS a losing child on exit, and a synchronous C call cannot observe
+    // cancellation, so racing inside `withTaskGroup` still waits for the wedged read.
+    // `TaskTimeout.swift:50-55` documents exactly this and ships `withDeadline`, which abandons
+    // the loser instead. Using the house helper rather than a fourth attempt at hand-rolling it.
+    //
+    // Bounding with `AXUIElementSetMessagingTimeout` is still refused: it mutates the ELEMENT
+    // handle the delivery path also holds, and an instrument may not change what it measures.
     nonisolated(unsafe) let element = evidence.element
-    let after: Int? = await withTaskGroup(of: Int??.self) { group in
-      group.addTask { PasteService.characterCount(of: element) }
-      group.addTask {
-        try? await Task.sleep(for: .milliseconds(slowReadMilliseconds))
-        return Int??.some(nil)
-      }
-      let first = await group.next() ?? nil
-      group.cancelAll()
-      return first ?? nil
-    }
+    let after: Int? = await withDeadline(seconds: Double(slowReadMilliseconds) / 1000.0) {
+      PasteService.characterCount(of: element)
+    } ?? nil
+
     if after == nil {
       await gate.disable(bundleID: targetBundleID)
     }

--- a/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
+++ b/Sources/EnviousWisprPipeline/PasteCopiesObserver.swift
@@ -193,11 +193,34 @@ package enum PasteCopiesObserver {
 
     try? await Task.sleep(for: .milliseconds(settleMilliseconds))
 
-    let started = DispatchTime.now()
-    let after = PasteService.characterCount(of: evidence.element)
-    let elapsedMs = Int(
-      (DispatchTime.now().uptimeNanoseconds &- started.uptimeNanoseconds) / 1_000_000)
-    if elapsedMs >= slowReadMilliseconds {
+    // A WEDGED DESTINATION MUST NOT TAKE THE GATE WITH IT.
+    //
+    // Cloud review, PR #2660: timing the read cannot bound it. `AXUIElementCopyAttributeValue`
+    // is a synchronous call into a foreign process, and if that process never answers, control
+    // never reaches the elapsed-time check OR `gate.release()`. The single-slot gate would then
+    // stay claimed for the rest of the session and EVERY later delivery — into healthy
+    // applications — would report `probe_busy`. One wedged app would silently retire the whole
+    // instrument.
+    //
+    // So the read races a deadline. Losing the race releases the gate and retires that
+    // destination; the wedged read is abandoned to finish or not on its own thread. That leaks
+    // at most one thread per destination, and the destination is disabled immediately after, so
+    // it cannot leak a second. Bounding with `AXUIElementSetMessagingTimeout` is still refused:
+    // it mutates the ELEMENT handle the delivery path also holds.
+    // `nonisolated(unsafe)` for the element crossing into the task group, the same spelling
+    // `PasteService.logElementDiagnostics` uses to run its AX reads off the caller's thread.
+    nonisolated(unsafe) let element = evidence.element
+    let after: Int? = await withTaskGroup(of: Int??.self) { group in
+      group.addTask { PasteService.characterCount(of: element) }
+      group.addTask {
+        try? await Task.sleep(for: .milliseconds(slowReadMilliseconds))
+        return Int??.some(nil)
+      }
+      let first = await group.next() ?? nil
+      group.cancelAll()
+      return first ?? nil
+    }
+    if after == nil {
       await gate.disable(bundleID: targetBundleID)
     }
 

--- a/Sources/EnviousWisprPipeline/PasteDeliveryPolicy.swift
+++ b/Sources/EnviousWisprPipeline/PasteDeliveryPolicy.swift
@@ -46,6 +46,17 @@ package struct PasteDeliveryPolicy: Sendable, Equatable {
       /// destination that genuinely accepts the write and genuinely does nothing loses
       /// its automatic delivery here.
       case axOneWriter
+
+      /// Deliberately deliver TWICE: after a successful key paste, paste once more.
+      ///
+      /// This arm exists to ARM the copies detector, not to test a candidate fix. A
+      /// detector that has never seen the thing it detects is a comment: every Mac we
+      /// own produces exactly one copy, so "it reported `once` on 300 dictations" is
+      /// equally consistent with a working detector and with one wired to a constant.
+      /// V6 stages the defect on purpose so the detector has a positive control.
+      ///
+      /// Never eligible in a release build, and never proposed as a fix.
+      case deliberateDouble
     #endif
   }
 
@@ -75,6 +86,7 @@ package struct PasteDeliveryPolicy: Sendable, Equatable {
         case "V2": writer == .axOneWriter && !boundTier1MessagingTimeout
         case "V4": writer == .current && boundTier1MessagingTimeout
         case "V5": writer == .webCmdV && boundTier1MessagingTimeout
+        case "V6": writer == .deliberateDouble && !boundTier1MessagingTimeout
         default: false
         }
     #else
@@ -127,6 +139,7 @@ package struct PasteDeliveryPolicy: Sendable, Equatable {
         case "V2": (.axOneWriter, false)
         case "V4": (.current, true)
         case "V5": (.webCmdV, true)
+        case "V6": (.deliberateDouble, false)
         default: nil
         }
       guard let combination else {

--- a/Sources/EnviousWisprPipeline/PasteDeliveryPolicy.swift
+++ b/Sources/EnviousWisprPipeline/PasteDeliveryPolicy.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Which delivery policy the cascade is running under (#2652).
+///
+/// **Why this type exists.** A reporter's dictation arrived TWICE in Safari page
+/// textareas and a WebKit-backed compose window, proven by exact character counts, and
+/// the defect does not reproduce on our hardware. Rather than argue a fix from a
+/// mechanism story, we measure: run the candidate policies against real applications
+/// and pick the one that delivers correctly in the widest set. This is the switch that
+/// bake-off forces.
+///
+/// **Everything except `.current` is DEBUG-only, and release is a literal V0.** No user
+/// ever runs a non-baseline policy; the release build's routing and its `app.log`
+/// format are byte-identical to what shipped before this type existed.
+///
+/// **The initializer validates rather than trusts.** A test seam on a delivery guard is
+/// a bypass unless it is logged AND unforgeable, and the specific way this one could
+/// have lied is subtle: the harness stamps `variant=V2` on every scored row, so a
+/// `writer`/`timeout`/`id` triple that disagrees with itself would produce a scorecard
+/// full of confident rows describing a policy that never ran. The `precondition` makes
+/// that combination unrepresentable instead of asking a reviewer to notice it.
+/// (`validation-discipline.md` RULE: a-test-seam-on-a-GUARD-is-a-bypass-unless-it-is-logged.)
+package struct PasteDeliveryPolicy: Sendable, Equatable {
+
+  /// Which writer policy the cascade applies.
+  ///
+  /// `.current` is the only case that exists in a release build. The other two are
+  /// compiled out entirely, so the release binary contains neither their behaviour nor
+  /// their raw values for an artifact scan to find.
+  package enum WriterPolicy: String, Sendable, Equatable {
+    /// Today's cascade, unchanged. The baseline every measurement is relative to.
+    case current
+
+    #if DEBUG
+      /// Skip Tier 1 when the target is POSITIVELY inside web content, and start at the
+      /// existing key-paste route. Native chrome — a browser address bar included — and
+      /// an ancestry we could not read both keep `.current` behaviour, so this arm tests
+      /// web content rather than AX uncertainty in general.
+      case webCmdV
+
+      /// Tier 1 stays exactly as eligible as it is today, but once
+      /// `AXUIElementSetAttributeValue` has RETURNED SUCCESS, no later automatic writer
+      /// runs whatever the verification says. Declines before the write, and a write
+      /// call that returns failure, still permit the fallback: nothing was mutated in
+      /// either case. This is the strongest test of the coverage concern, because a
+      /// destination that genuinely accepts the write and genuinely does nothing loses
+      /// its automatic delivery here.
+      case axOneWriter
+    #endif
+  }
+
+  package let writer: WriterPolicy
+
+  /// Whether to bound the Tier 1 element's own AX round trips with
+  /// `AXUIElementSetMessagingTimeout`.
+  ///
+  /// We already set a messaging timeout for app-scoped focused-element reads and menu
+  /// probing; what we have never done is apply one to the captured Tier 1 element
+  /// before its read/write/read sequence — the one place the stale-read hazard lives.
+  /// Three of the four competitors that attempt a direct write import this call.
+  /// It bounds how long a single AX call may take. It does NOT make a destination's
+  /// state settle sooner, and this arm exists to measure whether that distinction
+  /// matters here rather than to assume it does.
+  package let boundTier1MessagingTimeout: Bool
+
+  /// The pre-declared variant label, stamped on every bake-off log line.
+  package let id: String
+
+  package init(writer: WriterPolicy, boundTier1MessagingTimeout: Bool, id: String) {
+    #if DEBUG
+      let valid =
+        switch id {
+        case "V0": writer == .current && !boundTier1MessagingTimeout
+        case "V1": writer == .webCmdV && !boundTier1MessagingTimeout
+        case "V2": writer == .axOneWriter && !boundTier1MessagingTimeout
+        case "V4": writer == .current && boundTier1MessagingTimeout
+        case "V5": writer == .webCmdV && boundTier1MessagingTimeout
+        default: false
+        }
+    #else
+      let valid = writer == .current && !boundTier1MessagingTimeout && id == "V0"
+    #endif
+    precondition(valid, "Invalid paste-delivery policy combination: \(writer.rawValue)/\(id)")
+    self.writer = writer
+    self.boundTier1MessagingTimeout = boundTier1MessagingTimeout
+    self.id = id
+  }
+
+  /// The shipped policy. The only one a release build can construct.
+  package static let baseline = PasteDeliveryPolicy(
+    writer: .current, boundTier1MessagingTimeout: false, id: "V0")
+
+  /// True when this policy is the shipped baseline, so logging and routing can skip
+  /// every bake-off branch without asking about each field separately.
+  package var isBaseline: Bool { self == .baseline }
+
+  #if DEBUG
+    /// Environment variable naming the variant to force. DEBUG-only by construction:
+    /// this string does not exist in a release binary, which the artifact scan asserts.
+    package static let variantEnvironmentKey = "EW_PASTE_BAKEOFF_VARIANT"
+
+    /// Environment variable carrying the harness's run identity. A non-baseline run
+    /// without one is refused, so no scored row can be orphaned from the run that
+    /// produced it.
+    package static let runIDEnvironmentKey = "EW_PASTE_BAKEOFF_RUN_ID"
+
+    /// Resolve the forced policy from an environment snapshot.
+    ///
+    /// **Fails closed to the baseline on every uncertainty**, and says so out loud: an
+    /// unknown label, a missing run id, or an id whose combination does not validate all
+    /// return `(baseline, nil)` with a rejection reason. A bake-off that silently ran the
+    /// baseline while the harness believed otherwise is the one failure this whole type
+    /// exists to prevent, so the caller MUST log `rejection` when it is non-nil.
+    package static func resolve(
+      environment: [String: String]
+    ) -> (policy: PasteDeliveryPolicy, runID: String?, rejection: String?) {
+      guard let raw = environment[variantEnvironmentKey], !raw.isEmpty else {
+        return (.baseline, nil, nil)
+      }
+      guard let runID = environment[runIDEnvironmentKey], !runID.isEmpty else {
+        return (.baseline, nil, "variant \(raw) refused: no \(runIDEnvironmentKey)")
+      }
+      let combination: (WriterPolicy, Bool)? =
+        switch raw {
+        case "V0": (.current, false)
+        case "V1": (.webCmdV, false)
+        case "V2": (.axOneWriter, false)
+        case "V4": (.current, true)
+        case "V5": (.webCmdV, true)
+        default: nil
+        }
+      guard let combination else {
+        return (.baseline, nil, "variant \(raw) refused: not a declared variant")
+      }
+      return (
+        PasteDeliveryPolicy(
+          writer: combination.0, boundTier1MessagingTimeout: combination.1, id: raw),
+        runID, nil
+      )
+    }
+  #endif
+}

--- a/Sources/EnviousWisprPipeline/PasteDeliveryPolicy.swift
+++ b/Sources/EnviousWisprPipeline/PasteDeliveryPolicy.swift
@@ -46,17 +46,6 @@ package struct PasteDeliveryPolicy: Sendable, Equatable {
       /// destination that genuinely accepts the write and genuinely does nothing loses
       /// its automatic delivery here.
       case axOneWriter
-
-      /// Deliberately deliver TWICE: after a successful key paste, paste once more.
-      ///
-      /// This arm exists to ARM the copies detector, not to test a candidate fix. A
-      /// detector that has never seen the thing it detects is a comment: every Mac we
-      /// own produces exactly one copy, so "it reported `once` on 300 dictations" is
-      /// equally consistent with a working detector and with one wired to a constant.
-      /// V6 stages the defect on purpose so the detector has a positive control.
-      ///
-      /// Never eligible in a release build, and never proposed as a fix.
-      case deliberateDouble
     #endif
   }
 
@@ -86,7 +75,6 @@ package struct PasteDeliveryPolicy: Sendable, Equatable {
         case "V2": writer == .axOneWriter && !boundTier1MessagingTimeout
         case "V4": writer == .current && boundTier1MessagingTimeout
         case "V5": writer == .webCmdV && boundTier1MessagingTimeout
-        case "V6": writer == .deliberateDouble && !boundTier1MessagingTimeout
         default: false
         }
     #else
@@ -139,7 +127,6 @@ package struct PasteDeliveryPolicy: Sendable, Equatable {
         case "V2": (.axOneWriter, false)
         case "V4": (.current, true)
         case "V5": (.webCmdV, true)
-        case "V6": (.deliberateDouble, false)
         default: nil
         }
       guard let combination else {

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1484,18 +1484,66 @@ public enum PasteService {
     case unverifiable
   }
 
-  package static func ancestorChainVerifiedFreeOfWebArea(
-    _ element: AXUIElement, maxDepth: Int = 10
-  ) -> AXWebAreaAncestry {
-    var current = element
-    var depth = 0
-    while depth < maxDepth {
+  /// Why a traversal stopped, and how far it got (#2652 diagnosis).
+  ///
+  /// The Boolean and the three-way enum both record what the walk CONCLUDED and neither
+  /// records why. Measured on 2026-09-04: the V1 arm skipped Tier 1 in Brave 5/5 and in
+  /// Chrome 1/4, and nothing in the logs distinguished "the web area is further than
+  /// `maxDepth`" from "this focused element genuinely sits under no web area". Those two
+  /// want opposite fixes, so the gate is instrumented rather than tuned.
+  ///
+  /// `depthExamined` counts ROLE READS ATTEMPTED, the starting element included and a
+  /// failed read included. A web area found on read 11 is ten parent edges away.
+  ///
+  /// `resumeElement` is non-nil only on `.depthExhausted`, and exists so the remaining
+  /// distance can be measured AFTER delivery. Continuing before the write would add
+  /// synchronous accessibility traffic to a Chromium process inside the paste path and
+  /// could warm the very cache whose staleness is the subject — an unchanged Boolean is
+  /// not an unchanged experiment.
+  package struct AXWebAreaAncestryTrace {
+    package enum StopReason: String, Equatable, Sendable {
+      case foundWebArea
+      case reachedApplication
+      case roleReadFailed
+      case parentMissingNotApplication
+      case parentReadFailed
+      case depthExhausted
+    }
+    package let result: AXWebAreaAncestry
+    package let depthExamined: Int
+    package let stopReason: StopReason
+    package let roles: [String]
+    package let resumeElement: AXUIElement?
+  }
+
+  /// The traversal, with its stopping condition made observable.
+  ///
+  /// Every exit here reproduces an exit the Boolean version had, in the same order and
+  /// after the same accessibility calls. Nothing was added to the decision path: no
+  /// retry, no cycle exit, no timeout, no extra read.
+  private static func walkAncestry(
+    from start: AXUIElement, alreadyExamined: Int, roles seed: [String], maxExamined: Int
+  ) -> AXWebAreaAncestryTrace {
+    var current = start
+    var examined = alreadyExamined
+    var roles = seed
+    while examined < maxExamined {
       var roleRef: CFTypeRef?
       guard
         AXUIElementCopyAttributeValue(current, kAXRoleAttribute as CFString, &roleRef) == .success,
         let role = roleRef as? String
-      else { return .unverifiable }
-      if role == "AXWebArea" { return .containsWebArea }
+      else {
+        return AXWebAreaAncestryTrace(
+          result: .unverifiable, depthExamined: examined + 1, stopReason: .roleReadFailed,
+          roles: roles, resumeElement: nil)
+      }
+      examined += 1
+      roles.append(role)
+      if role == "AXWebArea" {
+        return AXWebAreaAncestryTrace(
+          result: .containsWebArea, depthExamined: examined, stopReason: .foundWebArea,
+          roles: roles, resumeElement: nil)
+      }
 
       var parentRef: CFTypeRef?
       let parentRead = AXUIElementCopyAttributeValue(
@@ -1507,16 +1555,54 @@ public enum PasteService {
         // codes — for whatever reason, including a page-content quirk — would
         // be read as "verified clean" without ever having been checked past
         // this point. `role` is already in hand from this same iteration.
-        return role == "AXApplication" ? .verifiedNative : .unverifiable
+        return role == "AXApplication"
+          ? AXWebAreaAncestryTrace(
+            result: .verifiedNative, depthExamined: examined, stopReason: .reachedApplication,
+            roles: roles, resumeElement: nil)
+          : AXWebAreaAncestryTrace(
+            result: .unverifiable, depthExamined: examined,
+            stopReason: .parentMissingNotApplication, roles: roles, resumeElement: nil)
       }
       guard parentRead == .success, let parentRef,
         CFGetTypeID(parentRef) == AXUIElementGetTypeID()
-      else { return .unverifiable }
+      else {
+        return AXWebAreaAncestryTrace(
+          result: .unverifiable, depthExamined: examined, stopReason: .parentReadFailed,
+          roles: roles, resumeElement: nil)
+      }
       // swift-format-ignore: NeverForceUnwrap — guarded by the CFGetTypeID check above.
       current = (parentRef as! AXUIElement)
-      depth += 1
     }
-    return .unverifiable
+    return AXWebAreaAncestryTrace(
+      result: .unverifiable, depthExamined: examined, stopReason: .depthExhausted,
+      roles: roles, resumeElement: current)
+  }
+
+  package static func ancestorChainTrace(
+    _ element: AXUIElement, maxDepth: Int = 10
+  ) -> AXWebAreaAncestryTrace {
+    walkAncestry(from: element, alreadyExamined: 0, roles: [], maxExamined: maxDepth)
+  }
+
+  /// Pick the walk up where `maxDepth` stopped it, never at the focused element again.
+  ///
+  /// Restarting would re-read every element the first pass already read, which is the
+  /// added traffic this design exists to avoid. Returns the prior trace unchanged when
+  /// there is nothing to resume, so a caller cannot accidentally report a continuation
+  /// that never ran.
+  package static func resumeAncestorChainTrace(
+    _ prior: AXWebAreaAncestryTrace, maxExamined: Int
+  ) -> AXWebAreaAncestryTrace {
+    guard let resume = prior.resumeElement else { return prior }
+    return walkAncestry(
+      from: resume, alreadyExamined: prior.depthExamined, roles: prior.roles,
+      maxExamined: maxExamined)
+  }
+
+  package static func ancestorChainVerifiedFreeOfWebArea(
+    _ element: AXUIElement, maxDepth: Int = 10
+  ) -> AXWebAreaAncestry {
+    ancestorChainTrace(element, maxDepth: maxDepth).result
   }
 
   /// Exact UTF-16 code-unit identity.

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -488,12 +488,29 @@ public enum PasteService {
     }
   }
 
+  /// The field's size immediately BEFORE a Tier 1 write, for the copies observation (#2652).
+  ///
+  /// Taken from reads `insertViaAccessibility` ALREADY performs; no read exists for this type's
+  /// sake. That is the whole constraint: the observation must add no synchronous accessibility
+  /// traffic to the delivery path, and a destination whose AX round trip is slow is precisely the
+  /// suspected population.
+  package struct CopiesBeforeImage: Sendable, Equatable {
+    package let count: Int
+    package let selectionLength: Int
+    package init(count: Int, selectionLength: Int) {
+      self.count = count
+      self.selectionLength = selectionLength
+    }
+  }
+
   package struct AXInsertResult: Sendable {
     package let outcome: AXInsertOutcome
     package let submitted: PastePayloadKind?
     package let writeCall: AXWriteCall
     package let declineReason: AXDeclineReason?
     package let settability: AXSettability?
+    /// Non-nil only where the setter was actually reached, so both reads happened.
+    package var copiesBeforeImage: CopiesBeforeImage?
 
     package init(
       outcome: AXInsertOutcome,
@@ -1615,8 +1632,17 @@ public enum PasteService {
   package static func copiesDelivered(
     countAfter: Int?, countBefore: Int, selectionLengthBefore: Int, insertedLength: Int
   ) -> Int? {
-    guard let countAfter, insertedLength > 0 else { return nil }
-    let expected = countBefore - selectionLengthBefore + insertedLength
+    // Overflow-safe throughout: these numbers come from a foreign application's accessibility
+    // implementation, so they are arbitrary Ints, not values this process produced.
+    guard let countAfter, insertedLength > 0, countBefore >= 0, selectionLengthBefore >= 0,
+      countAfter >= 0
+    else { return nil }
+    let (afterSelection, s1) = countBefore.subtractingReportingOverflow(selectionLengthBefore)
+    guard !s1 else { return nil }
+    let (expected, s2) = afterSelection.addingReportingOverflow(insertedLength)
+    guard !s2 else { return nil }
+    let (twoCopies, s3) = expected.addingReportingOverflow(insertedLength)
+    guard !s3 else { return nil }
 
     // A DESTINATION MAY NOT STORE EXACTLY WHAT IT WAS GIVEN, so exact arithmetic
     // answers `unknown` for a delivery that plainly worked.
@@ -1631,8 +1657,12 @@ public enum PasteService {
     // widened window from turning a single delivery into a reported duplicate, which is
     // the one error this detector must never make.
     let tolerance = min(3, insertedLength / 3)
-    if abs(countAfter - expected) <= tolerance { return 1 }
-    if abs(countAfter - (expected + insertedLength)) <= tolerance { return 2 }
+    func within(_ band: Int) -> Bool {
+      let (delta, overflowed) = countAfter.subtractingReportingOverflow(band)
+      return !overflowed && delta.magnitude <= UInt(tolerance)
+    }
+    if within(expected) { return 1 }
+    if within(twoCopies) { return 2 }
     return nil
   }
 
@@ -1962,13 +1992,16 @@ public enum PasteService {
     // The write was attempted with this payload, whatever the verification says
     // afterwards — including an outcome later classified `unverifiable`, where
     // the text may already be in the document.
-    return AXInsertResult(
+    var result = AXInsertResult(
       outcome: outcome,
       submitted: payload.kind,
       writeCall: .succeeded(attemptedText: text),
       declineReason: Self.declineReason(for: outcome),
       settability: settability
     )
+    result.copiesBeforeImage = CopiesBeforeImage(
+      count: countBefore, selectionLength: rangeBefore.length)
+    return result
   }
 
   // MARK: - Tier 2: CGEvent Cmd+V

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -155,8 +155,9 @@ public enum PasteService {
   public static func saveClipboard(from pasteboard: NSPasteboard = .general) -> ClipboardSnapshot {
     // Unbounded by contract, which is correct for a delivery: whatever the user had, they get back.
     // A caller that must bound its memory asks for the budgeted variant below and handles the nil.
-    boundedSaveClipboard(from: pasteboard, maximumBytes: nil) ?? ClipboardSnapshot(
-      items: [], changeCount: pasteboard.changeCount)
+    boundedSaveClipboard(from: pasteboard, maximumBytes: nil)
+      ?? ClipboardSnapshot(
+        items: [], changeCount: pasteboard.changeCount)
   }
 
   /// Capture the pasteboard, giving up as soon as the cumulative bytes exceed `maximumBytes`.
@@ -457,20 +458,53 @@ public enum PasteService {
   /// Replaces a `(outcome, submitted)` tuple. The decision evidence used to be
   /// discarded at this return boundary, which is why nothing downstream could
   /// say why the fast route lost.
+  /// Whether the AX write CALL was made, and with what text (#2652).
+  ///
+  /// `AXInsertOutcome` alone cannot answer this. `.noMutation` is returned both when we
+  /// declined before touching the element and when the write ran and provably changed
+  /// nothing — opposite facts, one value, because the cascade only ever needed to know
+  /// whether a retry was safe. The V2 arm needs the other question: once the setter has
+  /// RETURNED SUCCESS, no later writer may run, regardless of what verification says.
+  ///
+  /// The attempted text rides as an ASSOCIATED VALUE rather than a sibling field so
+  /// "not attempted, but here is the text" and "succeeded, but no text" cannot be
+  /// spelled. A first draft carried them as independent properties and the reviewer
+  /// found the contradictory pair immediately; this shape deletes the states instead of
+  /// documenting them.
+  package enum AXWriteCall: Equatable, Sendable {
+    /// The setter was never called. Nothing was mutated; fallback is safe.
+    case notAttempted
+    /// The setter was called and returned an error. Nothing was mutated.
+    case failed(attemptedText: String)
+    /// The setter returned success. The mutation MAY be in the document.
+    case succeeded(attemptedText: String)
+
+    /// The exact string handed to the setter, for the bake-off submission ledger.
+    package var attemptedText: String? {
+      switch self {
+      case .notAttempted: return nil
+      case .failed(let text), .succeeded(let text): return text
+      }
+    }
+  }
+
   package struct AXInsertResult: Sendable {
     package let outcome: AXInsertOutcome
     package let submitted: PastePayloadKind?
+    package let writeCall: AXWriteCall
     package let declineReason: AXDeclineReason?
     package let settability: AXSettability?
 
     package init(
       outcome: AXInsertOutcome,
       submitted: PastePayloadKind?,
+      writeCall: AXWriteCall,
       declineReason: AXDeclineReason?,
       settability: AXSettability?
     ) {
       self.outcome = outcome
       self.submitted = submitted
+      self.writeCall = writeCall
       self.declineReason = declineReason
       self.settability = settability
     }
@@ -482,7 +516,21 @@ public enum PasteService {
       _ reason: AXDeclineReason, settability: AXSettability? = nil
     ) -> AXInsertResult {
       AXInsertResult(
-        outcome: .noMutation, submitted: nil, declineReason: reason, settability: settability)
+        outcome: .noMutation, submitted: nil, writeCall: .notAttempted, declineReason: reason,
+        settability: settability)
+    }
+
+    /// The setter RAN and returned an error. Distinct from `declined` on purpose: this
+    /// factory is the only way to spell a failed write call, so no pre-write decline can
+    /// accidentally claim one, and no failed call can accidentally claim it never ran.
+    /// Nothing was mutated either way, so the cascade's retry rules are unchanged.
+    static func writeCallFailed(
+      attemptedText: String, settability: AXSettability?
+    ) -> AXInsertResult {
+      AXInsertResult(
+        outcome: .noMutation, submitted: nil,
+        writeCall: .failed(attemptedText: attemptedText), declineReason: .setFailed,
+        settability: settability)
     }
   }
 
@@ -1386,7 +1434,10 @@ public enum PasteService {
         bundleIdentifier: bundleIdentifier, axIdentifier: nil, axDOMClassList: axDOMClassList)
     }
     guard signatureMatches else { return nil }
-    return ancestorChainVerifiedFreeOfWebArea(element) ? family : nil
+    // Exactly the projection the Boolean version computed: only a chain walked to a
+    // verified native root yields a browser family. `containsWebArea` and
+    // `unverifiable` both yield nil, as `false` did before.
+    return ancestorChainVerifiedFreeOfWebArea(element) == .verifiedNative ? family : nil
   }
 
   /// Whether `element`'s AX ancestor chain can be POSITIVELY VERIFIED clean of
@@ -1413,9 +1464,29 @@ public enum PasteService {
   /// the walk was cut short, not that it reached the top, and must not be
   /// read as verification — the existing `.attributeUnsupported`/`.noValue`
   /// idiom in `firstPasteItem` above draws the same distinction one type over.
-  private static func ancestorChainVerifiedFreeOfWebArea(
+  /// Three states, because two callers need different halves of the answer (#2652).
+  ///
+  /// `addressBarFamily(of:)` needs only "is this positively native chrome", which is
+  /// what the Boolean said. The bake-off's V1 arm needs "is this positively PAGE
+  /// CONTENT", and those are not each other's negation: a chain we could not read is
+  /// neither. Collapsing the two into one Bool would route an unreadable chain as if it
+  /// were a web area, which would change behaviour on a target the arm is not testing.
+  ///
+  /// The traversal below is byte-for-byte what the Boolean version did; only the return
+  /// vocabulary widened. `.verifiedNative` is returned in exactly the one place the old
+  /// code returned `true`, so the projection `== .verifiedNative` reproduces it exactly.
+  package enum AXWebAreaAncestry: Equatable, Sendable {
+    /// An `AXWebArea` was found in the chain. Positively page content.
+    case containsWebArea
+    /// The chain was walked to a verified `AXApplication` root with no web area.
+    case verifiedNative
+    /// The walk was cut short. Proof of nothing, in either direction.
+    case unverifiable
+  }
+
+  package static func ancestorChainVerifiedFreeOfWebArea(
     _ element: AXUIElement, maxDepth: Int = 10
-  ) -> Bool {
+  ) -> AXWebAreaAncestry {
     var current = element
     var depth = 0
     while depth < maxDepth {
@@ -1423,8 +1494,8 @@ public enum PasteService {
       guard
         AXUIElementCopyAttributeValue(current, kAXRoleAttribute as CFString, &roleRef) == .success,
         let role = roleRef as? String
-      else { return false }
-      if role == "AXWebArea" { return false }
+      else { return .unverifiable }
+      if role == "AXWebArea" { return .containsWebArea }
 
       var parentRef: CFTypeRef?
       let parentRead = AXUIElementCopyAttributeValue(
@@ -1436,16 +1507,16 @@ public enum PasteService {
         // codes — for whatever reason, including a page-content quirk — would
         // be read as "verified clean" without ever having been checked past
         // this point. `role` is already in hand from this same iteration.
-        return role == "AXApplication"
+        return role == "AXApplication" ? .verifiedNative : .unverifiable
       }
       guard parentRead == .success, let parentRef,
         CFGetTypeID(parentRef) == AXUIElementGetTypeID()
-      else { return false }
+      else { return .unverifiable }
       // swift-format-ignore: NeverForceUnwrap — guarded by the CFGetTypeID check above.
       current = (parentRef as! AXUIElement)
       depth += 1
     }
-    return false
+    return .unverifiable
   }
 
   /// Exact UTF-16 code-unit identity.
@@ -1541,8 +1612,23 @@ public enum PasteService {
     repaired: String? = nil,
     context: CaretContext? = nil,
     element: AXUIElement,
-    requireFocusedElementMatch: Bool = false
+    requireFocusedElementMatch: Bool = false,
+    boundMessagingTimeout: Bool = false
   ) -> AXInsertResult {
+    // #2652 V4/V5: bound THIS element's own AX round trips.
+    //
+    // We already set a messaging timeout for app-scoped focused-element reads and menu
+    // probing. What has never been bounded is the captured Tier 1 element across its
+    // read/write/read sequence — the one place the stale-read hazard lives, and the one
+    // difference between us and the three competitors that import this call.
+    //
+    // It bounds how long a single call may BLOCK. It cannot make a destination's state
+    // settle sooner, and this arm exists to measure whether that distinction matters
+    // here rather than to assume either way. Off in every shipped build.
+    if boundMessagingTimeout {
+      _ = AXUIElementSetMessagingTimeout(element, Float(axMessagingTimeoutSeconds))
+    }
+
     // Verify the element is a text field or text area.
     var roleRef: CFTypeRef?
     let roleErr = AXUIElementCopyAttributeValue(
@@ -1688,7 +1774,9 @@ public enum PasteService {
       kAXSelectedTextAttribute as CFString,
       text as CFTypeRef
     )
-    guard err == .success else { return .declined(.setFailed, settability: settability) }
+    guard err == .success else {
+      return .writeCallFailed(attemptedText: text, settability: settability)
+    }
 
     // From here the write may have landed, so every remaining failure is
     // `unverifiable`, never `noMutation`.
@@ -1733,6 +1821,7 @@ public enum PasteService {
     return AXInsertResult(
       outcome: outcome,
       submitted: payload.kind,
+      writeCall: .succeeded(attemptedText: text),
       declineReason: Self.declineReason(for: outcome),
       settability: settability
     )

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -509,7 +509,15 @@ public enum PasteService {
     package let writeCall: AXWriteCall
     package let declineReason: AXDeclineReason?
     package let settability: AXSettability?
-    /// Non-nil only where the setter was actually reached, so both reads happened.
+    /// Non-nil on every return AFTER both before-image reads succeeded — not only the ones
+    /// that reached the setter.
+    ///
+    /// Review finding, 2026-09-04: attaching it to the success path alone discarded it on the
+    /// two paths where the observation is MOST useful. A Tier 1 write that returned an error,
+    /// and a decline after the reads, both hand delivery to the fallback — and that fallback
+    /// delivery is measurable, with a before-image already in hand. Reporting those as
+    /// `no_before_image` would have excluded exactly the uncertain cases the instrument exists
+    /// for. **Whether the SETTER ran is a separate question, answered by `writeCall`.**
     package var copiesBeforeImage: CopiesBeforeImage?
 
     package init(
@@ -530,11 +538,14 @@ public enum PasteService {
     /// in every case, because nothing was mutated — the reason is what tells
     /// the two dozen ways of getting here apart.
     static func declined(
-      _ reason: AXDeclineReason, settability: AXSettability? = nil
+      _ reason: AXDeclineReason, settability: AXSettability? = nil,
+      beforeImage: CopiesBeforeImage? = nil
     ) -> AXInsertResult {
-      AXInsertResult(
+      var result = AXInsertResult(
         outcome: .noMutation, submitted: nil, writeCall: .notAttempted, declineReason: reason,
         settability: settability)
+      result.copiesBeforeImage = beforeImage
+      return result
     }
 
     /// The setter RAN and returned an error. Distinct from `declined` on purpose: this
@@ -542,12 +553,15 @@ public enum PasteService {
     /// accidentally claim one, and no failed call can accidentally claim it never ran.
     /// Nothing was mutated either way, so the cascade's retry rules are unchanged.
     static func writeCallFailed(
-      attemptedText: String, settability: AXSettability?
+      attemptedText: String, settability: AXSettability?,
+      beforeImage: CopiesBeforeImage? = nil
     ) -> AXInsertResult {
-      AXInsertResult(
+      var result = AXInsertResult(
         outcome: .noMutation, submitted: nil,
         writeCall: .failed(attemptedText: attemptedText), declineReason: .setFailed,
         settability: settability)
+      result.copiesBeforeImage = beforeImage
+      return result
     }
   }
 
@@ -1897,7 +1911,9 @@ public enum PasteService {
     } else {
       // Without a trustworthy before-image, a successful AX call could never be
       // proven harmless. Bail while nothing has been mutated; Tier 2 is safe.
-      return .declined(.beforeImageUnreadableOrIncomplete, settability: settability)
+      return .declined(
+        .beforeImageUnreadableOrIncomplete, settability: settability,
+        beforeImage: CopiesBeforeImage(count: countBefore, selectionLength: rangeBefore.length))
     }
 
     // The payload choice, made from the range AND the surrounding text this
@@ -1938,7 +1954,9 @@ public enum PasteService {
           requireFocusedElementMatch: true,
           isFocused: freshFocusedElement(matching: element) != nil)
       else {
-        return .declined(.focusUnconfirmed, settability: settability)
+        return .declined(
+          .focusUnconfirmed, settability: settability,
+          beforeImage: CopiesBeforeImage(count: countBefore, selectionLength: rangeBefore.length))
       }
     }
 
@@ -1949,7 +1967,9 @@ public enum PasteService {
       text as CFTypeRef
     )
     guard err == .success else {
-      return .writeCallFailed(attemptedText: text, settability: settability)
+      return .writeCallFailed(
+        attemptedText: text, settability: settability,
+        beforeImage: CopiesBeforeImage(count: countBefore, selectionLength: rangeBefore.length))
     }
 
     // From here the write may have landed, so every remaining failure is

--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1578,6 +1578,64 @@ public enum PasteService {
       roles: roles, resumeElement: current)
   }
 
+  /// How many characters the field holds, or nil when it will not say.
+  ///
+  /// The copies detector is built on this NUMBER and never on the text, which is what
+  /// makes it shippable: a count crossing the network says nothing about what anybody
+  /// dictated, and a count is also the only reading that survives the case a text
+  /// comparison gets wrong — somebody deliberately dictating the same sentence twice
+  /// produces two separate deliveries, each with its own delta of one copy.
+  package static func characterCount(of element: AXUIElement) -> Int? {
+    var ref: CFTypeRef?
+    guard
+      AXUIElementCopyAttributeValue(
+        element, kAXNumberOfCharactersAttribute as CFString, &ref) == .success,
+      let count = ref as? Int, count >= 0
+    else { return nil }
+    return count
+  }
+
+  /// UTF-16 length of whatever is selected, or nil when the range will not read.
+  ///
+  /// A dictation that REPLACES a selection shortens the field by that much before it
+  /// lengthens it, so a copies count that ignores the selection reads a replacement as a
+  /// short delivery and lands on `unknown`.
+  package static func selectedTextLength(of element: AXUIElement) -> Int? {
+    guard let range = selectedRange(of: element), range.length >= 0 else { return nil }
+    return range.length
+  }
+
+  /// How many copies of a delivery of `insertedLength` landed, judged by length alone.
+  ///
+  /// `expected` is what the field must hold if exactly one copy arrived. One further
+  /// `insertedLength` beyond that is two copies. Anything else is `nil`: the user typing
+  /// during the settle window, an app that rewrites the field, a count we could not read.
+  /// Returning nil rather than guessing matters more here than usual, because this number
+  /// is destined for a dashboard where a wrong verdict becomes a wrong headline.
+  package static func copiesDelivered(
+    countAfter: Int?, countBefore: Int, selectionLengthBefore: Int, insertedLength: Int
+  ) -> Int? {
+    guard let countAfter, insertedLength > 0 else { return nil }
+    let expected = countBefore - selectionLengthBefore + insertedLength
+
+    // A DESTINATION MAY NOT STORE EXACTLY WHAT IT WAS GIVEN, so exact arithmetic
+    // answers `unknown` for a delivery that plainly worked.
+    //
+    // Measured 2026-09-04 across 8 deliveries of the same sentence: Discord landed on
+    // the exact expected count every time, and Slack was short by exactly one character
+    // per copy — one copy short by 1, two copies short by 2. Whatever Slack normalises
+    // away, it does so once per copy and reproducibly.
+    //
+    // The tolerance is bounded to a THIRD of one copy so the one-copy and two-copy
+    // bands can never overlap, whatever the sentence length. That bound is what keeps a
+    // widened window from turning a single delivery into a reported duplicate, which is
+    // the one error this detector must never make.
+    let tolerance = min(3, insertedLength / 3)
+    if abs(countAfter - expected) <= tolerance { return 1 }
+    if abs(countAfter - (expected + insertedLength)) <= tolerance { return 2 }
+    return nil
+  }
+
   package static func ancestorChainTrace(
     _ element: AXUIElement, maxDepth: Int = 10
   ) -> AXWebAreaAncestryTrace {

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2174,6 +2174,58 @@ public final class TelemetryService {
   /// SLOWER than AI polish when it is in fact ~16x faster. `latency_ms` keeps
   /// the raw millisecond value, so `$value` is a pure aggregation mirror and
   /// converting it loses nothing.
+  /// How many copies of one dictation landed (#2652).
+  ///
+  /// A SEPARATE event rather than a field on `paste.completed`, because the verdict is only
+  /// available after a settle window that `paste.completed` must not wait for — delaying an
+  /// existing latency metric to carry a new one would corrupt it, and a stalled probe would cost
+  /// us an otherwise valid completion. Joined on `take_id`. **Either arrival order is permitted;
+  /// no query may assume one.**
+  ///
+  /// **Lengths never leave the Mac.** The arithmetic runs locally and only its verdict is sent.
+  /// Field counts describe the size of whatever document the user is working in, which has nothing
+  /// to do with dictation, so shipping one would widen exposure beyond
+  /// `asr.completed.char_count`, which describes only dictated output.
+  ///
+  /// Machine characteristics are deliberately NOT repeated here: `app.launched` already carries
+  /// `os_version` and `device_model`, joinable by `distinct_id`. Repeating them per delivery would
+  /// put more on the wire to answer a question the existing join already answers.
+  ///
+  /// A MISSING event is a fourth state and must never be read as one copy.
+  public func pasteCopiesObserved(
+    takeID: String,
+    copiesEstimate: String,
+    status: String,
+    detectorVersion: Int,
+    settleMs: Int,
+    tier: String,
+    targetApp: String?,
+    tier1ReachedSetter: Bool
+  ) {
+    guard !takeID.isEmpty else { return }
+    var props: [String: Any] = [
+      "take_id": takeID,
+      "copies_estimate": copiesEstimate,
+      "status": status,
+      "detector_version": detectorVersion,
+      "settle_ms": settleMs,
+      "tier": tier,
+      "tier1_reached_setter": tier1ReachedSetter,
+    ]
+    if let targetApp { props["target_app"] = targetApp }
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "paste.copies_observed",
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: props.compactMapValues { $0 as? Int },
+          doubleProps: props.compactMapValues { $0 as? Double },
+          boolProps: props.compactMapValues { $0 as? Bool }
+        ))
+    #endif
+    PostHogSDK.shared.capture("paste.copies_observed", properties: props)
+  }
+
   public func pasteCompleted(
     tier: String, targetApp: String?, result: String, latencyMs: Int,
     insertion: PasteInsertionTelemetry = .init(),

--- a/Tests/EnviousWisprTests/Architecture/PasteBakeoffReleaseContainmentTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/PasteBakeoffReleaseContainmentTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// The bake-off control plane must not exist in a shipped build (#2652).
+//
+// Everything else about the seam is a promise made in Swift: `#if DEBUG` around the
+// non-baseline cases, a literal baseline at the one production construction site, a
+// validating initializer. Those are the right mechanisms and they are all invisible in
+// the artifact a user actually downloads.
+//
+// This suite asks the artifact instead. It is deliberately a STRING search rather than a
+// behavioural test, because the question is not "does the release build route correctly"
+// — a behavioural test would pass just as happily against a binary that carried the
+// whole control plane and merely defaulted it off.
+//
+// **A skip here is not a pass.** Every case reports what it could not check, loudly,
+// because the failure mode of an artifact test is silence on the machine that has no
+// artifact — which is every machine except the one that just built one.
+@Suite("Paste bake-off release containment (#2652)", .tags(.productOutcome))
+struct PasteBakeoffReleaseContainmentTests {
+
+  /// Strings that must never appear in a shipped executable.
+  ///
+  /// Two families, and both are needed. The environment keys are how a control plane
+  /// would be *reached*; the writer raw values are how it would be *spelled*. A binary
+  /// carrying either has the seam in it whatever its routing does at runtime.
+  static let forbidden: [String] = [
+    "EW_PASTE_BAKEOFF_VARIANT",
+    "EW_PASTE_BAKEOFF_RUN_ID",
+    "PASTE_BAKEOFF_CONTROL",
+    "PASTE_BAKEOFF_TRIAL",
+    "webCmdV",
+    "axOneWriter",
+  ]
+
+  /// Candidate release products, newest first. Returns nil when none was built.
+  static func releaseExecutable() -> URL? {
+    let root = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // Architecture
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+      .deletingLastPathComponent()  // checkout
+    let candidates = [
+      ".derivedData/Test/Build/Products/Release/EnviousWispr.app/Contents/MacOS/EnviousWispr",
+      ".derivedData/Build/Products/Release/EnviousWispr.app/Contents/MacOS/EnviousWispr",
+      "build/Release/EnviousWispr.app/Contents/MacOS/EnviousWispr",
+    ]
+    for relative in candidates {
+      let url = root.appendingPathComponent(relative)
+      if FileManager.default.fileExists(atPath: url.path) { return url }
+    }
+    return nil
+  }
+
+  @Test("the DEBUG-only control-plane strings are absent from a Release executable")
+  func releaseArtifactCarriesNoControlPlane() throws {
+    guard let executable = Self.releaseExecutable() else {
+      // Loud, and deliberately not an `.enabled(if:)` gate: a disabled test reports
+      // nothing at all, and this receipt is worth more than a tidy test list. The
+      // release lane builds the product this needs.
+      Issue.record(
+        """
+        SKIPPED, NOT PASSED: no Release executable found in this checkout, so release \
+        containment for #2652 is UNVERIFIED here. Build the release lane \
+        (`scripts/xcode-test.sh --release`) and re-run. This is a receipt that the check \
+        did not happen, not evidence that it succeeded.
+        """)
+      return
+    }
+
+    let data = try Data(contentsOf: executable)
+    // Search the raw bytes rather than a decoded string: Swift string literals land in
+    // the binary as UTF-8 inside a __cstring section, and decoding a Mach-O as text
+    // would silently drop most of it.
+    for needle in Self.forbidden {
+      let pattern = Array(needle.utf8)
+      #expect(
+        !data.contains(pattern),
+        """
+        \(executable.lastPathComponent) contains "\(needle)". The bake-off control plane \
+        reached a shipped artifact. Every non-baseline policy and both environment keys \
+        must be inside `#if DEBUG`.
+        """)
+    }
+  }
+
+  @Test("the baseline is the only policy a Release build can construct")
+  func releaseCanOnlyBuildTheBaseline() {
+    // Compile-time half of the same claim, and the reason it earns a row beside the
+    // artifact scan: this one runs everywhere, including CI on a Debug lane, so a
+    // regression is caught long before anyone builds a release.
+    #expect(PasteDeliveryPolicy.baseline.id == "V0")
+    #expect(PasteDeliveryPolicy.baseline.writer == .current)
+    #expect(!PasteDeliveryPolicy.baseline.boundTier1MessagingTimeout)
+    #expect(PasteDeliveryPolicy.baseline.isBaseline)
+  }
+}
+
+extension Data {
+  /// Whether these bytes contain the given byte sequence.
+  fileprivate func contains(_ pattern: [UInt8]) -> Bool {
+    guard !pattern.isEmpty, count >= pattern.count else { return false }
+    return withUnsafeBytes { raw -> Bool in
+      guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return false }
+      let limit = count - pattern.count
+      var index = 0
+      while index <= limit {
+        if base[index] == pattern[0] {
+          var matched = true
+          for offset in 1..<pattern.count where base[index + offset] != pattern[offset] {
+            matched = false
+            break
+          }
+          if matched { return true }
+        }
+        index += 1
+      }
+      return false
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/PasteBakeoffReleaseContainmentTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/PasteBakeoffReleaseContainmentTests.swift
@@ -15,9 +15,11 @@ import Testing
 // — a behavioural test would pass just as happily against a binary that carried the
 // whole control plane and merely defaulted it off.
 //
-// **A skip here is not a pass.** Every case reports what it could not check, loudly,
-// because the failure mode of an artifact test is silence on the machine that has no
-// artifact — which is every machine except the one that just built one.
+// **A skip here is not a pass, and the artifact case IS skipped on most machines.** It
+// runs only where a Release product exists, which is the release lane and nowhere else.
+// That boundary is stated in the plan's ship criteria rather than papered over, because
+// the failure mode of an artifact test is silence on every machine that has no artifact.
+// The second case runs everywhere and covers the half that needs no artifact.
 @Suite("Paste bake-off release containment (#2652)", .tags(.productOutcome))
 struct PasteBakeoffReleaseContainmentTests {
 
@@ -54,21 +56,26 @@ struct PasteBakeoffReleaseContainmentTests {
     return nil
   }
 
-  @Test("the DEBUG-only control-plane strings are absent from a Release executable")
+  // Gated, and the gate is the honest choice rather than the tidy one.
+  //
+  // A first draft called `Issue.record` when no Release product existed, so the suite
+  // would have gone RED on every machine that had not just built one — including the
+  // ordinary Debug lane, and therefore CI and `main`. That is a FALSE failure: it says
+  // "release containment is broken" when the truth is "no release artifact is here to
+  // look at", and a red main teaches everyone to ignore the row.
+  //
+  // The cost of gating is real and is stated in §13 rather than hidden: this check does
+  // not run in the Debug lane, so **release containment is only verified when the release
+  // lane runs it.** A skipped receipt is not a passed receipt, and the ship criteria say
+  // so. `releaseCanOnlyBuildTheBaseline` below runs everywhere and covers the half that
+  // can be checked without an artifact.
+  @Test(
+    "the DEBUG-only control-plane strings are absent from a Release executable",
+    .enabled(if: releaseExecutable() != nil))
   func releaseArtifactCarriesNoControlPlane() throws {
-    guard let executable = Self.releaseExecutable() else {
-      // Loud, and deliberately not an `.enabled(if:)` gate: a disabled test reports
-      // nothing at all, and this receipt is worth more than a tidy test list. The
-      // release lane builds the product this needs.
-      Issue.record(
-        """
-        SKIPPED, NOT PASSED: no Release executable found in this checkout, so release \
-        containment for #2652 is UNVERIFIED here. Build the release lane \
-        (`scripts/xcode-test.sh --release`) and re-run. This is a receipt that the check \
-        did not happen, not evidence that it succeeded.
-        """)
-      return
-    }
+    let executable = try #require(
+      Self.releaseExecutable(),
+      "gate said a Release executable exists and it was gone by the time the body ran")
 
     let data = try Data(contentsOf: executable)
     // Search the raw bytes rather than a decoded string: Swift string literals land in

--- a/Tests/EnviousWisprTests/Pipeline/PasteCascadeClipboardSeamTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteCascadeClipboardSeamTests.swift
@@ -60,7 +60,7 @@ struct PasteCascadeClipboardSeamTests {
     let board = NSPasteboard.withUniqueName()
     defer { board.releaseGlobally() }
 
-    let executor = PasteCascadeExecutor(pasteboard: board)
+    let executor = PasteCascadeExecutor(pasteboard: board, policy: .baseline)
     let result = await executor.deliver(request("the words the user just said"))
 
     #expect(result.tier == .clipboardOnly)
@@ -111,8 +111,8 @@ struct PasteCascadeClipboardSeamTests {
       second.releaseGlobally()
     }
 
-    let firstExecutor = PasteCascadeExecutor(pasteboard: first)
-    let secondExecutor = PasteCascadeExecutor(pasteboard: second)
+    let firstExecutor = PasteCascadeExecutor(pasteboard: first, policy: .baseline)
+    let secondExecutor = PasteCascadeExecutor(pasteboard: second, policy: .baseline)
     _ = await firstExecutor.deliver(request("first"))
     _ = await secondExecutor.deliver(request("second"))
 

--- a/Tests/EnviousWisprTests/Pipeline/PasteCopiesSelectionTrustTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteCopiesSelectionTrustTests.swift
@@ -5,34 +5,40 @@ import Testing
 // Whether a before-image's SELECTION LENGTH still describes the field the delivery wrote into
 // (#2652).
 //
-// The fallback activates the destination before pasting, and activation is allowed to change the
-// selection. A selection that is LOST means the field never shrank, so it grew by a whole payload
-// more than expected and reads as TWO COPIES. A false `two` is the one error this instrument must
-// never make, so where the selection cannot be trusted the observation declines.
+// Every route after Tier 1 activates the destination first, and activation is allowed to change
+// the selection. A selection that is LOST means the field never shrank, so it grew by a whole
+// payload more than expected and reads as TWO COPIES. A false `two` is the one error this
+// instrument must never make, so where the selection cannot be trusted the observation declines.
+//
+// The discriminator went through three review rounds as "did the Tier 1 setter run", and each
+// round found another case it trusted wrongly: a setter that failed, and a setter that returned
+// no mutation, both hand delivery to a fallback. Reaching the setter never proved it replaced the
+// selection. Activation is the property that actually decides.
 @Suite("Paste copies: when a selection can still be trusted", .tags(.observabilityContract))
 struct PasteCopiesSelectionTrustTests {
 
-  @Test("a write that reached the setter wrote over the selection it measured")
-  func setterReachedIsAlwaysTrusted() {
+  @Test("nothing activated the destination, so the selection still stands")
+  func noFallbackIsTrusted() {
     #expect(
-      PasteCopiesObserver.selectionStillDescribesTheField(setterReached: true, selectionLength: 27))
+      PasteCopiesObserver.selectionStillDescribesTheField(fallbackRan: false, selectionLength: 27))
     #expect(
-      PasteCopiesObserver.selectionStillDescribesTheField(setterReached: true, selectionLength: 0))
+      PasteCopiesObserver.selectionStillDescribesTheField(fallbackRan: false, selectionLength: 0))
   }
 
   @Test("a plain caret has no selection to lose")
   func caretWithoutSelectionIsTrusted() {
     #expect(
-      PasteCopiesObserver.selectionStillDescribesTheField(setterReached: false, selectionLength: 0))
+      PasteCopiesObserver.selectionStillDescribesTheField(fallbackRan: true, selectionLength: 0))
   }
 
-  @Test("a selection measured before a decline is NOT trusted")
-  func selectionAfterDeclineIsRefused() {
+  // The measured failure: a 100-character field with 27 selected, losing its selection during
+  // activation and receiving one 27-character paste, reaches 127 where one copy was expected at
+  // 100. Without this refusal the observation reports TWO.
+  @Test("a selection measured before a fallback ran is NOT trusted")
+  func selectionBeforeFallbackIsRefused() {
     #expect(
-      !PasteCopiesObserver.selectionStillDescribesTheField(
-        setterReached: false, selectionLength: 1))
+      !PasteCopiesObserver.selectionStillDescribesTheField(fallbackRan: true, selectionLength: 1))
     #expect(
-      !PasteCopiesObserver.selectionStillDescribesTheField(
-        setterReached: false, selectionLength: 27))
+      !PasteCopiesObserver.selectionStillDescribesTheField(fallbackRan: true, selectionLength: 27))
   }
 }

--- a/Tests/EnviousWisprTests/Pipeline/PasteCopiesSelectionTrustTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteCopiesSelectionTrustTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import EnviousWisprPipeline
+
+// Whether a before-image's SELECTION LENGTH still describes the field the delivery wrote into
+// (#2652).
+//
+// The fallback activates the destination before pasting, and activation is allowed to change the
+// selection. A selection that is LOST means the field never shrank, so it grew by a whole payload
+// more than expected and reads as TWO COPIES. A false `two` is the one error this instrument must
+// never make, so where the selection cannot be trusted the observation declines.
+@Suite("Paste copies: when a selection can still be trusted", .tags(.observabilityContract))
+struct PasteCopiesSelectionTrustTests {
+
+  @Test("a write that reached the setter wrote over the selection it measured")
+  func setterReachedIsAlwaysTrusted() {
+    #expect(
+      PasteCopiesObserver.selectionStillDescribesTheField(setterReached: true, selectionLength: 27))
+    #expect(
+      PasteCopiesObserver.selectionStillDescribesTheField(setterReached: true, selectionLength: 0))
+  }
+
+  @Test("a plain caret has no selection to lose")
+  func caretWithoutSelectionIsTrusted() {
+    #expect(
+      PasteCopiesObserver.selectionStillDescribesTheField(setterReached: false, selectionLength: 0))
+  }
+
+  @Test("a selection measured before a decline is NOT trusted")
+  func selectionAfterDeclineIsRefused() {
+    #expect(
+      !PasteCopiesObserver.selectionStillDescribesTheField(
+        setterReached: false, selectionLength: 1))
+    #expect(
+      !PasteCopiesObserver.selectionStillDescribesTheField(
+        setterReached: false, selectionLength: 27))
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/PasteDeliveryPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteDeliveryPolicyTests.swift
@@ -16,6 +16,14 @@ import Testing
 // would produce a scorecard full of confident rows about a policy that never ran, with
 // nothing downstream able to tell. These tests exist to make that state unreachable, not
 // merely unlikely.
+// THE WHOLE CONTROL PLANE IS `#if DEBUG`, so this whole suite is too.
+//
+// `resolve`, `variantEnvironmentKey`, `runIDEnvironmentKey`, `.webCmdV` and `.axOneWriter` are
+// all compiled out of a release build on purpose — a release binary contains neither the
+// candidate behaviour nor its raw values for an artifact scan to find. A test naming them
+// compiled in Debug and broke `build-release`, and no local run could see it:
+// `scripts/xcode-test.sh` builds Debug. `--release` is the flag that reproduces it.
+#if DEBUG
 @Suite("Paste delivery policy (#2652)", .tags(.productOutcome))
 struct PasteDeliveryPolicyTests {
 
@@ -34,8 +42,8 @@ struct PasteDeliveryPolicyTests {
   @Test("an unknown variant is refused LOUDLY rather than guessed")
   func unknownVariantIsRefused() {
     let resolved = PasteDeliveryPolicy.resolve(environment: [
-      PasteDeliveryPolicy.variantEnvironmentKey: "V9",
-      PasteDeliveryPolicy.runIDEnvironmentKey: "run-1",
+    PasteDeliveryPolicy.variantEnvironmentKey: "V9",
+    PasteDeliveryPolicy.runIDEnvironmentKey: "run-1",
     ])
     #expect(resolved.policy == .baseline)
     // The rejection is the whole point. A silent fallback here is the one failure mode
@@ -47,7 +55,7 @@ struct PasteDeliveryPolicyTests {
   @Test("a forced variant with no run id is refused")
   func missingRunIDIsRefused() {
     let resolved = PasteDeliveryPolicy.resolve(environment: [
-      PasteDeliveryPolicy.variantEnvironmentKey: "V2"
+    PasteDeliveryPolicy.variantEnvironmentKey: "V2"
     ])
     #expect(resolved.policy == .baseline)
     #expect(resolved.rejection != nil)
@@ -57,45 +65,45 @@ struct PasteDeliveryPolicyTests {
   @Test("an empty run id is refused, not treated as present")
   func emptyRunIDIsRefused() {
     let resolved = PasteDeliveryPolicy.resolve(environment: [
-      PasteDeliveryPolicy.variantEnvironmentKey: "V2",
-      PasteDeliveryPolicy.runIDEnvironmentKey: "",
+    PasteDeliveryPolicy.variantEnvironmentKey: "V2",
+    PasteDeliveryPolicy.runIDEnvironmentKey: "",
     ])
     #expect(resolved.policy == .baseline)
     #expect(resolved.rejection != nil)
   }
 
-  @Test(
+    @Test(
     "every declared variant resolves to its exact writer and timeout pair",
     arguments: [
-      ("V0", PasteDeliveryPolicy.WriterPolicy.current, false),
-      ("V1", .webCmdV, false),
-      ("V2", .axOneWriter, false),
-      ("V4", .current, true),
-      ("V5", .webCmdV, true),
+        ("V0", PasteDeliveryPolicy.WriterPolicy.current, false),
+        ("V1", .webCmdV, false),
+        ("V2", .axOneWriter, false),
+        ("V4", .current, true),
+        ("V5", .webCmdV, true),
     ])
-  func declaredVariantsResolveExactly(
+    func declaredVariantsResolveExactly(
     id: String, writer: PasteDeliveryPolicy.WriterPolicy, bounded: Bool
-  ) {
+    ) {
     let resolved = PasteDeliveryPolicy.resolve(environment: [
-      PasteDeliveryPolicy.variantEnvironmentKey: id,
-      PasteDeliveryPolicy.runIDEnvironmentKey: "run-1",
+        PasteDeliveryPolicy.variantEnvironmentKey: id,
+        PasteDeliveryPolicy.runIDEnvironmentKey: "run-1",
     ])
     #expect(resolved.rejection == nil)
     #expect(resolved.policy.id == id)
     #expect(resolved.policy.writer == writer)
     #expect(resolved.policy.boundTier1MessagingTimeout == bounded)
     #expect(resolved.runID == "run-1")
-  }
+    }
 
   @Test("only V0 is the baseline")
   func baselineIsExactlyV0() {
     #expect(PasteDeliveryPolicy.baseline.isBaseline)
     for id in ["V1", "V2", "V4", "V5"] {
-      let resolved = PasteDeliveryPolicy.resolve(environment: [
+    let resolved = PasteDeliveryPolicy.resolve(environment: [
         PasteDeliveryPolicy.variantEnvironmentKey: id,
         PasteDeliveryPolicy.runIDEnvironmentKey: "r",
-      ])
-      #expect(!resolved.policy.isBaseline, "\(id) must not read as the shipped baseline")
+    ])
+    #expect(!resolved.policy.isBaseline, "\(id) must not read as the shipped baseline")
     }
   }
 
@@ -109,37 +117,37 @@ struct PasteDeliveryPolicyTests {
   @Test("under the baseline, every outcome disposes exactly as it does today")
   func baselineDispositionIsUnchanged() {
     for (outcome, expected) in [
-      (PasteService.AXInsertOutcome.verified, AXDirectDisposition.delivered),
-      (.noMutation, .continueCascade),
-      (.unverifiable, .stopUnverified),
+    (PasteService.AXInsertOutcome.verified, AXDirectDisposition.delivered),
+    (.noMutation, .continueCascade),
+    (.unverifiable, .stopUnverified),
     ] {
-      let result = PasteService.AXInsertResult(
+    let result = PasteService.AXInsertResult(
         outcome: outcome, submitted: nil, writeCall: .succeeded(attemptedText: "x"),
         declineReason: nil, settability: nil)
-      #expect(dispositionForAXDirect(result, writerPolicy: .current) == expected)
-      // And the policy-free overload it delegates to must agree, or the two answers to
-      // one question could drift apart without anything noticing.
-      #expect(dispositionForAXDirect(outcome) == expected)
+    #expect(dispositionForAXDirect(result, writerPolicy: .current) == expected)
+    // And the policy-free overload it delegates to must agree, or the two answers to
+    // one question could drift apart without anything noticing.
+    #expect(dispositionForAXDirect(outcome) == expected)
     }
   }
 
-  @Test("V2 stops the cascade once the setter RETURNED SUCCESS, even on no-mutation")
-  func axOneWriterStopsAfterSuccessfulWrite() {
+    @Test("V2 stops the cascade once the setter RETURNED SUCCESS, even on no-mutation")
+    func axOneWriterStopsAfterSuccessfulWrite() {
     let noMutationAfterWrite = PasteService.AXInsertResult(
-      outcome: .noMutation, submitted: nil, writeCall: .succeeded(attemptedText: "hello"),
-      declineReason: nil, settability: nil)
+        outcome: .noMutation, submitted: nil, writeCall: .succeeded(attemptedText: "hello"),
+        declineReason: nil, settability: nil)
     // This is the reporter's exact shape: the write ran, verification said nothing
     // changed, and today that authorises a second writer.
     #expect(
-      dispositionForAXDirect(noMutationAfterWrite, writerPolicy: .current)
-        == .continueCascade)
+        dispositionForAXDirect(noMutationAfterWrite, writerPolicy: .current)
+          == .continueCascade)
     #expect(
-      dispositionForAXDirect(noMutationAfterWrite, writerPolicy: .axOneWriter)
-        == .stopUnverified)
-  }
+        dispositionForAXDirect(noMutationAfterWrite, writerPolicy: .axOneWriter)
+          == .stopUnverified)
+    }
 
-  @Test("V2 still allows the fallback when the setter was never called")
-  func axOneWriterAllowsFallbackWhenNotAttempted() {
+    @Test("V2 still allows the fallback when the setter was never called")
+    func axOneWriterAllowsFallbackWhenNotAttempted() {
     // The coverage half, and the reason V2 keys on the write CALL rather than on the
     // outcome. Every pre-write decline lands here, including the Electron destinations
     // that never accept an AX write at all. Reading `.noMutation` alone would refuse
@@ -148,31 +156,31 @@ struct PasteDeliveryPolicyTests {
     let declined = PasteService.AXInsertResult.declined(.roleNotText)
     #expect(declined.writeCall == .notAttempted)
     #expect(dispositionForAXDirect(declined, writerPolicy: .axOneWriter) == .continueCascade)
-  }
+    }
 
-  @Test("V2 still allows the fallback when the setter was called and FAILED")
-  func axOneWriterAllowsFallbackAfterFailedWrite() {
+    @Test("V2 still allows the fallback when the setter was called and FAILED")
+    func axOneWriterAllowsFallbackAfterFailedWrite() {
     // A failed setter mutated nothing, so refusing the fallback here would drop the
     // user's dictation for no safety gain. `.failed` exists as its own state precisely
     // so this case cannot be folded into either neighbour.
     let failed = PasteService.AXInsertResult.writeCallFailed(
-      attemptedText: "hello", settability: nil)
+        attemptedText: "hello", settability: nil)
     #expect(failed.writeCall == .failed(attemptedText: "hello"))
     #expect(dispositionForAXDirect(failed, writerPolicy: .axOneWriter) == .continueCascade)
-  }
+    }
 
-  @Test("V2 delivers, rather than merely stopping, when the write is positively verified")
-  func axOneWriterDeliversOnVerified() {
+    @Test("V2 delivers, rather than merely stopping, when the write is positively verified")
+    func axOneWriterDeliversOnVerified() {
     let verified = PasteService.AXInsertResult(
-      outcome: .verified, submitted: .legacy, writeCall: .succeeded(attemptedText: "hi"),
-      declineReason: nil, settability: nil)
+        outcome: .verified, submitted: .legacy, writeCall: .succeeded(attemptedText: "hi"),
+        declineReason: nil, settability: nil)
     #expect(dispositionForAXDirect(verified, writerPolicy: .axOneWriter) == .delivered)
-  }
+    }
 
-  // MARK: - The attempted text cannot contradict the call state
+    // MARK: - The attempted text cannot contradict the call state
 
-  @Test("attempted text is present exactly when a write call was made")
-  func attemptedTextTracksTheCallState() {
+    @Test("attempted text is present exactly when a write call was made")
+    func attemptedTextTracksTheCallState() {
     // The first draft carried these as independent fields, which permitted
     // "not attempted, here is the text" and "succeeded, no text". Both are nonsense and
     // both would have corrupted the submission ledger the byte veto reads. The
@@ -180,5 +188,6 @@ struct PasteDeliveryPolicyTests {
     #expect(PasteService.AXWriteCall.notAttempted.attemptedText == nil)
     #expect(PasteService.AXWriteCall.failed(attemptedText: "a").attemptedText == "a")
     #expect(PasteService.AXWriteCall.succeeded(attemptedText: "b").attemptedText == "b")
-  }
+    }
 }
+#endif

--- a/Tests/EnviousWisprTests/Pipeline/PasteDeliveryPolicyTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/PasteDeliveryPolicyTests.swift
@@ -1,0 +1,184 @@
+import Testing
+
+@testable import EnviousWisprPipeline
+@testable import EnviousWisprServices
+
+// The bake-off control plane (#2652).
+//
+// A reporter's dictation arrived twice in WebKit-backed fields, proven by exact
+// character counts, and the defect does not reproduce here. Rather than ship a fix
+// argued from a mechanism story, the cascade can be forced into candidate policies and
+// measured against real applications.
+//
+// A test seam on a delivery guard is a bypass unless it cannot lie, and the specific lie
+// available here is quiet: the harness stamps a variant on every scored row, so a
+// process that fell back to the baseline while the harness believed it was measuring V2
+// would produce a scorecard full of confident rows about a policy that never ran, with
+// nothing downstream able to tell. These tests exist to make that state unreachable, not
+// merely unlikely.
+@Suite("Paste delivery policy (#2652)", .tags(.productOutcome))
+struct PasteDeliveryPolicyTests {
+
+  // MARK: - Resolution fails closed
+
+  @Test("no bake-off environment resolves to the shipped baseline, silently")
+  func absentEnvironmentIsBaseline() {
+    let resolved = PasteDeliveryPolicy.resolve(environment: [:])
+    #expect(resolved.policy == .baseline)
+    #expect(resolved.runID == nil)
+    // Silence is correct HERE and only here: an ordinary debug session is not a rejected
+    // bake-off, and logging one would train the operator to ignore the line that matters.
+    #expect(resolved.rejection == nil)
+  }
+
+  @Test("an unknown variant is refused LOUDLY rather than guessed")
+  func unknownVariantIsRefused() {
+    let resolved = PasteDeliveryPolicy.resolve(environment: [
+      PasteDeliveryPolicy.variantEnvironmentKey: "V9",
+      PasteDeliveryPolicy.runIDEnvironmentKey: "run-1",
+    ])
+    #expect(resolved.policy == .baseline)
+    // The rejection is the whole point. A silent fallback here is the one failure mode
+    // that produces a plausible, wrong scorecard instead of an obvious error.
+    #expect(resolved.rejection != nil)
+    #expect(resolved.rejection?.contains("V9") == true)
+  }
+
+  @Test("a forced variant with no run id is refused")
+  func missingRunIDIsRefused() {
+    let resolved = PasteDeliveryPolicy.resolve(environment: [
+      PasteDeliveryPolicy.variantEnvironmentKey: "V2"
+    ])
+    #expect(resolved.policy == .baseline)
+    #expect(resolved.rejection != nil)
+    #expect(resolved.runID == nil)
+  }
+
+  @Test("an empty run id is refused, not treated as present")
+  func emptyRunIDIsRefused() {
+    let resolved = PasteDeliveryPolicy.resolve(environment: [
+      PasteDeliveryPolicy.variantEnvironmentKey: "V2",
+      PasteDeliveryPolicy.runIDEnvironmentKey: "",
+    ])
+    #expect(resolved.policy == .baseline)
+    #expect(resolved.rejection != nil)
+  }
+
+  @Test(
+    "every declared variant resolves to its exact writer and timeout pair",
+    arguments: [
+      ("V0", PasteDeliveryPolicy.WriterPolicy.current, false),
+      ("V1", .webCmdV, false),
+      ("V2", .axOneWriter, false),
+      ("V4", .current, true),
+      ("V5", .webCmdV, true),
+    ])
+  func declaredVariantsResolveExactly(
+    id: String, writer: PasteDeliveryPolicy.WriterPolicy, bounded: Bool
+  ) {
+    let resolved = PasteDeliveryPolicy.resolve(environment: [
+      PasteDeliveryPolicy.variantEnvironmentKey: id,
+      PasteDeliveryPolicy.runIDEnvironmentKey: "run-1",
+    ])
+    #expect(resolved.rejection == nil)
+    #expect(resolved.policy.id == id)
+    #expect(resolved.policy.writer == writer)
+    #expect(resolved.policy.boundTier1MessagingTimeout == bounded)
+    #expect(resolved.runID == "run-1")
+  }
+
+  @Test("only V0 is the baseline")
+  func baselineIsExactlyV0() {
+    #expect(PasteDeliveryPolicy.baseline.isBaseline)
+    for id in ["V1", "V2", "V4", "V5"] {
+      let resolved = PasteDeliveryPolicy.resolve(environment: [
+        PasteDeliveryPolicy.variantEnvironmentKey: id,
+        PasteDeliveryPolicy.runIDEnvironmentKey: "r",
+      ])
+      #expect(!resolved.policy.isBaseline, "\(id) must not read as the shipped baseline")
+    }
+  }
+
+  // MARK: - The behaviour change itself
+
+  // The disposition is where V2 actually differs from today, so these are the rows that
+  // decide whether the arm tests what it claims. They assert the WEAKEST input that
+  // satisfies each branch, because a test that only exercises the interesting case
+  // cannot show that the boring cases were left alone.
+
+  @Test("under the baseline, every outcome disposes exactly as it does today")
+  func baselineDispositionIsUnchanged() {
+    for (outcome, expected) in [
+      (PasteService.AXInsertOutcome.verified, AXDirectDisposition.delivered),
+      (.noMutation, .continueCascade),
+      (.unverifiable, .stopUnverified),
+    ] {
+      let result = PasteService.AXInsertResult(
+        outcome: outcome, submitted: nil, writeCall: .succeeded(attemptedText: "x"),
+        declineReason: nil, settability: nil)
+      #expect(dispositionForAXDirect(result, writerPolicy: .current) == expected)
+      // And the policy-free overload it delegates to must agree, or the two answers to
+      // one question could drift apart without anything noticing.
+      #expect(dispositionForAXDirect(outcome) == expected)
+    }
+  }
+
+  @Test("V2 stops the cascade once the setter RETURNED SUCCESS, even on no-mutation")
+  func axOneWriterStopsAfterSuccessfulWrite() {
+    let noMutationAfterWrite = PasteService.AXInsertResult(
+      outcome: .noMutation, submitted: nil, writeCall: .succeeded(attemptedText: "hello"),
+      declineReason: nil, settability: nil)
+    // This is the reporter's exact shape: the write ran, verification said nothing
+    // changed, and today that authorises a second writer.
+    #expect(
+      dispositionForAXDirect(noMutationAfterWrite, writerPolicy: .current)
+        == .continueCascade)
+    #expect(
+      dispositionForAXDirect(noMutationAfterWrite, writerPolicy: .axOneWriter)
+        == .stopUnverified)
+  }
+
+  @Test("V2 still allows the fallback when the setter was never called")
+  func axOneWriterAllowsFallbackWhenNotAttempted() {
+    // The coverage half, and the reason V2 keys on the write CALL rather than on the
+    // outcome. Every pre-write decline lands here, including the Electron destinations
+    // that never accept an AX write at all. Reading `.noMutation` alone would refuse
+    // their fallback and lose automatic delivery for them entirely — a coverage loss
+    // wearing a duplicate fix's clothes.
+    let declined = PasteService.AXInsertResult.declined(.roleNotText)
+    #expect(declined.writeCall == .notAttempted)
+    #expect(dispositionForAXDirect(declined, writerPolicy: .axOneWriter) == .continueCascade)
+  }
+
+  @Test("V2 still allows the fallback when the setter was called and FAILED")
+  func axOneWriterAllowsFallbackAfterFailedWrite() {
+    // A failed setter mutated nothing, so refusing the fallback here would drop the
+    // user's dictation for no safety gain. `.failed` exists as its own state precisely
+    // so this case cannot be folded into either neighbour.
+    let failed = PasteService.AXInsertResult.writeCallFailed(
+      attemptedText: "hello", settability: nil)
+    #expect(failed.writeCall == .failed(attemptedText: "hello"))
+    #expect(dispositionForAXDirect(failed, writerPolicy: .axOneWriter) == .continueCascade)
+  }
+
+  @Test("V2 delivers, rather than merely stopping, when the write is positively verified")
+  func axOneWriterDeliversOnVerified() {
+    let verified = PasteService.AXInsertResult(
+      outcome: .verified, submitted: .legacy, writeCall: .succeeded(attemptedText: "hi"),
+      declineReason: nil, settability: nil)
+    #expect(dispositionForAXDirect(verified, writerPolicy: .axOneWriter) == .delivered)
+  }
+
+  // MARK: - The attempted text cannot contradict the call state
+
+  @Test("attempted text is present exactly when a write call was made")
+  func attemptedTextTracksTheCallState() {
+    // The first draft carried these as independent fields, which permitted
+    // "not attempted, here is the text" and "succeeded, no text". Both are nonsense and
+    // both would have corrupted the submission ledger the byte veto reads. The
+    // associated value deletes the states rather than asking a reviewer to notice them.
+    #expect(PasteService.AXWriteCall.notAttempted.attemptedText == nil)
+    #expect(PasteService.AXWriteCall.failed(attemptedText: "a").attemptedText == "a")
+    #expect(PasteService.AXWriteCall.succeeded(attemptedText: "b").attemptedText == "b")
+  }
+}

--- a/Tests/EnviousWisprTests/Services/PasteCopiesDeliveredTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteCopiesDeliveredTests.swift
@@ -1,0 +1,117 @@
+import Testing
+
+@testable import EnviousWisprServices
+
+// How many copies landed (#2652).
+//
+// The live AX reads are exercised by Live UAT, matching the `classifyInsertOutcome` precedent
+// next door. The ARITHMETIC is pure, and it is what this suite pins.
+//
+// What the instrument is for: `paste.completed` fires once whether one copy or two copies arrive,
+// so the reported double-paste defect is invisible fleet-wide. What it is NOT: proof that identical
+// content arrived twice. Every row below is about LENGTH GROWTH, and several of them exist
+// specifically to document where length and meaning come apart.
+@Suite("PasteService.copiesDelivered", .tags(.observabilityContract))
+struct PasteCopiesDeliveredTests {
+
+  private func copies(
+    before: Int, selection: Int = 0, inserted: Int, after: Int?
+  ) -> Int? {
+    PasteService.copiesDelivered(
+      countAfter: after, countBefore: before, selectionLengthBefore: selection,
+      insertedLength: inserted)
+  }
+
+  // MARK: - The two answers it exists to give
+
+  @Test("one copy at the exact expected length")
+  func oneCopyExact() {
+    #expect(copies(before: 13, inserted: 27, after: 40) == 1)
+  }
+
+  @Test("two copies at exactly one more copy")
+  func twoCopiesExact() {
+    #expect(copies(before: 13, inserted: 27, after: 67) == 2)
+  }
+
+  // MARK: - A destination may not store what it was given
+
+  // Measured 2026-09-04 across 8 deliveries of one sentence: Discord landed on the exact
+  // expected count every time, and Slack was short by exactly one character PER COPY —
+  // one copy short by 1, two copies short by 2, reproducibly.
+  @Test("Slack's one-fewer-per-copy still reads as one copy")
+  func slackShrinksOneCopy() {
+    #expect(copies(before: 13, inserted: 27, after: 39) == 1)
+  }
+
+  @Test("Slack's two-fewer-for-two-copies still reads as two copies")
+  func slackShrinksTwoCopies() {
+    #expect(copies(before: 13, inserted: 27, after: 65) == 2)
+  }
+
+  // MARK: - Replacing a selection shortens before it lengthens
+
+  @Test("a delivery over a selection accounts for what it replaced")
+  func replacesSelection() {
+    // 40 characters, 10 of them selected, replaced by 27: 40 - 10 + 27 = 57.
+    #expect(copies(before: 40, selection: 10, inserted: 27, after: 57) == 1)
+    #expect(copies(before: 40, selection: 10, inserted: 27, after: 84) == 2)
+  }
+
+  // MARK: - The bands may never overlap, at any sentence length
+
+  // The tolerance is bounded to a THIRD of one copy. That bound, not its width, is what keeps a
+  // single delivery from ever being reported as a duplicate.
+  @Test("a very short delivery cannot read one copy as two", arguments: [1, 2, 3, 4, 6, 9])
+  func shortDeliveriesKeepTheirBandsApart(inserted: Int) {
+    let before = 100
+    let oneCopy = before + inserted
+    #expect(copies(before: before, inserted: inserted, after: oneCopy) == 1)
+    #expect(copies(before: before, inserted: inserted, after: oneCopy + inserted) == 2)
+    // The midpoint between the bands belongs to neither.
+    if inserted >= 8 {
+      #expect(copies(before: before, inserted: inserted, after: oneCopy + inserted / 2) == nil)
+    }
+  }
+
+  // MARK: - What it refuses to answer
+
+  @Test("an unreadable count is never a copy count")
+  func unreadableCountIsNil() {
+    #expect(copies(before: 13, inserted: 27, after: nil) == nil)
+  }
+
+  @Test("a delivery of nothing is not measurable")
+  func zeroLengthIsNil() {
+    #expect(copies(before: 13, inserted: 0, after: 13) == nil)
+  }
+
+  @Test("a length far from either band is unclassified")
+  func farFromBothBandsIsNil() {
+    #expect(copies(before: 13, inserted: 27, after: 200) == nil)
+  }
+
+  // MARK: - Arbitrary numbers from a foreign application
+
+  // These counts come from another app's accessibility implementation, so they are arbitrary
+  // Ints, not values this process produced. Overflow must return nil, never trap.
+  @Test("extreme inputs return nil rather than trapping")
+  func extremeInputsDoNotTrap() {
+    #expect(copies(before: Int.max, inserted: Int.max, after: Int.max) == nil)
+    #expect(copies(before: Int.max, selection: 0, inserted: 10, after: Int.max) == nil)
+    #expect(copies(before: 0, selection: Int.max, inserted: 10, after: 10) == nil)
+    #expect(copies(before: -1, inserted: 10, after: 10) == nil)
+    #expect(copies(before: 10, inserted: 10, after: -5) == nil)
+  }
+
+  // MARK: - Where length and meaning come apart, documented rather than asserted away
+
+  // A destination that normalises can move a TRUE DOUBLE into the one-copy band: submit 12,
+  // have each copy stored as 6, and the field grows by 12. This row is not a bug report. It
+  // records that a `one` verdict is an estimate about LENGTH and never a proof about content,
+  // which is why the dashboard label says estimate and why Phase 3 may not rest on a small count.
+  @Test("a normalising destination can hide a true double, and that is a known limit")
+  func normalisationCanHideADouble() {
+    #expect(copies(before: 0, inserted: 12, after: 12) == 1)
+  }
+}

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -485,20 +485,64 @@ def _script_reader(script: str, label: str, commit: str | None = None):
     return read
 
 
-def _setup_document(app_name: str, bundle_id: str, clear: str, reader_script: str):
-    """A word processor: empty the document, put the caret in the body, type the pre-image.
+def _own_the_document(
+    app_name: str, bundle_id: str, count_script: str, create_script: str, owned: set
+) -> tuple[bool, str]:
+    """Make sure the document we are about to CLEAR is one this harness created.
+
+    Cloud review, PR #2660: setup emptied the ACTIVE document. With a real workbook or
+    manuscript open, running this bench DESTROYED it — no scratch document, no ownership
+    check, and an irreversible AppleScript clear. The founder's own machine runs these apps.
+
+    This refuses rather than guesses. If the application already has documents open and we
+    have not created ours yet, the run stops and says so; nothing is cleared. Only after the
+    application is empty do we make one and record it as ours.
+    """
+    if bundle_id in owned:
+        return True, ""
+    ok, value = _osa(count_script)
+    if not ok:
+        return False, f"{app_name}_document_count_failed:{value}"
+    try:
+        existing = int(value.strip())
+    except ValueError:
+        return False, f"{app_name}_document_count_unreadable:{value!r}"
+    if existing > 0:
+        return False, (
+            f"{app_name}_refusing_to_clear_your_documents: {existing} already open. This "
+            "bench EMPTIES the document it works in, so it will only ever work in one it "
+            f"created. Close your {app_name} documents and run again."
+        )
+    ok, err = _osa(create_script)
+    if not ok:
+        return False, f"{app_name}_could_not_create_scratch_document:{err}"
+    owned.add(bundle_id)
+    time.sleep(1.0)
+    return True, ""
+
+
+def _setup_document(
+    app_name: str, bundle_id: str, clear: str, reader_script: str,
+    count_script: str, create_script: str
+):
+    """A word processor: empty OUR document, put the caret in the body, type the pre-image.
 
     The caret step is not optional and is not tidiness. A freshly raised Word or Pages
     window reports its focused element as an `AXScrollArea` with no text in it, and typing
     is what moves focus into the body. Cmd+End moves the caret to the end of the document
     and changes nothing, so it is safe to run before every trial.
     """
+    owned: set = set()
 
     def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
         if ax_oracle.pid_for_bundle(bundle_id) is None:
             return False, f"{app_name}_not_running"
         if not ax_oracle.activate(bundle_id, handoff=2.0):
             return False, f"{app_name}_would_not_come_forward"
+        ok, why = _own_the_document(
+            app_name, bundle_id, count_script, create_script, owned)
+        if not ok:
+            return False, why
         ok, err = _osa(clear)
         if not ok:
             return False, f"{app_name}_clear_failed:{err}"
@@ -522,7 +566,7 @@ def _setup_document(app_name: str, bundle_id: str, clear: str, reader_script: st
 
 
 def _setup_cell(app_name: str, bundle_id: str, clear: str, reader_script: str,
-                select_a1: str, edit_key: str):
+                select_a1: str, edit_key: str, count_script: str, create_script: str):
     """A spreadsheet cell in EDIT mode, which is where a dictation actually lands.
 
     Two things had to be got right, both found by hand before any trial ran:
@@ -536,11 +580,17 @@ def _setup_cell(app_name: str, bundle_id: str, clear: str, reader_script: str,
       is the state a person dictating into a cell is in.
     """
 
+    owned: set = set()
+
     def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
         if ax_oracle.pid_for_bundle(bundle_id) is None:
             return False, f"{app_name}_not_running"
         if not ax_oracle.activate(bundle_id, handoff=2.0):
             return False, f"{app_name}_would_not_come_forward"
+        ok, why = _own_the_document(
+            app_name, bundle_id, count_script, create_script, owned)
+        if not ok:
+            return False, why
         subprocess.run(["osascript", "-e",
                         'tell application "System Events" to key code 53'],
                        capture_output=True, timeout=15)
@@ -645,7 +695,9 @@ TARGETS = {
                        "Word", "com.microsoft.Word",
                        'tell application "Microsoft Word" to set content of text object '
                        'of active document to ""',
-                       WORD_READ),
+                       WORD_READ,
+                       'tell application "Microsoft Word" to count documents',
+                       'tell application "Microsoft Word" to make new document'),
                    reader=_script_reader(WORD_READ, "word")),
     "excel": Target("excel", "com.microsoft.Excel",
                     _setup_cell(
@@ -656,7 +708,9 @@ TARGETS = {
                         'tell application "Microsoft Excel" to select range "A1" of '
                         'active sheet',
                         # F2 opens the cell editor with the caret after the existing text.
-                        'tell application "System Events" to key code 120'),
+                        'tell application "System Events" to key code 120',
+                        'tell application "Microsoft Excel" to count workbooks',
+                        'tell application "Microsoft Excel" to make new workbook'),
                     # COMMIT THE CELL BEFORE READING IT. A spreadsheet's used range holds
                     # only committed values, so text sitting in an open cell editor is
                     # invisible to every reader — the delivery lands correctly and scores
@@ -668,7 +722,9 @@ TARGETS = {
                     _setup_document(
                         "Pages", "com.apple.iWork.Pages",
                         'tell application "Pages" to set body text of front document to ""',
-                        PAGES_READ),
+                        PAGES_READ,
+                        'tell application "Pages" to count documents',
+                        'tell application "Pages" to make new document'),
                     reader=_script_reader(PAGES_READ, "pages")),
     # A terminal. Its own context path in the cascade (`terminal_screen_refused`), and the
     # founder named terminals as coverage that must not regress.
@@ -899,10 +955,25 @@ def decide(scorecard: dict) -> dict:
         # a candidate with fewer than 80% of the best-measured candidate's valid trials
         # cannot win, because there is no honest way to rank a rate nobody sampled. Then
         # rank on the RATE rather than the count.
+        # AND A TOTAL HIDES A MISSING APPLICATION. Cloud review, second finding: a candidate
+        # with ten good native trials and ten invalid web trials clears any total-based floor
+        # while its web coverage is entirely unknown — which is the coverage this bench exists
+        # to compare. So the floor is applied PER TARGET, over the targets where the baseline
+        # actually delivers, and a candidate missing one of them cannot win.
+        def valid_in(variant: str, target: str) -> int:
+            c = cells.get((variant, target), {})
+            return c.get("once", 0) + c.get("duplicate", 0) + c.get("drop", 0)
+
+        measured_targets = [t for t in targets if baseline_ok.get(t)]
+        comparable, undermeasured = [], []
+        for v in eligible:
+            thin = [
+                t for t in measured_targets
+                if valid_in(v, t) < 0.8 * max(valid_in(c, t) for c in eligible)
+            ]
+            (undermeasured if thin else comparable).append(v)
         best_measured = max(verdicts[v]["valid_trials"] for v in eligible)
-        floor = 0.8 * best_measured
-        comparable = [v for v in eligible if verdicts[v]["valid_trials"] >= floor]
-        undermeasured = sorted(set(eligible) - set(comparable))
+        undermeasured = sorted(undermeasured)
         if not comparable:
             winner, why = None, "no eligible variant reached comparable coverage"
         else:
@@ -999,6 +1070,23 @@ def selftest() -> int:
     check("unseen does not veto", result["verdicts"]["V1"]["status"], "unmeasured")
     check("unseen is not a valid trial", result["verdicts"]["V1"]["valid_trials"], 0)
     check("winner has valid trials", result["winner"], "V4")
+
+    # 8. A candidate measured on one target and blind on another must not win. The rule
+    #    used to rank on an absolute duplicate COUNT with a total-based coverage floor, so
+    #    a perfect score on the cell nobody cares about beat a near-perfect score on both.
+    #    Cloud review's own counterexample, PR #2660.
+    def _rows(variant, target, verdict, n):
+        return [{"variant": variant, "target": target, "verdict": verdict} for _ in range(n)]
+
+    card = {"rows": (
+        _rows("V0", "native", "once", 10) + _rows("V0", "web", "once", 10)
+        + _rows("V1", "native", "once", 10) + _rows("V1", "web", "invalid", 10)
+        + _rows("V4", "native", "once", 10)
+        + _rows("V4", "web", "once", 9) + _rows("V4", "web", "duplicate", 1)
+    )}
+    result = decide(card)
+    check("a blind target loses to a measured one", result["winner"], "V4")
+    check("and the thin candidate is named", "V1" in result["why"], True)
 
     for failure in failures:
         print(f"  FAIL {failure}")

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -888,14 +888,40 @@ def decide(scorecard: dict) -> dict:
     elif not eligible:
         winner, why = None, "no candidate variant survived the coverage veto"
     else:
-        fewest = min(verdicts[v]["duplicates"] for v in eligible)
-        tied = [v for v in eligible if verdicts[v]["duplicates"] == fewest]
-        if len(tied) > 1:
-            winner, why = None, (
-                f"tie on duplicates ({fewest}) between {tied} — latency is the tie-break "
-                "and this screening run does not measure it")
+        # AN ABSOLUTE DUPLICATE COUNT FAVOURS THE LEAST-MEASURED CANDIDATE.
+        #
+        # Cloud review, PR #2660: `duplicates` is a COUNT, so a variant with one valid trial
+        # and zero duplicates beat one with a hundred valid trials and a single duplicate.
+        # Any nonzero `valid_total` was eligible, so the rule could crown the arm nobody
+        # measured — and it would read as a clean sweep rather than as a thin one.
+        #
+        # Two changes, and the first is the one that matters. Coverage must be COMPARABLE:
+        # a candidate with fewer than 80% of the best-measured candidate's valid trials
+        # cannot win, because there is no honest way to rank a rate nobody sampled. Then
+        # rank on the RATE rather than the count.
+        best_measured = max(verdicts[v]["valid_trials"] for v in eligible)
+        floor = 0.8 * best_measured
+        comparable = [v for v in eligible if verdicts[v]["valid_trials"] >= floor]
+        undermeasured = sorted(set(eligible) - set(comparable))
+        if not comparable:
+            winner, why = None, "no eligible variant reached comparable coverage"
         else:
-            winner, why = tied[0], f"fewest duplicates ({fewest}) among eligible variants"
+            def rate(v: str) -> float:
+                d = verdicts[v]
+                return d["duplicates"] / d["valid_trials"]
+
+            lowest = min(rate(v) for v in comparable)
+            tied = [v for v in comparable if rate(v) == lowest]
+            note = (f"; excluded as under-measured against {best_measured} valid trials: "
+                    f"{undermeasured}") if undermeasured else ""
+            if len(tied) > 1:
+                winner, why = None, (
+                    f"tie on duplicate rate ({lowest:.3f}) between {tied} — latency is the "
+                    f"tie-break and this screening run does not measure it{note}")
+            else:
+                winner, why = tied[0], (
+                    f"lowest duplicate rate ({lowest:.3f}) among eligible variants with "
+                    f"comparable coverage{note}")
 
     return {"cells": {f"{v}/{t}": c for (v, t), c in cells.items()},
             "verdicts": verdicts, "winner": winner, "why": why,
@@ -1040,6 +1066,19 @@ def main() -> int:
     if args.reps is None:
         print("--reps is required for a run: a default here would be a parameter nobody "
               "states and everybody inherits.", file=sys.stderr)
+        return 2
+
+    # THE MARKER IS WHAT COUNTS COPIES, so it has to occur exactly once in the sentence.
+    #
+    # Cloud review, PR #2660: both are public CLI inputs and neither was checked. Change
+    # `--sentence` without `--marker` and a perfect single delivery scores as a DROP; put the
+    # marker in twice and one delivery scores as a DUPLICATE. Either way an expensive run
+    # produces a scorecard that looks like a result.
+    occurrences = args.sentence.lower().count(args.marker.lower())
+    if not args.marker.strip() or occurrences != 1:
+        print(f"REFUSING TO RUN: the marker {args.marker!r} occurs {occurrences} times in the "
+              f"sentence {args.sentence!r}. It must occur exactly once, because occurrence "
+              "counting is how this bench tells one copy from two.", file=sys.stderr)
         return 2
 
     if ax_oracle.screen_is_locked():

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -269,36 +269,17 @@ def setup_textedit(pre_image: str, file_token: str) -> tuple[bool, str]:
     return ax_oracle.assert_precondition("com.apple.TextEdit", pre_image)
 
 
-def _close_fixture_tabs(app: str) -> None:
-    """Close every tab this harness opened. NOT hygiene — correctness.
-
-    Each trial opens a new tab and, without this, they accumulate. Measured 2026-09-04:
-    after ~40 trials Safari's accessibility tree exceeded the oracle's whole node budget,
-    so the walk never reached the newest tab and returned a scan with no fields — which
-    the scorer reads as "nothing landed". The bench degraded as it ran, and the later a
-    variant was scheduled the worse it looked. Randomised variant order limits the damage
-    to noise rather than bias; closing the tabs removes it.
-
-    Scoped to our own fixture URLs so the operator's real tabs are never touched.
-    """
-    # Bounded. The script enumerates every tab of every window, which on a browser the
-    # operator actually uses is slow enough to stall a run: measured 2026-09-04, one call
-    # sat for 35 seconds and the bench made no progress behind it. Cleanup is best-effort
-    # housekeeping, so a timeout here costs one noisy cell rather than the whole run.
-    try:
-        subprocess.run(
-            ["osascript", "-e",
-             f'tell application "{app}" to close (every tab of every window '
-             'whose URL contains "EnviousWispr-bakeoff")'],
-            capture_output=True, timeout=20)
-    except subprocess.TimeoutExpired:
-        pass
-
+# Tab cleanup DELETED, not fixed.
+#
+# It existed because the old oracle walked the whole application looking for the right
+# field, and forty accumulated tabs blew past its node budget. The oracle now asks the
+# system which element has focus, so stray tabs cost nothing at all. The cleanup also
+# needed an Automation grant per browser, and an ungranted one raises a modal that blocks
+# focus for the whole machine — paying a permission prompt to solve a problem that no
+# longer exists.
 
 def _setup_browser(app: str, bundle_id: str, focus_id: str):
     def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
-        if ax_oracle.pid_for_bundle(bundle_id) is not None:
-            _close_fixture_tabs(app)
         path = _write_fixture(file_token, pre_image, focus_id)
         subprocess.run(["open", "-a", app, str(path)], capture_output=True)
         ax_oracle.activate(bundle_id, handoff=2.0)

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -269,8 +269,29 @@ def setup_textedit(pre_image: str, file_token: str) -> tuple[bool, str]:
     return ax_oracle.assert_precondition("com.apple.TextEdit", pre_image)
 
 
+def _close_fixture_tabs(app: str) -> None:
+    """Close every tab this harness opened. NOT hygiene — correctness.
+
+    Each trial opens a new tab and, without this, they accumulate. Measured 2026-09-04:
+    after ~40 trials Safari's accessibility tree exceeded the oracle's whole node budget,
+    so the walk never reached the newest tab and returned a scan with no fields — which
+    the scorer reads as "nothing landed". The bench degraded as it ran, and the later a
+    variant was scheduled the worse it looked. Randomised variant order limits the damage
+    to noise rather than bias; closing the tabs removes it.
+
+    Scoped to our own fixture URLs so the operator's real tabs are never touched.
+    """
+    subprocess.run(
+        ["osascript", "-e",
+         f'tell application "{app}" to close (every tab of every window '
+         'whose URL contains "EnviousWispr-bakeoff")'],
+        capture_output=True)
+
+
 def _setup_browser(app: str, bundle_id: str, focus_id: str):
     def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
+        if ax_oracle.pid_for_bundle(bundle_id) is not None:
+            _close_fixture_tabs(app)
         path = _write_fixture(file_token, pre_image, focus_id)
         subprocess.run(["open", "-a", app, str(path)], capture_output=True)
         ax_oracle.activate(bundle_id, handoff=2.0)
@@ -278,10 +299,35 @@ def _setup_browser(app: str, bundle_id: str, focus_id: str):
     return setup
 
 
+def _setup_composer(app_name: str, bundle_id: str):
+    """A chat app's message composer.
+
+    **Nothing is ever sent.** The pre-image is typed and Return is never pressed, so the
+    worst case is an unsent draft the operator can clear. No teardown clears it
+    deliberately: a stray select-all-and-delete aimed at a field that turned out not to be
+    the composer is a far worse outcome than a leftover draft, and the composer is only
+    ever FOCUSED here, never identified with certainty.
+
+    The composer is whatever holds focus when the app comes forward, which is true of
+    Slack, Discord and WhatsApp on open. When it is not, the pre-image lands somewhere the
+    oracle cannot find and the precondition marks the trial `invalid` — the honest answer,
+    and never a verdict about a variant.
+    """
+
+    def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
+        if ax_oracle.pid_for_bundle(bundle_id) is None:
+            return False, f"{app_name}_not_running"
+        ax_oracle.activate(bundle_id, handoff=2.0)
+        subprocess.run(
+            ["osascript", "-e",
+             f'tell application "System Events" to keystroke "{pre_image} "'],
+            capture_output=True)
+        return ax_oracle.assert_precondition(bundle_id, pre_image)
+
+    return setup
+
+
 TARGETS = {
-    # Native `AXTextArea`. The coverage anchor: the one cell where the direct write is
-    # expected to succeed outright, so a variant that loses it has lost the fast path.
-    "textedit": Target("textedit", "com.apple.TextEdit", setup_textedit),
     # The reported defect surface.
     "safari_textarea": Target(
         "safari_textarea", "com.apple.Safari",
@@ -298,6 +344,21 @@ TARGETS = {
     "chrome_textarea": Target(
         "chrome_textarea", "com.google.Chrome",
         _setup_browser("Google Chrome", "com.google.Chrome", "ta")),
+    # A THIRD Chromium build, because "Chromium" is not one behaviour: Brave ships its own
+    # patches and its own accessibility defaults, and the teardown found it in the same
+    # both-outcomes population as Safari.
+    "brave_textarea": Target(
+        "brave_textarea", "com.brave.Browser",
+        _setup_browser("Brave Browser", "com.brave.Browser", "ta")),
+    # Chat composers. Founder's list, and the reason it matters: these are Electron and
+    # web-view surfaces where the direct write may genuinely do nothing, so they are the
+    # cells that separate a variant which reroutes the fallback from one that refuses it.
+    "slack": Target("slack", "com.tinyspeck.slackmacgap",
+                    _setup_composer("Slack", "com.tinyspeck.slackmacgap")),
+    "discord": Target("discord", "com.hnc.Discord",
+                      _setup_composer("Discord", "com.hnc.Discord")),
+    "whatsapp": Target("whatsapp", "net.whatsapp.WhatsApp",
+                       _setup_composer("WhatsApp", "net.whatsapp.WhatsApp")),
 }
 
 
@@ -363,6 +424,14 @@ def run_trial(variant: str, run_id: str, target: Target, sentence: str, marker: 
         row.update(verdict="invalid", why=why)
         return row
 
+    # The recording is driven through EnviousWispr's own menu, which activates
+    # EnviousWispr. Delivery then targets whatever is frontmost when the pipeline
+    # finishes. If that is not our target, the words land somewhere real and the oracle
+    # honestly reports nothing in the field under test — a DROP, which is the verdict that
+    # disqualifies a variant. Measured 2026-09-04: the baseline dropped 2/5 in TextEdit,
+    # which is impossible for today's shipped behaviour and was the tell that the harness,
+    # not the app, was being measured.
+    frontmost_before = ax_oracle.pid_for_bundle(target.bundle_id)
     boundary = log_size()
     try:
         wispr_eyes.test_recording(sentence=sentence, expect=None)
@@ -370,7 +439,11 @@ def run_trial(variant: str, run_id: str, target: Target, sentence: str, marker: 
         row.update(verdict="invalid", why=f"recording_raised:{type(exc).__name__}:{exc}")
         return row
 
-    scan = ax_oracle.settled_scan(target.bundle_id, max_wait=6.0)
+    if ax_oracle.pid_for_bundle(target.bundle_id) != frontmost_before:
+        row.update(verdict="invalid", why="target_process_changed_during_trial")
+        return row
+
+    scan = ax_oracle.settled_focused(target.bundle_id, max_wait=6.0)
     if not scan.ok:
         row.update(verdict="invalid", why=f"oracle:{scan.why}")
         return row
@@ -389,12 +462,26 @@ def run_trial(variant: str, run_id: str, target: Target, sentence: str, marker: 
         row.update(tier=ev["tier"], attempts=ev["attempts"], ledger=ev["ledger"],
                    duration_ms=int(ev["duration"]))
     else:
-        tier = re.search(r"Paste cascade: tier=(\S+?),", text)
-        row["tier"] = tier.group(1) if tier else None
+        tiers = re.findall(r"Paste cascade: tier=(\S+?), app=(\S+?),", text)
+        if len(tiers) != 1:
+            # Zero means the dictation never delivered (a recording fault); more than one
+            # means a stray delivery landed inside this trial's window. Neither is a
+            # statement about the variant, and scoring either as a drop would put harness
+            # noise into the column that disqualifies variants.
+            row.update(verdict="invalid", why=f"baseline_delivery_lines={len(tiers)}")
+            return row
+        row["tier"], row["delivered_to"] = tiers[0]
         row["ledger"] = None
     del evidence
 
     verdict, detail = classify(pre_image, marker, scan.fields)
+    # The app said it delivered and the destination does not have it. That is either a
+    # real drop or the delivery went to a window this scan did not read, and the two are
+    # not distinguishable from here. Call it what it is rather than guessing: a `drop`
+    # verdict must mean "the user lost their words", because that verdict vetoes a
+    # variant, and a veto built on an ambiguous row is how a bench picks the wrong winner.
+    if verdict == "drop" and row.get("tier") not in (None, "clipboard_only"):
+        verdict, detail = "unseen", dict(detail, why=f"app_reported_{row.get('tier')}")
     row.update(verdict=verdict, **detail)
     return row
 
@@ -414,7 +501,8 @@ def decide(scorecard: dict) -> dict:
     cells: dict[tuple[str, str], dict] = {}
     for row in rows:
         key = (row.get("variant"), row.get("target"))
-        bucket = cells.setdefault(key, {"once": 0, "duplicate": 0, "drop": 0, "invalid": 0})
+        bucket = cells.setdefault(
+            key, {"once": 0, "duplicate": 0, "drop": 0, "unseen": 0, "invalid": 0})
         bucket[row.get("verdict", "invalid")] += 1
 
     targets = sorted({t for _, t in cells if t})
@@ -425,6 +513,13 @@ def decide(scorecard: dict) -> dict:
 
     verdicts: dict[str, dict] = {}
     for variant in variants:
+        # THREE statuses, not two. A first draft had `eligible` and `disqualified`, so a
+        # variant with no scoreable trials came out DISQUALIFIED — which reads as "it
+        # failed" when the truth is "we never learned anything about it". The self-test
+        # caught it on its first run. Same shape as every other defect in this bench: a
+        # three-valued reality read by a two-valued caller, collapsing toward the answer
+        # that looks like a finding.
+        vetoes: list[str] = []
         reasons: list[str] = []
         valid_total = 0
         duplicates = 0
@@ -433,20 +528,30 @@ def decide(scorecard: dict) -> dict:
             if cell is None:
                 reasons.append(f"{target}: not run")
                 continue
+            # `unseen` is deliberately NOT valid: the app reported a delivery the oracle
+            # could not find, so the row says nothing about the variant either way.
             valid = cell["once"] + cell["duplicate"] + cell["drop"]
             valid_total += valid
             duplicates += cell["duplicate"]
             if valid == 0:
-                reasons.append(f"{target}: no valid trials ({cell['invalid']} invalid)")
+                reasons.append(
+                    f"{target}: no scoreable trials "
+                    f"({cell['invalid']} invalid, {cell['unseen']} unseen)")
                 continue
             # COVERAGE VETO. Only fires where the baseline demonstrably works, so a target
             # nobody can deliver to cannot disqualify a variant for failing there too.
             if cell["drop"] > 0 and baseline_ok.get(target):
-                reasons.append(
+                vetoes.append(
                     f"{target}: VETO — dropped {cell['drop']}/{valid} where V0 delivers")
-        status = "eligible" if not reasons else "disqualified"
         if variant == "V0":
             status = "baseline"
+        elif vetoes:
+            status = "disqualified"
+        elif valid_total == 0:
+            status = "unmeasured"
+        else:
+            status = "eligible"
+        reasons = vetoes + reasons
         verdicts[variant] = {
             "status": status, "reasons": reasons,
             "valid_trials": valid_total, "duplicates": duplicates,
@@ -454,8 +559,14 @@ def decide(scorecard: dict) -> dict:
 
     eligible = [v for v, d in verdicts.items()
                 if d["status"] == "eligible" and d["valid_trials"] > 0]
-    if not eligible:
-        winner, why = None, "no eligible variant survived the coverage veto"
+    candidates = [v for v in verdicts if v != "V0"]
+    if not candidates:
+        # Baseline-only run. Saying "nothing survived the veto" here would be a plausible
+        # sentence about a comparison that never happened — the same shape of wrong answer
+        # this bench exists to avoid, one level up.
+        winner, why = None, "baseline-only run: no candidate variant was measured"
+    elif not eligible:
+        winner, why = None, "no candidate variant survived the coverage veto"
     else:
         fewest = min(verdicts[v]["duplicates"] for v in eligible)
         tied = [v for v in eligible if verdicts[v]["duplicates"] == fewest]
@@ -471,6 +582,84 @@ def decide(scorecard: dict) -> dict:
             "baseline_delivers": baseline_ok}
 
 
+def selftest() -> int:
+    """Exercise the scoring logic against the defects it has already had.
+
+    The scorer is the only part of this bench that can turn a correct delivery into a
+    verdict that disqualifies a variant, and it has done exactly that once. These rows are
+    the regression net for the specific ways it was wrong, built from the real values that
+    fooled it rather than from imagined ones.
+    """
+    from types import SimpleNamespace as F
+
+    failures: list[str] = []
+
+    def check(name: str, got, want):
+        if got != want:
+            failures.append(f"{name}: got {got!r}, want {want!r}")
+
+    pre = "PRE-CD7735EA"
+    marker = "brown fox"
+
+    # 1. The bug that scored a perfect delivery as a DROP. Safari's address bar carried
+    #    the pre-image because it was in the filename, and it was LONGER than the real box.
+    address_bar = F(role="AXTextField", depth=4, chars=76, focused=False,
+                    value=f"file:///Users/x/Library/Caches/EnviousWispr-bakeoff-{pre}.html")
+    textarea = F(role="AXTextArea", depth=8, chars=39, focused=True,
+                 value=f"The quick brown fox jumps. {pre}")
+    verdict, detail = classify(pre, marker, [address_bar, textarea])
+    check("focused editable wins over longer chrome", verdict, "once")
+    check("and says how it chose", detail["field_choice"], "focused")
+
+    # 2. The AXStaticText mirror. `_dedupe` removes it upstream, but the scorer must not
+    #    depend on that: a mirror reaching it must not become a second occurrence.
+    mirror = F(role="AXStaticText", depth=9, chars=None, focused=False,
+               value=f"The quick brown fox jumps. {pre}")
+    verdict, _ = classify(pre, marker, [textarea, mirror])
+    check("a non-editable mirror is not a duplicate", verdict, "once")
+
+    # 3. A real duplicate must still read as one.
+    doubled = F(role="AXTextArea", depth=8, chars=65, focused=True,
+                value=f"The quick brown fox jumps. The quick brown fox jumps. {pre}")
+    verdict, _ = classify(pre, marker, [doubled])
+    check("a genuine double insertion", verdict, "duplicate")
+
+    # 4. A real drop.
+    untouched = F(role="AXTextArea", depth=8, chars=12, focused=True, value=pre)
+    verdict, _ = classify(pre, marker, [untouched])
+    check("nothing landed", verdict, "drop")
+
+    # 5. The pre-image gone entirely is unscoreable, not a drop.
+    verdict, _ = classify(pre, marker, [F(role="AXTextArea", depth=1, chars=3,
+                                          focused=True, value="hi")])
+    check("pre-image absent is invalid", verdict, "invalid")
+
+    # 6. The decision rule must not read a baseline-only run as a failed comparison.
+    card = {"rows": [{"variant": "V0", "target": "t", "verdict": "once"}]}
+    result = decide(card)
+    check("baseline-only run", result["winner"], None)
+    check("and says why honestly", "baseline-only" in result["why"], True)
+
+    # 7. A candidate that drops where the baseline delivers is vetoed; `unseen` is not
+    #    evidence either way and must not veto.
+    card = {"rows": [
+        {"variant": "V0", "target": "t", "verdict": "once"},
+        {"variant": "V1", "target": "t", "verdict": "unseen"},
+        {"variant": "V4", "target": "t", "verdict": "once"},
+        {"variant": "V2", "target": "t", "verdict": "drop"},
+    ]}
+    result = decide(card)
+    check("a real drop vetoes", result["verdicts"]["V2"]["status"], "disqualified")
+    check("unseen does not veto", result["verdicts"]["V1"]["status"], "unmeasured")
+    check("unseen is not a valid trial", result["verdicts"]["V1"]["valid_trials"], 0)
+    check("winner has valid trials", result["winner"], "V4")
+
+    for failure in failures:
+        print(f"  FAIL {failure}")
+    print(f"selftest: {len(failures)} failure(s)")
+    return 1 if failures else 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--variants", default="V0,V1,V2", help="comma-separated, in VARIANTS")
@@ -482,9 +671,14 @@ def main() -> int:
     ap.add_argument("--sentence", default="the quick brown fox jumps")
     ap.add_argument("--marker", default="brown fox")
     ap.add_argument("--out", default=None)
+    ap.add_argument("--selftest", action="store_true",
+                    help="check the scoring logic against the defects it has already had")
     ap.add_argument("--report", default=None,
                     help="apply the decision rule to an existing scorecard and exit")
     args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
 
     if args.report:
         card = json.loads(pathlib.Path(args.report).read_text())
@@ -495,6 +689,12 @@ def main() -> int:
     if args.reps is None:
         print("--reps is required for a run: a default here would be a parameter nobody "
               "states and everybody inherits.", file=sys.stderr)
+        return 2
+
+    if ax_oracle.screen_is_locked():
+        print("REFUSING TO RUN: the Mac is locked. Every trial would be scored against a "
+              "screen no app can reach, and the results would look like dropped text "
+              "rather than like a locked machine.", file=sys.stderr)
         return 2
 
     seed = args.seed if args.seed is not None else random.randrange(1 << 30)
@@ -537,7 +737,8 @@ def main() -> int:
     summary: dict = {}
     for row in rows:
         key = f"{row['variant']}/{row['target']}"
-        bucket = summary.setdefault(key, {"once": 0, "duplicate": 0, "drop": 0, "invalid": 0})
+        bucket = summary.setdefault(
+            key, {"once": 0, "duplicate": 0, "drop": 0, "unseen": 0, "invalid": 0})
         bucket[row.get("verdict", "invalid")] = bucket.get(row.get("verdict", "invalid"), 0) + 1
 
     out_path.write_text(json.dumps(

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -1012,25 +1012,51 @@ def main() -> int:
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     rows: list[dict] = []
-    # Variant order is randomized so a drift in the machine's state cannot be mistaken
-    # for a property of whichever variant happened to run last.
-    schedule = [(v, t) for v in variants for t in targets]
-    random.shuffle(schedule)
+    # RELAUNCH ONCE PER VARIANT, NOT ONCE PER CELL.
+    #
+    # The variant is baked into the app's launch environment, so it is the variant — never
+    # the destination — that a relaunch exists to change. The old schedule interleaved
+    # (variant, target) pairs and relaunched for every one of them, which on a 5-variant,
+    # 4-target run meant 20 relaunches to change 5 things.
+    #
+    # Measured 2026-09-04 mid-run, from delivery timestamps in `app.log`: 12s between
+    # dictations inside a cell, 65s between cells. The 65s is TERM, launch, model load and
+    # the control line; it is not overhead that can be tuned away, it is a whole app
+    # start. Twenty of them is 22 minutes of a 34-minute run spent restarting an app to
+    # give it a setting it already had.
+    #
+    # **The cost of grouping, stated rather than glossed.** Interleaving was there so a
+    # drift in the machine's state could not be read as a property of whichever variant
+    # ran last. Blocks give that up: every trial of one variant is now adjacent, so a
+    # drift during a block lands on that block. Two things bound it. The variant ORDER and
+    # the target order within each block are still shuffled, so no variant occupies a
+    # fixed position across runs. And the veto this bench turns on is DROPS — a variant
+    # losing text where the baseline delivers — which is a coarse, near-binary signal
+    # rather than a rate that a slow machine could nudge across a threshold.
+    variant_order = list(variants)
+    random.shuffle(variant_order)
 
-    for variant, target in schedule:
+    for variant in variant_order:
         launched, why = launch_dev_app(variant, run_id)
+        block = list(targets)
+        random.shuffle(block)
         if not launched:
-            rows.append({"variant": variant, "target": target.key,
-                         "verdict": "invalid", "why": f"launch:{why}"})
-            print(f"[{variant}/{target.key}] LAUNCH FAILED: {why}", flush=True)
+            for target in block:
+                rows.append({"variant": variant, "target": target.key,
+                             "verdict": "invalid", "why": f"launch:{why}"})
+            print(f"[{variant}] LAUNCH FAILED: {why}", flush=True)
             continue
-        print(f"[{variant}/{target.key}] launched ({why})", flush=True)
-        for i in range(args.reps):
-            row = run_trial(variant, run_id, target, args.sentence, args.marker)
-            row["rep"] = i
-            rows.append(row)
-            print(f"  rep {i}: {row.get('verdict')} tier={row.get('tier')} "
-                  f"{row.get('why', '')}", flush=True)
+        print(f"[{variant}] launched ({why}) — "
+              f"{len(block)} cells on this launch: {', '.join(t.key for t in block)}",
+              flush=True)
+        for target in block:
+            print(f"  [{variant}/{target.key}]", flush=True)
+            for i in range(args.reps):
+                row = run_trial(variant, run_id, target, args.sentence, args.marker)
+                row["rep"] = i
+                rows.append(row)
+                print(f"    rep {i}: {row.get('verdict')} tier={row.get('tier')} "
+                      f"{row.get('why', '')}", flush=True)
 
     summary: dict = {}
     for row in rows:

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -71,10 +71,16 @@ TRIAL_RE = re.compile(
     r"ledger=(?P<ledger>\S*) duration=(?P<duration>\d+)ms"
 )
 
-# V6 is not a candidate fix. It delivers TWICE on purpose, to arm the copies detector
-# with a positive control — no Mac we own produces a real double, so without it a
-# detector wired to a constant would pass every run we could think to do.
-VARIANTS = ["V0", "V1", "V2", "V4", "V5", "V6"]
+# V6 delivered TWICE on purpose, to arm the copies detector with a positive control. It is
+# NOT committed: a second `pasteToActiveApp` call site reads to the clipboard-isolation freeze
+# as a fourth shipped automatic paste route, and a third attempt to satisfy that guard moved the
+# write out of its snapshot's scope, which the guard also refused. Correctly, all three times.
+#
+# Recipe to re-add it locally and uncommitted when the detector needs re-proving: a
+# `deliberateDouble` writer policy mapped to "V6", and a second delivery IN THE SNAPSHOT'S OWN
+# SCOPE. Proof it produced on 2026-09-04: 40 trials, four destinations, both directions, zero
+# wrong verdicts and zero unknowns.
+VARIANTS = ["V0", "V1", "V2", "V4", "V5"]
 
 
 # --------------------------------------------------------------------------- log

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""paste_bakeoff.py — measure which delivery policy is most reliable (#2652).
+
+A reporter's dictation arrived TWICE in Safari page textareas and a WebKit-backed
+compose window, proven by exact character counts, and the defect does not reproduce on
+this hardware. The founder refused to accept a fix on the strength of a mechanism story
+and asked for a measurement instead. This is it.
+
+## What makes a row believable
+
+Three sources, and a row is scored only when all three agree about the same trial:
+
+1. **The bootstrap control record** — which policy the process actually resolved.
+   `PASTE_BAKEOFF_CONTROL run_id=… variant=…`, emitted once per launch.
+2. **The executor evidence line** — which routes ran and the exact bytes each was
+   handed. `PASTE_BAKEOFF_TRIAL … ledger=…`.
+3. **The destination oracle** — the target application's own text, read by
+   `paste_oracles.ax_oracle` from a different process.
+
+EnviousWispr's own logs never determine whether delivery succeeded. That is the whole
+point: the defect IS the app being wrong about its own write.
+
+## Why the app never sees a trial id
+
+An earlier design had the app stamp one. It has no way to obtain it — the variant and
+run id arrive in the environment at launch, and a trial is a harness concept that begins
+after the process is already running. So the harness brackets each trial with its own
+log boundary and requires EXACTLY ONE new evidence line inside it. Zero or two is
+`invalid`, which is also the honest answer when a stray dictation lands mid-trial.
+
+## Invalid is not failure
+
+A trial whose precondition sentinel could not be found, whose control line is missing,
+or whose oracle could not read the destination is `invalid` with a reason. Scoring it as
+a drop would make every variant look like it loses text whenever the harness blinks, and
+that error runs in the direction that would pick the wrong winner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import random
+import re
+import subprocess
+import sys
+import time
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "paste_oracles"))
+
+import ax_oracle  # noqa: E402
+import wispr_eyes  # noqa: E402
+
+APP_LOG = pathlib.Path.home() / "Library/Logs/EnviousWispr/app.log"
+
+# Derived from THIS FILE's checkout, never a literal path. `build-dev-app.sh` builds into
+# `$PROJECT_ROOT/build`, so a hardcoded path would silently measure whichever checkout
+# happened to build last — and this repo keeps the root on `main` while feature work
+# lives in worktrees, so the wrong answer is the likely one.
+CHECKOUT = pathlib.Path(__file__).resolve().parents[2]
+DEV_APP = CHECKOUT / "build/EnviousWispr Local.app"
+
+CONTROL_RE = re.compile(r"PASTE_BAKEOFF_CONTROL run_id=(\S+) variant=(\S+)")
+REJECT_RE = re.compile(r"PASTE_BAKEOFF_CONTROL rejected: (.+)")
+TRIAL_RE = re.compile(
+    r"PASTE_BAKEOFF_TRIAL run_id=(?P<run>\S+) variant=(?P<variant>\S+) "
+    r"tier=(?P<tier>\S+) app=(?P<app>\S+) attempts=(?P<attempts>\S*) "
+    r"ledger=(?P<ledger>\S*) duration=(?P<duration>\d+)ms"
+)
+
+VARIANTS = ["V0", "V1", "V2", "V4", "V5"]
+
+
+# --------------------------------------------------------------------------- log
+
+
+def log_size() -> int:
+    """Byte offset to read from. The boundary that brackets a trial."""
+    try:
+        return APP_LOG.stat().st_size
+    except OSError:
+        return 0
+
+
+def log_since(offset: int) -> str:
+    try:
+        with APP_LOG.open("rb") as fh:
+            fh.seek(offset)
+            return fh.read().decode("utf-8", "replace")
+    except OSError:
+        return ""
+
+
+# ------------------------------------------------------------------------ app
+
+
+def running_dev_pids() -> list[int]:
+    """PIDs of dev instances, identified by EXECUTABLE PATH.
+
+    Never by name or bundle id: a bare name also matches the production app, and a
+    Release-configuration test host carries the production identifier while living under
+    a different path.
+    """
+    out = subprocess.run(
+        ["pgrep", "-f", "EnviousWispr Local.app/Contents/MacOS/EnviousWispr"],
+        capture_output=True, text=True,
+    )
+    return [int(p) for p in out.stdout.split() if p.strip().isdigit()]
+
+
+def stop_dev_app() -> None:
+    for pid in running_dev_pids():
+        subprocess.run(["kill", "-TERM", str(pid)], capture_output=True)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if not running_dev_pids():
+            return
+        time.sleep(0.3)  # settle: polling the process table, which exposes no exit signal
+    for pid in running_dev_pids():
+        subprocess.run(["kill", "-KILL", str(pid)], capture_output=True)
+
+
+def launch_dev_app(variant: str, run_id: str) -> tuple[bool, str]:
+    """Launch the sole dev instance under one variant, and PROVE it took.
+
+    Returns (ok, reason). The proof is the control line: without it the process may have
+    fallen back to the baseline while the harness believed otherwise, which would fill a
+    scorecard with confident rows about a policy that never ran.
+    """
+    if not DEV_APP.exists():
+        return False, f"dev_app_missing:{DEV_APP}"
+    stop_dev_app()
+    boundary = log_size()
+    # `open` hands off to LaunchServices, which does NOT inherit this process's
+    # environment — passing `env=` to subprocess.run sets it for `open` itself and the
+    # app would never see it. Measured before the first run rather than discovered as a
+    # run of "control_line_never_appeared" that looks like a code fault.
+    command = ["open", "-n"]
+    if variant != "V0":
+        command += ["--env", f"EW_PASTE_BAKEOFF_VARIANT={variant}",
+                    "--env", f"EW_PASTE_BAKEOFF_RUN_ID={run_id}"]
+    command += ["-a", str(DEV_APP)]
+    subprocess.run(command, capture_output=True)
+
+    if variant == "V0":
+        # The baseline emits no control line by design, so its proof is that the process
+        # came up at all. A V0 row cannot be confused with a forced one: a forced variant
+        # without its control line is refused below.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if running_dev_pids():
+                return True, "baseline_launched"
+            time.sleep(0.5)  # settle: waiting on the process table
+        return False, "baseline_never_started"
+
+    def look_for_control(seconds: float) -> tuple[bool, str] | None:
+        """None means "not yet"; a tuple is a settled answer."""
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            text = log_since(boundary)
+            rejection = REJECT_RE.search(text)
+            if rejection:
+                return False, f"control_rejected:{rejection.group(1)}"
+            match = CONTROL_RE.search(text)
+            if match:
+                if match.group(1) == run_id and match.group(2) == variant:
+                    return True, "control_confirmed"
+                return False, f"control_mismatch:{match.group(1)}/{match.group(2)}"
+            time.sleep(0.5)  # settle: polling the log for the control line, the real signal
+        return None
+
+    settled = look_for_control(45)
+    if settled is not None:
+        return settled
+
+    # The policy resolves when the dictation driver is CONSTRUCTED, and the app builds
+    # that lazily. Measured 2026-09-04: the environment variables were confirmed present
+    # in the process with `ps -E` while the control line had still not appeared — a
+    # perfectly healthy launch that a naive gate reads as a broken control plane.
+    #
+    # So force construction with one throwaway dictation and require the line after it.
+    # The gate is not weakened: a forced variant with no control line is still refused,
+    # and this trial's own result is discarded rather than scored.
+    try:
+        wispr_eyes.test_recording(sentence="warm up the driver", expect=None)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"warmup_raised:{type(exc).__name__}"
+    settled = look_for_control(20)
+    if settled is not None:
+        return settled
+    return False, "control_line_never_appeared_even_after_warmup"
+
+
+# --------------------------------------------------------------------- targets
+
+
+class Target:
+    """One destination cell: how to put it into a known state and how to read it back."""
+
+    def __init__(self, key: str, bundle_id: str, setup, teardown=None):
+        self.key = key
+        self.bundle_id = bundle_id
+        self.setup = setup
+        self.teardown = teardown
+
+
+def _write_fixture(token: str, pre_image: str, focus_id: str) -> pathlib.Path:
+    path = _fixture_path(token)
+    body = path.read_text()
+    other = "OTHERFIELD"
+    if focus_id == "ta":
+        body = body.replace("__PRE__", pre_image).replace("__PRE2__", other)
+    else:
+        body = body.replace("__PRE__", other).replace("__PRE2__", pre_image)
+    path.write_text(body.replace("__FOCUS__", focus_id))
+    return path
+
+
+def _fixture_path(token: str) -> pathlib.Path:
+    # A NEW path per trial. Rewriting one file in place is how the first smoke run failed:
+    # both TextEdit and Safari serve the window/document they already have, so the file on
+    # disk changed and the thing being measured did not. The precondition control caught
+    # it, which is the whole reason that control is mandatory rather than nice to have.
+    path = pathlib.Path.home() / f"Library/Caches/EnviousWispr-bakeoff-{token}.html"
+    path.write_text(
+        "<!doctype html><meta charset='utf-8'><title>EW bake-off</title>"
+        "<style>body{font:16px -apple-system;padding:24px}"
+        "textarea,div[contenteditable]{width:96%;min-height:110px;font-size:16px;"
+        "padding:8px;border:2px solid #6b46ff;border-radius:8px;display:block;"
+        "margin-bottom:20px}</style>"
+        "<h1>EW bake-off</h1><textarea id='ta'>__PRE__</textarea>"
+        "<div id='ce' contenteditable='true'>__PRE2__</div>"
+        # The caret goes to the END, which is where a dictation appends. Without it the
+        # caret sits at offset 0 in a contenteditable and the insertion lands BEFORE the
+        # pre-image — a different case from the one this cell claims to test, and one
+        # that would still score `once` while measuring something else.
+        "<script>const el=document.getElementById('__FOCUS__');el.focus();"
+        "const r=document.createRange();r.selectNodeContents(el);r.collapse(false);"
+        "const s=getSelection();s.removeAllRanges();s.addRange(r);"
+        "if(el.setSelectionRange)el.setSelectionRange(el.value.length,el.value.length);"
+        "</script>"
+    )
+    return path
+
+
+def setup_textedit(pre_image: str, file_token: str) -> tuple[bool, str]:
+    # Close whatever this harness opened last, so a stale window cannot be measured, then
+    # open a fresh document. `close saving no` is safe: every one of these files is ours.
+    subprocess.run(
+        ["osascript", "-e",
+         'tell application "TextEdit" to close (every document whose name contains '
+         '"EnviousWispr-bakeoff") saving no'],
+        capture_output=True)
+    scratch = (pathlib.Path.home()
+               / f"Library/Caches/EnviousWispr-bakeoff-{file_token}.txt")
+    scratch.write_text(pre_image)
+    subprocess.run(["open", "-a", "TextEdit", str(scratch)], capture_output=True)
+    ax_oracle.activate("com.apple.TextEdit")
+    # Put the caret at the end of the document, which is where a dictation lands.
+    subprocess.run(
+        ["osascript", "-e",
+         'tell application "System Events" to keystroke "a" using command down'],
+        capture_output=True)
+    subprocess.run(
+        ["osascript", "-e", 'tell application "System Events" to key code 124'],
+        capture_output=True)
+    return ax_oracle.assert_precondition("com.apple.TextEdit", pre_image)
+
+
+def _setup_browser(app: str, bundle_id: str, focus_id: str):
+    def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
+        path = _write_fixture(file_token, pre_image, focus_id)
+        subprocess.run(["open", "-a", app, str(path)], capture_output=True)
+        ax_oracle.activate(bundle_id, handoff=2.0)
+        return ax_oracle.assert_precondition(bundle_id, pre_image)
+    return setup
+
+
+TARGETS = {
+    # Native `AXTextArea`. The coverage anchor: the one cell where the direct write is
+    # expected to succeed outright, so a variant that loses it has lost the fast path.
+    "textedit": Target("textedit", "com.apple.TextEdit", setup_textedit),
+    # The reported defect surface.
+    "safari_textarea": Target(
+        "safari_textarea", "com.apple.Safari",
+        _setup_browser("Safari", "com.apple.Safari", "ta")),
+    # A DIFFERENT WebKit editor. A rich contenteditable and a plain textarea are not one
+    # cell wearing two names: they take different paths inside WebKit, and collapsing them
+    # would let a result about one be reported as a result about web content generally.
+    "safari_contenteditable": Target(
+        "safari_contenteditable", "com.apple.Safari",
+        _setup_browser("Safari", "com.apple.Safari", "ce")),
+    # Chromium, whose web area is the population where `no_mutation` is genuinely true —
+    # the write really does nothing there. This is the cell that can tell a variant which
+    # refuses the fallback (V2) apart from one that merely reroutes it (V1).
+    "chrome_textarea": Target(
+        "chrome_textarea", "com.google.Chrome",
+        _setup_browser("Google Chrome", "com.google.Chrome", "ta")),
+}
+
+
+# --------------------------------------------------------------------- scoring
+
+
+# Roles that can hold a dictation. A browser's address bar is an `AXTextField` too, so
+# role alone does not identify the field under test — see `classify`.
+EDITABLE_ROLES = {"AXTextArea", "AXTextField"}
+
+
+def classify(pre_image: str, spoken_marker: str, fields) -> tuple[str, dict]:
+    """Turn what the destination holds into a verdict.
+
+    `spoken_marker` is a word from the dictated sentence, so counting its occurrences in
+    the field that also holds the pre-image answers the only question that matters:
+    once, twice, or not at all.
+
+    **Picking the WRONG field is the failure mode this function had, and it reported a
+    plausible verdict rather than an error.** Measured 2026-09-04 on the first real Safari
+    trial: the fixture filename contained the pre-image token, so Safari's ADDRESS BAR
+    also "carried" the pre-image, was longer than the textarea, and won a
+    longest-match tie-break. The text had landed perfectly — `The quick brown fox jumps.
+    PRE-CD7735EA`, one copy, right field — and the bench recorded a DROP.
+    A drop is the verdict that disqualifies a variant, so this bug could have vetoed the
+    winner.
+
+    Two independent fixes, because either alone leaves the class open: the caller no
+    longer puts the pre-image in any filename, and selection here prefers the FOCUSED
+    editable field over any browser chrome rather than the longest string.
+    """
+    editable = [f for f in fields if f.role in EDITABLE_ROLES and pre_image in f.value]
+    if not editable:
+        # No editable field holds the pre-image. Either the pre-image is gone entirely, or
+        # only non-editable mirrors carry it — neither is a scoreable state.
+        return "invalid", {"why": "pre_image_in_no_editable_field"}
+    focused = [f for f in editable if f.focused]
+    # The focused editable field IS the field under test: the harness put the caret there
+    # and the dictation was aimed at it. Falling back to the longest is a last resort and
+    # is recorded, so a row that relied on the guess can be told from one that did not.
+    target = focused[0] if focused else max(editable, key=lambda f: len(f.value))
+    occurrences = target.value.lower().count(spoken_marker.lower())
+    detail = {"chars": target.chars, "role": target.role, "occurrences": occurrences,
+              "field_choice": "focused" if focused else "longest_fallback",
+              "editable_candidates": len(editable)}
+    if occurrences == 0:
+        return "drop", detail
+    if occurrences == 1:
+        return "once", detail
+    return "duplicate", detail
+
+
+def run_trial(variant: str, run_id: str, target: Target, sentence: str, marker: str) -> dict:
+    pre_image = f"PRE-{uuid.uuid4().hex[:8].upper()}"
+    # A SEPARATE token for filenames. The pre-image must never appear in a path, or the
+    # browser's address bar carries it and becomes a candidate for the field under test.
+    file_token = uuid.uuid4().hex[:8]
+    row = {"variant": variant, "run_id": run_id, "target": target.key,
+           "pre_image": pre_image, "sentence": sentence}
+
+    ok, why = target.setup(pre_image, file_token)
+    if not ok:
+        row.update(verdict="invalid", why=why)
+        return row
+
+    boundary = log_size()
+    try:
+        wispr_eyes.test_recording(sentence=sentence, expect=None)
+    except Exception as exc:  # noqa: BLE001 - a harness fault is invalid, never a failure
+        row.update(verdict="invalid", why=f"recording_raised:{type(exc).__name__}:{exc}")
+        return row
+
+    scan = ax_oracle.settled_scan(target.bundle_id, max_wait=6.0)
+    if not scan.ok:
+        row.update(verdict="invalid", why=f"oracle:{scan.why}")
+        return row
+
+    text = log_since(boundary)
+    evidence = TRIAL_RE.findall(text)
+    matches = [m for m in TRIAL_RE.finditer(text)]
+    if variant != "V0":
+        if len(matches) != 1:
+            row.update(verdict="invalid", why=f"delivery_lines={len(matches)}")
+            return row
+        ev = matches[0].groupdict()
+        if ev["run"] != run_id or ev["variant"] != variant:
+            row.update(verdict="invalid", why=f"evidence_mismatch:{ev['run']}/{ev['variant']}")
+            return row
+        row.update(tier=ev["tier"], attempts=ev["attempts"], ledger=ev["ledger"],
+                   duration_ms=int(ev["duration"]))
+    else:
+        tier = re.search(r"Paste cascade: tier=(\S+?),", text)
+        row["tier"] = tier.group(1) if tier else None
+        row["ledger"] = None
+    del evidence
+
+    verdict, detail = classify(pre_image, marker, scan.fields)
+    row.update(verdict=verdict, **detail)
+    return row
+
+
+def decide(scorecard: dict) -> dict:
+    """Apply the pre-registered decision rule to a scorecard. No judgement calls.
+
+    The rule is mechanical on purpose. A bench whose winner is argued rather than computed
+    is a slower way of having the same opinion, and the whole reason this exists is that
+    the opinion was not good enough.
+
+    Order matters, and the vetoes come first because a duplicate improvement may never buy
+    back a coverage loss. That ordering is the founder's, stated before any data existed:
+    "I don't want to lose our ability to paste reliably into applications."
+    """
+    rows = scorecard["rows"]
+    cells: dict[tuple[str, str], dict] = {}
+    for row in rows:
+        key = (row.get("variant"), row.get("target"))
+        bucket = cells.setdefault(key, {"once": 0, "duplicate": 0, "drop": 0, "invalid": 0})
+        bucket[row.get("verdict", "invalid")] += 1
+
+    targets = sorted({t for _, t in cells if t})
+    variants = sorted({v for v, _ in cells if v})
+    baseline_ok = {
+        t: cells.get(("V0", t), {}).get("once", 0) > 0 for t in targets
+    }
+
+    verdicts: dict[str, dict] = {}
+    for variant in variants:
+        reasons: list[str] = []
+        valid_total = 0
+        duplicates = 0
+        for target in targets:
+            cell = cells.get((variant, target))
+            if cell is None:
+                reasons.append(f"{target}: not run")
+                continue
+            valid = cell["once"] + cell["duplicate"] + cell["drop"]
+            valid_total += valid
+            duplicates += cell["duplicate"]
+            if valid == 0:
+                reasons.append(f"{target}: no valid trials ({cell['invalid']} invalid)")
+                continue
+            # COVERAGE VETO. Only fires where the baseline demonstrably works, so a target
+            # nobody can deliver to cannot disqualify a variant for failing there too.
+            if cell["drop"] > 0 and baseline_ok.get(target):
+                reasons.append(
+                    f"{target}: VETO — dropped {cell['drop']}/{valid} where V0 delivers")
+        status = "eligible" if not reasons else "disqualified"
+        if variant == "V0":
+            status = "baseline"
+        verdicts[variant] = {
+            "status": status, "reasons": reasons,
+            "valid_trials": valid_total, "duplicates": duplicates,
+        }
+
+    eligible = [v for v, d in verdicts.items()
+                if d["status"] == "eligible" and d["valid_trials"] > 0]
+    if not eligible:
+        winner, why = None, "no eligible variant survived the coverage veto"
+    else:
+        fewest = min(verdicts[v]["duplicates"] for v in eligible)
+        tied = [v for v in eligible if verdicts[v]["duplicates"] == fewest]
+        if len(tied) > 1:
+            winner, why = None, (
+                f"tie on duplicates ({fewest}) between {tied} — latency is the tie-break "
+                "and this screening run does not measure it")
+        else:
+            winner, why = tied[0], f"fewest duplicates ({fewest}) among eligible variants"
+
+    return {"cells": {f"{v}/{t}": c for (v, t), c in cells.items()},
+            "verdicts": verdicts, "winner": winner, "why": why,
+            "baseline_delivers": baseline_ok}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--variants", default="V0,V1,V2", help="comma-separated, in VARIANTS")
+    ap.add_argument("--targets", default="textedit,safari_textarea")
+    ap.add_argument("--reps", type=int, default=None,
+                    help="repetitions per variant/target. Required: a default here would "
+                         "be a parameter nobody states and everybody inherits.")
+    ap.add_argument("--seed", type=int, default=None)
+    ap.add_argument("--sentence", default="the quick brown fox jumps")
+    ap.add_argument("--marker", default="brown fox")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--report", default=None,
+                    help="apply the decision rule to an existing scorecard and exit")
+    args = ap.parse_args()
+
+    if args.report:
+        card = json.loads(pathlib.Path(args.report).read_text())
+        result = decide(card)
+        print(json.dumps(result, indent=1))
+        return 0
+
+    if args.reps is None:
+        print("--reps is required for a run: a default here would be a parameter nobody "
+              "states and everybody inherits.", file=sys.stderr)
+        return 2
+
+    seed = args.seed if args.seed is not None else random.randrange(1 << 30)
+    random.seed(seed)
+    run_id = uuid.uuid4().hex[:12]
+    variants = [v.strip() for v in args.variants.split(",") if v.strip()]
+    unknown = [v for v in variants if v not in VARIANTS]
+    if unknown:
+        print(f"unknown variants: {unknown}", file=sys.stderr)
+        return 2
+    targets = [TARGETS[t.strip()] for t in args.targets.split(",") if t.strip() in TARGETS]
+
+    out_path = pathlib.Path(
+        args.out or (pathlib.Path.home()
+                     / "Developer/EnviousLabs/EnviousWispr/.validation"
+                     / f"paste-bakeoff-{run_id}.json"))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict] = []
+    # Variant order is randomized so a drift in the machine's state cannot be mistaken
+    # for a property of whichever variant happened to run last.
+    schedule = [(v, t) for v in variants for t in targets]
+    random.shuffle(schedule)
+
+    for variant, target in schedule:
+        launched, why = launch_dev_app(variant, run_id)
+        if not launched:
+            rows.append({"variant": variant, "target": target.key,
+                         "verdict": "invalid", "why": f"launch:{why}"})
+            print(f"[{variant}/{target.key}] LAUNCH FAILED: {why}", flush=True)
+            continue
+        print(f"[{variant}/{target.key}] launched ({why})", flush=True)
+        for i in range(args.reps):
+            row = run_trial(variant, run_id, target, args.sentence, args.marker)
+            row["rep"] = i
+            rows.append(row)
+            print(f"  rep {i}: {row.get('verdict')} tier={row.get('tier')} "
+                  f"{row.get('why', '')}", flush=True)
+
+    summary: dict = {}
+    for row in rows:
+        key = f"{row['variant']}/{row['target']}"
+        bucket = summary.setdefault(key, {"once": 0, "duplicate": 0, "drop": 0, "invalid": 0})
+        bucket[row.get("verdict", "invalid")] = bucket.get(row.get("verdict", "invalid"), 0) + 1
+
+    out_path.write_text(json.dumps(
+        {"run_id": run_id, "seed": seed, "sentence": args.sentence,
+         "summary": summary, "rows": rows}, indent=1))
+    print("\n=== summary ===")
+    for key, bucket in sorted(summary.items()):
+        print(f"  {key}: {bucket}")
+    card = json.loads(out_path.read_text())
+    decision = decide(card)
+    print("\n=== decision (pre-registered rule, applied mechanically) ===")
+    for variant, detail in sorted(decision["verdicts"].items()):
+        print(f"  {variant}: {detail['status']} "
+              f"(valid={detail['valid_trials']}, duplicates={detail['duplicates']})")
+        for reason in detail["reasons"]:
+            print(f"      {reason}")
+    print(f"  WINNER: {decision['winner']} — {decision['why']}")
+    card["decision"] = decision
+    out_path.write_text(json.dumps(card, indent=1))
+    print(f"\nscorecard: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import pathlib
 import random
 import re
@@ -966,6 +967,34 @@ def selftest() -> int:
     return 1 if failures else 0
 
 
+def ensure_targets_running(targets: list["Target"], wait: float = 25.0) -> list[tuple[str, str]]:
+    """Launch every destination app, and report the ones that never came up.
+
+    Measured 2026-09-04: a 240-trial run scored 120 trials `app_not_running` because
+    Safari, Brave and Word happened to be closed. The harness discovered this once per
+    TRIAL, thirty times per target, and reported it as an ordinary invalid row — so the
+    run took its full fifty minutes and produced a scorecard that looked like data.
+
+    A missing app is knowable BEFORE the first dictation, so it is asked once, up front,
+    where the answer costs a second instead of an evening. Returns the targets that are
+    still not running, which the caller turns into a refusal rather than a warning: a
+    warning here reads exactly like the run that already wasted the evening.
+    """
+    launched: list["Target"] = []
+    for target in targets:
+        if ax_oracle.pid_for_bundle(target.bundle_id) is None:
+            subprocess.run(["open", "-b", target.bundle_id], capture_output=True, timeout=20)
+            launched.append(target)
+    if not launched:
+        return []
+    deadline = time.time() + wait
+    pending = list(launched)
+    while pending and time.time() < deadline:
+        time.sleep(1.0)
+        pending = [t for t in pending if ax_oracle.pid_for_bundle(t.bundle_id) is None]
+    return [(t.name, t.bundle_id) for t in pending]
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--variants", default="V0,V1,V2", help="comma-separated, in VARIANTS")
@@ -1011,7 +1040,23 @@ def main() -> int:
     if unknown:
         print(f"unknown variants: {unknown}", file=sys.stderr)
         return 2
-    targets = [TARGETS[t.strip()] for t in args.targets.split(",") if t.strip() in TARGETS]
+    requested = [t.strip() for t in args.targets.split(",") if t.strip()]
+    # An unknown target used to be DROPPED here, silently. A typo therefore produced a
+    # shorter run that looked complete, which is the same failure shape as the one below.
+    unknown_targets = [t for t in requested if t not in TARGETS]
+    if unknown_targets:
+        print(f"unknown targets: {unknown_targets}. Known: {sorted(TARGETS)}", file=sys.stderr)
+        return 2
+    targets = [TARGETS[t] for t in requested]
+
+    not_running = ensure_targets_running(targets)
+    if not_running:
+        print("REFUSING TO RUN: these destination apps are not running, and every trial "
+              "against them would be scored invalid rather than measured:", file=sys.stderr)
+        for name, bundle_id in not_running:
+            print(f"  {name} ({bundle_id})", file=sys.stderr)
+        print("Open them and re-run.", file=sys.stderr)
+        return 2
 
     out_path = pathlib.Path(
         args.out or (pathlib.Path.home()
@@ -1019,7 +1064,24 @@ def main() -> int:
                      / f"paste-bakeoff-{run_id}.json"))
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # HOLD THE MAC AWAKE FOR THE WHOLE RUN, and let it die with the run.
+    #
+    # Measured 2026-09-04: a 16-trial run was killed by the Mac locking, and the only
+    # caffeinate on the machine was `caffeinate -i -t 300` from an unrelated tool — five
+    # minutes, and `-i` holds off IDLE SYSTEM SLEEP ONLY. It does not hold the display,
+    # does not declare the user active, and expires long before a 50-minute run ends.
+    #
+    # `-d` display, `-i` idle, `-m` disk, `-s` on AC, `-u` declare the user active. `-w`
+    # ties its life to this process, so an aborted run leaves nothing holding the machine
+    # awake — an orphaned caffeinate is a worse bug than the lock it prevents.
+    keep_awake = subprocess.Popen(
+        ["caffeinate", "-dimsu", "-w", str(os.getpid())],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    print(f"holding the Mac awake for this run (caffeinate pid {keep_awake.pid})",
+          flush=True)
+
     rows: list[dict] = []
+    locked_early = False
     # RELAUNCH ONCE PER VARIANT, NOT ONCE PER CELL.
     #
     # The variant is baked into the app's launch environment, so it is the variant — never
@@ -1060,11 +1122,28 @@ def main() -> int:
         for target in block:
             print(f"  [{variant}/{target.key}]", flush=True)
             for i in range(args.reps):
-                row = run_trial(variant, run_id, target, args.sentence, args.marker)
+                try:
+                    row = run_trial(variant, run_id, target, args.sentence, args.marker)
+                except ax_oracle.ScreenLocked:
+                    # The Mac locked mid-run. Every reading from here on is taken against
+                    # a screen no application can reach, so a trial scored now would read
+                    # as DROPPED TEXT rather than as a locked machine — and drops are the
+                    # verdict this bench vetoes on. Stop, keep what was already measured,
+                    # and say why. An uncaught raise here loses every completed row and
+                    # reads as a harness fault rather than as a locked Mac.
+                    print("\nSTOPPED: the Mac locked mid-run. Rows measured before the "
+                          "lock are kept and written below; nothing after it was scored.",
+                          file=sys.stderr)
+                    locked_early = True
+                    break
                 row["rep"] = i
                 rows.append(row)
                 print(f"    rep {i}: {row.get('verdict')} tier={row.get('tier')} "
                       f"{row.get('why', '')}", flush=True)
+            if locked_early:
+                break
+        if locked_early:
+            break
 
     summary: dict = {}
     for row in rows:

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -281,11 +281,18 @@ def _close_fixture_tabs(app: str) -> None:
 
     Scoped to our own fixture URLs so the operator's real tabs are never touched.
     """
-    subprocess.run(
-        ["osascript", "-e",
-         f'tell application "{app}" to close (every tab of every window '
-         'whose URL contains "EnviousWispr-bakeoff")'],
-        capture_output=True)
+    # Bounded. The script enumerates every tab of every window, which on a browser the
+    # operator actually uses is slow enough to stall a run: measured 2026-09-04, one call
+    # sat for 35 seconds and the bench made no progress behind it. Cleanup is best-effort
+    # housekeeping, so a timeout here costs one noisy cell rather than the whole run.
+    try:
+        subprocess.run(
+            ["osascript", "-e",
+             f'tell application "{app}" to close (every tab of every window '
+             'whose URL contains "EnviousWispr-bakeoff")'],
+            capture_output=True, timeout=20)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def _setup_browser(app: str, bundle_id: str, focus_id: str):
@@ -317,11 +324,38 @@ def _setup_composer(app_name: str, bundle_id: str):
     def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
         if ax_oracle.pid_for_bundle(bundle_id) is None:
             return False, f"{app_name}_not_running"
-        ax_oracle.activate(bundle_id, handoff=2.0)
+        if not ax_oracle.activate(bundle_id, handoff=2.0):
+            return False, f"{app_name}_would_not_come_forward"
+
+        # CLEAR the composer first, and this is correctness rather than tidiness.
+        #
+        # A browser cell gets a brand new tab each trial. A chat composer does not: it
+        # keeps whatever the last trial left. Measured 2026-09-04 — WhatsApp's composer
+        # held `PRE-32EE4C1F The quick brown fox jumps. PRE-ACA6175F The quick brown fox
+        # jumps. PRE-3ED5B80E The quick brown fox jumps.` after three trials, and the
+        # scorer counted the PREVIOUS trial's sentence and reported a DUPLICATE. Those
+        # were the first duplicates this bench had ever produced, in a bench built to
+        # count duplicates, and every one of them was manufactured here.
+        #
+        # Select-all-and-delete is only ever aimed at an element already CONFIRMED to be
+        # an editable text field, so it cannot reach a message list or a document.
+        focused = ax_oracle.read_focused(bundle_id)
+        if not focused.ok or focused.fields[0].role not in EDITABLE_ROLES:
+            return False, f"{app_name}_composer_not_focused"
+        if focused.fields[0].value.strip():
+            subprocess.run(
+                ["osascript", "-e",
+                 'tell application "System Events" to keystroke "a" using command down'],
+                capture_output=True)
+            subprocess.run(
+                ["osascript", "-e",
+                 'tell application "System Events" to key code 51'],
+                capture_output=True)
+
         subprocess.run(
             ["osascript", "-e",
              f'tell application "System Events" to keystroke "{pre_image} "'],
-            capture_output=True)
+            capture_output=True, timeout=20)
         return ax_oracle.assert_precondition(bundle_id, pre_image)
 
     return setup

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -619,9 +619,17 @@ TARGETS = {
     # stand-ins because Word was unlicensed; the licence was bought on 2026-09-04, so the
     # bench measures Microsoft's apps directly and the stand-in argument is retired.
     #
-    # This is the `PasteTier.menuPaste` family — a container where Cmd+V cannot be aimed
-    # at a writable element, delivered by driving the app's own Edit > Paste menu item.
-    # No web cell exercises it, so before today no trial had touched this route at all.
+    # **Word and Excel were expected to exercise `PasteTier.menuPaste` and they DO NOT.**
+    # Measured 2026-09-04 across 23 deliveries: every one went out as `cgevent`, plain
+    # Cmd+V, and `menu_paste` appears three times in the whole log — none of them in an
+    # Office app. The expectation came from `PasteTier.menuPaste`'s own comment, which
+    # names "Word/Excel/Numbers/OneNote"; that comment describes what the tier is FOR, not
+    # where it is reached, and reading it as coverage was the error.
+    #
+    # So these cells are worth having for a different and smaller reason than the one they
+    # were added for: they are real desktop applications, they are what a user writing a
+    # document is actually in, and no browser or chat cell speaks for them. They do not
+    # close the menu-paste gap, and that gap stays open and stated.
     "word": Target("word", "com.microsoft.Word",
                    _setup_document(
                        "Word", "com.microsoft.Word",

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -199,11 +199,15 @@ def launch_dev_app(variant: str, run_id: str) -> tuple[bool, str]:
 class Target:
     """One destination cell: how to put it into a known state and how to read it back."""
 
-    def __init__(self, key: str, bundle_id: str, setup, teardown=None):
+    def __init__(self, key: str, bundle_id: str, setup, teardown=None, reader=None):
         self.key = key
         self.bundle_id = bundle_id
         self.setup = setup
         self.teardown = teardown
+        # A cell whose destination text Accessibility cannot read supplies its own reader.
+        # `None` means the default focused-element read, which is right for every web and
+        # chat surface. See `_script_reader` for why the document apps need their own.
+        self.reader = reader
 
 
 def _write_fixture(token: str, pre_image: str, focus_id: str) -> pathlib.Path:
@@ -223,6 +227,13 @@ def _fixture_path(token: str) -> pathlib.Path:
     # both TextEdit and Safari serve the window/document they already have, so the file on
     # disk changed and the thing being measured did not. The precondition control caught
     # it, which is the whole reason that control is mandatory rather than nice to have.
+    # Sweep this harness's own leftovers. A fresh file per trial is deliberate; keeping
+    # every one of them is not. One run left 77 in Caches.
+    now = time.time()
+    for stale in pathlib.Path.home().glob("Library/Caches/EnviousWispr-bakeoff-*"):
+        if now - stale.stat().st_mtime > 600:
+            stale.unlink(missing_ok=True)
+
     path = pathlib.Path.home() / f"Library/Caches/EnviousWispr-bakeoff-{token}.html"
     path.write_text(
         "<!doctype html><meta charset='utf-8'><title>EW bake-off</title>"
@@ -278,8 +289,45 @@ def setup_textedit(pre_image: str, file_token: str) -> tuple[bool, str]:
 # focus for the whole machine — paying a permission prompt to solve a problem that no
 # longer exists.
 
+def _close_bakeoff_tabs(app: str) -> int:
+    """Close every bake-off tab this harness left in `app`, one at a time.
+
+    A fresh file per trial is what keeps a stale document from being measured, and the
+    cost of that is a new tab per trial: one full run left 30 tabs in Safari and 16 in
+    Brave, on top of the operator's own. Closing before opening keeps the count at one.
+
+    One at a time on purpose. Collecting the doomed tabs and closing them in a second
+    loop fails with `Invalid index (-1719)` partway through, because closing a tab
+    renumbers the ones behind it and the collected references go stale mid-loop. That
+    error closed exactly half of them and reported failure, which reads as "cleanup is
+    broken" rather than "cleanup half worked".
+    """
+    script = pathlib.Path.home() / "Library/Caches/ew-bakeoff-close.scpt"
+    script.write_text(
+        f'tell application "{app}"\n'
+        "  repeat with w in windows\n"
+        "    repeat with t in (tabs of w)\n"
+        '      if (URL of t) contains "EnviousWispr-bakeoff" then\n'
+        "        close t\n"
+        "        return 1\n"
+        "      end if\n"
+        "    end repeat\n"
+        "  end repeat\n"
+        "end tell\n"
+        "return 0\n"
+    )
+    closed = 0
+    for _ in range(60):
+        out = subprocess.run(["osascript", str(script)], capture_output=True, text=True)
+        if out.stdout.strip() != "1":
+            break
+        closed += 1
+    return closed
+
+
 def _setup_browser(app: str, bundle_id: str, focus_id: str):
     def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
+        _close_bakeoff_tabs(app)
         path = _write_fixture(file_token, pre_image, focus_id)
         subprocess.run(["open", "-a", app, str(path)], capture_output=True)
         ax_oracle.activate(bundle_id, handoff=2.0)
@@ -337,9 +385,190 @@ def _setup_composer(app_name: str, bundle_id: str):
             ["osascript", "-e",
              f'tell application "System Events" to keystroke "{pre_image} "'],
             capture_output=True, timeout=20)
-        return ax_oracle.assert_precondition(bundle_id, pre_image)
+        ok, why = ax_oracle.assert_precondition(bundle_id, pre_image)
+        if not ok:
+            return ok, why
+        return _still_frontmost(app_name, bundle_id)
 
     return setup
+
+
+def _still_frontmost(app_name: str, bundle_id: str) -> tuple[bool, str]:
+    """The last thing every setup does: prove the target STILL owns focus.
+
+    Delivery goes wherever the caret is when the pipeline finishes, so a target that lost
+    focus during setup sends the dictation into a bystander. Measured 2026-09-04 on the
+    first Excel trial: setup succeeded, the pre-image was in the sheet, and the app
+    reported delivering to `com.mitchellh.ghostty` — the operator's TERMINAL. The trial
+    scored `unseen`, which is honest and says nothing about the variant, and the words
+    went somewhere real.
+
+    Raising once more is not enough on its own; the point is that a setup which cannot
+    hold focus returns INVALID rather than handing the trial a destination it does not own.
+    """
+    pid = ax_oracle.pid_for_bundle(bundle_id)
+    if pid is None:
+        return False, f"{app_name}_vanished_during_setup"
+    if ax_oracle.is_frontmost(pid):
+        return True, "ok"
+    if ax_oracle.activate(bundle_id, handoff=1.5) and ax_oracle.is_frontmost(pid):
+        return True, "ok"
+    return False, f"{app_name}_lost_focus_during_setup"
+
+
+def _osa(script: str, timeout: float = 30.0) -> tuple[bool, str]:
+    """Run one AppleScript. Returns (ok, output-or-error)."""
+    out = subprocess.run(["osascript", "-e", script],
+                         capture_output=True, text=True, timeout=timeout)
+    if out.returncode != 0:
+        return False, out.stderr.strip()[:120]
+    return True, out.stdout.rstrip("\n")
+
+
+def _script_reader(script: str, label: str, commit: str | None = None):
+    """Read a destination's text through the APPLICATION'S OWN scripting, not through AX.
+
+    **Pages, Numbers and Excel do not expose their document text to Accessibility in any
+    form this oracle can find, and the failure is silent.** Measured 2026-09-04: a marker
+    typed into a blank Pages document was plainly visible on screen, `read_focused`
+    returned `focused_element_has_no_text_value:AXScrollArea`, and a full tree walk visited
+    81 nodes and found it in none of them. An unreadable destination scores every trial as
+    a DROP, which is the verdict that disqualifies a variant — so a blind oracle here would
+    have vetoed whichever variant happened to be measured in these cells.
+
+    The app's own dictionary answers it exactly. This stays an INDEPENDENT oracle in the
+    sense that matters: the reading comes from the destination application, never from
+    EnviousWispr's account of what it delivered.
+
+    Gates on STABILITY rather than a fixed sleep, for the same reason `settled_focused`
+    does: "unchanged across two reads" has no parameter to get wrong.
+    """
+
+    def read() -> ax_oracle.Scan:
+        if commit is not None:
+            subprocess.run(["osascript", "-e", commit], capture_output=True, timeout=15)
+            time.sleep(0.5)
+        previous = None
+        stable = 0
+        deadline = time.monotonic() + 8.0
+        text = ""
+        while time.monotonic() < deadline:
+            time.sleep(0.4)
+            ok, value = _osa(script)
+            if not ok:
+                return ax_oracle.Scan(ok=False, why=f"{label}_reader_failed:{value}")
+            text = value
+            if value == previous:
+                stable += 1
+                if stable >= 2:
+                    break
+            else:
+                stable = 0
+                previous = value
+        return ax_oracle.Scan(
+            ok=True,
+            nodes_visited=1,
+            fields=[ax_oracle.Field(role="AXTextArea", depth=0, chars=len(text),
+                                    focused=True, value=text)],
+        )
+
+    return read
+
+
+def _setup_document(app_name: str, bundle_id: str, clear: str, reader_script: str):
+    """A word processor: empty the document, put the caret in the body, type the pre-image.
+
+    The caret step is not optional and is not tidiness. A freshly raised Word or Pages
+    window reports its focused element as an `AXScrollArea` with no text in it, and typing
+    is what moves focus into the body. Cmd+End moves the caret to the end of the document
+    and changes nothing, so it is safe to run before every trial.
+    """
+
+    def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
+        if ax_oracle.pid_for_bundle(bundle_id) is None:
+            return False, f"{app_name}_not_running"
+        if not ax_oracle.activate(bundle_id, handoff=2.0):
+            return False, f"{app_name}_would_not_come_forward"
+        ok, err = _osa(clear)
+        if not ok:
+            return False, f"{app_name}_clear_failed:{err}"
+        time.sleep(0.5)
+        subprocess.run(["osascript", "-e",
+                        'tell application "System Events" to key code 119 using command down'],
+                       capture_output=True, timeout=15)
+        time.sleep(0.4)
+        subprocess.run(["osascript", "-e",
+                        f'tell application "System Events" to keystroke "{pre_image} "'],
+                       capture_output=True, timeout=25)
+        time.sleep(0.6)
+        ok, value = _osa(reader_script)
+        if not ok:
+            return False, f"{app_name}_precondition_read_failed:{value}"
+        if pre_image not in value:
+            return False, f"{app_name}_precondition_sentinel_not_in_document"
+        return _still_frontmost(app_name, bundle_id)
+
+    return setup
+
+
+def _setup_cell(app_name: str, bundle_id: str, clear: str, reader_script: str,
+                select_a1: str, edit_key: str):
+    """A spreadsheet cell in EDIT mode, which is where a dictation actually lands.
+
+    Two things had to be got right, both found by hand before any trial ran:
+
+    - **Escape first.** Numbers was sitting in an open, empty cell editor left by an
+      earlier attempt, and every keystroke sent to it vanished. The typed marker appeared
+      nowhere in the sheet and nothing reported an error.
+    - **Edit mode, not selection.** A selected-but-not-editing cell REPLACES its contents
+      on the next input, which would delete the pre-image the scorer needs to find the
+      field by. `edit_key` opens the editor with the caret after the existing text, which
+      is the state a person dictating into a cell is in.
+    """
+
+    def setup(pre_image: str, file_token: str) -> tuple[bool, str]:
+        if ax_oracle.pid_for_bundle(bundle_id) is None:
+            return False, f"{app_name}_not_running"
+        if not ax_oracle.activate(bundle_id, handoff=2.0):
+            return False, f"{app_name}_would_not_come_forward"
+        subprocess.run(["osascript", "-e",
+                        'tell application "System Events" to key code 53'],
+                       capture_output=True, timeout=15)
+        time.sleep(0.4)
+        ok, err = _osa(clear)
+        if not ok:
+            return False, f"{app_name}_clear_failed:{err}"
+        ok, err = _osa(select_a1)
+        if not ok:
+            return False, f"{app_name}_select_failed:{err}"
+        time.sleep(0.5)
+        subprocess.run(["osascript", "-e",
+                        f'tell application "System Events" to keystroke "{pre_image} "'],
+                       capture_output=True, timeout=25)
+        subprocess.run(["osascript", "-e",
+                        'tell application "System Events" to key code 36'],
+                       capture_output=True, timeout=15)
+        time.sleep(0.6)
+        ok, err = _osa(select_a1)
+        if not ok:
+            return False, f"{app_name}_reselect_failed:{err}"
+        time.sleep(0.4)
+        subprocess.run(["osascript", "-e", edit_key], capture_output=True, timeout=15)
+        time.sleep(0.5)
+        ok, value = _osa(reader_script)
+        if not ok:
+            return False, f"{app_name}_precondition_read_failed:{value}"
+        if pre_image not in value:
+            return False, f"{app_name}_precondition_sentinel_not_in_sheet"
+        return _still_frontmost(app_name, bundle_id)
+
+    return setup
+
+
+WORD_READ = 'tell application "Microsoft Word" to get content of text object of active document'
+PAGES_READ = 'tell application "Pages" to get body text of front document'
+EXCEL_READ = ('tell application "Microsoft Excel" to get string value of used range '
+              'of active sheet')
 
 
 TARGETS = {
@@ -374,6 +603,59 @@ TARGETS = {
                       _setup_composer("Discord", "com.hnc.Discord")),
     "whatsapp": Target("whatsapp", "net.whatsapp.WhatsApp",
                        _setup_composer("WhatsApp", "net.whatsapp.WhatsApp")),
+    # Pages and Numbers stand in for Word and Excel, and it is not a compromise.
+    #
+    # `PasteTier.menuPaste` exists for exactly this family — its own comment names
+    # "Word/Excel/Numbers/OneNote" — so all four take the SAME route through our cascade:
+    # a non-text container where Cmd+V cannot be aimed at a writable element, delivered by
+    # driving the app's own Edit > Paste menu item. Word is unlicensed on this Mac
+    # ("Subscription Required to Edit and Save"), and buying one to exercise a code path
+    # two free preinstalled apps already exercise would be spending money for nothing.
+    #
+    # Stated so nobody over-reads it: this covers the ROUTE, not Microsoft's apps. A
+    # Word-specific defect would not be caught here, and that is written into the plan's
+    # uncovered list rather than glossed.
+    # Word and Excel, the real ones. The plan previously used Pages and Numbers as
+    # stand-ins because Word was unlicensed; the licence was bought on 2026-09-04, so the
+    # bench measures Microsoft's apps directly and the stand-in argument is retired.
+    #
+    # This is the `PasteTier.menuPaste` family — a container where Cmd+V cannot be aimed
+    # at a writable element, delivered by driving the app's own Edit > Paste menu item.
+    # No web cell exercises it, so before today no trial had touched this route at all.
+    "word": Target("word", "com.microsoft.Word",
+                   _setup_document(
+                       "Word", "com.microsoft.Word",
+                       'tell application "Microsoft Word" to set content of text object '
+                       'of active document to ""',
+                       WORD_READ),
+                   reader=_script_reader(WORD_READ, "word")),
+    "excel": Target("excel", "com.microsoft.Excel",
+                    _setup_cell(
+                        "Excel", "com.microsoft.Excel",
+                        'tell application "Microsoft Excel" to clear contents of used '
+                        'range of active sheet',
+                        EXCEL_READ,
+                        'tell application "Microsoft Excel" to select range "A1" of '
+                        'active sheet',
+                        # F2 opens the cell editor with the caret after the existing text.
+                        'tell application "System Events" to key code 120'),
+                    # COMMIT THE CELL BEFORE READING IT. A spreadsheet's used range holds
+                    # only committed values, so text sitting in an open cell editor is
+                    # invisible to every reader — the delivery lands correctly and scores
+                    # as nothing at all. Return closes the editor and writes the value.
+                    reader=_script_reader(EXCEL_READ, "excel",
+                                          commit='tell application "System Events" to '
+                                                 'key code 36')),
+    "pages": Target("pages", "com.apple.iWork.Pages",
+                    _setup_document(
+                        "Pages", "com.apple.iWork.Pages",
+                        'tell application "Pages" to set body text of front document to ""',
+                        PAGES_READ),
+                    reader=_script_reader(PAGES_READ, "pages")),
+    # A terminal. Its own context path in the cascade (`terminal_screen_refused`), and the
+    # founder named terminals as coverage that must not regress.
+    "ghostty": Target("ghostty", "com.mitchellh.ghostty",
+                      _setup_composer("Ghostty", "com.mitchellh.ghostty")),
 }
 
 
@@ -458,7 +740,8 @@ def run_trial(variant: str, run_id: str, target: Target, sentence: str, marker: 
         row.update(verdict="invalid", why="target_process_changed_during_trial")
         return row
 
-    scan = ax_oracle.settled_focused(target.bundle_id, max_wait=6.0)
+    scan = (target.reader() if target.reader
+            else ax_oracle.settled_focused(target.bundle_id, max_wait=6.0))
     if not scan.ok:
         row.update(verdict="invalid", why=f"oracle:{scan.why}")
         return row

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -71,7 +71,10 @@ TRIAL_RE = re.compile(
     r"ledger=(?P<ledger>\S*) duration=(?P<duration>\d+)ms"
 )
 
-VARIANTS = ["V0", "V1", "V2", "V4", "V5"]
+# V6 is not a candidate fix. It delivers TWICE on purpose, to arm the copies detector
+# with a positive control — no Mac we own produces a real double, so without it a
+# detector wired to a constant would pass every run we could think to do.
+VARIANTS = ["V0", "V1", "V2", "V4", "V5", "V6"]
 
 
 # --------------------------------------------------------------------------- log

--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -672,6 +672,10 @@ TARGETS = {
                     reader=_script_reader(PAGES_READ, "pages")),
     # A terminal. Its own context path in the cascade (`terminal_screen_refused`), and the
     # founder named terminals as coverage that must not regress.
+    # The default target, and it was missing from this table while `--targets` advertised it —
+    # so the harness's own documented invocation refused to run. `setup_textedit` has been here
+    # all along.
+    "textedit": Target("textedit", "com.apple.TextEdit", setup_textedit),
     "ghostty": Target("ghostty", "com.mitchellh.ghostty",
                       _setup_composer("Ghostty", "com.mitchellh.ghostty")),
 }
@@ -1001,7 +1005,10 @@ def ensure_targets_running(targets: list["Target"], wait: float = 25.0) -> list[
     while pending and time.time() < deadline:
         time.sleep(1.0)
         pending = [t for t in pending if ax_oracle.pid_for_bundle(t.bundle_id) is None]
-    return [(t.name, t.bundle_id) for t in pending]
+    # `Target` defines `key`, never `name`. This line runs ONLY when an app fails to launch,
+    # so nothing had executed it: the refusal path this function exists to provide would have
+    # raised `AttributeError` instead of refusing.
+    return [(t.key, t.bundle_id) for t in pending]
 
 
 def main() -> int:

--- a/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
+++ b/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
@@ -1,0 +1,232 @@
+"""Independent destination oracle for the paste bake-off (#2652).
+
+**Why an oracle at all.** The defect under test is that EnviousWispr's own verdict
+about its own write is wrong. So EnviousWispr's logs cannot score delivery; only the
+destination application's text can. This module reads that text out of a foreign app
+through the Accessibility API, from a DIFFERENT process, after a settle the app
+itself could never afford.
+
+That last clause is why an AX-based oracle is legitimate here even though the
+suspected mechanism is AX lag: the app must decide in microseconds, this oracle may
+wait seconds and re-read until the value stops moving.
+
+## Two traps found while building this, both measured on 2026-09-04
+
+**1. A scan taken before the target is frontmost returns `ok: True` with an EMPTY
+field list.** Measured against Safari: 541 nodes visited, zero sentinel matches, no
+error — and the page was there the whole time. That is a silent-empty read that means
+"nothing landed" in the scorer's vocabulary, which is the answer that would make every
+variant look like it drops text.
+**Defence, mandatory:** `assert_precondition()` must find the pre-image sentinel BEFORE
+the trial runs. A cell whose pre-image cannot be found is `invalid`, never `fail`.
+(`validation-discipline.md`: before believing any sweep's silence, run the pattern
+against a case you KNOW is present.)
+
+**2. One web field appears TWICE in the tree.** A Safari `<textarea>` yields an
+`AXTextArea` carrying the value AND a child `AXStaticText` mirroring the same string
+with `AXNumberOfCharacters` of `None`. A scorer counting matches would read one
+insertion as two — a fabricated duplicate, in the exact direction of the defect we are
+hunting. **Defence:** `_dedupe()` keeps only elements reporting a real character count
+and collapses identical (role, value) pairs.
+
+## What this module does NOT do
+
+It does not decide pass or fail. It returns what it read plus why a read is
+untrustworthy, and the harness classifies. Anything it cannot establish comes back as
+`invalid` with a reason, never as a verdict.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from AppKit import NSWorkspace
+
+# The constant is a module-level symbol in pyobjc, NOT a class attribute on
+# NSRunningApplication — reading it off the class raises AttributeError at call time,
+# which is a runtime failure inside the harness rather than an import error. Bind it
+# once here so a missing symbol fails loudly at import instead of mid-run.
+try:
+    from AppKit import NSApplicationActivateIgnoringOtherApps as _ACTIVATE_IGNORING
+except ImportError:  # pragma: no cover - platform constant, present on every macOS
+    _ACTIVATE_IGNORING = 1 << 1
+from ApplicationServices import (
+    AXIsProcessTrusted,
+    AXUIElementCopyAttributeValue,
+    AXUIElementCreateApplication,
+    kAXChildrenAttribute,
+    kAXFocusedAttribute,
+    kAXNumberOfCharactersAttribute,
+    kAXRoleAttribute,
+    kAXValueAttribute,
+)
+
+# Roles that can carry an editable payload. `AXGroup` and `AXWebArea` are included
+# because WebKit and Chromium wrap page fields in them; the dedupe below removes the
+# mirrors this inclusiveness drags in.
+TEXT_ROLES = frozenset({"AXTextArea", "AXTextField", "AXStaticText", "AXWebArea", "AXGroup"})
+
+# A scan this small in a windowed app means the window contents were not in the tree —
+# almost always because the app was not frontmost yet. Menus alone reach ~250 nodes.
+MIN_PLAUSIBLE_NODES = 40
+
+
+class OracleUntrusted(RuntimeError):
+    """The harness process lacks Accessibility permission. Never a trial failure."""
+
+
+@dataclass(frozen=True)
+class Field:
+    role: str
+    depth: int
+    chars: int | None
+    focused: bool
+    value: str
+
+
+@dataclass
+class Scan:
+    ok: bool
+    why: str | None = None
+    nodes_visited: int = 0
+    fields: list[Field] = field(default_factory=list)
+
+    def carrying(self, needle: str) -> list[Field]:
+        return [f for f in self.fields if needle in f.value]
+
+
+def _attr(element: Any, name: str) -> Any:
+    err, value = AXUIElementCopyAttributeValue(element, name, None)
+    return value if err == 0 else None
+
+
+def pid_for_bundle(bundle_id: str) -> int | None:
+    for app in NSWorkspace.sharedWorkspace().runningApplications():
+        if app.bundleIdentifier() == bundle_id:
+            return app.processIdentifier()
+    return None
+
+
+def activate(bundle_id: str, handoff: float = 1.0) -> bool:
+    """Bring the target forward. Trap 1 above is why every scan needs this first.
+
+    The wait below is not the wait that matters: `settled_scan` gates on the text
+    signature going quiet, and this only covers the window-server handoff, which
+    exposes no completion signal to a foreign process.
+    """
+    for app in NSWorkspace.sharedWorkspace().runningApplications():
+        if app.bundleIdentifier() == bundle_id:
+            app.activateWithOptions_(_ACTIVATE_IGNORING)
+            time.sleep(handoff)  # settle: window-server activation has no foreign-process signal
+            return True
+    return False
+
+
+def _dedupe(found: list[Field]) -> list[Field]:
+    """Collapse a web field's AXStaticText mirror into the element that owns the text.
+
+    Trap 2. Drops an entry with no character count whose value duplicates one that has
+    a count, then keeps the first occurrence of each (role, value) pair.
+    """
+    counted = {f.value for f in found if f.chars is not None}
+    kept: list[Field] = []
+    seen: set[tuple[str, str]] = set()
+    for f in found:
+        if f.chars is None and f.value in counted:
+            continue
+        key = (f.role, f.value)
+        if key in seen:
+            continue
+        seen.add(key)
+        kept.append(f)
+    return kept
+
+
+def scan(bundle_id: str, max_nodes: int = 6000, max_depth: int = 45) -> Scan:
+    if not AXIsProcessTrusted():
+        raise OracleUntrusted("harness process is not Accessibility-trusted")
+    pid = pid_for_bundle(bundle_id)
+    if pid is None:
+        return Scan(ok=False, why="app_not_running")
+
+    root = AXUIElementCreateApplication(pid)
+    found: list[Field] = []
+    visited = 0
+    stack: list[tuple[Any, int]] = [(root, 0)]
+    while stack and visited < max_nodes:
+        element, depth = stack.pop()
+        visited += 1
+        role = _attr(element, kAXRoleAttribute)
+        if role in TEXT_ROLES:
+            value = _attr(element, kAXValueAttribute)
+            if isinstance(value, str) and value.strip():
+                found.append(
+                    Field(
+                        role=role,
+                        depth=depth,
+                        chars=_attr(element, kAXNumberOfCharactersAttribute),
+                        focused=bool(_attr(element, kAXFocusedAttribute)),
+                        value=value,
+                    )
+                )
+        if depth < max_depth:
+            for child in _attr(element, kAXChildrenAttribute) or []:
+                stack.append((child, depth + 1))
+
+    if visited < MIN_PLAUSIBLE_NODES:
+        return Scan(
+            ok=False,
+            why="tree_too_small_target_probably_not_frontmost",
+            nodes_visited=visited,
+        )
+    return Scan(ok=True, nodes_visited=visited, fields=_dedupe(found))
+
+
+def settled_scan(
+    bundle_id: str,
+    *,
+    poll_interval: float = 0.4,
+    max_wait: float = 3.0,
+    stable_polls: int = 2,
+) -> Scan:
+    """Scan until the readable text stops changing.
+
+    **Gates on STABILITY, never on elapsed time.** A fixed wait is a parameter that can
+    be wrong, and wrong in the silent direction; "unchanged across N polls" has no
+    parameter to get wrong. `max_wait` is a deadline AROUND the signal, not the signal.
+    """
+    deadline = time.monotonic() + max_wait
+    previous: str | None = None
+    stable = 0
+    last = Scan(ok=False, why="never_scanned")
+    while time.monotonic() < deadline:
+        time.sleep(poll_interval)  # settle: poll gap between two reads of the gating signal
+        last = scan(bundle_id)
+        if not last.ok:
+            continue
+        signature = "\x00".join(f"{f.role}:{f.chars}:{f.value}" for f in last.fields)
+        if signature == previous:
+            stable += 1
+            if stable >= stable_polls:
+                return last
+        else:
+            stable = 0
+            previous = signature
+    return last
+
+
+def assert_precondition(bundle_id: str, sentinel: str) -> tuple[bool, str]:
+    """Positive control. MUST pass before a trial is allowed to run.
+
+    A False here makes the trial `invalid`, never `fail` — the difference between "the
+    variant dropped the text" and "the oracle was blind" is the whole value of this
+    function.
+    """
+    result = settled_scan(bundle_id)
+    if not result.ok:
+        return False, f"precondition_scan_failed:{result.why}"
+    if not result.carrying(sentinel):
+        return False, "precondition_sentinel_not_found"
+    return True, "ok"

--- a/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
+++ b/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
@@ -38,6 +38,7 @@ untrustworthy, and the harness classifies. Anything it cannot establish comes ba
 
 from __future__ import annotations
 
+import subprocess
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -56,8 +57,11 @@ from ApplicationServices import (
     AXIsProcessTrusted,
     AXUIElementCopyAttributeValue,
     AXUIElementCreateApplication,
+    AXUIElementGetPid,
     kAXChildrenAttribute,
     kAXFocusedAttribute,
+    AXUIElementCreateSystemWide,
+    kAXFocusedApplicationAttribute,
     kAXFocusedUIElementAttribute,
     kAXWindowsAttribute,
     kAXNumberOfCharactersAttribute,
@@ -143,37 +147,59 @@ def pid_for_bundle(bundle_id: str) -> int | None:
     return None
 
 
+def frontmost_pid() -> int | None:
+    """The pid of the app that actually owns focus, asked LIVE.
+
+    **`NSWorkspace.frontmostApplication()` is not usable here.** It is maintained by
+    workspace notifications, which need a run loop the harness does not spin, so in a
+    long-running process it returns a value that never changes. Measured 2026-09-04: in a
+    one-shot probe Slack activated fine; inside the bench, twelve of fifteen trials came
+    back `would_not_come_forward` while the browsers — which happened to be frontmost
+    already — sailed through. The check was reporting the state at import time.
+
+    `AXFocusedApplication` on the system-wide element is a live query with no cache, and
+    it is the same thing the paste path itself cares about: who receives the keystroke.
+    """
+    system = AXUIElementCreateSystemWide()
+    err, focused_app = AXUIElementCopyAttributeValue(
+        system, kAXFocusedApplicationAttribute, None)
+    if err != 0 or focused_app is None:
+        return None
+    err, pid = AXUIElementGetPid(focused_app, None)
+    return pid if err == 0 else None
+
+
 def activate(bundle_id: str, handoff: float = 1.0) -> bool:
-    """Bring the target to the FRONT, and verify it got there.
+    """Bring the target to the front with `open -b`, and VERIFY it got there.
 
-    **`NSRunningApplication.activateWithOptions_` is deprecated on macOS 26 and did
-    nothing here.** Measured 2026-09-04: every target reported `no_focused_element` or an
-    `AXApplication` as its focused element — the shape a BACKGROUND app returns — while the
-    call reported success. Every earlier probe that worked had gone through AppleScript
-    without anyone noticing that was the load-bearing difference.
+    Three methods were tried before this one, and the first two failed silently:
 
-    So this tries the modern API, then AppleScript, and then CHECKS. An activation helper
-    that returns True without the app being frontmost poisons every trial downstream, and
-    the poison looks like "the variant dropped the text".
+    - `NSRunningApplication.activateWithOptions_` is deprecated on macOS 26 and does
+      nothing while reporting success.
+    - `NSRunningApplication.activate()` **does not exist in this pyobjc build**, so the
+      call raised `AttributeError` and fell through to the deprecated one above. Browsers
+      appeared to work only because their setup calls `open -a <file>`, which was doing
+      the activation; chat apps had nothing doing it, and twelve of fifteen trials came
+      back `would_not_come_forward`.
+    - `osascript ... to activate` works, but every app needs a separate macOS Automation
+      grant, and an ungranted one puts a MODAL on screen that blocks focus machine-wide.
+      One of those sat unanswered for an hour while a script was rewritten around
+      readings it fully explains.
+
+    `open -b` needs no Automation grant, so it raises no dialog. The verification is
+    `NSWorkspace.frontmostApplication()`, which was checked by hand against three other
+    sources and agrees with all of them — an earlier theory that it returned a stale
+    cached value was wrong and is recorded here so nobody re-derives it.
     """
     if pid_for_bundle(bundle_id) is None:
         return False
-    for app in NSWorkspace.sharedWorkspace().runningApplications():
-        if app.bundleIdentifier() == bundle_id:
-            try:
-                app.activate()
-            except AttributeError:
-                app.activateWithOptions_(_ACTIVATE_IGNORING)
-            break
-    # Ten seconds, not three. Measured 2026-09-04: Slack took longer than three to come
-    # forward from a minimised state and every Slack trial was recorded
-    # `would_not_come_forward` — honest, and useless. An activation deadline is a
-    # PARAMETER, and a parameter that is too small turns a slow app into an unmeasured one.
-    deadline = time.monotonic() + max(handoff, 10.0)
+    subprocess.run(["open", "-b", bundle_id], capture_output=True, timeout=15)
+    workspace = NSWorkspace.sharedWorkspace()
+    deadline = time.monotonic() + max(handoff, 8.0)
     while time.monotonic() < deadline:
         # settle: poll gap between two reads of the signal this loop gates on
         time.sleep(0.25)
-        front = NSWorkspace.sharedWorkspace().frontmostApplication()
+        front = workspace.frontmostApplication()
         if front is not None and front.bundleIdentifier() == bundle_id:
             time.sleep(handoff)  # settle: window-server handoff has no foreign-process signal
             return True

--- a/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
+++ b/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
@@ -58,6 +58,8 @@ from ApplicationServices import (
     AXUIElementCreateApplication,
     kAXChildrenAttribute,
     kAXFocusedAttribute,
+    kAXFocusedUIElementAttribute,
+    kAXWindowsAttribute,
     kAXNumberOfCharactersAttribute,
     kAXRoleAttribute,
     kAXValueAttribute,
@@ -68,9 +70,41 @@ from ApplicationServices import (
 # mirrors this inclusiveness drags in.
 TEXT_ROLES = frozenset({"AXTextArea", "AXTextField", "AXStaticText", "AXWebArea", "AXGroup"})
 
-# A scan this small in a windowed app means the window contents were not in the tree —
-# almost always because the app was not frontmost yet. Menus alone reach ~250 nodes.
-MIN_PLAUSIBLE_NODES = 40
+# A scan this small means the window subtree was not readable. The walk now starts at the
+# windows rather than the application root, so the menu bar no longer inflates this count
+# and a genuine document reaches dozens of nodes on its own.
+MIN_PLAUSIBLE_NODES = 5
+
+# Subtrees that can never hold the field under test and can be enormous. TextEdit's
+# Open Recent menu alone grew past the whole node budget once 38 fixture files had
+# accumulated, and the walk exhausted its cap before reaching the document — returning
+# SUCCESS with an empty field list, which the scorer reads as "nothing landed".
+SKIP_ROLES = frozenset({"AXMenuBar", "AXMenu", "AXMenuItem", "AXMenuBarItem"})
+
+
+def screen_is_locked() -> bool:
+    """Whether the login window owns the screen.
+
+    **A locked Mac makes every reading in this file worthless, and every one of them
+    fails SILENTLY into a verdict.** No app can be brought forward, so `activate` reports
+    failure, `AXFocusedUIElement` returns nothing, the precondition finds no sentinel, and
+    a trial that never ran is recorded as one that did.
+
+    Measured 2026-09-04, and this function exists because of the cost rather than the
+    theory: a full 100-trial run degraded into precondition failures partway through, and
+    the next forty minutes went into rewriting the tree walk, adding a cycle guard, and
+    re-rooting the traversal — three changes made to explain readings that a locked screen
+    fully accounts for. The tell was one line: the frontmost application was
+    `com.apple.loginwindow`.
+    """
+    import Quartz
+
+    session = Quartz.CGSessionCopyCurrentDictionary()
+    return bool(session.get("CGSSessionScreenIsLocked", 0)) if session else False
+
+
+class ScreenLocked(RuntimeError):
+    """The Mac is locked. Never a trial failure, and never a finding about a variant."""
 
 
 class OracleUntrusted(RuntimeError):
@@ -110,16 +144,34 @@ def pid_for_bundle(bundle_id: str) -> int | None:
 
 
 def activate(bundle_id: str, handoff: float = 1.0) -> bool:
-    """Bring the target forward. Trap 1 above is why every scan needs this first.
+    """Bring the target to the FRONT, and verify it got there.
 
-    The wait below is not the wait that matters: `settled_scan` gates on the text
-    signature going quiet, and this only covers the window-server handoff, which
-    exposes no completion signal to a foreign process.
+    **`NSRunningApplication.activateWithOptions_` is deprecated on macOS 26 and did
+    nothing here.** Measured 2026-09-04: every target reported `no_focused_element` or an
+    `AXApplication` as its focused element — the shape a BACKGROUND app returns — while the
+    call reported success. Every earlier probe that worked had gone through AppleScript
+    without anyone noticing that was the load-bearing difference.
+
+    So this tries the modern API, then AppleScript, and then CHECKS. An activation helper
+    that returns True without the app being frontmost poisons every trial downstream, and
+    the poison looks like "the variant dropped the text".
     """
+    if pid_for_bundle(bundle_id) is None:
+        return False
     for app in NSWorkspace.sharedWorkspace().runningApplications():
         if app.bundleIdentifier() == bundle_id:
-            app.activateWithOptions_(_ACTIVATE_IGNORING)
-            time.sleep(handoff)  # settle: window-server activation has no foreign-process signal
+            try:
+                app.activate()
+            except AttributeError:
+                app.activateWithOptions_(_ACTIVATE_IGNORING)
+            break
+    deadline = time.monotonic() + max(handoff, 3.0)
+    while time.monotonic() < deadline:
+        # settle: poll gap between two reads of the signal this loop gates on
+        time.sleep(0.25)
+        front = NSWorkspace.sharedWorkspace().frontmostApplication()
+        if front is not None and front.bundleIdentifier() == bundle_id:
+            time.sleep(handoff)  # settle: window-server handoff has no foreign-process signal
             return True
     return False
 
@@ -144,7 +196,17 @@ def _dedupe(found: list[Field]) -> list[Field]:
     return kept
 
 
-def scan(bundle_id: str, max_nodes: int = 6000, max_depth: int = 45) -> Scan:
+def scan(bundle_id: str, max_nodes: int = 20000, max_depth: int = 45) -> Scan:
+    """Walk the app's AX tree and return every text-bearing element.
+
+    **The tree is a GRAPH, not a tree, and walking it as a tree does not terminate.**
+    Measured 2026-09-04 against TextEdit: an unguarded walk visited 3,000 nodes and found
+    `AXApplication` NINE times and 2,646 menu items — menu subtrees link back to the
+    application root, so the walk cycled through menus forever and never reached the open
+    document. The scan then returned SUCCESS with an empty field list, which the scorer
+    reads as "nothing landed". Two independent guards, because either alone is thin: an
+    identity set so no element is expanded twice, and skipping menu subtrees outright.
+    """
     if not AXIsProcessTrusted():
         raise OracleUntrusted("harness process is not Accessibility-trusted")
     pid = pid_for_bundle(bundle_id)
@@ -152,6 +214,21 @@ def scan(bundle_id: str, max_nodes: int = 6000, max_depth: int = 45) -> Scan:
         return Scan(ok=False, why="app_not_running")
 
     root = AXUIElementCreateApplication(pid)
+
+    # **Walk from the APPLICATION root, and skip menu subtrees.**
+    #
+    # A window-rooted walk was tried and reverted the same hour. It fixed TextEdit and
+    # broke Safari, Chrome and every chat app — Safari fell from finding both page fields
+    # to finding none, because a browser's page content is not reached through
+    # `AXWindows` the way a document window's is. The change was made to rescue ONE target
+    # that is not even in the matrix, and it silently cost the targets that mattered.
+    #
+    # What remains is the guard that was actually needed: `SKIP_ROLES` prunes the menu bar,
+    # which is where TextEdit's cycle lived (an unguarded walk found `AXApplication` nine
+    # times and 2,646 menu items before reaching any document). Pruning the cycle's source
+    # needs no equality semantics to be correct — an identity set was also tried, and
+    # pyobjc collapsed every AX element into one, visiting two nodes total while reporting
+    # success.
     found: list[Field] = []
     visited = 0
     stack: list[tuple[Any, int]] = [(root, 0)]
@@ -159,6 +236,8 @@ def scan(bundle_id: str, max_nodes: int = 6000, max_depth: int = 45) -> Scan:
         element, depth = stack.pop()
         visited += 1
         role = _attr(element, kAXRoleAttribute)
+        if role in SKIP_ROLES:
+            continue
         if role in TEXT_ROLES:
             value = _attr(element, kAXValueAttribute)
             if isinstance(value, str) and value.strip():
@@ -181,7 +260,89 @@ def scan(bundle_id: str, max_nodes: int = 6000, max_depth: int = 45) -> Scan:
             why="tree_too_small_target_probably_not_frontmost",
             nodes_visited=visited,
         )
+    # A TRUNCATED walk is not a completed one, and the difference is invisible in the
+    # result: both return a field list, and a truncated walk's list can be empty. Measured
+    # 2026-09-04 against TextEdit — 6000 nodes visited, zero fields found, the document
+    # sitting there the whole time. Reporting that as a successful empty scan is how an
+    # oracle tells the scorer that nothing landed.
+    if visited >= max_nodes and not found:
+        return Scan(ok=False, why="scan_truncated_at_node_cap", nodes_visited=visited)
     return Scan(ok=True, nodes_visited=visited, fields=_dedupe(found))
+
+
+def read_focused(bundle_id: str) -> Scan:
+    """Read the FOCUSED element only. One call, no tree walk.
+
+    **This is the oracle that works, and the tree walk is the one that did not.** The
+    harness puts the caret in the field under test, so the focused element IS that field;
+    everything the walk was for — finding it among siblings — is a question the system
+    already answers.
+
+    The walk failed three different ways on three different apps and each failure returned
+    an EMPTY field list rather than an error, which the scorer reads as "nothing landed":
+    TextEdit's menus link back to the application root, so an unguarded walk cycled through
+    2,646 menu items and never reached the document; pruning menus then left 91 reachable
+    nodes with no text in them; and a browser with forty accumulated tabs exceeded any node
+    budget. Every fix traded one app's failure for another's.
+
+    `scan()` is kept for the WRONG-FIELD question — did the text land somewhere it should
+    not have — where enumerating siblings is the actual question. It is never the primary
+    verdict source.
+    """
+    if not AXIsProcessTrusted():
+        raise OracleUntrusted("harness process is not Accessibility-trusted")
+    if screen_is_locked():
+        raise ScreenLocked("the Mac is locked; no reading here means anything")
+    pid = pid_for_bundle(bundle_id)
+    if pid is None:
+        return Scan(ok=False, why="app_not_running")
+    application = AXUIElementCreateApplication(pid)
+    element = _attr(application, kAXFocusedUIElementAttribute)
+    if element is None:
+        return Scan(ok=False, why="no_focused_element")
+    role = _attr(element, kAXRoleAttribute)
+    value = _attr(element, kAXValueAttribute)
+    if not isinstance(value, str):
+        return Scan(ok=False, why=f"focused_element_has_no_text_value:{role}")
+    return Scan(
+        ok=True,
+        nodes_visited=1,
+        fields=[Field(role=role or "unknown", depth=0,
+                      chars=_attr(element, kAXNumberOfCharactersAttribute),
+                      focused=True, value=value)],
+    )
+
+
+def settled_focused(
+    bundle_id: str,
+    *,
+    poll_interval: float = 0.4,
+    max_wait: float = 4.0,
+    stable_polls: int = 2,
+) -> Scan:
+    """Read the focused element until its text stops changing.
+
+    Gates on STABILITY, never on elapsed time: "unchanged across N polls" has no parameter
+    to get wrong, and `max_wait` is a deadline around the signal rather than the signal.
+    """
+    deadline = time.monotonic() + max_wait
+    previous: str | None = None
+    stable = 0
+    last = Scan(ok=False, why="never_read")
+    while time.monotonic() < deadline:
+        time.sleep(poll_interval)  # settle: poll gap between two reads of the gating signal
+        last = read_focused(bundle_id)
+        if not last.ok:
+            continue
+        signature = f"{last.fields[0].chars}:{last.fields[0].value}"
+        if signature == previous:
+            stable += 1
+            if stable >= stable_polls:
+                return last
+        else:
+            stable = 0
+            previous = signature
+    return last
 
 
 def settled_scan(
@@ -224,9 +385,9 @@ def assert_precondition(bundle_id: str, sentinel: str) -> tuple[bool, str]:
     variant dropped the text" and "the oracle was blind" is the whole value of this
     function.
     """
-    result = settled_scan(bundle_id)
+    result = settled_focused(bundle_id)
     if not result.ok:
-        return False, f"precondition_scan_failed:{result.why}"
+        return False, f"precondition_read_failed:{result.why}"
     if not result.carrying(sentinel):
-        return False, "precondition_sentinel_not_found"
+        return False, "precondition_sentinel_not_in_focused_field"
     return True, "ok"

--- a/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
+++ b/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
@@ -62,8 +62,6 @@ from ApplicationServices import (
     AXUIElementSetAttributeValue,
     kAXChildrenAttribute,
     kAXFocusedAttribute,
-    AXUIElementCreateSystemWide,
-    kAXFocusedApplicationAttribute,
     kAXFocusedUIElementAttribute,
     kAXFrontmostAttribute,
     kAXRaiseAction,
@@ -151,26 +149,32 @@ def pid_for_bundle(bundle_id: str) -> int | None:
     return None
 
 
-def frontmost_pid() -> int | None:
-    """The pid of the app that actually owns focus, asked LIVE.
+def is_frontmost(pid: int) -> bool:
+    """Does this application own focus RIGHT NOW? Asked live, of the application itself.
 
-    **`NSWorkspace.frontmostApplication()` is not usable here.** It is maintained by
-    workspace notifications, which need a run loop the harness does not spin, so in a
-    long-running process it returns a value that never changes. Measured 2026-09-04: in a
-    one-shot probe Slack activated fine; inside the bench, twelve of fifteen trials came
-    back `would_not_come_forward` while the browsers — which happened to be frontmost
-    already — sailed through. The check was reporting the state at import time.
+    Two earlier answers to this question were both wrong, and both failed toward "no",
+    which the caller reports as `would_not_come_forward` — a harness fault dressed as a
+    fact about the destination app.
 
-    `AXFocusedApplication` on the system-wide element is a live query with no cache, and
-    it is the same thing the paste path itself cares about: who receives the keystroke.
+    - **`NSWorkspace.frontmostApplication()`** is maintained by workspace notifications
+      that need a run loop the harness does not spin. Inside one process it returns
+      whatever was true at import and never moves. Measured 2026-09-04: after a raise, the
+      target was frontmost within 0.4s and this call still named the previous app on every
+      poll for 3.2s.
+    - **`AXFocusedApplication` on the system-wide element** returns `None` on this machine,
+      every time, for every application. It is a live query with no cache, which is why it
+      was reached for, and it simply does not answer.
+
+    `AXFrontmost` read from the target's OWN application element does answer, immediately
+    and correctly, and needs no Automation grant. Verified against the menu bar and
+    against `System Events`, which agreed with it and with each other.
+
+    Returns False on any AX error, which is the safe direction: a caller that cannot tell
+    must retry rather than proceed against an app that may not be listening.
     """
-    system = AXUIElementCreateSystemWide()
-    err, focused_app = AXUIElementCopyAttributeValue(
-        system, kAXFocusedApplicationAttribute, None)
-    if err != 0 or focused_app is None:
-        return None
-    err, pid = AXUIElementGetPid(focused_app, None)
-    return pid if err == 0 else None
+    application = AXUIElementCreateApplication(pid)
+    err, value = AXUIElementCopyAttributeValue(application, kAXFrontmostAttribute, None)
+    return bool(value) if err == 0 else False
 
 
 def activate(bundle_id: str, handoff: float = 1.0) -> bool:
@@ -190,10 +194,18 @@ def activate(bundle_id: str, handoff: float = 1.0) -> bool:
       One of those sat unanswered for an hour while a script was rewritten around
       readings it fully explains.
 
-    `open -b` needs no Automation grant, so it raises no dialog. The verification is
-    `NSWorkspace.frontmostApplication()`, which was checked by hand against three other
-    sources and agrees with all of them — an earlier theory that it returned a stale
-    cached value was wrong and is recorded here so nobody re-derives it.
+    `open -b` needs no Automation grant, so it raises no dialog.
+
+    **The sentence that used to sit here said `NSWorkspace.frontmostApplication()` had
+    been checked against three other sources, agreed with all of them, and that the stale
+    cache theory was wrong. The stale cache theory was RIGHT.** The three sources were
+    read in three SEPARATE one-shot processes, and a fresh process reads a fresh cache, so
+    the check that was meant to falsify the theory could not have. Inside one long-running
+    process the value never moves at all — see `is_frontmost`, which is what this function
+    verifies with now.
+
+    A comment recording that a question is CLOSED is the shape to distrust: it stops the
+    next reader checking, and this one stopped two runs' worth of readings being believed.
     """
     pid = pid_for_bundle(bundle_id)
     if pid is None:
@@ -207,22 +219,58 @@ def activate(bundle_id: str, handoff: float = 1.0) -> bool:
     # `AXRaise` on its first window moves all three, and needs no Automation grant, so it
     # raises no modal. The fourth method tried, and the first that works everywhere.
     application = AXUIElementCreateApplication(pid)
-    AXUIElementSetAttributeValue(application, kAXFrontmostAttribute, True)
-    err, windows = AXUIElementCopyAttributeValue(application, kAXWindowsAttribute, None)
-    if err == 0 and windows:
-        AXUIElementPerformAction(windows[0], kAXRaiseAction)
-    else:
+
+    def _raise_via_ax() -> None:
+        AXUIElementSetAttributeValue(application, kAXFrontmostAttribute, True)
+        err, windows = AXUIElementCopyAttributeValue(application, kAXWindowsAttribute, None)
+        if err == 0 and windows:
+            AXUIElementPerformAction(windows[0], kAXRaiseAction)
+
+    def _wait_front(seconds: float) -> bool:
+        """Ask LIVE whether the target owns focus.
+
+        **`NSWorkspace.frontmostApplication()` is unusable here and this function used it
+        anyway, while the function directly above documents exactly why.** The
+        workspace value is maintained by notifications that need a run loop the harness
+        does not spin, so inside one process it returns whatever was true at import and
+        never moves. Measured 2026-09-04: after an AX raise, the live AX query reported
+        Discord frontmost within 0.4s and NSWorkspace still said WhatsApp 3.2s later, for
+        every single poll. The raise had worked every time; the verification could not see
+        it. Two full runs — 45 trials, then 30 — were scrapped as
+        `would_not_come_forward` on a check that was reading a frozen value.
+        """
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            # settle: poll gap between two reads of the signal this loop gates on
+            time.sleep(0.25)
+            if is_frontmost(pid):
+                return True
+        return False
+
+    # NEITHER METHOD WORKS EVERYWHERE, AND EACH FAILS SILENTLY WHERE THE OTHER SUCCEEDS.
+    #
+    # `open -b` raises a browser reliably and does NOT raise an already-running Electron
+    # app with an open window: Slack, Discord and WhatsApp all refused it, costing 45
+    # trials in one run. Setting `AXFrontmost` and performing `AXRaise` moves those three
+    # — but measured 2026-09-04, with Discord frontmost, the same AX raise aimed at
+    # WhatsApp returned with Discord STILL frontmost, and the whole 30-trial chat run came
+    # back `would_not_come_forward` for cells that had passed by hand ten minutes earlier.
+    #
+    # So they are tried in sequence rather than as alternatives, and the fallback is
+    # unconditional rather than reserved for an app with no windows. The earlier version
+    # only reached `open -b` when the app reported NO windows, which is the one case where
+    # an AX raise cannot work — never the case where it silently does not.
+    _raise_via_ax()
+    if not _wait_front(max(handoff, 3.0)):
         subprocess.run(["open", "-b", bundle_id], capture_output=True, timeout=15)
-    workspace = NSWorkspace.sharedWorkspace()
-    deadline = time.monotonic() + max(handoff, 8.0)
-    while time.monotonic() < deadline:
-        # settle: poll gap between two reads of the signal this loop gates on
-        time.sleep(0.25)
-        front = workspace.frontmostApplication()
-        if front is not None and front.bundleIdentifier() == bundle_id:
-            time.sleep(handoff)  # settle: window-server handoff has no foreign-process signal
-            return True
-    return False
+        if not _wait_front(3.0):
+            # Last try: both methods once more. A raise refused while another app is
+            # settling into the front often succeeds a second later.
+            _raise_via_ax()
+            if not _wait_front(3.0):
+                return False
+    time.sleep(handoff)  # settle: window-server handoff has no foreign-process signal
+    return True
 
 
 def _dedupe(found: list[Field]) -> list[Field]:
@@ -352,7 +400,20 @@ def read_focused(bundle_id: str) -> Scan:
     role = _attr(element, kAXRoleAttribute)
     value = _attr(element, kAXValueAttribute)
     if not isinstance(value, str):
-        return Scan(ok=False, why=f"focused_element_has_no_text_value:{role}")
+        # AN EMPTY EDITABLE FIELD IS A STATE, NOT AN UNREADABLE ELEMENT. WhatsApp's
+        # composer returns no value at all while it is empty and a real string the moment
+        # anything is in it. Rejecting the empty case made every WhatsApp trial
+        # `composer_not_focused`, because the setup reads the field BEFORE it types the
+        # pre-image into it — the one moment the field is guaranteed to be empty.
+        #
+        # Narrow on purpose: only a role that can hold typed text is read as empty. A
+        # scroll area or a window with no value really is unreadable and must stay an
+        # error, or a document app with no caret in it would score as an empty field and
+        # every trial there would read as a DROP.
+        if role in ("AXTextArea", "AXTextField", "AXComboBox"):
+            value = ""
+        else:
+            return Scan(ok=False, why=f"focused_element_has_no_text_value:{role}")
     return Scan(
         ok=True,
         nodes_visited=1,

--- a/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
+++ b/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
@@ -165,7 +165,11 @@ def activate(bundle_id: str, handoff: float = 1.0) -> bool:
             except AttributeError:
                 app.activateWithOptions_(_ACTIVATE_IGNORING)
             break
-    deadline = time.monotonic() + max(handoff, 3.0)
+    # Ten seconds, not three. Measured 2026-09-04: Slack took longer than three to come
+    # forward from a minimised state and every Slack trial was recorded
+    # `would_not_come_forward` — honest, and useless. An activation deadline is a
+    # PARAMETER, and a parameter that is too small turns a slow app into an unmeasured one.
+    deadline = time.monotonic() + max(handoff, 10.0)
     while time.monotonic() < deadline:
         # settle: poll gap between two reads of the signal this loop gates on
         time.sleep(0.25)

--- a/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
+++ b/Tests/RuntimeUAT/paste_oracles/ax_oracle.py
@@ -58,11 +58,15 @@ from ApplicationServices import (
     AXUIElementCopyAttributeValue,
     AXUIElementCreateApplication,
     AXUIElementGetPid,
+    AXUIElementPerformAction,
+    AXUIElementSetAttributeValue,
     kAXChildrenAttribute,
     kAXFocusedAttribute,
     AXUIElementCreateSystemWide,
     kAXFocusedApplicationAttribute,
     kAXFocusedUIElementAttribute,
+    kAXFrontmostAttribute,
+    kAXRaiseAction,
     kAXWindowsAttribute,
     kAXNumberOfCharactersAttribute,
     kAXRoleAttribute,
@@ -191,9 +195,24 @@ def activate(bundle_id: str, handoff: float = 1.0) -> bool:
     sources and agrees with all of them — an earlier theory that it returned a stale
     cached value was wrong and is recorded here so nobody re-derives it.
     """
-    if pid_for_bundle(bundle_id) is None:
+    pid = pid_for_bundle(bundle_id)
+    if pid is None:
         return False
-    subprocess.run(["open", "-b", bundle_id], capture_output=True, timeout=15)
+
+    # Raise through ACCESSIBILITY, which is already granted, then fall back to `open -b`.
+    #
+    # `open -b` raises a browser reliably and does NOT raise an already-running Electron
+    # app with an open window — Slack, Discord and WhatsApp all refused it, which cost 45
+    # trials in one run. Setting `AXFrontmost` on the application element and performing
+    # `AXRaise` on its first window moves all three, and needs no Automation grant, so it
+    # raises no modal. The fourth method tried, and the first that works everywhere.
+    application = AXUIElementCreateApplication(pid)
+    AXUIElementSetAttributeValue(application, kAXFrontmostAttribute, True)
+    err, windows = AXUIElementCopyAttributeValue(application, kAXWindowsAttribute, None)
+    if err == 0 and windows:
+        AXUIElementPerformAction(windows[0], kAXRaiseAction)
+    else:
+        subprocess.run(["open", "-b", bundle_id], capture_output=True, timeout=15)
     workspace = NSWorkspace.sharedWorkspace()
     deadline = time.monotonic() + max(handoff, 8.0)
     while time.monotonic() < deadline:

--- a/scripts/telemetry-join.py
+++ b/scripts/telemetry-join.py
@@ -114,6 +114,10 @@ TAKE_KEYED_EVENTS = (
     "llm.polish_failed",
     "llm.polish_skipped",
     "paste.completed",
+    # #2652. Reports how many copies of one dictation landed. Registered here because this
+    # list is the authority for which events carry `take_id`, and an event absent from it is
+    # invisible to every join whatever its payload says.
+    "paste.copies_observed",
     "recording.cap_warning_shown",
 )
 


### PR DESCRIPTION
## What this is

Two things for one issue, and only one of them reaches users.

**A measurement that ships.** `paste.completed` fires once whether one copy or two copies of a
dictation arrive, so the reported double-paste defect is invisible fleet-wide: one user reported
it, and we cannot say whether he is one of one or one of thousands. `paste.copies_observed`
reports an estimated one-copy or two-copy length growth, computed on the user's own Mac.

**A bake-off harness that does not.** `Tests/RuntimeUAT/` drives real dictations into real
applications and scores each one against the destination's own text.

**No delivery behaviour changes.** Deliberately: a fix shipped alongside its own measurement has
no before picture to be judged against.

## What the measurement can and cannot do

It estimates LENGTH GROWTH. A matching band does not prove identical content arrived.

- A normalising destination can move a true double INTO the one-copy band.
- An edit inside the settle window can produce a false `two`, a false `one`, or an unclassified
  observation.
- The 400 ms window is proved on an M5 Max, where the SECOND write lands. It is not proved on the
  affected population, whose working explanation is that the FIRST write lands late.

`PasteCopiesDeliveredTests` documents each of these rather than asserting them away.

**Lengths never leave the Mac.** The arithmetic is local and only the verdict is sent. Field
counts describe the size of whatever document a user is in, which has nothing to do with
dictation.

**No pre-write accessibility read was added.** The before-image comes only from reads
`insertViaAccessibility` already performs. A destination whose AX round trip is slow is the
suspected population, so an added round trip on the delivery path would risk causing what it
measures.

**The observation can write nothing.** `PasteCopiesObserver`'s reachable call graph contains no
accessibility content setter, no pasteboard mutation, no simulated input and no executor call.
Checked by reading it, not argued from what the caller withheld — a raw `AXUIElement` can be
handed straight to a setter.

## What the harness found

The V1 arm skips Tier 1 where the ancestor chain positively contains `AXWebArea`. It fired in
Brave 5/5 and Chrome 1/4 during hand testing, and nothing on disk said why. Instrumented and
measured, 195 trials, zero variance within any application:

| app | `AXWebArea` distance | gate result today |
|---|---|---|
| Safari (60) | 2 | containsWebArea |
| Brave (30) | 2 | containsWebArea |
| Chrome (25) | 2 | containsWebArea |
| WhatsApp (29) | none, native root at 7 | verifiedNative |
| **Slack (29)** | **17** | unverifiable, depthExhausted at 10 |
| **Discord (22)** | **17** | unverifiable, depthExhausted at 10 |

`maxDepth: 10` cannot reach an `AXWebArea` seventeen reads away, and `.unverifiable` fails closed.
Not marginal, not intermittent. **The fix that follows from this is deliberately NOT in this PR.**

Across 210 automated trials and ~70 hand dictations, V2 (no writer after a successful AX write)
lost text on six independent surfaces and is disqualified. V1, V4 and V5 tie at zero duplicates,
because the defect does not reproduce on any of four machines here.

## The trap this PR names, because it will bite the next one

The measurement needs a before-image, which exists only where Tier 1 runs. **The fix we want next
stops Tier 1 running.** So after that fix, those deliveries become UNMEASURABLE, not fixed, and a
falling duplicate count would look like success.

Observed live in this PR's own verification: Slack reported `measured / one`, Safari reported
`no_before_image`, for exactly this reason. Any dashboard must show the measured denominator
beside the numerator.

## Review

One coverage round and three grounded rounds on the plan. Four code-review rounds on the diff.

Three of those four found the same family of defect — a before-image that no longer described the
field written into. The fourth was answered by replacing the question rather than adding a case:
the discriminator moved from "did the Tier 1 setter run" to "did anything ACTIVATE the destination
after the before-image was taken", read from `tiersAttempted` rather than inferred. The round after
that came back clean.

## Validation

- `scripts/xcode-test.sh` — 7446 tests, all accepted.
- `paste_bakeoff.py --selftest` — green.
- Live UAT of the shipping path: 6 dictations, 6 `paste.copies_observed` events arrived in
  PostHog, 6 of 6 joined to their `paste.completed` by `take_id`.
- Detector proof: 40 trials, four destinations, one delivery and a deliberate double each, zero
  wrong verdicts and zero unknowns.

## Still owed, stated rather than implied

A dashboard reporting duplicates beside the measured denominator, and a baseline collection window
agreed before any delivery fix is planned.

Part of #2652.
