### PR TITLE
feat(validation): let a human recipe row name a RuntimeUAT Python self-test (#2570)

### DIFF
--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2504,6 +2504,55 @@ if result.returncode != 2 or "carries 2 explicit recipe blocks" not in _issue_ou
 else:
     print("  ok  the filing validator shares the runner's single-recipe issue contract")
 
+# #2672 review: `self_test_problems` accepted ANY `"--self-test"` constant that was not a bare
+# docstring statement, so a module constant, a help message or an unreachable branch made a
+# module "parse" a flag it never inspects, and the validator printed a command whose exit
+# code would exercise only the module's normal path. Two-way over the shapes a module can
+# take: the ways to answer the flag are accepted, spelling it anywhere else is refused.
+_battery_for_validator = validator.load_battery()
+
+
+def check_flag_parse(name, body, *, accepted):
+    global ran
+    ran += 1
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "Tests" / "RuntimeUAT").mkdir(parents=True)
+        (root / "Tests" / "RuntimeUAT" / "probe.py").write_text(body)
+        problems = validator.self_test_problems(
+            _battery_for_validator, "RuntimeUAT/probe", root)
+    refused = any("does not parse --self-test" in problem for problem in problems)
+    if accepted and problems:
+        failures.append(f"{name}: expected acceptance, got {problems!r}")
+    elif not accepted and not refused:
+        failures.append(f"{name}: expected refusal, got {problems!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+check_flag_parse("the self-test check accepts a sys.argv membership test of the flag",
+                 'import sys\nif "--self-test" in sys.argv:\n    pass\n', accepted=True)
+check_flag_parse("the self-test check accepts an equality against the flag",
+                 'import sys\ncmd = sys.argv[1]\nif cmd == "--self-test":\n    pass\n',
+                 accepted=True)
+check_flag_parse("the self-test check accepts an argparse registration of the flag",
+                 'import argparse\nparser = argparse.ArgumentParser()\n'
+                 'parser.add_argument("--self-test", action="store_true")\n', accepted=True)
+check_flag_parse("the self-test check accepts a whole-argv comparison with a list holding the flag",
+                 'import sys\nif sys.argv[1:] == ["--self-test"]:\n    pass\n', accepted=True)
+check_flag_parse("the self-test check accepts a comparison through a module constant bound to the flag",
+                 'import sys\nFLAG = "--self-test"\nif FLAG in sys.argv:\n    pass\n', accepted=True)
+check_flag_parse("the self-test check refuses a module constant that only spells the flag",
+                 'SELF_TEST_FLAG = "--self-test"\n', accepted=False)
+check_flag_parse("the self-test check refuses a help message that only spells the flag",
+                 'print("--self-test")\n', accepted=False)
+check_flag_parse("the self-test check refuses an unreachable assignment of the flag",
+                 'if False:\n    flag = "--self-test"\n', accepted=False)
+check_flag_parse("the self-test check refuses a docstring that only mentions the flag",
+                 '"""Run with --self-test."""\n', accepted=False)
+check_flag_parse("the self-test check refuses a module that never spells the flag",
+                 'x = 1\n', accepted=False)
+
 print()
 if failures:
     print(f"{len(failures)} of {ran} FAILED:")

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -176,6 +176,16 @@ check("a bare suite name is refused as not target-qualified",
       [dict(VALID_ROW, suite="ThingTests")],
       expect_exit=2, expect_text="not target-qualified")
 
+# #2570: `RuntimeUAT/<module>` on a human row is a Python self-test, and the runner defers it
+# with the one command that namespace means — nothing is guessed from the instruction.
+check("a human row naming a RuntimeUAT self-test is deferred with its fixed command",
+      [{"mode": "human", "label": "break the guard", "instruction": "drop the pid filter",
+        "suite": "RuntimeUAT/wispr_eyes"}],
+      expect_exit=0, expect_text="run: python3 Tests/RuntimeUAT/wispr_eyes.py --self-test")
+check("a mechanical row naming a RuntimeUAT self-test is refused before anything runs",
+      [dict(VALID_ROW, suite="RuntimeUAT/wispr_eyes")],
+      expect_exit=2, expect_text="only valid on a human row")
+
 check("a non-string suite is refused, not crashed on",
       [dict(VALID_ROW, suite=1)],
       expect_exit=2, expect_text="suite must be a string")
@@ -2107,10 +2117,12 @@ def check_validator(name, row=None, *, document=None, expected_rc, expected_text
             capture_output=True, text=True,
         )
     output = result.stdout + result.stderr
-    if result.returncode != expected_rc or expected_text not in output:
+    expected = (expected_text,) if isinstance(expected_text, str) else tuple(expected_text)
+    missing = [text for text in expected if text not in output]
+    if result.returncode != expected_rc or missing:
         failures.append(
             f"{name}: exit {result.returncode}, wanted {expected_rc}; "
-            f"missing {expected_text!r} in {output[:300]!r}")
+            f"missing {missing!r} in {output[:300]!r}")
     else:
         print(f"  ok  {name}")
 
@@ -2248,6 +2260,49 @@ check_validator("the filing validator does not accept a nested test's inner-only
                 dict(_validator_base, suite=_nested_suite,
                      expect_fail="OnboardingWarmingGateTests/gateHoldsUntilTheEngineAnswers()"),
                 expected_rc=1, expected_text="DOES NOT EXIST")
+
+# #2570: a human row may name a non-Swift self-test target, `RuntimeUAT/<module>`, which is
+# `python3 Tests/RuntimeUAT/<module>.py --self-test` and nothing else. The oracle indexes only
+# Swift, so the truthful target for wispr_eyes's own control was "NOT FOUND", a blank suite was
+# refused, and the only green row was one naming an unrelated Swift suite — a result that
+# proved nothing. Two-way: the real target is accepted with the exact command the validator
+# proved, a missing module and a module that never parses the flag are refused by name.
+_self_test_row = {"mode": "human", "label": "break the single-instance guard",
+                  "instruction": "Drop the `if pid == me` filter, then run the self-test.",
+                  "suite": "RuntimeUAT/wispr_eyes"}
+check_validator("the filing validator accepts a human row naming a real RuntimeUAT self-test",
+                _self_test_row,
+                expected_rc=0,
+                expected_text=("DEFERRED", "python3 Tests/RuntimeUAT/wispr_eyes.py --self-test",
+                               "1/1 rows runnable"))
+check_validator("the filing validator reads an argparse --self-test as well as a sys.argv one",
+                dict(_self_test_row, suite="RuntimeUAT/ptt_binding"),
+                expected_rc=0, expected_text="python3 Tests/RuntimeUAT/ptt_binding.py --self-test")
+check_validator("the filing validator refuses a RuntimeUAT module that does not exist",
+                dict(_self_test_row, suite="RuntimeUAT/no_such_module"),
+                expected_rc=1,
+                expected_text=("Tests/RuntimeUAT/no_such_module.py", "DOES NOT EXIST"))
+check_validator("the filing validator refuses a RuntimeUAT module that never parses --self-test",
+                dict(_self_test_row, suite="RuntimeUAT/ui_helpers"),
+                expected_rc=1,
+                expected_text=("Tests/RuntimeUAT/ui_helpers.py", "does not parse --self-test"))
+check_validator("the filing validator refuses a RuntimeUAT target that is not one module name",
+                dict(_self_test_row, suite="RuntimeUAT/scenarios/wispr_eyes"),
+                expected_rc=1, expected_text="one module name")
+check_validator("the filing validator refuses Swift test names on a RuntimeUAT self-test row",
+                dict(_self_test_row, must_fire=["the guard fires"]),
+                expected_rc=1, expected_text="no addressable test names")
+check_validator("the filing validator refuses a RuntimeUAT target on a mechanical row",
+                dict(_validator_base, suite="RuntimeUAT/wispr_eyes", expect_fail=_guard_name),
+                expected_rc=1, expected_text="only valid on a human row")
+check_validator("the filing validator still finds a Swift suite next to a RuntimeUAT row",
+                document={"rows": [
+                    _self_test_row,
+                    {"mode": "human", "label": "semantic route", "instruction": "restore it",
+                     "suite": "EnviousWisprTests/ProviderStatusMappingTests",
+                     "must_fire": [_guard_name]},
+                ]},
+                expected_rc=0, expected_text="2/2 rows runnable")
 
 # #2525 part 2: the validator hands the runner ONE row at a time so that every row is
 # judged, which means the runner's own `row N` prefix is always `row 1`. Printed after the

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2552,6 +2552,21 @@ check_flag_parse("the self-test check refuses a docstring that only mentions the
                  '"""Run with --self-test."""\n', accepted=False)
 check_flag_parse("the self-test check refuses a module that never spells the flag",
                  'x = 1\n', accepted=False)
+check_flag_parse("the self-test check refuses a recognised check under `if False:`",
+                 'import sys\nif False:\n    if "--self-test" in sys.argv:\n        pass\n',
+                 accepted=False)
+check_flag_parse("the self-test check refuses a recognised check under `while 0:`",
+                 'import sys\nwhile 0:\n    if "--self-test" in sys.argv:\n        pass\n',
+                 accepted=False)
+check_flag_parse("the self-test check refuses a recognised check in the else of `if True:`",
+                 'import sys\nif True:\n    pass\nelse:\n    if "--self-test" in sys.argv:\n'
+                 '        pass\n', accepted=False)
+check_flag_parse("the self-test check accepts a recognised check in the else of `if False:`",
+                 'import sys\nif False:\n    pass\nelse:\n    if "--self-test" in sys.argv:\n'
+                 '        pass\n', accepted=True)
+check_flag_parse("the self-test check accepts a recognised check under a name it cannot evaluate",
+                 'import sys\nDEBUG = False\nif DEBUG:\n    if "--self-test" in sys.argv:\n'
+                 '        pass\n', accepted=True)
 
 print()
 if failures:

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -182,6 +182,10 @@ check("a human row naming a RuntimeUAT self-test is deferred with its fixed comm
       [{"mode": "human", "label": "break the guard", "instruction": "drop the pid filter",
         "suite": "RuntimeUAT/wispr_eyes"}],
       expect_exit=0, expect_text="run: python3 Tests/RuntimeUAT/wispr_eyes.py --self-test")
+check("a human row naming a RuntimeUAT self-test with a legacy expect_fail is refused",
+      [{"mode": "human", "label": "break the guard", "instruction": "drop the pid filter",
+        "suite": "RuntimeUAT/wispr_eyes", "expect_fail": "the guard fires"}],
+      expect_exit=2, expect_text="expect_fail is not accepted")
 check("a mechanical row naming a RuntimeUAT self-test is refused before anything runs",
       [dict(VALID_ROW, suite="RuntimeUAT/wispr_eyes")],
       expect_exit=2, expect_text="only valid on a human row")
@@ -2292,6 +2296,9 @@ check_validator("the filing validator refuses a RuntimeUAT target that is not on
 check_validator("the filing validator refuses Swift test names on a RuntimeUAT self-test row",
                 dict(_self_test_row, must_fire=["the guard fires"]),
                 expected_rc=1, expected_text="no addressable test names")
+check_validator("the filing validator refuses a legacy expect_fail on a RuntimeUAT self-test row",
+                dict(_self_test_row, expect_fail="the guard fires"),
+                expected_rc=1, expected_text=("no addressable test names", "expect_fail"))
 check_validator("the filing validator refuses a RuntimeUAT target on a mechanical row",
                 dict(_validator_base, suite="RuntimeUAT/wispr_eyes", expect_fail=_guard_name),
                 expected_rc=1, expected_text="only valid on a human row")
@@ -2540,6 +2547,9 @@ check_flag_parse("the self-test check accepts an argparse registration of the fl
                  'parser.add_argument("--self-test", action="store_true")\n', accepted=True)
 check_flag_parse("the self-test check accepts a whole-argv comparison with a list holding the flag",
                  'import sys\nif sys.argv[1:] == ["--self-test"]:\n    pass\n', accepted=True)
+check_flag_parse("the self-test check refuses a whole-argv comparison the fixed command cannot match",
+                 'import sys\nif sys.argv[1:] == ["--verbose", "--self-test"]:\n    pass\n',
+                 accepted=False)
 check_flag_parse("the self-test check accepts a comparison through a module constant bound to the flag",
                  'import sys\nFLAG = "--self-test"\nif FLAG in sys.argv:\n    pass\n', accepted=True)
 check_flag_parse("the self-test check refuses a module constant that only spells the flag",

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -75,6 +75,14 @@ RECIPE FORMAT (JSON; the same block that goes in the `test-hardening` issue body
     a literal pipe. A semantic instruction that cannot be an anchor/replacement pair
     is mode `human`; it is reported as DEFERRED and is never guessed into source code.
 
+    A human row may instead name a NON-SWIFT SELF-TEST as its suite: `RuntimeUAT/<module>`
+    means `python3 Tests/RuntimeUAT/<module>.py --self-test`, and nothing else. The target
+    segment is the marker; the module is the file; the command is fixed by the namespace the
+    same way a Swift suite fixes its `-only-testing:` filter, so no command is ever read out
+    of prose. The whole exit code is the verdict, so such a row carries no `must_fire` or
+    `must_not_fire`. The filing validator proves the module exists and really parses
+    `--self-test`; the runner defers the row and prints the command an operator runs.
+
     `expect_fail` NAMES A TEST AND IS MATCHED EXACTLY — it is not a substring of the
     failure line. Any one of the three spellings the result bundle carries will do:
     the `Suite/function()` identifier, the bare `function()`, or the display name in
@@ -905,6 +913,30 @@ def preflight(worktree: Path):
             )
 
 
+# A human row's suite may name a self-test outside Swift Testing. `RuntimeUAT/<module>` is
+# `python3 Tests/RuntimeUAT/<module>.py --self-test` — one namespace, one command shape — so
+# the command is a function of the suite, never a field an author fills from prose (#2570).
+SELF_TEST_TARGET = "RuntimeUAT"
+SELF_TEST_FLAG = "--self-test"
+
+
+def self_test_module(suite):
+    """The module a `RuntimeUAT/<module>` suite names, or None for anything else."""
+    if not isinstance(suite, str):
+        return None
+    target, _, module = suite.partition("/")
+    return module if target == SELF_TEST_TARGET else None
+
+
+def self_test_source(module):
+    return f"Tests/{SELF_TEST_TARGET}/{module}.py"
+
+
+def self_test_command(suite):
+    module = self_test_module(suite)
+    return f"python3 {self_test_source(module)} {SELF_TEST_FLAG}" if module else None
+
+
 FENCE_RE = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
 MARKDOWN_FENCE_RE = re.compile(r"```mutation-recipe\s*\n(.*?)```", re.DOTALL)
 MARKDOWN_RECIPE_COLUMNS = (
@@ -1096,6 +1128,17 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
             if not isinstance(row["suite"], str) or "/" not in row["suite"]:
                 raise Refusal(
                     f"human row {i} suite must be a target-qualified string, got {row['suite']!r}.")
+            module = self_test_module(row["suite"])
+            if module is not None:
+                if not module.isidentifier():
+                    raise Refusal(
+                        f"human row {i} suite {row['suite']!r} must be {SELF_TEST_TARGET}/<module>, "
+                        f"one module name: it is {self_test_source('<module>')}.")
+                if row["must_fire"] or row["must_not_fire"]:
+                    raise Refusal(
+                        f"human row {i} names a {SELF_TEST_TARGET} self-test, which has no "
+                        f"addressable test names: `{self_test_command(row['suite'])}` passes or "
+                        "fails as a whole, so must_fire and must_not_fire must be empty.")
             row["_must_fire"] = row["must_fire"]
             row["_must_not_fire"] = row["must_not_fire"]
             row["_mode"] = "human"
@@ -1157,6 +1200,10 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
                 "(A non-string here used to raise TypeError and exit 1, which the exit codes reserve "
                 "for a row SURVIVING.)"
             )
+        if self_test_module(row["suite"]) is not None:
+            raise Refusal(
+                f"row {i} suite '{row['suite']}' names a {SELF_TEST_TARGET} self-test, which is "
+                "only valid on a human row: a mechanical row names the Swift suite xcodebuild runs.")
         if "/" not in row["suite"]:
             raise Refusal(
                 f"row {i} suite '{row['suite']}' is not target-qualified. It must read "
@@ -1600,9 +1647,11 @@ def main(argv=None):
             suite = f" [{row.get('suite')}]" if row.get("suite") else ""
             fire = f"; must fire: {row['must_fire']}" if row["must_fire"] else ""
             silent = f"; must not fire: {row['must_not_fire']}" if row["must_not_fire"] else ""
+            command = self_test_command(row.get("suite"))
+            invocation = f"; run: {command}" if command else ""
             print(
                 f"  - row {row['_recipe_index']}: {row['label']}{suite}: "
-                f"{row['instruction']}{fire}{silent}"
+                f"{row['instruction']}{fire}{silent}{invocation}"
             )
 
     if args.validate_only:

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1134,11 +1134,12 @@ def load_recipes(path: Path, worktree: Path, raw: str = None):
                     raise Refusal(
                         f"human row {i} suite {row['suite']!r} must be {SELF_TEST_TARGET}/<module>, "
                         f"one module name: it is {self_test_source('<module>')}.")
-                if row["must_fire"] or row["must_not_fire"]:
+                if row["must_fire"] or row["must_not_fire"] or "expect_fail" in row:
                     raise Refusal(
                         f"human row {i} names a {SELF_TEST_TARGET} self-test, which has no "
                         f"addressable test names: `{self_test_command(row['suite'])}` passes or "
-                        "fails as a whole, so must_fire and must_not_fire must be empty.")
+                        "fails as a whole, so must_fire and must_not_fire must be empty and "
+                        "expect_fail is not accepted.")
             row["_must_fire"] = row["must_fire"]
             row["_must_not_fire"] = row["must_not_fire"]
             row["_mode"] = "human"

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -369,6 +369,22 @@ def flag_aliases(tree, flag):
     }
 
 
+def reachable_nodes(tree):
+    """`ast.walk`, minus the branches Python can never enter: the body of `if False:`,
+    `if 0:` or `while False:`, and the else of `if True:`. A recognised check under one of
+    those proves nothing about the command the validator prints, and `ast.walk` visits it
+    anyway (#2672 review, round 2). Only a literal constant test is treated as static; a
+    name or expression is assumed live, since deciding otherwise would need evaluation."""
+    stack = [tree]
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, (ast.If, ast.While)) and isinstance(node.test, ast.Constant):
+            stack.extend(node.body if node.test.value else node.orelse)
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
 def parses_flag(node, flag, aliases=frozenset()):
     """Does this AST node PARSE the flag, rather than merely spell it?
 
@@ -377,8 +393,9 @@ def parses_flag(node, flag, aliases=frozenset()):
     `sys.argv[1:] == ["--self-test"]`, or the same through a module constant bound to
     it), or an argparse registration (`parser.add_argument("--self-test", ...)`). A
     constant anywhere else — an unused module constant, a help string, a print, a
-    docstring, an unreachable branch — is not evidence the module inspects its arguments
-    for it, and the old check accepted every one of those (#2672 review).
+    docstring — is not evidence the module inspects its arguments for it, and the old
+    check accepted every one of those (#2672 review). Unreachable branches are the
+    caller's job: `self_test_problems` feeds this only the nodes `reachable_nodes` yields.
     """
     if isinstance(node, ast.Compare):
         return any(_holds_flag(operand, flag, aliases)
@@ -409,7 +426,8 @@ def self_test_problems(battery, suite, root):
     except SyntaxError as error:
         return [f"self-test target {shown} is not valid Python: {error}"]
     aliases = flag_aliases(tree, battery.SELF_TEST_FLAG)
-    if not any(parses_flag(node, battery.SELF_TEST_FLAG, aliases) for node in ast.walk(tree)):
+    if not any(parses_flag(node, battery.SELF_TEST_FLAG, aliases)
+               for node in reachable_nodes(tree)):
         return [f"self-test target {shown} does not parse {battery.SELF_TEST_FLAG}; "
                 f"`{battery.self_test_command(suite)}` would prove nothing"]
     return []

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -2,6 +2,7 @@
 """Validate mutation recipes against a checkout without running Xcode."""
 
 import argparse
+import ast
 import importlib.util
 import json
 import pathlib
@@ -341,6 +342,37 @@ def missing_test_problem(name, known_names):
     return f"expectation names a test that DOES NOT EXIST: {name!r}"
 
 
+def self_test_problems(battery, suite, root):
+    """Prove a `RuntimeUAT/<module>` target exists and really parses `--self-test`.
+
+    Nothing is executed: wispr_eyes imports Quartz transitively, so running it here would
+    test the host's PyObjC, not the recipe. The module is parsed instead, and the flag must
+    appear as a string the code compares or registers — a docstring that merely mentions
+    `--self-test` (a bare string statement) is not evidence the module answers it.
+    """
+    source = root / battery.self_test_source(battery.self_test_module(suite))
+    shown = source.relative_to(root)
+    if not source.is_file():
+        return [f"self-test target {shown} DOES NOT EXIST"]
+    try:
+        tree = ast.parse(source.read_text(errors="replace"), filename=str(shown))
+    except SyntaxError as error:
+        return [f"self-test target {shown} is not valid Python: {error}"]
+    docstrings = {
+        id(node.value) for node in ast.walk(tree)
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+    }
+    parsed = any(
+        isinstance(node, ast.Constant) and node.value == battery.SELF_TEST_FLAG
+        and id(node) not in docstrings
+        for node in ast.walk(tree)
+    )
+    if not parsed:
+        return [f"self-test target {shown} does not parse {battery.SELF_TEST_FLAG}; "
+                f"`{battery.self_test_command(suite)}` would prove nothing"]
+    return []
+
+
 def validate(recipes, root, label):
     names_by_suite = test_oracle(root)
     battery = load_battery()
@@ -407,7 +439,16 @@ def validate(recipes, root, label):
                             for test_id, aliases in sorted(duplicates.items())
                         ))
 
-            if suite and suite not in names_by_suite:
+            # A `RuntimeUAT/<module>` suite is a Python self-test, not a Swift suite (#2570):
+            # the oracle cannot know it, so it is proved against the checkout instead. The
+            # runner has already refused it on a mechanical row and with test names attached.
+            command = battery.self_test_command(suite)
+            if command:
+                if suite in names_by_suite:
+                    problems.append(
+                        f"suite {suite} is both a Swift suite and a self-test target — ambiguous")
+                problems.extend(self_test_problems(battery, suite, root))
+            elif suite and suite not in names_by_suite:
                 problems.append(f"suite {suite} NOT FOUND in Tests/")
 
             if problems:
@@ -417,7 +458,8 @@ def validate(recipes, root, label):
                 print(f"        {str(row_label)[:90]}")
             else:
                 status = "DEFERRED" if normalized.get("_mode") == "human" else "runnable"
-                print(f"row {index}: {status:<10} | {str(normalized.get('label', ''))[:70]}")
+                run = f" — run: {command}" if command else ""
+                print(f"row {index}: {status:<10} | {str(normalized.get('label', ''))[:70]}{run}")
 
     print(f"\n{label}: {total - bad}/{total} rows runnable"
           + (f", {bad} UNRUNNABLE" if bad else ""))

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -342,13 +342,63 @@ def missing_test_problem(name, known_names):
     return f"expectation names a test that DOES NOT EXIST: {name!r}"
 
 
+def _holds_flag(node, flag, aliases):
+    """Is `node` the flag itself, a module-level name assigned the flag, or a
+    list/tuple/set literal holding either?"""
+    if isinstance(node, ast.Constant):
+        return node.value == flag
+    if isinstance(node, ast.Name):
+        return node.id in aliases
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return any(_holds_flag(item, flag, aliases) for item in node.elts)
+    return False
+
+
+def flag_aliases(tree, flag):
+    """Module-level names bound to the flag by a plain assignment, `FLAG = "--self-test"`,
+    so a module that compares through its own constant is read the same as one that
+    compares the literal. Only the binding is followed; a name that is never compared or
+    registered still proves nothing."""
+    return {
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Constant) and node.value.value == flag
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+
+
+def parses_flag(node, flag, aliases=frozenset()):
+    """Does this AST node PARSE the flag, rather than merely spell it?
+
+    Two shapes count, because they are the ways a module answers the flag: a comparison
+    with it as an operand (`cmd == "--self-test"`, `"--self-test" in sys.argv`,
+    `sys.argv[1:] == ["--self-test"]`, or the same through a module constant bound to
+    it), or an argparse registration (`parser.add_argument("--self-test", ...)`). A
+    constant anywhere else — an unused module constant, a help string, a print, a
+    docstring, an unreachable branch — is not evidence the module inspects its arguments
+    for it, and the old check accepted every one of those (#2672 review).
+    """
+    if isinstance(node, ast.Compare):
+        return any(_holds_flag(operand, flag, aliases)
+                   for operand in [node.left, *node.comparators])
+    if isinstance(node, ast.Call):
+        callee = node.func
+        name = callee.attr if isinstance(callee, ast.Attribute) else getattr(callee, "id", None)
+        return name == "add_argument" and any(
+            _holds_flag(arg, flag, aliases) for arg in node.args)
+    return False
+
+
 def self_test_problems(battery, suite, root):
     """Prove a `RuntimeUAT/<module>` target exists and really parses `--self-test`.
 
     Nothing is executed: wispr_eyes imports Quartz transitively, so running it here would
     test the host's PyObjC, not the recipe. The module is parsed instead, and the flag must
-    appear as a string the code compares or registers — a docstring that merely mentions
-    `--self-test` (a bare string statement) is not evidence the module answers it.
+    be an operand of a comparison or an argument to `add_argument` (see `parses_flag`) —
+    a docstring, a constant, or a help message that merely spells `--self-test` is not
+    evidence the module answers it.
     """
     source = root / battery.self_test_source(battery.self_test_module(suite))
     shown = source.relative_to(root)
@@ -358,16 +408,8 @@ def self_test_problems(battery, suite, root):
         tree = ast.parse(source.read_text(errors="replace"), filename=str(shown))
     except SyntaxError as error:
         return [f"self-test target {shown} is not valid Python: {error}"]
-    docstrings = {
-        id(node.value) for node in ast.walk(tree)
-        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
-    }
-    parsed = any(
-        isinstance(node, ast.Constant) and node.value == battery.SELF_TEST_FLAG
-        and id(node) not in docstrings
-        for node in ast.walk(tree)
-    )
-    if not parsed:
+    aliases = flag_aliases(tree, battery.SELF_TEST_FLAG)
+    if not any(parses_flag(node, battery.SELF_TEST_FLAG, aliases) for node in ast.walk(tree)):
         return [f"self-test target {shown} does not parse {battery.SELF_TEST_FLAG}; "
                 f"`{battery.self_test_command(suite)}` would prove nothing"]
     return []

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -344,13 +344,16 @@ def missing_test_problem(name, known_names):
 
 def _holds_flag(node, flag, aliases):
     """Is `node` the flag itself, a module-level name assigned the flag, or a
-    list/tuple/set literal holding either?"""
+    one-element list/tuple/set literal holding either?"""
     if isinstance(node, ast.Constant):
         return node.value == flag
     if isinstance(node, ast.Name):
         return node.id in aliases
     if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
-        return any(_holds_flag(item, flag, aliases) for item in node.elts)
+        # An aggregate stands for the WHOLE argv tail, and the fixed command supplies
+        # exactly one argument, so `["--verbose", "--self-test"]` is a branch that command
+        # can never enter (#2672 review, round 3). Only a one-element aggregate matches.
+        return len(node.elts) == 1 and _holds_flag(node.elts[0], flag, aliases)
     return False
 
 


### PR DESCRIPTION
## Summary

**Stacked on #2669.** This PR's base is that PR's branch, so the diff here shows only the #2570 change; GitHub retargets it to `main` when #2669 merges. Merge #2669 first. The latest #2669 commit (c446373) is merged into this branch.

The mutation-recipe format supports `mode: human`, but the validator required every human row's `suite` to resolve to a Swift suite under `Tests/`. A truthful recipe for `Tests/RuntimeUAT/wispr_eyes.py --self-test` was impossible to validate: a blank suite is refused, `RuntimeUAT/wispr_eyes` was refused because the oracle only indexes Swift, and naming an unrelated Swift suite would have produced a green result that proves nothing. This blocked #2511 at plan review.

Closes #2570.

`Tier: SMALL | Lane: Docs/dev-tooling | Modules: scripts`

## The contract

No new field. A human row's `suite` may be `RuntimeUAT/<module>`, and that namespace means exactly one command, `python3 Tests/RuntimeUAT/<module>.py --self-test`, the same way `EnviousWisprTests/Foo` means exactly one `-only-testing:` filter. The command is a function of the suite, never a string an author fills from prose.

```json
{"mode": "human", "label": "break the single-instance guard",
 "instruction": "Drop the `if pid == me` filter, then run the self-test.",
 "suite": "RuntimeUAT/wispr_eyes"}
```

Validator output: `row 1: DEFERRED   | break the single-instance guard — run: python3 Tests/RuntimeUAT/wispr_eyes.py --self-test`. The runner's deferral line prints the same command. The row fits the existing Markdown table unchanged.

## Changes

- `scripts/mutation-battery.py` (owner of the format): `SELF_TEST_TARGET`, `self_test_module`, `self_test_source`, `self_test_command`; schema refusals for a module that is not one identifier, for `must_fire`/`must_not_fire` on such a row (the whole exit code is the verdict, so there are no addressable test names), and for the namespace on a mechanical row; a RECIPE FORMAT docstring paragraph; the deferral line prints the command.
- `scripts/validate-mutation-recipe.py`: for a `RuntimeUAT/<module>` suite, prove the module file exists, `ast.parse`s, and PARSES `--self-test`: the flag must be an operand of a comparison (`cmd == "--self-test"`, `"--self-test" in sys.argv`, `sys.argv[1:] == ["--self-test"]`, or any of those through a module-level constant bound to the literal) or an argument to `add_argument`, in a branch Python can reach. A constant that is only assigned, printed or in a docstring is refused (Codex P2, 2198c66), and so is a recognised check under `if False:`, `if 0:`, `while False:` or the else of `if True:` (Codex P2 round 2, cae0895); only a literal constant test is treated as static. Nothing is executed: `wispr_eyes` imports Quartz transitively, so running it here would test the host's PyObjC, not the recipe. A suite that is both a Swift suite and a self-test target is refused as ambiguous. Existing Swift rows and their fail-closed test-name checks are untouched.
- `scripts/mutation-battery-test.py`: ten two-way cases from the first commit (two runner-side, eight validator-side): a real Python target validates; a missing module, a module that does not parse the flag (`ui_helpers`), a nested path, test names on the row, and a mechanical row are each refused with a message naming the fault. Fifteen more exercise `self_test_problems` directly on throwaway modules: the accepted shapes, the refused spellings, three dead branches refused, and the live else of `if False:` and a check under an unevaluable name accepted.

Probing every module under `Tests/RuntimeUAT` with the parse check finds exactly `wispr_eyes`, `ptt_binding` and `faultInjection`, and nothing else, before and after both fixes.

## Rejected alternatives

- An explicit `command` string field: redundant with the suite, needs shell parsing plus a suite/command consistency check, cannot verify positional args, and forces a tenth column onto the strict Markdown header.
- A `self_test: true` boolean: repeats what the target segment already says.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — N/A, no Swift touched
- [x] Logic tests pass locally — before: the positive row was `UNRUNNABLE — suite RuntimeUAT/wispr_eyes NOT FOUND in Tests/`. After: `python3 scripts/mutation-battery-test.py` all 212 cases pass (187 from #2669 plus 25). `scripts/check-validation.sh --self-test`: 6 passed, 0 failed.
- [ ] CI `build-check` status is green — the PR Check workflow does not trigger on a PR whose base is not `main`; it runs once this retargets after #2669 merges.

### Behavioral Testing (Local UAT)
- N/A, no app code changed

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval
- N/A

### Review
- [x] Codex P2 (any constant counted as parsing the flag): fixed in 2198c66, thread resolved
- [x] Codex P2 round 2 (a check under a dead branch counted): fixed in cae0895, thread resolved

### Release Housekeeping
- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM