### PR TITLE
fix: three sandbox-verifiable fixes (#2611, #2467, #2586)

### DIFF
--- a/.github/workflows/older-macos-launch.yml
+++ b/.github/workflows/older-macos-launch.yml
@@ -21,7 +21,7 @@ name: Older macOS Launch
 # baseline proves nothing about users at it.
 #
 # The app cannot be BUILT on an older runner (it needs the macOS 26 SDK), so the build happens
-# on macos-26 and the product is carried to macos-15 as an artifact.
+# on macos-26 and the product is carried to macos-14 as an artifact.
 
 on:
   pull_request:

--- a/Tests/RuntimeUAT/measure_overlay_first_render_test.py
+++ b/Tests/RuntimeUAT/measure_overlay_first_render_test.py
@@ -1700,13 +1700,25 @@ def _identity_for(side):
     return IDENTITY_A if side == "A" else IDENTITY_B
 
 
+SYNTHETIC_HARDWARE = {"model": "Test,1", "cpu": "synthetic", "cores": "0",
+                      "memory_bytes": "0", "os": "0.0"}
+
+
 def _patch_benchmark_environment(script):
     """Runs `script(calls)` with `_drive_one_launch`, `bundle_identity`,
-    `screen_lock_state`, and `running_instances` all patched to synthetic,
-    deterministic behavior — A and B pinned to genuinely DIFFERENT
-    identities, since `run_benchmark` now refuses to compare a build with
-    itself. `calls` accumulates one dict per launch in call order, so a test
-    can assert on ORDER without depending on real timing.
+    `screen_lock_state`, `running_instances`, and `hardware_identity` all
+    patched to synthetic, deterministic behavior — A and B pinned to
+    genuinely DIFFERENT identities, since `run_benchmark` now refuses to
+    compare a build with itself. `calls` accumulates one dict per launch in
+    call order, so a test can assert on ORDER without depending on real
+    timing.
+
+    `hardware_identity` is patched because the real one shells out to
+    `sysctl` and `sw_vers`, and `run_benchmark` calls it before any guard or
+    mocked launch runs. Left unpatched, every test here raises
+    `FileNotFoundError` on a non-macOS host before reaching the path it
+    exists to check — which the module's own docstring promises cannot
+    happen to the pure half (#2467).
     """
     calls = []
 
@@ -1715,9 +1727,11 @@ def _patch_benchmark_environment(script):
         "bundle_identity": m.bundle_identity,
         "screen_lock_state": m.screen_lock_state,
         "running_instances": m.running_instances,
+        "hardware_identity": m.hardware_identity,
     }
     m.screen_lock_state = lambda: False
     m.running_instances = lambda: {}
+    m.hardware_identity = lambda: dict(SYNTHETIC_HARDWARE)
     m.bundle_identity = lambda bundle_path: (
         IDENTITY_A if str(bundle_path) == "A.app" else IDENTITY_B)
 
@@ -1748,6 +1762,10 @@ def test_run_benchmark_drives_pairs_in_the_declared_ab_ba_order():
     expect("a clean run with distinct identities reaches a real benchmark verdict",
            receipt["verdict"] in (m.BENCHMARK_PASS, m.BENCHMARK_FAIL), True)
     expect("the schedule alternates AB/BA", receipt["schedule"][:4], ["AB", "BA", "AB", "BA"])
+    # The receipt names its host through the patched lookup, so this suite
+    # can prove the field is carried without touching sysctl or sw_vers.
+    expect("the receipt carries the host identity it was handed",
+           receipt["hardware"], SYNTHETIC_HARDWARE)
     # The letter 'A' must always resolve to "A.app" and 'B' to "B.app" in the
     # per-pair receipt — not merely alternate SOMETHING, which a bug swapping
     # the bundle-for-letter mapping would still satisfy.
@@ -1767,7 +1785,9 @@ def test_run_benchmark_blocks_on_identity_drift_mid_run_never_pass_or_fail():
     saved = {"_drive_one_launch": m._drive_one_launch,
             "bundle_identity": m.bundle_identity,
             "screen_lock_state": m.screen_lock_state,
-            "running_instances": m.running_instances}
+            "running_instances": m.running_instances,
+            "hardware_identity": m.hardware_identity}
+    m.hardware_identity = lambda: dict(SYNTHETIC_HARDWARE)
     m.screen_lock_state = lambda: False
     m.running_instances = lambda: {}
     # Pinning (the first two calls, one per bundle) sees the ORIGINAL identity.
@@ -1854,7 +1874,9 @@ def test_run_benchmark_stops_after_the_first_bad_side_no_top_up():
     saved = {"_drive_one_launch": m._drive_one_launch,
             "bundle_identity": m.bundle_identity,
             "screen_lock_state": m.screen_lock_state,
-            "running_instances": m.running_instances}
+            "running_instances": m.running_instances,
+            "hardware_identity": m.hardware_identity}
+    m.hardware_identity = lambda: dict(SYNTHETIC_HARDWARE)
     m.screen_lock_state = lambda: False
     m.running_instances = lambda: {}
     m.bundle_identity = lambda bundle_path: (
@@ -1901,7 +1923,9 @@ def test_run_benchmark_rechecks_occupancy_before_every_launch():
     saved = {"_drive_one_launch": m._drive_one_launch,
             "bundle_identity": m.bundle_identity,
             "screen_lock_state": m.screen_lock_state,
-            "running_instances": m.running_instances}
+            "running_instances": m.running_instances,
+            "hardware_identity": m.hardware_identity}
+    m.hardware_identity = lambda: dict(SYNTHETIC_HARDWARE)
     m.screen_lock_state = lambda: False
     m.bundle_identity = lambda bundle_path: (
         IDENTITY_A if str(bundle_path) == "A.app" else IDENTITY_B)
@@ -1937,10 +1961,17 @@ def test_run_benchmark_rejects_any_pair_count_other_than_the_binding_thirty():
     """Fewer than 30 pairs has no statistical claim on a p95; more than 30
     is not the binding evidence set the plan names. Every count other than
     exactly `PAIR_COUNT` must block before any launch."""
-    for bad_count in (0, 2, 29, 32):
-        receipt = m.run_benchmark("A.app", "B.app", pairs=bad_count, out_dir="/tmp")
-        expect(f"{bad_count} pairs blocks before any launch",
-               receipt["verdict"], m.BLOCKED_INCOMPLETE_PAIRS)
+    # The host lookup runs before the count guard, so even a run that blocks
+    # on its first check names its host; patch it so this holds off-macOS.
+    saved_hardware = m.hardware_identity
+    m.hardware_identity = lambda: dict(SYNTHETIC_HARDWARE)
+    try:
+        for bad_count in (0, 2, 29, 32):
+            receipt = m.run_benchmark("A.app", "B.app", pairs=bad_count, out_dir="/tmp")
+            expect(f"{bad_count} pairs blocks before any launch",
+                   receipt["verdict"], m.BLOCKED_INCOMPLETE_PAIRS)
+    finally:
+        m.hardware_identity = saved_hardware
 
     def script(calls):
         return m.run_benchmark("A.app", "B.app", pairs=m.PAIR_COUNT, out_dir="/tmp")
@@ -1955,7 +1986,9 @@ def test_run_benchmark_refuses_two_arms_that_resolve_to_the_same_build():
     Path OR hash matching alone must block."""
     saved = {"bundle_identity": m.bundle_identity,
             "screen_lock_state": m.screen_lock_state,
-            "running_instances": m.running_instances}
+            "running_instances": m.running_instances,
+            "hardware_identity": m.hardware_identity}
+    m.hardware_identity = lambda: dict(SYNTHETIC_HARDWARE)
     m.screen_lock_state = lambda: False
     m.running_instances = lambda: {}
     m.bundle_identity = lambda bundle_path: IDENTITY_A  # both arms identical
@@ -1997,7 +2030,9 @@ def test_run_benchmark_pins_identity_before_the_first_pair():
     saved = {"_drive_one_launch": m._drive_one_launch,
             "bundle_identity": m.bundle_identity,
             "screen_lock_state": m.screen_lock_state,
-            "running_instances": m.running_instances}
+            "running_instances": m.running_instances,
+            "hardware_identity": m.hardware_identity}
+    m.hardware_identity = lambda: dict(SYNTHETIC_HARDWARE)
     m.screen_lock_state = lambda: False
     m.running_instances = lambda: {}
 

--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -314,7 +314,7 @@ const tableCols = ["Handy", "FluidVoice", "WisprFlow", "SuperWhisper", "MacWhisp
       <div class="honesty reveal">
         <h2>Choose a different tool instead if&hellip;</h2>
         <ul>
-          <li>You need snippets, backtrack, per-app tones, cross-platform support, or command-mode features today: choose <a href="/compare/wisprflow/">WisprFlow</a>.</li>
+          <li>You need team-shared snippets, backtrack, per-app tones, cross-platform support, or command-mode features today: choose <a href="/compare/wisprflow/">WisprFlow</a>.</li>
           <li>You record and summarise meetings with multiple speakers: choose <a href="/compare/otter-ai/">Otter.ai</a> or <a href="/compare/notta/">Notta</a>.</li>
           <li>You want the broadest speech and writing model library: choose <a href="/compare/superwhisper/">SuperWhisper</a>.</li>
           <li>You want editable local modes, Windows support, or a voice-controlled Mac task list: choose <a href="/compare/vox/">Vox</a>.</li>

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -80,7 +80,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Is Juno just a dictation app, or something more?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Something more. Juno can create Notes, Reminders, and one-shot alarms from Voice Actions after you say Hey Juno. Its separate Voice Commands for rewriting text do not need a wake phrase while dictating. It can also learn from clear corrections, expand snippets, and apply a different Style per app. EnviousWispr focuses on turning speech into clean text wherever your cursor is."
+        "text": "Something more. Juno can create Notes, Reminders, and one-shot alarms from Voice Actions after you say Hey Juno. Its separate Voice Commands for rewriting text do not need a wake phrase while dictating. It can also learn from clear corrections, expand snippets, and apply a different Style per app. EnviousWispr has snippets too, and otherwise focuses on turning speech into clean text wherever your cursor is."
       }
     },
     {
@@ -461,7 +461,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Snippets and direct replacements</td>
-            <td><span class="table-cross">No snippet expansion</span></td>
+            <td><span class="table-check">Yes</span>, snippets: say a keyword, then a short phrase, and the saved text is pasted exactly as you typed it</td>
             <td><span class="table-check">Yes</span>, both are built in</td>
           </tr>
           <tr>
@@ -713,7 +713,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is Juno just a dictation app, or something more?</div>
-        <p class="faq-a">Something more. Juno can create Notes, Reminders, and one-shot alarms from Voice Actions after you say Hey Juno. Its separate Voice Commands for rewriting text do not need a wake phrase while dictating. It can also learn from clear corrections, expand snippets, and apply a different Style per app. EnviousWispr focuses on turning speech into clean text wherever your cursor is.</p>
+        <p class="faq-a">Something more. Juno can create Notes, Reminders, and one-shot alarms from Voice Actions after you say Hey Juno. Its separate Voice Commands for rewriting text do not need a wake phrase while dictating. It can also learn from clear corrections, expand snippets, and apply a different Style per app. EnviousWispr has snippets too, and otherwise focuses on turning speech into clean text wherever your cursor is.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does Juno have AI cleanup like EnviousWispr's EG-1?</div>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -473,7 +473,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Snippets / shortcuts</td>
-            <td><span class="table-cross">Not yet</span></td>
+            <td><span class="table-check">Yes.</span> Say a keyword, then a short phrase, and the saved text is pasted exactly as you typed it. Snippets stay on your Mac; there is no team sharing.</td>
             <td><span class="table-check">Yes.</span> Voice-triggered text shortcuts with shared snippets for teams.</td>
           </tr>
           <tr>


### PR DESCRIPTION
## Summary

Three small, independent fixes that could be verified end to end on a Linux host with no Swift toolchain. Each is its own commit so it can be cherry-picked or split out if the repo's single-lane preference applies; they land on one branch because this session was scoped to one branch.

Closes #2611, closes #2467, closes #2586.

## Changes

- **#2611, CI/workflow lane.** `older-macos-launch.yml` header said the product is carried to macos-15; the job runs on macos-14 (the deployment target). One-word comment fix, no behaviour change.
- **#2467, dev-tooling lane.** `run_benchmark` calls `hardware_identity()` before any guard or launch, and that shells out to `sysctl` and `sw_vers`. The eight `run_benchmark` unit tests patched every other seam but not that one, so off-macOS they all raised `FileNotFoundError` before reaching the path under test. Every benchmark test now hands `run_benchmark` a synthetic host identity (via the shared `_patch_benchmark_environment` and in the five tests that roll their own patch set). The order test also asserts the receipt carries the identity it was handed. The real `hardware_identity()` is untouched.
- **#2586, Content lane.** Four claims on three comparison pages said EnviousWispr has no snippets. Juno's table cell and both copies of its FAQ answer (JSON-LD and visible), WisprFlow's table cell, and the "choose WisprFlow if" bullet on the best-of page are corrected. WisprFlow's team-shared snippets remain the stated difference, so "broader set of snippets" on that page is left standing per the issue.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally (`scripts/build-dev-app.sh`, Xcode/Tuist engine) — not run; no Swift toolchain in this environment. No Swift files are touched.
- [x] Logic tests pass locally — the Python suite this PR fixes: `python3 Tests/RuntimeUAT/measure_overlay_first_render_test.py` went from 48 tests / 8 failures to 48 / 0 on Linux.
- [x] CI `build-check` status is green — all nine checks passed on `4219a1c`, including the macOS 14 launch job whose header #2611 corrects.

### Behavioral Testing (Local UAT)
- [ ] App rebuilt and relaunched — N/A, no app code changed
- [ ] Smart UAT tests generated and passed — N/A
- [ ] Manual smoke test of core dictation flow — N/A

### Code Quality
- [x] Commits follow conventional commit format (`type(scope): message`)
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed from FluidAudio/WhisperKit/AVFoundation

### Polish Eval
- N/A, does not touch `Sources/EnviousWisprLLM/`, `CustomWordsManager.swift`, or `scripts/eval/`

### Release Housekeeping
- N/A

## Notes for review

- Website: `npm run build` passes (135 pages); both Juno FAQ copies render the same corrected sentence, and a sweep of the marketing surface for "no snippets" style claims comes back empty. The EnviousMarketing brand guide referenced in #2586 is not in this repo, so the wording follows the existing comparison-table voice on the same pages.
- The `dateModified` / "Last reviewed" fields on the three pages were left alone, matching how the last content fix to these pages (#2578) handled them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM