### PR TITLE
test(eval): mutate the rubric-equivalence guards, and bind the one axis nothing reached (#2577)

### DIFF
--- a/scripts/eval/behavior_judge_test.py
+++ b/scripts/eval/behavior_judge_test.py
@@ -3052,7 +3052,40 @@ def test_floor_cli_reports_the_real_sealed_floor():
     assert "--adjudication" in err and "--production" in err, err
 
 
-EXPECTED_TESTS = 140
+def test_floor_compares_blinding_exactly():
+    # #2577 row 4. `comparable()` checks `evaluation.get("judgeBlind") == blind`
+    # EXACTLY, and the comment beside it says why: `bool(None) == bool(False)`, so a
+    # truthy comparison makes an evaluation whose receipt never recorded blinding
+    # compare as SIGHTED, and twelve of the evaluations on record are exactly that.
+    # None of the four #2576 tests reaches this line, so a mutation to
+    # `bool(...) == bool(...)` survived the whole suite. Driven against the REAL
+    # registry: the 1.2 winner's rows all record `judgeBlind: false`, so the
+    # sighted query finds the 31 floor and the "unknown blinding" query finds
+    # nothing. Under the truthy mutant both queries answer 31.
+    import model_registry
+    doc = model_registry.load()
+    query = dict(corpus="sealed_v1.jsonl", rubric="626d3a1c5219",
+                 judge="azure/gpt-5-6-luna@d9697a344ff6", cases=1462, doc=doc,
+                 system="new", adjudication="0.15:15",
+                 production="sealed_shipped.jsonl")
+
+    count, where = model_registry.floor(blind=False, **query)
+    assert count == 31 and where.startswith("eg1-1.2-c003 "), (count, where)
+
+    # The control that makes the None answer meaningful: the row that set the 31
+    # floor RECORDED its blinding as False. If it ever recorded nothing, the query
+    # below would be asking a different question and this test must say so.
+    winner = next(a for a in doc["artifacts"] if a["artifactId"] == "eg1-1.2-c003")
+    recorded = [e.get("judgeBlind") for e in winner["evaluations"]
+                if model_registry.comparable(e, blind=False, **query)]
+    assert recorded and all(r is False for r in recorded), recorded
+
+    count, why = model_registry.floor(blind=None, **query)
+    assert count is None, f"unknown blinding matched a sighted evaluation: {count} ({why})"
+    assert "blind=no" in why, why
+
+
+EXPECTED_TESTS = 141
 
 
 def _run() -> int:


### PR DESCRIPTION
## Summary

**Stacked on #2667.** This PR's base is that PR's branch (both edit `behavior_judge_test.py` and its `EXPECTED_TESTS` count), so the diff here shows only the #2577 change; GitHub retargets it to `main` when #2667 merges. Merge #2667 first.

#2577 asked for the four rubric-equivalence guard tests from #2576 to be mutated by hand (they are Python, so the Swift battery does not apply) and named one gap: nothing covered the exact-blinding comparison in `comparable()`. This PR adds the missing test and records the measured outcome of all four rows.

Closes #2577.

`Tier: SMALL | Lane: Eval-harness | Modules: scripts/eval`

## The new test

`test_floor_compares_blinding_exactly` drives `floor()` against the real checked-in registry with the axes that set the 1.2 floor (`sealed_v1.jsonl`, 1462 cases, rubric `626d3a1c5219`, judge `azure/gpt-5-6-luna@d9697a344ff6`, system `new`, adjudication `0.15:15`, production `sealed_shipped.jsonl`). `blind=False` returns 31 from `eg1-1.2-c003`; `blind=None` returns `None`. A control asserts every comparable row on that winner recorded `judgeBlind: false` explicitly, so the `None` answer is a refusal to match a known value rather than a missing-field accident. Under the row-4 mutant (`bool(...) == bool(...)`) both queries answer 31, so the test goes red. `EXPECTED_TESTS` 140 → 141.

## Measured mutation results

Each row: anchor replaced after confirming it occurs exactly once, full suite run with the repo's own runner, file restored with `git checkout --` and `git diff --stat` confirmed clean before the next row. Baseline before and after every row: 140 passed, 1 failed (141 total), the one failure being the pre-existing shell quarantine case.

| Row | Mutation | Named test | Went red? | Other new reds |
|---|---|---|---|---|
| 1 | connectedness check → `if False:` | `test_registry_refuses_a_group_with_no_connection_to_history` | yes | none |
| 2 | `any(...)` → `all(...)` | `test_registry_survives_an_ordinary_edit_to_the_scorer` | yes | none |
| 3 | hexdigest `[:12]` → `[:11]` | `test_live_rubric_identity_matches_the_scorer` | yes | `test_check_live_reports_the_recorded_identity`, `test_registry_survives_an_ordinary_edit_to_the_scorer` (both consume `live_rubric_identity()` downstream; expected collateral) |
| 4 | `== blind` → `bool(..) == bool(..)` | `test_floor_compares_blinding_exactly` (new) | yes | none |

Row 2 is the one worth noting: on the checked-in registry the `all` mutant still loads, because both group members are stamped or live, so only the simulated-scorer-edit test can see it. That is exactly the time bomb it was written for.

## Where the evidence lives

No on-disk convention exists for Python mutation outcomes: the battery and validator are a Swift-only lane, and past test-hardening commits record measured results in the commit body with the recipe frozen in the issue. This PR does the same; the table above is in the commit body. If a checked-in location is wanted, that is a decision for the founder rather than one to invent here. No Python lane was taught to the battery.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — N/A, no Swift touched
- [x] Logic tests pass locally — `python3 scripts/eval/behavior_judge_test.py`: 140 passed, 1 failed (141 total); the failure is the known quarantine case, identical on `main`. Run twice, once independently.
- [ ] CI `build-check` status is green

### Behavioral Testing (Local UAT)
- N/A

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval (touches `scripts/eval/`)
- [ ] `polish-eval-smoke` CI check is green
- [x] Swift → Python sync: N/A, tests only
- [x] No new polish capability, no baseline change

### Release Housekeeping
- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM

---
_Generated by [Claude Code](https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM)_