### PR TITLE
fix(eval): refuse a registry rebuild that drops a registered artifact (#2581)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -657,6 +657,10 @@ jobs:
           # count, because both runners exit 0 on ZERO discovered tests.
           python3 scripts/eval/tests/test_alias_scorer.py
           python3 scripts/eval/tests/test_v4_adversarial_runner.py
+          # The registry rebuild's history-loss guards (#2581): a deleted or
+          # renamed ARMS row must be REFUSED, not silently dropped. Same runner
+          # shape and exact-count assertion as the two above.
+          python3 scripts/eval/tests/test_rebuild_model_registry.py
 
       - name: Require every lane
         run: |

--- a/scripts/eval/rebuild-model-registry.py
+++ b/scripts/eval/rebuild-model-registry.py
@@ -268,6 +268,14 @@ def main() -> int:
     # candidate whose four summaries became one still passes it, because the KEY is
     # present. Comparing per-artifact evaluation COUNTS against the file being
     # replaced catches that, which the key check cannot.
+    #
+    # And the count check has a blind spot of its own: it walks the REBUILT records,
+    # so an artifact that is not in them is never examined. Delete an ARMS row, or
+    # rename its immutable id, and the artifact and every evaluation on it fall out
+    # of the registry while the staged file still validates and the script exits 0
+    # (#2581). A floor-setting winner can vanish that way. So the WHOLE id set of
+    # the file being replaced is compared first: an id that was registered and is
+    # absent from the rebuild is a refusal, before any per-artifact count is read.
     sys.path.insert(0, str(Path(__file__).parent))
     import model_registry
 
@@ -286,6 +294,17 @@ def main() -> int:
         for key in ("_rubricEquivalence", "_rubricEquivalenceContract"):
             if key in previous:
                 doc[key] = previous[key]
+
+        # SETS, not lengths: a row added beside a row dropped nets out to the same
+        # count, and an id is immutable, so a rename IS a drop plus an add.
+        gone = sorted(set(was) - {r["artifactId"] for r in records})
+        if gone:
+            raise SystemExit(
+                "REFUSED: this rebuild would DROP registered artifacts:\n  " +
+                "\n  ".join(f"{aid}: {was[aid]} eval(s) on record" for aid in gone) +
+                "\nAn artifact id is immutable and its history is not rebuilt from "
+                "receipts. Restore the row under its original id, or say why the "
+                "artifact leaves the record.")
 
         lost = [(r["artifactId"], was[r["artifactId"]], len(r["evaluations"]))
                 for r in records

--- a/scripts/eval/tests/test_rebuild_model_registry.py
+++ b/scripts/eval/tests/test_rebuild_model_registry.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Regression tests for rebuild-model-registry.py's history-loss guards (#2581).
+
+WHAT THIS LOCKS. A rebuild must never make a registered artifact disappear with
+nothing said. The per-artifact evaluation-count guard only examines artifacts that
+still appear in the rebuilt `records`, so an ARMS row that is deleted outright, or
+whose immutable id is renamed, was never examined at all: the artifact and every
+evaluation attached to it were dropped, the staged registry still validated, and
+the script exited 0. A floor-setting winner could vanish that way.
+
+Pure stdlib, no pytest, no network. Run from the repo root:
+    python3 scripts/eval/tests/test_rebuild_model_registry.py
+
+HOW THE SUBJECT IS REACHED. The script's name carries a hyphen, so it is loaded
+through `importlib` rather than imported. Its receipt root, output path and arm
+table are module-level names read inside `main()`, so each case points them at a
+temp tree and drives the REAL `main()`, including the validation and the
+`staged.replace(OUT)` at the end — a stub of any layer would pass without the
+replacement under test ever running. The "previous" registry is produced by a
+real first rebuild rather than hand-written, so the second rebuild is replacing a
+file the script itself considers valid.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "eval" / "rebuild-model-registry.py"
+sys.path.insert(0, str(SCRIPT.parent))
+
+
+def _load_subject():
+    spec = importlib.util.spec_from_file_location("rebuild_model_registry", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# fixtures                                                                    #
+# --------------------------------------------------------------------------- #
+
+def _receipt(cand: str, s4: int = 3) -> dict:
+    """One score receipt of the shape `read_receipts()` reads and `load()` accepts."""
+    return {
+        "meta": {"candidates_file": cand, "corpus_files": ["sealed_v1.jsonl"],
+                 "judge_identity": "judge-a", "rubric_identity": None,
+                 "system": "new", "adjudicate": True,
+                 "adjudicate_pct": 10, "adjudicate_min": 5,
+                 "production_file": "prod.jsonl"},
+        "overall": {"total_scored": 100, "pass_rate_pct": 90.0, "critical_fail_count": s4},
+        "judge_blind": True, "run_complete": True,
+        "release_gate": {"verdict": "PASS"},
+    }
+
+
+REJECTED = ("eg1-1.1-c001", "1.1", "loser", ["loser.jsonl"], "rejected", "Lost.")
+WINNER = ("eg1-1.1-c002", "1.1", "winner", ["winner.jsonl"], "shipped", "Shipped.")
+
+
+class _Harness:
+    """A temp checkout: receipts three levels deep (as `summaryPath` requires) and
+    a registry file the rebuild replaces in place."""
+
+    def __init__(self, td: str):
+        self.mod = _load_subject()
+        root = Path(td)
+        # `summaryPath` is relative to RUNS.parent.parent.parent, so mirror the
+        # real scripts/eval/runs layout rather than a flat directory.
+        self.runs = root / "scripts" / "eval" / "runs"
+        for cand in ("loser.jsonl", "winner.jsonl"):
+            d = self.runs / cand.replace(".jsonl", "")
+            d.mkdir(parents=True)
+            (d / "summary.json").write_text(json.dumps(_receipt(cand)), encoding="utf-8")
+        self.out = root / "model-registry.json"
+        self.mod.RUNS = self.runs
+        self.mod.OUT = self.out
+
+    def rebuild(self, arms) -> int:
+        self.mod.ARMS = list(arms)
+        return self.mod.main()
+
+    def ids(self) -> list[str]:
+        doc = json.loads(self.out.read_text(encoding="utf-8"))
+        return [a["artifactId"] for a in doc["artifacts"]]
+
+
+def _refused(h: _Harness, arms) -> str:
+    """Run a rebuild that must be REFUSED; return the message. Asserts the
+    registry on disk is untouched, since a refusal that already replaced the file
+    is no refusal at all."""
+    before = h.out.read_bytes()
+    try:
+        h.rebuild(arms)
+    except SystemExit as exc:
+        msg = str(exc)
+    else:
+        raise AssertionError("rebuild exited 0 instead of refusing")
+    assert msg.startswith("REFUSED"), msg
+    assert h.out.read_bytes() == before, "a refused rebuild replaced the registry anyway"
+    return msg
+
+
+# --------------------------------------------------------------------------- #
+# cases                                                                       #
+# --------------------------------------------------------------------------- #
+
+def test_deleting_a_registered_row_is_refused():
+    # THE DEFECT. The shipped winner's row is removed from ARMS. The evaluation-
+    # count guard iterates the rebuilt records, so it never looks at c002 and the
+    # rebuild used to write a registry without it and exit 0.
+    with tempfile.TemporaryDirectory() as td:
+        h = _Harness(td)
+        assert h.rebuild([REJECTED, WINNER]) == 0
+        assert h.ids() == ["eg1-1.1-c001", "eg1-1.1-c002"]
+
+        msg = _refused(h, [REJECTED])
+        assert "eg1-1.1-c002" in msg, msg
+        assert h.ids() == ["eg1-1.1-c001", "eg1-1.1-c002"]
+
+
+def test_renaming_a_registered_id_is_refused():
+    # An id is immutable. A rename is a delete plus an add, and the delete half
+    # was invisible for exactly the reason above: the renamed row appears in the
+    # rebuild under its new name, and the old name is absent from `records`.
+    with tempfile.TemporaryDirectory() as td:
+        h = _Harness(td)
+        assert h.rebuild([REJECTED, WINNER]) == 0
+
+        renamed = ("eg1-1.1-c003",) + WINNER[1:]
+        msg = _refused(h, [REJECTED, renamed])
+        assert "eg1-1.1-c002" in msg, msg
+        assert h.ids() == ["eg1-1.1-c001", "eg1-1.1-c002"]
+
+
+def test_an_unchanged_artifact_set_still_rebuilds():
+    # CONTROL. The guard must refuse a loss, not every rebuild: the same table
+    # rebuilt over itself is the ordinary case and must exit 0 and rewrite.
+    with tempfile.TemporaryDirectory() as td:
+        h = _Harness(td)
+        assert h.rebuild([REJECTED, WINNER]) == 0
+        h.out.write_text(h.out.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        assert h.rebuild([REJECTED, WINNER]) == 0
+        assert h.ids() == ["eg1-1.1-c001", "eg1-1.1-c002"]
+
+
+def test_adding_a_row_still_rebuilds():
+    # CONTROL, other direction. Growth is what the rebuild is FOR (a forgotten arm
+    # being added); comparing id SETS rather than lengths is what keeps a rebuild
+    # that adds one row and drops another from netting out to "unchanged".
+    with tempfile.TemporaryDirectory() as td:
+        h = _Harness(td)
+        assert h.rebuild([REJECTED]) == 0
+        assert h.ids() == ["eg1-1.1-c001"]
+        assert h.rebuild([REJECTED, WINNER]) == 0
+        assert h.ids() == ["eg1-1.1-c001", "eg1-1.1-c002"]
+
+        # Add one, drop one: same length, different set. Must still refuse.
+        swapped = ("eg1-1.1-c003", "1.1", "other", ["loser.jsonl"], "rejected", "Lost.")
+        msg = _refused(h, [swapped, WINNER])
+        assert "eg1-1.1-c001" in msg, msg
+
+
+EXPECTED_TESTS = 4
+
+
+def _run() -> int:
+    """Discover and run every `test_*`, with an EXACT count and `BaseException`.
+
+    Same shape as `test_alias_scorer.py`, for the same two reasons: a discovery
+    runner exits 0 on zero tests, and the subject here raises `SystemExit` by
+    design, which is not an `Exception`.
+    """
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    if len(tests) != EXPECTED_TESTS:
+        print(f"FAIL: discovered {len(tests)} tests, expected {EXPECTED_TESTS}. "
+              f"A suite that silently shrinks still exits 0 without this check.")
+        return 1
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            passed += 1
+            print(f"  PASS {t.__name__}")
+        except KeyboardInterrupt:
+            raise
+        except BaseException:
+            failed += 1
+            print(f"  FAIL {t.__name__}")
+            traceback.print_exc()
+    print(f"\n{passed} passed, {failed} failed ({len(tests)} total)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run())


### PR DESCRIPTION
## Summary

`rebuild-model-registry.py` guards against history loss by comparing each artifact's evaluation count against the file being replaced, but that guard walks the rebuilt records. An artifact absent from them is never examined: delete an ARMS row or rename its immutable id and the artifact, with every evaluation attached to it, falls out of the registry while the staged file still validates and the script exits 0. Codex finding from #2562.

Closes #2581.

`Tier: SMALL | Lane: Docs/dev-tooling | Modules: scripts/eval`

## Changes

- `scripts/eval/rebuild-model-registry.py`: before any per-artifact count is read, compare the complete previous vs rebuilt artifact-id sets and REFUSE (same `SystemExit("REFUSED: ...")` shape as the existing guards) naming each missing id and how many evaluations it carried. Sets rather than lengths, so add-one-drop-one cannot net out and a rename is caught as the drop it is. No override flag: the script has no flag convention and its other guards say "restore, or say why".
- `scripts/eval/tests/test_rebuild_model_registry.py`: new, four cases in the same pure-stdlib runner shape as `test_alias_scorer.py`. Loads the script via `importlib`, patches its paths, and drives the real `main()` over a temp receipt tree; the "previous" registry is produced by a real first rebuild.
- `.github/workflows/pr-check.yml`: the new suite runs in the "Eval harness self-tests" step beside its siblings, since a tracked suite no gate runs reports nothing.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — N/A, no Swift touched
- [x] Logic tests pass locally — `python3 scripts/eval/tests/test_rebuild_model_registry.py`: 1 passed / 3 failed before the fix (each "rebuild exited 0 instead of refusing"), 4 passed after. `test_alias_scorer.py` (23) and `test_v4_adversarial_runner.py` unchanged. `model_registry.py validate` still reports 20 artifacts, 71 evaluations.
- [x] CI `build-check` status is green — all seven checks passed on `9f6e879`, including `eval-packages`, which runs the new suite.

### Behavioral Testing (Local UAT)
- N/A, no app code changed

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval (touches `scripts/eval/`)
- [x] `polish-eval-smoke` CI check is green (`polish-quality-gate` passed)
- [x] Swift → Python sync: N/A, no polish logic changed
- [x] No new polish capability, no baseline change

### Release Housekeeping
- N/A

## Notes for review

`behavior_judge_test.py` has one pre-existing failure (`test_a_failed_quarantine_aborts_the_arm_instead_of_mis_stamping`, a shell quarantine case) that fails identically on `main`; it is unrelated to this script and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM