### PR TITLE
fix(itn): scope the magnitude guard to a lone marker letter, not any letter (#2583)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -1695,13 +1695,25 @@ public struct InverseTextNormalizer: Sendable {
     // fires where \b failed on the full figure — ordinal suffixes ('1,000,000,000th' #1201),
     // decimals past the (?!\.\d) block ('$5,000,000,000.00'), plurals ('1,000,000,000s').
     return reSub(
-      // `(?<![A-Za-z])` so a compact alphanumeric tag is never split: "P one million" renders
-      // "P1,000,000" and must stay that way, matching the reverse form "one million P" ->
-      // "1,000,000P". Without it the two directions of #2496 disagreed — "P1 million" against
-      // "1,000,000P" (Codex diff review r1). A letter glued directly to a comma-grouped number
-      // is a tag by construction; every real house-style case is preceded by "$", a space, or
-      // the start of the text.
-      #"(?<![A-Za-z])(?<cur>\$)?(?<n>\d{1,3}(?:,\d{3})+)\b(?!\.\d)(?!,\d)"#, t,
+      // A compact alphanumeric tag is never split: "P one million" renders "P1,000,000" and
+      // must stay that way, matching the reverse form "one million P" -> "1,000,000P". Without
+      // a guard the two directions of #2496 disagreed — "P1 million" against "1,000,000P"
+      // (Codex diff review r1).
+      //
+      // The guard exempts EXACTLY the shape `listMarkers` emits and nothing wider: ONE
+      // uppercase ASCII letter (`markerLetterOK`) that sat at a word boundary
+      // (`\b(?<letter>[A-Za-z])`), i.e. a single capital preceded by the start of the text or a
+      // non-word character. Anything else in front of the figure — "$", a space, or a run of
+      // two or more letters — is not a tag and keeps house style: "USD1,000,000" ->
+      // "USD1 million", as it always had. The first cut of this guard was a bare
+      // `(?<![A-Za-z])`, which exempted EVERY letter-prefixed figure and silently froze
+      // code-prefixed currency (#2583).
+      //
+      // Spelled as an alternation of two single-level lookbehinds rather than the equivalent
+      // nested `(?<!(?<!\w)[A-Z])`, so it leans only on bounded, un-nested lookbehind in ICU.
+      // Read it as: the previous character is NOT a capital, OR it is a capital that itself
+      // follows a word character (so it is the tail of a longer token, not a lone marker).
+      #"(?:(?<=\w[A-Z])|(?<![A-Z]))(?<cur>\$)?(?<n>\d{1,3}(?:,\d{3})+)\b(?!\.\d)(?!,\d)"#, t,
       caseInsensitive: false
     ) {
       m in

--- a/Tests/EnviousWisprTests/Pipeline/ListMarkerUpstreamCasingTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ListMarkerUpstreamCasingTests.swift
@@ -161,19 +161,32 @@ struct ListMarkerUpstreamCasingTests {
     #expect(itn.normalize("One A, two B, three C.") == "1A, 2B, 3C.")
   }
 
-  /// The magnitude guard must protect a letter TOUCHING the number, not one separated by "$".
+  /// The magnitude guard must protect a letter TOUCHING the number, not one separated by "$",
+  /// and only a SINGLE capital — the shape `listMarkers` emits — never a currency code.
   ///
-  /// **Product Outcome.** `keepMagnitude` gained a `(?<![A-Za-z])` so a compact tag is never
-  /// split ("P1,000,000" must not become "P1 million"). A letter-prefixed currency is the case
-  /// where that guard could over-reach — nothing in either parity fixture covers "US$", so this
-  /// surface was untested in both implementations until now.
+  /// **Product Outcome.** `keepMagnitude` gained a lookbehind so a compact tag is never split
+  /// ("P1,000,000" must not become "P1 million"). A letter-prefixed currency is the case where
+  /// that guard could over-reach — nothing in either parity fixture covers "US$", so this
+  /// surface was untested in both implementations until now. The first cut, a bare
+  /// `(?<![A-Za-z])`, DID over-reach one step further: a code-prefixed figure ("USD1,000,000")
+  /// stopped collapsing to the "USD1 million" it had always received (#2583). The guard now
+  /// exempts exactly one capital at a word boundary, which is all `listMarkers` can produce.
   @Test("a letter-prefixed currency still gets house-style magnitude")
   func letterPrefixedCurrencyKeepsMagnitude() {
     let itn = InverseTextNormalizer()
     #expect(itn.normalize("US$1,000,000") == "US$1 million")
     #expect(itn.normalize("US$5,200,000") == "US$5.2 million")
     #expect(itn.normalize("$1,000,000") == "$1 million")
-    // The tag this guard exists for, asserted beside it so neither can drift alone.
+    // #2583: a currency CODE is a letter run, not a marker, so it collapses exactly as "$" does.
+    #expect(itn.normalize("USD1,000,000") == "USD1 million")
+    #expect(itn.normalize("EUR1,000,000") == "EUR1 million")
+    #expect(itn.normalize("GBP2,500,000") == "GBP2.5 million")
+    #expect(itn.normalize("raised USD1,000,000") == "raised USD1 million")
+    // The tag this guard exists for, asserted beside it so neither can drift alone — both the
+    // spoken form and the already-compact form the guard actually sees.
     #expect(itn.normalize("P one million") == "P1,000,000")
+    #expect(itn.normalize("P1,000,000") == "P1,000,000")
+    #expect(itn.normalize("(P1,000,000)") == "(P1,000,000)")
+    #expect(itn.normalize("A1,000,000") == "A1,000,000")
   }
 }

--- a/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
+++ b/Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl
@@ -2198,6 +2198,9 @@
 {"input": "I take One A Day.", "expected": "I take One A Day.", "category": "listmarker", "slice": "mixedstate"}
 {"input": "One A Day, every day", "expected": "One A Day, every day", "category": "listmarker", "slice": "mixedstate"}
 {"input": "US$1,000,000", "expected": "US$1 million", "category": "listmarker", "slice": "mixedstate"}
+{"input": "USD1,000,000", "expected": "USD1 million", "category": "listmarker", "slice": "mixedstate"}
+{"input": "EUR1,000,000", "expected": "EUR1 million", "category": "listmarker", "slice": "mixedstate"}
+{"input": "P1,000,000", "expected": "P1,000,000", "category": "listmarker", "slice": "mixedstate"}
 {"input": "P one hundred and five Q two", "expected": "P105 Q2", "category": "listmarker", "slice": "mixedstate"}
 {"input": "one hundred and five B two C", "expected": "105B 2C", "category": "listmarker", "slice": "mixedstate"}
 {"input": "He said, \"P one Q two\"", "expected": "He said, \"P1 Q2\"", "category": "listmarker", "slice": "mixedstate"}


### PR DESCRIPTION
## Summary

The keep-magnitude pass (`1,000,000` -> `1 million`) gained a `(?<[A-Za-z])` lookbehind in #2572 so a compact list-marker tag like `P1,000,000` is never split. That guard exempted every letter-prefixed figure, so code-prefixed currency (`USD1,000,000`, `EUR1,000,000`) silently stopped collapsing to the house-style `USD1 million` it had always received. Codex finding from #2572.

Closes #2583.

`Tier: SMALL | Lane: Code | Modules: EnviousWisprPostProcessing`

**Verification note:** this was authored on a Linux host with no Swift toolchain. The regex was cross-checked in Python (transcript below) and the Swift diff re-read for syntax; the macOS CI lanes on this PR were the first compile and the first run of the tests, and they passed: `build-debug` (which runs the ITN unit and parity suites), `build-release`, and the macOS 14 launch job are all green on `ca53a39`.

## What a compact marker actually is

Read from the code, not the comment: `markerLetterOK` admits exactly one uppercase ASCII letter, and the direction-2 pattern requires that letter at `\b`, so a compact tag is a single capital preceded by start-of-text or a non-word character. Direction 1 emits the letter trailing (`1,000,000P`) and is unaffected.

## Changes

- `Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift`: the guard becomes
  ```
  (?:(?<=\w[A-Z])|(?<[A-Z]))
  ```
  "the previous character is not a capital, OR it is a capital that itself follows a word character." That exempts exactly the marker shape. Spelled as an alternation of two single-level lookbehinds rather than the equivalent nested `(?<!(?<!\w)[A-Z])` so it leans only on bounded, un-nested lookbehind in ICU. The comment above it now states the rule and the #2583 history.
- `Tests/EnviousWisprTests/Pipeline/ListMarkerUpstreamCasingTests.swift`: `letterPrefixedCurrencyKeepsMagnitude` gains `USD1,000,000`, `EUR1,000,000`, `GBP2,500,000`, `raised USD1,000,000` collapsing, and `P1,000,000`, `(P1,000,000)`, `A1,000,000` staying intact, beside the existing `$`, `US$` and `P one million` assertions.
- `Tests/EnviousWisprTests/Resources/InverseTextNormalizer/parity.jsonl`: three `listmarker/mixedstate` rows (`USD1,000,000`, `EUR1,000,000`, `P1,000,000`) next to the `US$1,000,000` row #2572 added. Hand-authored, as #2572's rows were; the Python oracle behind `gen_parity_fixture.py` lives outside this repo.

## Python cross-check of the regex

Old guard vs the new one, applied through a faithful port of the collapse:

| input | old (#2572) | new |
|---|---|---|
| `P1,000,000` | `P1,000,000` | `P1,000,000` |
| `USD1,000,000` | `USD1,000,000` | `USD1 million` |
| `EUR1,000,000` | `EUR1,000,000` | `EUR1 million` |
| `GBP2,500,000` | `GBP2,500,000` | `GBP2.5 million` |
| `$1,000,000` | `$1 million` | `$1 million` |
| `US$5,200,000` | `US$5.2 million` | `US$5.2 million` |
| `A1,000,000` | `A1,000,000` | `A1,000,000` |
| `(P1,000,000)` | `(P1,000,000)` | `(P1,000,000)` |
| `1,000,000P` | `1,000,000P` | `1,000,000P` |
| `Q3 1,000,000` | `Q3 1 million` | `Q3 1 million` |
| `$5,000,000.00` | unchanged | unchanged |
| `1,000,000,000th` | unchanged | unchanged |
| `a1,000,000` | `a1,000,000` | `a1 million` |
| `3P1,000,000` | `3P1,000,000` | `3P1 million` |

The last two rows are the only behavioural change beyond the issue's ask: a lowercase or digit-preceded letter is not a marker shape, so both return to pre-#2572 behaviour. Running old vs new over the `input` and `expected` of all 2,239 `parity.jsonl` and 3,881 `parity_holdout.jsonl` rows produced no disagreement other than the rows this PR adds, so no existing fixture expectation moves.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — not possible on the authoring host
- [ ] Logic tests pass locally — not possible on the authoring host; Python cross-check above stands in
- [x] CI `build-check` status is green — all nine checks passed on `ca53a39`, including `build-debug`, which runs the ITN unit tests and the parity harness against the new fixture rows

### Behavioral Testing (Local UAT)
- [ ] App rebuilt and relaunched — N/A, deterministic text pass with unit and parity coverage
- [ ] Manual smoke test — N/A

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval
- N/A, does not touch `Sources/EnviousWisprLLM/`, `CustomWordsManager.swift`, or `scripts/eval/`

### Release Housekeeping
- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM