### PR TITLE
fix(validation): find a nested @Suite by its qualified path, and number refusals by their row (#2525)

### DIFF
--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -11,6 +11,7 @@ exact vacuity this harness exists to catch.
 """
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -2297,6 +2298,50 @@ try:
 finally:
     Path.read_text = _real_read_text
 
+ran += 1
+
+# #2669 review: a nested @Suite's tests may be hosted by a QUALIFIED extension,
+# `extension Outer.Inner { @Test ... }`, and `swift test list` files them under
+# `Outer/Inner/...`. The declaration regex captured only `Outer`, so the oracle filed the
+# test one level up and the validator rejected a valid recipe for it. Two-way against a
+# copy of the real corpus plus one fixture file: the test is under the qualified path, and
+# NOT under the bare outer name it used to land on.
+_qualified_fixture = """
+import Testing
+
+enum QualifiedFixtureOuter {
+  @Suite("qualified fixture inner") struct QualifiedFixtureInner {}
+}
+
+extension QualifiedFixtureOuter.QualifiedFixtureInner {
+  @Test("an extension-hosted nested test") func hostedByExtension() {}
+}
+"""
+with tempfile.TemporaryDirectory() as _qtd:
+    _qroot = Path(_qtd)
+    shutil.copytree(BATTERY.parent.parent / "Tests", _qroot / "Tests")
+    (_qroot / "Tests" / "EnviousWisprTests" / "QualifiedExtensionFixture.swift").write_text(
+        _qualified_fixture)
+    _qnames = validator.test_oracle(_qroot)
+_qcanonical = "QualifiedFixtureOuter/QualifiedFixtureInner/hostedByExtension()"
+_qunder = _qnames.get("EnviousWisprTests/QualifiedFixtureOuter/QualifiedFixtureInner", {})
+_qwrong = _qnames.get("EnviousWisprTests/QualifiedFixtureOuter", {})
+if _qunder.get("hostedByExtension()") != {_qcanonical} \
+        or _qunder.get("an extension-hosted nested test") != {_qcanonical}:
+    failures.append(
+        "the filing-time oracle files an extension-hosted nested test under its qualified "
+        f"path: got {_qunder!r}")
+else:
+    print("  ok  the filing-time oracle files an extension-hosted nested test under its "
+          "qualified path")
+ran += 1
+if "hostedByExtension()" in _qwrong:
+    failures.append(
+        "the filing-time oracle no longer files an extension-hosted nested test under the "
+        "bare outer name")
+else:
+    print("  ok  the filing-time oracle no longer files an extension-hosted nested test "
+          "under the bare outer name")
 ran += 1
 result = subprocess.run(
     [sys.executable, str(VALIDATOR), "--issue", "0",

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2214,6 +2214,63 @@ check_validator("the filing validator rejects a runtime-gated individual test",
                      suite="EnviousWisprTests/TerminalProcessScannerTests"),
                 expected_rc=1, expected_text="DOES NOT EXIST")
 
+# #2525: a @Suite nested inside another @Suite is addressed by its whole declaration chain,
+# `Outer/Inner`, which is the path the test filter accepts. The oracle used to key every
+# suite by its innermost type name alone, so the qualified path — the only one that runs —
+# was "NOT FOUND" and every one of its rows retired, while the bare inner name — a filter
+# that executes zero tests — was accepted. Three spellings in, one spelling out.
+_nested_suite = "EnviousWisprTests/OnboardingPracticeStepSuite/OnboardingWarmingGateTests"
+_nested_display = "the gate stays shut while the warm-up is still running"
+check_validator("the filing validator finds a @Suite nested inside another @Suite by its qualified path",
+                dict(_validator_base, suite=_nested_suite, expect_fail=_nested_display),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator resolves a nested test's fully qualified id",
+                dict(_validator_base, suite=_nested_suite,
+                     expect_fail="OnboardingPracticeStepSuite/OnboardingWarmingGateTests/"
+                                 "gateHoldsUntilTheEngineAnswers()"),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator resolves a nested test's bare function name",
+                dict(_validator_base, suite=_nested_suite,
+                     expect_fail="gateHoldsUntilTheEngineAnswers()"),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator finds a sibling nested @Suite under the same parent",
+                dict(_validator_base,
+                     suite="EnviousWisprTests/OnboardingPracticeStepSuite/"
+                           "OnboardingWarmingGateTelemetryTests",
+                     expect_fail="a warmed gate completes the step once, with a duration"),
+                expected_rc=0, expected_text="1/1 rows runnable")
+check_validator("the filing validator does not accept a nested @Suite by its bare inner name",
+                dict(_validator_base, suite="EnviousWisprTests/OnboardingWarmingGateTests",
+                     expect_fail=_nested_display),
+                expected_rc=1, expected_text="NOT FOUND in Tests")
+check_validator("the filing validator does not accept a nested test's inner-only id",
+                dict(_validator_base, suite=_nested_suite,
+                     expect_fail="OnboardingWarmingGateTests/gateHoldsUntilTheEngineAnswers()"),
+                expected_rc=1, expected_text="DOES NOT EXIST")
+
+# #2525 part 2: the validator hands the runner ONE row at a time so that every row is
+# judged, which means the runner's own `row N` prefix is always `row 1`. Printed after the
+# validator's real `row 2:` label it read as an anchor index. The number must be the row's.
+check_validator("the filing validator labels a later row's refusal with that row's own number",
+                document={"rows": [
+                    dict(_validator_base, expect_fail=_guard_name),
+                    dict(_validator_base, expect_fail=_guard_name,
+                         anchor="this text is nowhere in the file"),
+                ]},
+                expected_rc=1, expected_text="row 2: UNRUNNABLE — row 2 anchor not found in")
+check_validator("the filing validator still labels the first row's refusal as row 1",
+                dict(_validator_base, expect_fail=_guard_name,
+                     anchor="this text is nowhere in the file"),
+                expected_rc=1, expected_text="row 1: UNRUNNABLE — row 1 anchor not found in")
+check_validator("the filing validator renumbers a later row's field refusal too",
+                document={"rows": [
+                    dict(_validator_base, expect_fail=_guard_name),
+                    {k: v for k, v in dict(_validator_base, expect_fail=_guard_name).items()
+                     if k != "anchor"},
+                ]},
+                expected_rc=1,
+                expected_text="row 2: UNRUNNABLE — row 2 is missing required field 'anchor'")
+
 _validator_spec = importlib.util.spec_from_file_location("mutation_validator", VALIDATOR)
 validator = importlib.util.module_from_spec(_validator_spec)
 _validator_spec.loader.exec_module(validator)

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2316,6 +2316,10 @@ enum QualifiedFixtureOuter {
 extension QualifiedFixtureOuter.QualifiedFixtureInner {
   @Test("an extension-hosted nested test") func hostedByExtension() {}
 }
+
+extension QualifiedFixtureOuter . `QualifiedFixtureInner` {
+  @Test("a spaced, backticked extension-hosted test") func hostedBySpacedExtension() {}
+}
 """
 with tempfile.TemporaryDirectory() as _qtd:
     _qroot = Path(_qtd)
@@ -2342,6 +2346,19 @@ if "hostedByExtension()" in _qwrong:
 else:
     print("  ok  the filing-time oracle no longer files an extension-hosted nested test "
           "under the bare outer name")
+ran += 1
+# Legal spellings with trivia around the dot and a backtick-escaped segment name the SAME
+# type; the key must not depend on which one the author typed (#2669 review, round 2).
+_qspaced = "QualifiedFixtureOuter/QualifiedFixtureInner/hostedBySpacedExtension()"
+if _qunder.get("hostedBySpacedExtension()") != {_qspaced} \
+        or "hostedBySpacedExtension()" in _qwrong \
+        or any("`" in key or " " in key for key in _qnames if "QualifiedFixture" in key):
+    failures.append(
+        "the filing-time oracle normalises a spaced, backticked qualified extension to the "
+        f"same key: got {sorted(k for k in _qnames if 'QualifiedFixture' in k)!r}")
+else:
+    print("  ok  the filing-time oracle normalises a spaced, backticked qualified extension "
+          "to the same key")
 ran += 1
 result = subprocess.run(
     [sys.executable, str(VALIDATOR), "--issue", "0",

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2329,11 +2329,31 @@ extension GatedFixtureOuter.GatedFixtureInner {
   @Test("an extension-hosted test under a gated declaration") func hostedUnderGate() {}
 }
 """
+# The gated declaration and its extension in DIFFERENT files: the gate must reach across
+# the file boundary the way Swift's type system does (#2669 review, round 4).
+_cross_file_declaration = """
+import Testing
+
+@Suite(.disabled("cross-file gate")) enum CrossFileGatedOuter {
+  @Suite struct CrossFileGatedInner {}
+}
+"""
+_cross_file_extension = """
+import Testing
+
+extension CrossFileGatedOuter.CrossFileGatedInner {
+  @Test("an extension-hosted test gated from another file") func hostedAcrossFiles() {}
+}
+"""
 with tempfile.TemporaryDirectory() as _qtd:
     _qroot = Path(_qtd)
     shutil.copytree(BATTERY.parent.parent / "Tests", _qroot / "Tests")
     (_qroot / "Tests" / "EnviousWisprTests" / "QualifiedExtensionFixture.swift").write_text(
         _qualified_fixture)
+    (_qroot / "Tests" / "EnviousWisprTests" / "CrossFileGateDeclaration.swift").write_text(
+        _cross_file_declaration)
+    (_qroot / "Tests" / "EnviousWisprTests" / "CrossFileGateExtension.swift").write_text(
+        _cross_file_extension)
     _qnames = validator.test_oracle(_qroot)
 _qcanonical = "QualifiedFixtureOuter/QualifiedFixtureInner/hostedByExtension()"
 _qunder = _qnames.get("EnviousWisprTests/QualifiedFixtureOuter/QualifiedFixtureInner", {})
@@ -2380,6 +2400,15 @@ if _qgated or any("hostedUnderGate()" in names for names in _qnames.values()):
 else:
     print("  ok  the filing-time oracle applies a declaration's gate to an extension-hosted "
           "test of the nested type")
+ran += 1
+_qcross = sorted(key for key in _qnames if "CrossFileGated" in key)
+if _qcross or any("hostedAcrossFiles()" in names for names in _qnames.values()):
+    failures.append(
+        "the filing-time oracle applies a declaration's gate to an extension in another "
+        f"file: found {_qcross!r}")
+else:
+    print("  ok  the filing-time oracle applies a declaration's gate to an extension in "
+          "another file")
 ran += 1
 result = subprocess.run(
     [sys.executable, str(VALIDATOR), "--issue", "0",

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2320,6 +2320,14 @@ extension QualifiedFixtureOuter.QualifiedFixtureInner {
 extension QualifiedFixtureOuter . `QualifiedFixtureInner` {
   @Test("a spaced, backticked extension-hosted test") func hostedBySpacedExtension() {}
 }
+
+@Suite(.disabled("gated fixture")) enum GatedFixtureOuter {
+  @Suite struct GatedFixtureInner {}
+}
+
+extension GatedFixtureOuter.GatedFixtureInner {
+  @Test("an extension-hosted test under a gated declaration") func hostedUnderGate() {}
+}
 """
 with tempfile.TemporaryDirectory() as _qtd:
     _qroot = Path(_qtd)
@@ -2359,6 +2367,19 @@ if _qunder.get("hostedBySpacedExtension()") != {_qspaced} \
 else:
     print("  ok  the filing-time oracle normalises a spaced, backticked qualified extension "
           "to the same key")
+ran += 1
+# A `.disabled` on the ORIGINAL declaration gates a test hosted in a qualified extension of
+# the nested type, exactly as Swift Testing skips it through the parent trait; the
+# extension's braces are not inside the gated declaration's, so this cannot come from the
+# brace chain alone (#2669 review, round 3).
+_qgated = sorted(key for key in _qnames if "GatedFixture" in key)
+if _qgated or any("hostedUnderGate()" in names for names in _qnames.values()):
+    failures.append(
+        "the filing-time oracle applies a declaration's gate to an extension-hosted test of "
+        f"the nested type: found {_qgated!r}")
+else:
+    print("  ok  the filing-time oracle applies a declaration's gate to an extension-hosted "
+          "test of the nested type")
 ran += 1
 result = subprocess.run(
     [sys.executable, str(VALIDATOR), "--issue", "0",

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -231,6 +231,22 @@ def test_oracle(root):
                     has_runtime_gate(suite_attribute)
                 ))
 
+        # Gates by QUALIFIED PATH, not only by brace range. A test hosted in a top-level
+        # `extension Outer.Inner` sits in no brace of `Outer`, so the chain of ranges
+        # around it never sees a `.disabled` on `Outer`'s own declaration — yet Swift
+        # Testing skips that test through the parent trait (#2669 review, round 3). Every
+        # declaration records the gate on its own path, and a test is gated when any
+        # prefix of its path is, whichever braces it was written inside.
+        gate_by_path = {}
+        for opening, closing, name, gated in ranges:
+            outer = sorted(
+                ((end - start, outer_name) for start, end, outer_name, _ in ranges
+                 if start < opening < end),
+                key=lambda entry: -entry[0],
+            )
+            path = "/".join([outer_name for _, outer_name in outer] + [name])
+            gate_by_path[path] = gate_by_path.get(path, False) or gated
+
         for attribute in re.finditer(r"@Test\b", code):
             function_match = re.search(r"\bfunc\s+(\w+)\s*\(", code[attribute.end():])
             if not function_match:
@@ -263,10 +279,16 @@ def test_oracle(root):
             )
             if not containing:
                 continue
-            # A `.enabled`/`.disabled` on any level of the chain gates every test beneath it.
+            # A `.enabled`/`.disabled` on any level of the chain gates every test beneath it,
+            # whether that level is a brace around the test or the original declaration of
+            # a type the hosting extension names.
             if any(gated for _, _, gated in containing):
                 continue
-            enclosing = "/".join(name for _, name, _ in containing)
+            segments = [name for _, name, _ in containing]
+            enclosing = "/".join(segments)
+            if any(gate_by_path.get("/".join(enclosing.split("/")[:depth]), False)
+                   for depth in range(1, enclosing.count("/") + 2)):
+                continue
             body = part[attribute.end():function_start]
             display_names = []
             display = re.match(r'\s*\(\s*"((?:[^"\\]|\\.)*)"', body)

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -204,8 +204,13 @@ def test_oracle(root):
         target = path.relative_to(test_root).parts[0]
         code = mask_inactive_debug_branches(mask_noncode(part))
         ranges = []
+        # The name may be QUALIFIED: `extension Outer.Inner { @Test ... }` hosts tests for
+        # the nested suite, and `swift test list` files them under `Outer/Inner/...`.
+        # Capturing only the first segment filed them under `Outer`, so the validator
+        # rejected a valid recipe for every extension-hosted nested test (#2669 review).
+        # The dots become the path separator the chain below already uses.
         for declaration in re.finditer(
-            r"\b(?:struct|final\s+class|class|enum|actor|extension)\s+(\w+)", code
+            r"\b(?:struct|final\s+class|class|enum|actor|extension)\s+(\w+(?:\.\w+)*)", code
         ):
             opening = code.find("{", declaration.end())
             closing = matching_delimiter(code, opening, "{", "}") if opening >= 0 else None
@@ -216,7 +221,8 @@ def test_oracle(root):
                 if "{" in suite_attribute or "}" in suite_attribute:
                     suite_attribute = ""
                 ranges.append((
-                    opening, closing, declaration.group(1), has_runtime_gate(suite_attribute)
+                    opening, closing, declaration.group(1).replace(".", "/"),
+                    has_runtime_gate(suite_attribute)
                 ))
 
         for attribute in re.finditer(r"@Test\b", code):

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -200,6 +200,12 @@ def test_oracle(root):
             "validate against a suspiciously small oracle")
 
     names_by_suite = {}
+    # Pass one: every declaration's brace range and gate, for EVERY file, before any test
+    # is extracted. Gates are keyed by target-qualified path (`Target/Outer/Inner`) so a
+    # `.disabled` on a declaration in one file reaches a qualified extension of that type
+    # in another file; a map rebuilt per file could not see across (#2669 review, round 4).
+    parsed = []
+    gate_by_path = {}
     for path, part in sources:
         target = path.relative_to(test_root).parts[0]
         code = mask_inactive_debug_branches(mask_noncode(part))
@@ -236,17 +242,19 @@ def test_oracle(root):
         # around it never sees a `.disabled` on `Outer`'s own declaration — yet Swift
         # Testing skips that test through the parent trait (#2669 review, round 3). Every
         # declaration records the gate on its own path, and a test is gated when any
-        # prefix of its path is, whichever braces it was written inside.
-        gate_by_path = {}
+        # prefix of its path is, whichever braces — and whichever file — it was written in.
         for opening, closing, name, gated in ranges:
             outer = sorted(
                 ((end - start, outer_name) for start, end, outer_name, _ in ranges
                  if start < opening < end),
                 key=lambda entry: -entry[0],
             )
-            path = "/".join([outer_name for _, outer_name in outer] + [name])
-            gate_by_path[path] = gate_by_path.get(path, False) or gated
+            qualified = "/".join([target] + [outer_name for _, outer_name in outer] + [name])
+            gate_by_path[qualified] = gate_by_path.get(qualified, False) or gated
+        parsed.append((target, part, code, ranges))
 
+    # Pass two: the tests, each judged against the whole target's gates.
+    for target, part, code, ranges in parsed:
         for attribute in re.finditer(r"@Test\b", code):
             function_match = re.search(r"\bfunc\s+(\w+)\s*\(", code[attribute.end():])
             if not function_match:
@@ -284,10 +292,13 @@ def test_oracle(root):
             # a type the hosting extension names.
             if any(gated for _, _, gated in containing):
                 continue
-            segments = [name for _, name, _ in containing]
-            enclosing = "/".join(segments)
-            if any(gate_by_path.get("/".join(enclosing.split("/")[:depth]), False)
-                   for depth in range(1, enclosing.count("/") + 2)):
+            enclosing = "/".join(name for _, name, _ in containing)
+            # Walk the PATH components, not the chain entries: a qualified extension is one
+            # chain entry whose name already holds a `/`, and the gate it must inherit sits
+            # on the shorter path (`Target/Outer`) that only a component walk reaches.
+            components = enclosing.split("/")
+            if any(gate_by_path.get("/".join([target] + components[:depth]), False)
+                   for depth in range(1, len(components) + 1)):
                 continue
             body = part[attribute.end():function_start]
             display_names = []

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -237,15 +237,24 @@ def test_oracle(root):
             suffix = function_suffix(code[opening + 1:closing])
             if suffix is None:
                 continue
-            containing = [
-                (end - start, name, gated) for start, end, name, gated in ranges
-                if start < attribute.start() < end
-            ]
+            # Every declaration wrapping this test, outermost first. Brace ranges nest, so
+            # the ranges containing one point form a chain, and the whole chain is the
+            # suite's name: a @Suite nested inside another @Suite is `Outer/Inner`, which
+            # is the path the test filter accepts. Keying by the innermost name alone put
+            # the qualified path — the only one that runs — at "NOT FOUND" and accepted the
+            # bare inner name, a filter that executes zero tests (#2525). A top-level suite
+            # is a chain of one, so its name is unchanged.
+            containing = sorted(
+                ((end - start, name, gated) for start, end, name, gated in ranges
+                 if start < attribute.start() < end),
+                key=lambda entry: -entry[0],
+            )
             if not containing:
                 continue
-            _, enclosing, suite_is_gated = min(containing)
-            if suite_is_gated:
+            # A `.enabled`/`.disabled` on any level of the chain gates every test beneath it.
+            if any(gated for _, _, gated in containing):
                 continue
+            enclosing = "/".join(name for _, name, _ in containing)
             body = part[attribute.end():function_start]
             display_names = []
             display = re.match(r'\s*\(\s*"((?:[^"\\]|\\.)*)"', body)
@@ -306,12 +315,17 @@ def validate(recipes, root, label):
             total += 1
             problems = []
             normalized = {}
+            # One row per call, so the runner's first refusal cannot hide the rows behind
+            # it. The cost is that the runner numbers every row as `row 1`; printed after
+            # this loop's own `row N:` label that read as an anchor index (#2525). Only the
+            # leading prefix is renumbered — a `row 1` inside a quoted path is left alone.
             single_row = {"suite_default": default_suite, "rows": [row]}
             try:
                 normalized = battery.load_recipes(
                     None, root, raw=json.dumps(single_row))[0]
             except battery.Refusal as error:
-                problems.append(str(error))
+                problems.append(re.sub(
+                    r"^((?:human )?row )1\b", rf"\g<1>{index}", str(error)))
 
             suite = normalized.get("suite")
             suite_names = names_by_suite.get(suite, {})

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -208,9 +208,14 @@ def test_oracle(root):
         # the nested suite, and `swift test list` files them under `Outer/Inner/...`.
         # Capturing only the first segment filed them under `Outer`, so the validator
         # rejected a valid recipe for every extension-hosted nested test (#2669 review).
-        # The dots become the path separator the chain below already uses.
+        # Swift also accepts trivia around the dot and backtick-escaped segments
+        # (`extension Outer . \`Inner\``), which the inventory freeze already treats as the
+        # same name; both are stripped so the spelling never decides the key. The dots
+        # become the path separator the chain below already uses.
         for declaration in re.finditer(
-            r"\b(?:struct|final\s+class|class|enum|actor|extension)\s+(\w+(?:\.\w+)*)", code
+            r"\b(?:struct|final\s+class|class|enum|actor|extension)\s+"
+            r"(`?\w+`?(?:\s*\.\s*`?\w+`?)*)",
+            code,
         ):
             opening = code.find("{", declaration.end())
             closing = matching_delimiter(code, opening, "{", "}") if opening >= 0 else None
@@ -221,7 +226,8 @@ def test_oracle(root):
                 if "{" in suite_attribute or "}" in suite_attribute:
                     suite_attribute = ""
                 ranges.append((
-                    opening, closing, declaration.group(1).replace(".", "/"),
+                    opening, closing,
+                    re.sub(r"[\s`]", "", declaration.group(1)).replace(".", "/"),
                     has_runtime_gate(suite_attribute)
                 ))
 


### PR DESCRIPTION
## Summary

`validate-mutation-recipe.py` could not see a nested `@Suite`. For a recipe naming `EnviousWisprTests/OnboardingPracticeStepSuite/OnboardingWarmingGateTests`, the oracle keyed the suite by its innermost name only, reported the qualified path (the only spelling `xcodebuild`'s filter runs) as NOT FOUND, and cascaded every expectation to DOES NOT EXIST, retiring 23 working rows as a false negative that fails toward "do not bother". Worse, the bare inner name, a filter that executes zero tests, was accepted as runnable.

Second, every unrunnable row was labelled `row 1 anchor not found` whatever its number, which reads as an anchor index and sends the reader to the wrong row.

Refs #2525. Parts 1 and 2 of the issue; part 3 (the replacement is never compiled) needs a Swift compiler and is deliberately left open, so this is `Refs`, not `Closes`.

`Tier: SMALL | Lane: Docs/dev-tooling | Modules: scripts`

## Changes

- `scripts/validate-mutation-recipe.py`
  - `test_oracle` already collects the brace range of every declaration wrapping a `@Test`; it took `min(containing)`, the innermost only. It now sorts the chain outermost-in and joins it, so the suite key is `Target/Outer/Inner` and the canonical test id is `Outer/Inner/test()`, matching what `mutation-battery.py` reads from the bundle's `nodeIdentifier`. A top-level suite is a chain of one, keyed exactly as before. A `.enabled`/`.disabled` on any level of the chain now gates the tests beneath it, matching Swift Testing semantics.
  - The declaration regex captures a QUALIFIED name, so `extension Outer.Inner { @Test ... }` files under `Target/Outer/Inner` rather than `Target/Outer` (Codex P2, 9b51d38). Trivia around the dots and backtick-escaped segments are stripped, so `extension Outer . `Inner`` keys the same way (Codex P2 round 2, c8a18e0); the inventory freeze already treats those spellings as one name.
  - Gates are recorded by qualified path as well as by brace range, so a `.disabled` on `Outer`'s own declaration gates a test hosted in a top-level `extension Outer.Inner`, which sits in none of `Outer`'s braces (Codex P2 round 3, c446373).
  - `validate()` calls the battery's `load_recipes` with a one-row document per row so one bad row cannot hide the rest, which is why the battery's refusal always says `row 1`. Only the leading `row 1` prefix is renumbered with the validator's real index; a `row 1` inside a quoted path is left alone. Output now reads `row 2: UNRUNNABLE — row 2 anchor not found in …`.
- `scripts/mutation-battery-test.py`: nine paired cases against the real `OnboardingWarmingGateTests.swift` (the oracle refuses synthetic trees under 100 files). They freeze: the qualified path resolves; the bare inner name and `Inner/test()` are refused; an outer-level gate excludes nested tests; the row label carries the row's own number, including the non-anchor `row N is missing required field` form. Four more run the oracle over a copy of the real corpus plus one fixture file: two extension-hosted nested tests (contiguous, and spaced plus backticked) land under the same qualified key and not under the bare outer name, no key carries a space or backtick, and an extension-hosted test of a type whose declaration is `.disabled` appears under no key.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — N/A, no Swift touched
- [x] Logic tests pass locally — `python3 scripts/mutation-battery-test.py`: 174 passed before the tests were added; with the new tests on unfixed code, exactly the seven meant to fail failed (183 total) while the two paired controls passed; after the fix, all 183 pass. With the three extension fixes: 187 pass, and each fixture case was shown failing on the previous commit first. `scripts/check-validation.sh --self-test`: 6 passed, 0 failed.
- [ ] CI `build-check` status is green on the current head — all seven checks passed on `6278f56` and `9b51d38`; re-running on `c446373`.

### Behavioral Testing (Local UAT)
- N/A, no app code changed

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval
- N/A, does not touch `scripts/eval/`

### Review
- [x] Codex P2 (qualified extension names): fixed in 9b51d38, thread resolved
- [x] Codex P2 round 2 (spaced or backticked qualified names): fixed in c8a18e0, thread resolved
- [x] Codex P2 round 3 (declaration gate not applied to a qualified extension): fixed in c446373, thread resolved

### Release Housekeeping
- N/A

## Notes for review

- Oracle key dump before and after: 667 suites both times; the only changed rows are the three suites under `OnboardingPracticeStepSuite`. Every other suite is byte-identical. No test in the current corpus lives in a qualified extension, so the three extension commits alter no existing key; the fixture test is what exercises them.
- A parent-suite-only path (`Target/OnboardingPracticeStepSuite`) is a valid `xcodebuild` filter but is still NOT FOUND here; it is outside the issue's scope and neither changed nor frozen.
- `scripts/test-validation.sh` was not run: it requires `shellcheck` and `bats`, neither installed on the Linux host, and it does not exercise this validator. Nothing in the repo's scripts or workflows runs `mutation-battery-test.py`; that gap predates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM