### PR TITLE
fix(eval): sort the mirrored custom vocabulary the way production does (#2609)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -655,12 +655,18 @@ jobs:
           # argparse json os sys time datetime pathlib), so both run here under
           # bare python3 with no pytest install. Each asserts its own exact test
           # count, because both runners exit 0 on ZERO discovered tests.
+          #
+          # test_custom_vocab_mirror (#2609) joins them under the same rule: it
+          # pins the gate's CUSTOM VOCABULARY block to production's
+          # (priority, canonical) sort order. Importing acceptance_gate pulls in
+          # only the stdlib and reads no key, so it runs here on the same terms.
           python3 scripts/eval/tests/test_alias_scorer.py
           python3 scripts/eval/tests/test_v4_adversarial_runner.py
           # The registry rebuild's history-loss guards (#2581): a deleted or
           # renamed ARMS row must be REFUSED, not silently dropped. Same runner
           # shape and exact-count assertion as the two above.
           python3 scripts/eval/tests/test_rebuild_model_registry.py
+          python3 scripts/eval/tests/test_custom_vocab_mirror.py
 
       - name: Require every lane
         run: |

--- a/scripts/eval/acceptance_gate.py
+++ b/scripts/eval/acceptance_gate.py
@@ -194,9 +194,31 @@ CUSTOM_VOCAB_HEADER = (
 )
 
 
+# Mirrors `CustomWord.init(priority: Int = 0)`. Every `builtinDefaults` entry takes
+# the default, so the mirror carries no priority column: the tuple below is
+# production's key with that column filled in.
+BUILTIN_VOCAB_PRIORITY = 0
+
+
 def render_custom_vocab() -> str:
+    # Production SORTS before rendering (#2609). CustomVocabularyFormatter.render:
+    #   words.sorted { ($0.priority, $0.canonical) < ($1.priority, $1.canonical) }
+    # Until this sort, the gate rendered the list in declaration order (EnviousWispr
+    # first) while every user's prompt led with API — a prompt no user received.
+    #
+    # Swift's String `<` compares Unicode scalars after canonical normalization:
+    # case-sensitive, every uppercase letter before every lowercase one, so the
+    # shipped order is API, CLI, ChatGPT, ..., VS Code, ..., iOS, macOS. Python's
+    # str `<` compares raw code points, which is the same relation on ASCII and can
+    # differ only for non-ASCII forms that normalization would fold. Every canonical
+    # here is ASCII and none differ only by case; tests/test_custom_vocab_mirror.py
+    # fails the moment a non-ASCII canonical is added, so the equivalence is checked
+    # rather than assumed. Alias order within a line is NOT sorted by production
+    # either, so aliases stay in declaration order.
     lines = [CUSTOM_VOCAB_HEADER]
-    for canonical, aliases in DEFAULT_CUSTOM_VOCAB:
+    for canonical, aliases in sorted(
+        DEFAULT_CUSTOM_VOCAB, key=lambda entry: (BUILTIN_VOCAB_PRIORITY, entry[0])
+    ):
         if aliases:
             lines.append(f"- {canonical} (may be misheard as: {', '.join(aliases)})")
         else:

--- a/scripts/eval/tests/test_custom_vocab_mirror.py
+++ b/scripts/eval/tests/test_custom_vocab_mirror.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression tests for the CUSTOM VOCABULARY mirror in acceptance_gate.py (#2609).
+
+Production renders the block through `CustomVocabularyFormatter.render`, which
+sorts the words by `(priority, canonical)` before emitting a line per word. The
+Python mirror iterated `DEFAULT_CUSTOM_VOCAB` in declaration order, so the gate
+measured a system prompt in which `EnviousWispr` led the list while every user
+received one led by `API`. Same class as the #1255 prompt-body drift, one layer
+down: a byte-identical prompt body above a differently ordered vocab block is
+still a different prompt.
+
+Run from repo root:
+  python3 scripts/eval/tests/test_custom_vocab_mirror.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import acceptance_gate as gate  # noqa: E402
+
+# Mirrors `CustomWord.init(priority: Int = 0)`: every `builtinDefaults` entry
+# takes the default, so production's `(priority, canonical)` key collapses to
+# `(0, canonical)` for the whole shipped list.
+BUILTIN_PRIORITY = 0
+
+_ALIAS_MARKER = " (may be misheard as: "
+
+
+def _rendered_canonicals(block: str) -> list[str]:
+    """The canonical of each `- ...` line, in the order the block emits them."""
+    header, *lines = block.split("\n")
+    assert header == gate.CUSTOM_VOCAB_HEADER, header
+    out = []
+    for line in lines:
+        assert line.startswith("- "), line
+        out.append(line[2:].split(_ALIAS_MARKER, 1)[0])
+    return out
+
+
+class CustomVocabMirrorTests(unittest.TestCase):
+    def test_first_entry_is_api_like_production(self) -> None:
+        # The concrete symptom from #2609: production emits `API` first, the
+        # gate emitted `EnviousWispr` first.
+        self.assertEqual(_rendered_canonicals(gate.render_custom_vocab())[0], "API")
+
+    def test_render_order_matches_swift_priority_canonical_sort(self) -> None:
+        expected = [
+            canonical
+            for canonical, _aliases in sorted(
+                gate.DEFAULT_CUSTOM_VOCAB,
+                key=lambda entry: (BUILTIN_PRIORITY, entry[0]),
+            )
+        ]
+        self.assertEqual(_rendered_canonicals(gate.render_custom_vocab()), expected)
+        # Nothing was dropped or duplicated by sorting.
+        self.assertEqual(len(expected), len(gate.DEFAULT_CUSTOM_VOCAB))
+
+    def test_canonicals_stay_within_ascii_so_python_and_swift_sort_alike(self) -> None:
+        # Swift's String `<` compares Unicode scalars after canonical
+        # normalization; Python's str `<` compares raw code points. Those agree
+        # on ASCII (case-sensitive, uppercase before lowercase, so
+        # "VS Code" < "iOS" < "macOS") but can diverge on precomposed vs
+        # decomposed non-ASCII forms. The mirror's sort is only provably
+        # production-identical while every canonical is ASCII, so a non-ASCII
+        # addition must fail here rather than silently reorder the block.
+        for canonical, _aliases in gate.DEFAULT_CUSTOM_VOCAB:
+            self.assertTrue(canonical.isascii(), f"non-ASCII canonical: {canonical!r}")
+
+
+EXPECTED_TESTS = 3
+
+
+def _main() -> int:
+    """Run the suite, but refuse to report success on a shrunken one (#2013).
+
+    `unittest.main()` exits 0 when it discovers ZERO tests, so wiring this into CI
+    without a count assertion would buy a green check that means nothing.
+    """
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    found = suite.countTestCases()
+    if found != EXPECTED_TESTS:
+        print(f"FAIL: discovered {found} tests, expected {EXPECTED_TESTS}")
+        return 1
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
## Summary

The polish acceptance gate built its CUSTOM VOCABULARY prompt block in source-declaration order, while `CustomVocabularyFormatter` sorts by `(priority, canonical)` before rendering. The gate was measuring a system prompt no user receives: production leads with `API`, the gate led with `EnviousWispr`.

Closes #2609.

`Tier: SMALL | Lane: Eval-harness | Modules: scripts/eval`

## Changes

- `scripts/eval/acceptance_gate.py`: `render_custom_vocab()` iterates `sorted(DEFAULT_CUSTOM_VOCAB, key=(BUILTIN_VOCAB_PRIORITY, canonical))` with the priority column filled in at 0, since every `builtinDefaults` entry takes `CustomWord`'s default. The comment records why Python's `str <` and Swift's `String <` agree here: all fourteen canonicals are ASCII and none differ only by case, so the shipped order (`API, CLI, ChatGPT, …, VS Code, …, iOS, macOS`) is reproduced exactly. Alias order within a line is left in declaration order because production does not sort it either.
- `scripts/eval/tests/test_custom_vocab_mirror.py`: new, three cases. Asserts the first entry is `API`, the full canonical order equals the production sort, and every canonical is ASCII so a future non-ASCII addition fails loudly instead of diverging silently.
- `.github/workflows/pr-check.yml`: the new suite runs in the "Eval harness self-tests" step beside its siblings.

Rendered order, first three entries: before `EnviousWispr, Envious Labs, macOS`; after `API, CLI, ChatGPT`.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — N/A, no Swift touched
- [x] Logic tests pass locally — `test_custom_vocab_mirror.py`: 2 of 3 failed before the fix (`'EnviousWispr' != 'API'`), 3 passed after. `acceptance_gate.py --mode selftest` passes (the only mode that runs without API keys). `test_alias_scorer.py` (23) and `test_v4_adversarial_runner.py` (2) unchanged.
- [x] CI `build-check` status is green — all seven checks passed on `2eac2eb`, including `eval-packages`, which runs the new suite.

### Behavioral Testing (Local UAT)
- N/A, no app code changed

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval (touches `scripts/eval/`)
- [x] `polish-eval-smoke` CI check is green (`polish-quality-gate` passed)
- [x] Swift → Python sync: this PR IS the sync, in the Python direction; no Swift changed
- [x] No new polish capability
- [ ] **Baseline re-capture is deliberately NOT in this PR.** The issue asks for it because prompt ordering can move model output, but it needs API keys and, per the template, founder approval with a `BASELINE-BUMP` line. `scripts/eval/baselines/gpt-4o-mini.json` is untouched here; the founder should re-capture against the corrected prompt.

### Release Housekeeping
- N/A

## Found while here, deliberately not fixed

The mirror has also drifted from `builtinDefaults` in content, not only order:

- `EG-1` is in production (`CustomWordsManager.swift:180`) but absent from `DEFAULT_CUSTOM_VOCAB`. #2564 added it to the mirror and #2612 reverted that row along with the duplicate Swift built-in, leaving the original Swift entry with no mirror.
- `EnviousWispr` in the mirror lacks the eight aliases added on 2026-09-01.

`polish-eval-smoke.yml`'s path filter does not cover `CustomWordsManager.swift`, and `_selftest_mirrors()` checks only the prompt body, so nothing catches this. Worth its own issue; syncing the content changes the block again and should ride the same baseline re-capture as this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM