### PR TITLE
fix(eval): let the floor CLI supply every comparability axis (#2582)

### DIFF
--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -3007,7 +3007,52 @@ def test_check_live_reports_the_recorded_identity():
         f"run `python3 scripts/eval/model_registry.py check-live`")
 
 
-EXPECTED_TESTS = 139
+def test_floor_cli_reports_the_real_sealed_floor():
+    # #2582. PR #2576 made `adjudication` and `productionBaseline` comparability
+    # axes, but the documented `floor` CLI kept forwarding only four of the six
+    # and let the new two fall to None. Every floor-setting sealed evaluation on
+    # record carries "0.15:15" and a baseline, so the documented interface answered
+    # NO FLOOR for a history whose floor is 63. Driven through `main()` against the
+    # REAL checked-in registry, not a fixture: a fixture shaped to pass would prove
+    # nothing about the history the operator actually queries.
+    import model_registry
+
+    def run(argv):
+        out, err = io.StringIO(), io.StringIO()
+        old = sys.argv
+        sys.argv = ["model_registry.py", *argv]
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                try:
+                    code = model_registry.main()
+                except SystemExit as exc:  # argparse refusals exit rather than return
+                    code = exc.code
+        finally:
+            sys.argv = old
+        return code, out.getvalue(), err.getvalue()
+
+    base = ["floor", "--corpus", "sealed_v1.jsonl", "--cases", "1462",
+            "--rubric", "626d3a1c5219", "--judge", "azure/gpt-5-6-luna@d9697a344ff6"]
+
+    code, out, err = run(base + ["--adjudication", "0.15:15", "--production", "none"])
+    assert code == 0, f"floor CLI failed on the real history:\n{out}{err}"
+    assert out.startswith("63 S4 — eg1-1.1-c016 "), out
+
+    # Same query with the baseline the 1.2 winner was measured against: a
+    # different setup and a different floor, which is the whole point of the axis.
+    code, out, _ = run(base + ["--adjudication", "0.15:15",
+                               "--production", "sealed_shipped.jsonl"])
+    assert code == 0 and out.startswith("31 S4 — eg1-1.2-c003 "), out
+
+    # Without the two axes the query is REFUSED at the parser, never answered.
+    # A None default matches only a row whose receipt recorded null, which the
+    # module says may never set a bar — so the old silent NO FLOOR must not return.
+    code, out, err = run(base)
+    assert code == 2 and "NO FLOOR" not in err, (code, out, err)
+    assert "--adjudication" in err and "--production" in err, err
+
+
+EXPECTED_TESTS = 140
 
 
 def _run() -> int:

--- a/scripts/eval/model_registry.py
+++ b/scripts/eval/model_registry.py
@@ -16,7 +16,12 @@ CLI:
     model_registry.py list                 every artifact, newest release first
     model_registry.py list --release 1.2   one release
     model_registry.py validate             schema + convention + one-winner rules
-    model_registry.py floor --corpus sealed_v1.jsonl --cases 1462 --rubric <id> --judge <id>
+    model_registry.py floor --corpus sealed_v1.jsonl --cases 1462 --rubric <id> --judge <id> \
+                            --adjudication 0.15:15 --production none [--system new] [--blind]
+
+`floor` takes EVERY axis `comparable()` checks. `--adjudication` and `--production`
+are required because their absence can never match a floor-setting evaluation, so
+a query without them is not a looser question, it is a different one.
 """
 import argparse
 import hashlib
@@ -600,7 +605,14 @@ def cmd_validate(_args) -> int:
 
 
 def cmd_floor(args) -> int:
-    count, where = floor(args.corpus, args.rubric, args.judge, args.cases)
+    # EVERY axis `comparable()` checks is forwarded. The first version forwarded
+    # four of them and let `adjudication` and `production` fall to their None
+    # defaults, which no floor-setting evaluation on record carries — so the
+    # documented CLI answered NO FLOOR for a history whose floor is 63 (#2582).
+    count, where = floor(args.corpus, args.rubric, args.judge, args.cases,
+                         system=args.system, blind=args.blind,
+                         adjudication=args.adjudication,
+                         production=args.production)
     if count is None:
         print(f"NO FLOOR: {where}", file=sys.stderr)
         return 1
@@ -622,6 +634,21 @@ def main() -> int:
     p.add_argument("--judge", required=True, help="judge identity, exactly as recorded")
     p.add_argument("--cases", required=True, type=int,
                    help="cases scored; a corpus FILENAME is reused for different sets")
+    # REQUIRED, not defaulted to None. `comparable()` matches these exactly, so a
+    # None default would match only an evaluation whose receipt recorded null —
+    # the one kind of row the module says may never set a bar — and would answer
+    # NO FLOOR for every real sealed history. `release_gate.s4_floor()` refuses to
+    # ask without them for the same reason; the CLI asks the same question.
+    p.add_argument("--adjudication", required=True,
+                   help='adjudication policy exactly as recorded: "<pct>:<min>" '
+                        '(e.g. 0.15:15) or "none"')
+    p.add_argument("--production", required=True,
+                   help='production baseline exactly as recorded: its filename '
+                        '(e.g. sealed_shipped.jsonl) or "none"')
+    p.add_argument("--system", default="new",
+                   help='grading system as recorded (default: "new")')
+    p.add_argument("--blind", action="store_true",
+                   help="the judge was blinded (default: sighted)")
     p.set_defaults(fn=cmd_floor)
     args = ap.parse_args()
     try:


### PR DESCRIPTION
## Summary

#2576 made `adjudication` and `productionBaseline` required comparability axes in `comparable()`, but the documented `model_registry.py floor` command still accepted only `--corpus/--rubric/--judge/--cases` and let the other axes fall to `None`. No floor-setting sealed evaluation carries a null on those axes, so the CLI answered `NO FLOOR` for a history whose floor is 63. Codex finding from #2576.

Closes #2582.

`Tier: SMALL | Lane: Docs/dev-tooling | Modules: scripts/eval`

## Changes

- `scripts/eval/model_registry.py`: `cmd_floor` forwards `system`, `blind`, `adjudication` and `production` to `floor()`. Four new options on the `floor` subparser:
  - `--adjudication` (required): policy exactly as recorded, e.g. `0.15:15` or `none`
  - `--production` (required): baseline filename as recorded, or `none`
  - `--system` (default `new`, matching `floor()`'s own default)
  - `--blind` (flag, default sighted, matching `floor()`'s default)
  The two string axes are required rather than defaulted because a `None` can only match a null-adjudication row, the one kind the module says may never set a bar, and `release_gate.s4_floor()` already refuses to ask without them. The module docstring's CLI line is updated.
- `scripts/eval/behavior_judge_test.py`: `test_floor_cli_reports_the_real_sealed_floor` drives the CLI against the checked-in registry and expects 63; `EXPECTED_TESTS` 139 → 140.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — N/A, no Swift touched
- [x] Logic tests pass locally — new test fails on the pre-fix module (`unrecognized arguments: --adjudication`), passes after. `behavior_judge_test.py`: 139 passed, 1 failed (140 total); the one failure is the pre-existing shell quarantine case that fails identically on `main`.
- [x] CI `build-check` status is green — all seven checks passed on `3fa0898`.

### Behavioral Testing (Local UAT)
- N/A, no app code changed

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval (touches `scripts/eval/`)
- [x] `polish-eval-smoke` CI check is green (`polish-quality-gate` passed)
- [x] Swift → Python sync: N/A, no polish logic changed
- [x] No new polish capability, no baseline change

### Release Housekeeping
- N/A

## Reproduction

Before, from `scripts/eval/`:
```
python3 model_registry.py floor --corpus sealed_v1.jsonl --cases 1462 --rubric 626d3a1c5219 --judge azure/gpt-5-6-luna@d9697a344ff6
NO FLOOR: ... adjudication=None, production=None   (exit 1)
```
After:
```
... --adjudication 0.15:15 --production none
63 S4 — eg1-1.1-c016 (scripts/eval/runs/sealed-2026-08-15/regrade_v20_confirm/summary.json)   (exit 0)
... --adjudication 0.15:15 --production sealed_shipped.jsonl
31 S4 — eg1-1.2-c003 (...)   (exit 0)
```
The second query shows the production axis genuinely partitions real history, which is why it has no silent default. Nothing else in the repo invokes the `floor` subcommand.

## Follow-up worth its own issue

`comparable()`'s comment says a null receipt "never matches", but `None == None` is true in Python, so a library caller of `floor()` that omits these kwargs can still match a null row. `release_gate` guards this by refusing early and the CLI now does the same; the library default is left alone here as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM