### PR TITLE
fix(uat): park and restore the language-chip state keys structurally, not from printed text (#2579)

### DIFF
--- a/Tests/RuntimeUAT/defaults_store.py
+++ b/Tests/RuntimeUAT/defaults_store.py
@@ -53,19 +53,22 @@ equal to the list `["a"]`, and a mangled restore reads as dirty instead of clean
 
 **Why the import carries the whole domain and not only the parked keys.** The
 man page does not say whether `defaults import` merges its keys into the domain
-or REPLACES the domain with them, and the first draft of this module assumed
-merge. Under replace semantics that draft would have deleted every unrelated
-preference in the developer's dev domain on each language-hover run, and
-`check_plist` would still have reported a clean restore because it looks only
-at the parked keys (cloud review on #2674). Overlaying the parked keys onto a
-fresh export is correct under EITHER semantics: merge makes the unchanged keys
-a no-op, replace puts them back as they were. The export is taken at restore
-time rather than reused from the snapshot for the reason the old draft gave
-for importing less: a live instance may write unrelated keys between the
-snapshot and the restore, and this module must not revert them. The control
-test asserts the bystander's survival with a key written AFTER the snapshot,
-so it proves the property the harness relies on rather than the one that
-happened to hold.
+or REPLACES the domain with them. Measured on macOS on 2026-09-05: it MERGES
+(a bystander survived an import of a plist holding only the parked keys). The
+first draft relied on that without stating it as a measurement, and a review
+read it the other way; rather than argue from an undocumented behaviour, the
+restore now overlays the parked keys onto a fresh export of the domain, which
+is correct under EITHER semantics: merge makes the unchanged keys a no-op,
+replace would put them back as they were. The cost is a few milliseconds
+between the export and the import during which a write by a live instance
+could be re-covered by the export; the old draft had no such window but had
+the undocumented assumption instead. The export is taken at restore time
+rather than reused from the snapshot for the reason the old draft gave for
+importing less: a live instance may write unrelated keys between the snapshot
+and the restore, and this module must not revert them. The control test
+asserts the bystander's survival with a key written AFTER the snapshot, so it
+proves the property the harness relies on rather than the one that happened
+to hold.
 
 Control test: `test_defaults_store.py`, which round-trips every type on a
 throwaway domain and asserts the type SURVIVES, not merely the printed text.
@@ -189,13 +192,24 @@ def export_domain(domain):
     """Every key in the domain as parsed plist values, `{}` when it has none.
 
     `defaults export <domain> -` writes an XML plist to stdout. A domain that
-    does not exist yet is reported the same way `read_typed` reports an absent
-    key: as nothing there, so a first run on a fresh install parks `None` and
-    restores by deleting.
+    does not exist yet EXITS 0 with an empty `<dict/>` (measured on macOS,
+    2026-09-05), so it parses to `{}` and is reported the same way `read_typed`
+    reports an absent key: as nothing there, and a first run on a fresh install
+    parks `None` and restores by deleting.
+
+    A non-zero exit is therefore never "no keys"; it is `defaults` failing to
+    answer, and it RAISES. The first draft returned `{}` there, which turned
+    "I could not ask" into "the domain is empty": `snapshot_plist` would have
+    parked `None` for keys that were really present, and `restore_plist` would
+    then have DELETED them on the developer's own machine with every check
+    green -- the silent-empty shape `validation-discipline.md` tabulates
+    (cloud review on #2674).
     """
     got = subprocess.run(["defaults", "export", domain, "-"], capture_output=True)
-    if got.returncode != 0 or not got.stdout.strip():
-        return {}
+    if got.returncode != 0:
+        raise RuntimeError(
+            f"defaults export {domain} failed (exit {got.returncode}): "
+            f"{got.stderr.decode(errors='replace').strip()}")
     return plistlib.loads(got.stdout)
 
 

--- a/Tests/RuntimeUAT/defaults_store.py
+++ b/Tests/RuntimeUAT/defaults_store.py
@@ -45,19 +45,27 @@ survives a trip through printed text.
 The plist path (`snapshot_plist` / `restore_plist`) never goes through text.
 It reads the whole domain with `defaults export <domain> -` (XML plist on
 stdout), parses it with `plistlib`, and keeps the Python VALUE -- `bytes`,
-`list`, `dict`, nested or not. Restore writes a plist holding ONLY the parked
-keys and hands it to `defaults import <domain> <file>`, then re-exports and
-compares the parsed values with `==`. So the check is structural: a string
-`"(\n a\n)"` is not equal to the list `["a"]`, and a mangled restore reads as
-dirty instead of clean.
+`list`, `dict`, nested or not. Restore re-exports the domain AS IT IS AT THAT
+MOMENT, overlays the parked keys on that copy, hands the whole thing to
+`defaults import <domain> <file>`, then re-exports and compares the parsed
+values with `==`. So the check is structural: a string `"(\n a\n)"` is not
+equal to the list `["a"]`, and a mangled restore reads as dirty instead of clean.
 
-**Assumption, stated because the man page does not:** `defaults import` MERGES
-the plist's keys into the domain and leaves every other key alone. That is the
-documented shape of `CFPreferencesSetMultiple`, which is what `import` wraps, and
-the control test asserts it directly with a bystander key rather than trusting
-this paragraph. Importing only the parked keys, rather than the whole exported
-domain, is deliberate: a live instance may write unrelated keys between the
-snapshot and the restore, and this module must not revert them.
+**Why the import carries the whole domain and not only the parked keys.** The
+man page does not say whether `defaults import` merges its keys into the domain
+or REPLACES the domain with them, and the first draft of this module assumed
+merge. Under replace semantics that draft would have deleted every unrelated
+preference in the developer's dev domain on each language-hover run, and
+`check_plist` would still have reported a clean restore because it looks only
+at the parked keys (cloud review on #2674). Overlaying the parked keys onto a
+fresh export is correct under EITHER semantics: merge makes the unchanged keys
+a no-op, replace puts them back as they were. The export is taken at restore
+time rather than reused from the snapshot for the reason the old draft gave
+for importing less: a live instance may write unrelated keys between the
+snapshot and the restore, and this module must not revert them. The control
+test asserts the bystander's survival with a key written AFTER the snapshot,
+so it proves the property the harness relies on rather than the one that
+happened to hold.
 
 Control test: `test_defaults_store.py`, which round-trips every type on a
 throwaway domain and asserts the type SURVIVES, not merely the printed text.
@@ -223,17 +231,22 @@ def restore_plist(domain, snap):
 
     Absent keys are DELETED, not written as an empty container -- an empty
     `Data` is a decodable JSON failure to the presenter, not the fresh-install
-    state it had. Present keys go back through ONE `defaults import` of a plist
-    holding only those keys (merge semantics; see the module docstring).
+    state it had. Present keys go back through ONE `defaults import` of the
+    domain as it stands right now with the parked keys overlaid, so every key
+    this module was not asked about keeps its current value whether `import`
+    merges or replaces (see the module docstring).
     """
     present = {k: v for k, v in snap.items() if v is not None}
     for key in snap:
         if key not in present:
             subprocess.run(["defaults", "delete", domain, key], capture_output=True)
     if present:
+        # Exported AFTER the deletes, so an absent key does not ride back in.
+        merged = export_domain(domain)
+        merged.update(present)
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "restore.plist")
             with open(path, "wb") as fh:
-                plistlib.dump(present, fh)
+                plistlib.dump(merged, fh)
             subprocess.run(["defaults", "import", domain, path], check=True)
     return check_plist(domain, snap)

--- a/Tests/RuntimeUAT/defaults_store.py
+++ b/Tests/RuntimeUAT/defaults_store.py
@@ -32,15 +32,16 @@ cannot be put back through `defaults write` at all -- and that is exactly what
 `phase5_language_hover.py` used to do (#2579). It parked
 `languageChipSuppressedLanguages` and `languageChipDismissalCounts` from
 `defaults read`'s printed text and handed that text back to `defaults write` as
-one positional argument, which stores a STRING (or an old-style-plist dictionary)
-where the original value was. The restore check compared the same printed text
-on both sides, so it could not see the difference.
+one positional argument. Measured on macOS 26.7 (2026-09-05): for a `Data` value
+`defaults write` REFUSES the `{length = N, bytes = ...}` text (exit 1), so the
+driven value simply stays where the original was. The restore check compared the
+same printed text on both sides, so it could not see the difference.
 
 Those two keys are JSON-encoded `Data` on disk (`LanguageSuggestionPresenter
 .persistState` writes `JSONEncoder` output with `defaults.set(data, forKey:)`),
 so `defaults read` prints `{length = N, bytes = 0x...}` and `read-type` says
 `data`; logically they hold a list and a dictionary. Either way the value never
-survives a trip through printed text.
+comes back from its printed text.
 
 The plist path (`snapshot_plist` / `restore_plist`) never goes through text.
 It reads the whole domain with `defaults export <domain> -` (XML plist on

--- a/Tests/RuntimeUAT/defaults_store.py
+++ b/Tests/RuntimeUAT/defaults_store.py
@@ -23,18 +23,50 @@ after it bit the founder's own `escapeRecoveryEnabled` on 2026-08-19. That
 harness is the prior art and this module is its generalisation, so the three that
 lacked it were the outliers rather than the norm.
 
-**Known and NOT handled, stated rather than hidden:**
-`phase5_language_hover.py` parks two keys that hold an array and a dictionary and
-restores them from `defaults read`'s printed text, which cannot round-trip either
-type. That is the same class and a different mechanism -- it needs a plist
-export/import, not a type flag -- so this module REFUSES those types loudly
-(`UnsupportedType`) rather than appearing to cover them.
+**Two paths, chosen by what the value IS, and the typed path is unchanged.**
 
-Control test: `test_defaults_store.py`, which round-trips both types on a
+The typed path above (`snapshot` / `restore`) covers the four scalar types that
+have a single-token `defaults write` form. It REFUSES anything else
+(`UnsupportedType`) rather than guessing, because a value that has no such form
+cannot be put back through `defaults write` at all -- and that is exactly what
+`phase5_language_hover.py` used to do (#2579). It parked
+`languageChipSuppressedLanguages` and `languageChipDismissalCounts` from
+`defaults read`'s printed text and handed that text back to `defaults write` as
+one positional argument, which stores a STRING (or an old-style-plist dictionary)
+where the original value was. The restore check compared the same printed text
+on both sides, so it could not see the difference.
+
+Those two keys are JSON-encoded `Data` on disk (`LanguageSuggestionPresenter
+.persistState` writes `JSONEncoder` output with `defaults.set(data, forKey:)`),
+so `defaults read` prints `{length = N, bytes = 0x...}` and `read-type` says
+`data`; logically they hold a list and a dictionary. Either way the value never
+survives a trip through printed text.
+
+The plist path (`snapshot_plist` / `restore_plist`) never goes through text.
+It reads the whole domain with `defaults export <domain> -` (XML plist on
+stdout), parses it with `plistlib`, and keeps the Python VALUE -- `bytes`,
+`list`, `dict`, nested or not. Restore writes a plist holding ONLY the parked
+keys and hands it to `defaults import <domain> <file>`, then re-exports and
+compares the parsed values with `==`. So the check is structural: a string
+`"(\n a\n)"` is not equal to the list `["a"]`, and a mangled restore reads as
+dirty instead of clean.
+
+**Assumption, stated because the man page does not:** `defaults import` MERGES
+the plist's keys into the domain and leaves every other key alone. That is the
+documented shape of `CFPreferencesSetMultiple`, which is what `import` wraps, and
+the control test asserts it directly with a bystander key rather than trusting
+this paragraph. Importing only the parked keys, rather than the whole exported
+domain, is deliberate: a live instance may write unrelated keys between the
+snapshot and the restore, and this module must not revert them.
+
+Control test: `test_defaults_store.py`, which round-trips every type on a
 throwaway domain and asserts the type SURVIVES, not merely the printed text.
 """
 
+import os
+import plistlib
 import subprocess
+import tempfile
 
 # `defaults read-type` wording -> the flag `defaults write` needs for it.
 _TYPE_FLAG = {
@@ -139,3 +171,69 @@ def restore_multi(domain_of, snap):
         write_typed(domain, key, text, flag)
         landed[key] = read_typed(domain, key) == want
     return landed
+
+
+# ---------------------------------------------------------------------------
+# The plist path: values that have no `defaults write` form (#2579).
+# ---------------------------------------------------------------------------
+
+def export_domain(domain):
+    """Every key in the domain as parsed plist values, `{}` when it has none.
+
+    `defaults export <domain> -` writes an XML plist to stdout. A domain that
+    does not exist yet is reported the same way `read_typed` reports an absent
+    key: as nothing there, so a first run on a fresh install parks `None` and
+    restores by deleting.
+    """
+    got = subprocess.run(["defaults", "export", domain, "-"], capture_output=True)
+    if got.returncode != 0 or not got.stdout.strip():
+        return {}
+    return plistlib.loads(got.stdout)
+
+
+def read_plist(domain, key):
+    """The stored value of one key as a Python object, or `None` when absent.
+
+    A `data` value comes back as `bytes`, an array as `list`, a dictionary as
+    `dict`, nested as stored. Nothing here is text, so nothing here can be
+    compared as text.
+    """
+    return export_domain(domain).get(key)
+
+
+def snapshot_plist(domain, keys):
+    """What the machine holds now: `{key: value or None}`, structurally."""
+    values = export_domain(domain)
+    return {k: values.get(k) for k in keys}
+
+
+def check_plist(domain, snap):
+    """`{key: bool}`: does each key hold EXACTLY the snapshotted value now?
+
+    Parsed-value equality, so an array restored as the string `defaults read`
+    printed for it is reported as NOT landed. Exposed on its own so a harness,
+    or the control test, can ask the question without performing a restore.
+    """
+    values = export_domain(domain)
+    return {k: values.get(k) == want for k, want in snap.items()}
+
+
+def restore_plist(domain, snap):
+    """Put every key back exactly as it was, and SAY whether each one landed.
+
+    Absent keys are DELETED, not written as an empty container -- an empty
+    `Data` is a decodable JSON failure to the presenter, not the fresh-install
+    state it had. Present keys go back through ONE `defaults import` of a plist
+    holding only those keys (merge semantics; see the module docstring).
+    """
+    present = {k: v for k, v in snap.items() if v is not None}
+    for key in snap:
+        if key not in present:
+            subprocess.run(["defaults", "delete", domain, key], capture_output=True)
+    if present:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "restore.plist")
+            with open(path, "wb") as fh:
+                plistlib.dump(present, fh)
+            subprocess.run(["defaults", "import", domain, path], check=True)
+    return check_plist(domain, snap)

--- a/Tests/RuntimeUAT/defaults_store.py
+++ b/Tests/RuntimeUAT/defaults_store.py
@@ -230,15 +230,43 @@ def snapshot_plist(domain, keys):
     return {k: values.get(k) for k in keys}
 
 
+def same_plist_value(got, want):
+    """`==` PLUS the exact type, recursively. `True`, `1` and `1.0` are three.
+
+    Python equality alone would call all three equal, so a restore that put an
+    integer where a boolean was would read as clean -- the check reporting a
+    pass for the class of defect it exists to catch (cloud review on #2674).
+    `bool` is its own type in Python, so `type(...) is type(...)` separates it
+    from `int` without a special case; a `list` compares element by element and
+    a `dict` key by key, because a container's mangling lives inside it.
+    """
+    if type(got) is not type(want):
+        return False
+    if isinstance(want, list):
+        return len(got) == len(want) and all(
+            same_plist_value(g, w) for g, w in zip(got, want))
+    if isinstance(want, dict):
+        return got.keys() == want.keys() and all(
+            same_plist_value(got[k], want[k]) for k in want)
+    return got == want
+
+
 def check_plist(domain, snap):
     """`{key: bool}`: does each key hold EXACTLY the snapshotted value now?
 
-    Parsed-value equality, so an array restored as the string `defaults read`
-    printed for it is reported as NOT landed. Exposed on its own so a harness,
-    or the control test, can ask the question without performing a restore.
+    Parsed-value equality AND type, so an array restored as the string
+    `defaults read` printed for it is reported as NOT landed, and so is a
+    boolean restored as the integer that prints identically. Exposed on its own
+    so a harness, or the control test, can ask the question without performing
+    a restore.
     """
     values = export_domain(domain)
-    return {k: values.get(k) == want for k, want in snap.items()}
+    absent = object()
+    return {
+        k: (want is None and values.get(k, absent) is absent)
+        or (want is not None and same_plist_value(values.get(k, absent), want))
+        for k, want in snap.items()
+    }
 
 
 def restore_plist(domain, snap):

--- a/Tests/RuntimeUAT/phase5_language_hover.py
+++ b/Tests/RuntimeUAT/phase5_language_hover.py
@@ -31,10 +31,10 @@ chip and the row would read as the dwell being broken.
 **Both are parked and restored STRUCTURALLY, never through printed text (#2579).**
 They are JSON-encoded `Data` on disk (`LanguageSuggestionPresenter.persistState`),
 logically a list and a dictionary. `defaults read` prints such a value as a
-multi-line blob, and handing that blob back to `defaults write` as one argument
-stores something else entirely — so a run that began with either key populated
-never put it back, and `restore_clean` could not see it because it compared the
-same printed text on both sides. Owner: `defaults_store`'s plist path, which goes
+`{length = N, bytes = ...}` blob, and `defaults write` refuses that blob as an
+argument (measured on macOS 26.7, 2026-09-05) — so a run that began with either
+key populated never put it back, and `restore_clean` could not see it because it
+compared the same printed text on both sides. Owner: `defaults_store`'s plist path, which goes
 through `defaults export` / `defaults import` and compares parsed values.
 
 **THE LANGUAGE CHIP IS UNREACHABLE ON PARAKEET, AND NOTHING SAYS SO.**

--- a/Tests/RuntimeUAT/phase5_language_hover.py
+++ b/Tests/RuntimeUAT/phase5_language_hover.py
@@ -24,9 +24,18 @@ dictating Spanish with the language mode on Auto — which is also the only way 
 prove the production trigger still reaches the new clock.
 
 The presenter persists a suppression set and dismissal counts
-(`languageChipSuppressedLanguages`), so both are snapshotted and restored; a
-language suppressed by an earlier run produces no chip and the row would read as
-the dwell being broken.
+(`languageChipSuppressedLanguages`, `languageChipDismissalCounts`), so both are
+snapshotted and restored; a language suppressed by an earlier run produces no
+chip and the row would read as the dwell being broken.
+
+**Both are parked and restored STRUCTURALLY, never through printed text (#2579).**
+They are JSON-encoded `Data` on disk (`LanguageSuggestionPresenter.persistState`),
+logically a list and a dictionary. `defaults read` prints such a value as a
+multi-line blob, and handing that blob back to `defaults write` as one argument
+stores something else entirely — so a run that began with either key populated
+never put it back, and `restore_clean` could not see it because it compared the
+same printed text on both sides. Owner: `defaults_store`'s plist path, which goes
+through `defaults export` / `defaults import` and compares parsed values.
 
 **THE LANGUAGE CHIP IS UNREACHABLE ON PARAKEET, AND NOTHING SAYS SO.**
 `languageDetector.detect(...)` has exactly ONE caller in the tree,
@@ -61,6 +70,7 @@ import time
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
+import defaults_store as ds  # noqa: E402  (structural park-and-restore)
 import phase5_geometry_relaunch as g  # noqa: E402
 import phase5_paste_target as pt  # noqa: E402
 import wispr_eyes as rk  # noqa: E402  (record-key helpers; merged in #2425)
@@ -167,9 +177,21 @@ def backend_in_use(since_bytes):
     return seen[-1].split("Backend:")[1].split(",")[0].strip()
 
 
-def read_dev(k):
-    r = subprocess.run(["defaults", "read", DEV_DOMAIN, k], capture_output=True, text=True)
-    return r.stdout.strip() if r.returncode == 0 else None
+def readable(value):
+    """The parked value as the artifact should show it.
+
+    The two state keys are JSON bytes; decoded they are the list and the
+    dictionary the presenter holds, which is what a reader of the report wants
+    to see. Only the REPORT goes through this — the restore and its check work
+    on the parsed plist value itself, so a decode here can never make a dirty
+    restore look clean.
+    """
+    if isinstance(value, bytes):
+        try:
+            return json.loads(value.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError):
+            return {"undecodable_bytes_hex": value.hex()}
+    return value
 
 
 def dictate(audio):
@@ -278,11 +300,12 @@ def main():
         return
     pid = pids[0]
 
-    snapshot = {k: read_dev(k) for k in STATE_KEYS}
+    # STRUCTURE, not printed text. See the module docstring and #2579.
+    snapshot = ds.snapshot_plist(DEV_DOMAIN, STATE_KEYS)
     backend_before = subprocess.run(["defaults", "read", SHARED_DOMAIN, "selectedBackend"],
                                     capture_output=True, text=True).stdout.strip() or None
-    report = {"pid": pid, "snapshot": snapshot, "dwell_seconds": CHIP_DWELL,
-              "backend_before": backend_before}
+    report = {"pid": pid, "snapshot": {k: readable(v) for k, v in snapshot.items()},
+              "dwell_seconds": CHIP_DWELL, "backend_before": backend_before}
     try:
         for k in STATE_KEYS:
             subprocess.run(["defaults", "delete", DEV_DOMAIN, k], capture_output=True)
@@ -350,13 +373,14 @@ def main():
         report["backend_restored"] = subprocess.run(
             ["defaults", "read", SHARED_DOMAIN, "selectedBackend"],
             capture_output=True, text=True).stdout.strip() or None
-        for k, v in snapshot.items():
-            if v is None:
-                subprocess.run(["defaults", "delete", DEV_DOMAIN, k], capture_output=True)
-            else:
-                subprocess.run(["defaults", "write", DEV_DOMAIN, k, v], check=True)
-        report["restored"] = {k: read_dev(k) for k in STATE_KEYS}
-        report["restore_clean"] = report["restored"] == snapshot
+        # An absent key is DELETED, a present one goes back through `defaults
+        # import` as the same plist value, and `landed` is parsed-value equality
+        # — a check that can actually fail, unlike the printed-text comparison
+        # this replaced.
+        landed = ds.restore_plist(DEV_DOMAIN, snapshot)
+        report["restored"] = {k: readable(ds.read_plist(DEV_DOMAIN, k)) for k in STATE_KEYS}
+        report["restore_clean"] = all(landed.values())
+        report["restore_failed_keys"] = [k for k, good in landed.items() if not good]
         (UAT / "language-hover.json").write_text(json.dumps(report, indent=2, default=str))
         print(json.dumps(report, indent=2, default=str))
 

--- a/Tests/RuntimeUAT/test_defaults_store.py
+++ b/Tests/RuntimeUAT/test_defaults_store.py
@@ -141,6 +141,26 @@ def main():
         ok("and it is the original bytes", ds.read_plist(DOMAIN, "d") == b'["es"]',
            repr(ds.read_plist(DOMAIN, "d")))
 
+        print("\nan INTEGER standing where a BOOLEAN was is reported as NOT landed")
+        # Python calls `True`, `1` and `1.0` equal, so a value-only check would
+        # report a pass for the class of defect this check exists to catch. Every
+        # row here FAILS under a plain `==` and passes under the typed compare.
+        subprocess.run(["defaults", "write", DOMAIN, "flag", "-bool", "true"], check=True)
+        subprocess.run(["defaults", "write", DOMAIN, "row", "-array", "-bool", "true"], check=True)
+        typed = ds.snapshot_plist(DOMAIN, ["flag", "row"])
+        ok("precondition: the snapshot holds real booleans",
+           typed == {"flag": True, "row": [True]}, repr(typed))
+        subprocess.run(["defaults", "write", DOMAIN, "flag", "-int", "1"], check=True)
+        subprocess.run(["defaults", "write", DOMAIN, "row", "-array", "-int", "1"], check=True)
+        swapped = ds.check_plist(DOMAIN, typed)
+        ok("an integer in place of a boolean is caught", swapped["flag"] is False,
+           repr(ds.read_plist(DOMAIN, "flag")))
+        ok("an integer INSIDE an array is caught too", swapped["row"] is False,
+           repr(ds.read_plist(DOMAIN, "row")))
+        ok("and a real restore puts both booleans back",
+           all(ds.restore_plist(DOMAIN, typed).values()))
+        ok("the boolean is a boolean again", read_type("flag") == "boolean", read_type("flag"))
+
         print("\na domain that does not exist exports as EMPTY, and is not mistaken for a failure")
         # `defaults export` on a missing domain exits 0 with an empty <dict/>. That is the
         # only way `{}` may come back: a non-zero exit RAISES, because returning `{}` there

--- a/Tests/RuntimeUAT/test_defaults_store.py
+++ b/Tests/RuntimeUAT/test_defaults_store.py
@@ -118,19 +118,28 @@ def main():
            ds.read_plist(DOMAIN, "keep") == 7, repr(ds.read_plist(DOMAIN, "keep")))
         ok("the bystander is still an integer", read_type("keep") == "integer", read_type("keep"))
 
-        print("\na restore from PRINTED text is reported as NOT clean")
+        print("\na restore from PRINTED text does not land, and the check says so")
         # Exactly what phase5_language_hover.py did before #2579: `defaults read`,
         # then the printed blob back through `defaults write` as one argument.
-        for k in ("arr", "d"):
-            blob = subprocess.run(["defaults", "read", DOMAIN, k],
-                                  capture_output=True, text=True).stdout.strip()
-            subprocess.run(["defaults", "write", DOMAIN, k, blob], check=True)
+        # Measured on macOS 26.7 (2026-09-05): for DATA, the on-disk type of both
+        # language-chip keys, `defaults write` REFUSES the `{length = N, bytes = ...}`
+        # text (exit 1, "Could not parse"), so the driven value simply stays. The
+        # printed text of an ARRAY or a DICTIONARY happens to parse back on this
+        # macOS; that is a property of `defaults`, not of the harness, and it is not
+        # asserted either way here.
+        blob = subprocess.run(["defaults", "read", DOMAIN, "d"],
+                              capture_output=True, text=True).stdout.strip()
+        subprocess.run(["defaults", "write", DOMAIN, "d", "-data", "5b226672225d"], check=True)
+        refused = subprocess.run(["defaults", "write", DOMAIN, "d", blob], capture_output=True)
+        ok("the printed-text write of DATA is refused", refused.returncode != 0, refused.returncode)
         checked = ds.check_plist(DOMAIN, snap)
-        ok("the mangled array is caught", checked["arr"] is False, repr(ds.read_plist(DOMAIN, "arr")))
-        ok("the mangled data is caught", checked["d"] is False, repr(ds.read_plist(DOMAIN, "d")))
+        ok("the un-restored data is caught", checked["d"] is False, repr(ds.read_plist(DOMAIN, "d")))
+        ok("the untouched array still reads clean", checked["arr"] is True)
         ok("the untouched dictionary still reads clean", checked["dct"] is True)
         landed = ds.restore_plist(DOMAIN, snap)
-        ok("a real restore repairs the mangling", all(landed.values()), repr(landed))
+        ok("a real restore puts the data back", all(landed.values()), repr(landed))
+        ok("and it is the original bytes", ds.read_plist(DOMAIN, "d") == b'["es"]',
+           repr(ds.read_plist(DOMAIN, "d")))
 
         print("\na domain that does not exist exports as EMPTY, and is not mistaken for a failure")
         # `defaults export` on a missing domain exits 0 with an empty <dict/>. That is the

--- a/Tests/RuntimeUAT/test_defaults_store.py
+++ b/Tests/RuntimeUAT/test_defaults_store.py
@@ -11,7 +11,8 @@ fixed-flag restore.
 
 The plist-path rows (#2579) assert STRUCTURE: a `data`, an array and a dictionary
 must come back as the same parsed value, an absent key must come back absent, a
-bystander key must survive the `defaults import`, and the restore of a value from
+bystander key written AFTER the snapshot must survive the `defaults import`
+whether it merges or replaces the domain, and the restore of a value from
 its PRINTED text -- what `phase5_language_hover.py` used to do -- must be reported
 as NOT clean rather than compared equal.
 
@@ -94,12 +95,15 @@ def main():
         subprocess.run(["defaults", "write", DOMAIN, "d", "-data", "5b226573225d"], check=True)
         subprocess.run(["defaults", "write", DOMAIN, "arr", "-array", "a", "b"], check=True)
         subprocess.run(["defaults", "write", DOMAIN, "dct", "-dict", "k1", "v1", "k2", "v2"], check=True)
-        # A bystander the restore must NOT touch: this is the merge assumption
-        # `defaults import` is trusted with, asserted rather than assumed.
-        subprocess.run(["defaults", "write", DOMAIN, "keep", "-int", "7"], check=True)
         want = {"d": b'["es"]', "arr": ["a", "b"], "dct": {"k1": "v1", "k2": "v2"}}
         snap = ds.snapshot_plist(DOMAIN, ["d", "arr", "dct"])
         ok("the snapshot holds parsed VALUES, not printed text", snap == want, repr(snap))
+        # A bystander the restore must NOT touch, written AFTER the snapshot the
+        # way a live instance writes between park and restore. It must survive
+        # whether `defaults import` merges or replaces the domain: the restore
+        # overlays the parked keys on a fresh export, and this is the row that
+        # would catch a return to importing only the parked keys (#2674 review).
+        subprocess.run(["defaults", "write", DOMAIN, "keep", "-int", "7"], check=True)
         for k in ("d", "arr", "dct"):  # the harness clears its rows, as language_hover does
             subprocess.run(["defaults", "delete", DOMAIN, k], capture_output=True)
         ok("precondition: the rows really are gone",
@@ -110,7 +114,7 @@ def main():
         ok("the ARRAY came back as an array", read_type("arr") == "array", read_type("arr"))
         ok("the DICTIONARY came back as a dictionary", read_type("dct") == "dictionary", read_type("dct"))
         ok("the values are structurally identical", ds.snapshot_plist(DOMAIN, ["d", "arr", "dct"]) == want)
-        ok("the bystander key survived the import (merge, not replace)",
+        ok("a bystander written after the snapshot survived the import",
            ds.read_plist(DOMAIN, "keep") == 7, repr(ds.read_plist(DOMAIN, "keep")))
         ok("the bystander is still an integer", read_type("keep") == "integer", read_type("keep"))
 

--- a/Tests/RuntimeUAT/test_defaults_store.py
+++ b/Tests/RuntimeUAT/test_defaults_store.py
@@ -132,6 +132,15 @@ def main():
         landed = ds.restore_plist(DOMAIN, snap)
         ok("a real restore repairs the mangling", all(landed.values()), repr(landed))
 
+        print("\na domain that does not exist exports as EMPTY, and is not mistaken for a failure")
+        # `defaults export` on a missing domain exits 0 with an empty <dict/>. That is the
+        # only way `{}` may come back: a non-zero exit RAISES, because returning `{}` there
+        # would park None for keys that are really present and then delete them on restore.
+        subprocess.run(["defaults", "delete", DOMAIN + ".never"], capture_output=True)
+        ok("a missing domain reads as no keys", ds.export_domain(DOMAIN + ".never") == {})
+        ok("a missing domain snapshots as absent",
+           ds.snapshot_plist(DOMAIN + ".never", ["x"]) == {"x": None})
+
         print("\nan ABSENT key on the plist path is restored to ABSENT, not to an empty container")
         snap = ds.snapshot_plist(DOMAIN, ["never"])
         ok("snapshot says absent", snap["never"] is None)

--- a/Tests/RuntimeUAT/test_defaults_store.py
+++ b/Tests/RuntimeUAT/test_defaults_store.py
@@ -8,6 +8,15 @@ read` prints a boolean `false` and a string `"0"` identically as `0`.
 Two-way by construction: the string row and the boolean row would BOTH pass under
 a correct implementation, and the string row is the one that fails under the old
 fixed-flag restore.
+
+The plist-path rows (#2579) assert STRUCTURE: a `data`, an array and a dictionary
+must come back as the same parsed value, an absent key must come back absent, a
+bystander key must survive the `defaults import`, and the restore of a value from
+its PRINTED text -- what `phase5_language_hover.py` used to do -- must be reported
+as NOT clean rather than compared equal.
+
+Run: `python3 Tests/RuntimeUAT/test_defaults_store.py` on a Mac. It needs the real
+`defaults` binary; there is no fake.
 """
 
 import subprocess
@@ -78,6 +87,55 @@ def main():
         except ds.UnsupportedType:
             refused = True
         ok("an array REFUSES rather than being guessed", refused)
+
+        print("\nthe plist path round-trips DATA, an ARRAY and a DICTIONARY structurally (#2579)")
+        # The real shape of the two language-chip keys: JSON bytes stored as
+        # `data`. This is `["es"]` as hex, which is what `-data` takes.
+        subprocess.run(["defaults", "write", DOMAIN, "d", "-data", "5b226573225d"], check=True)
+        subprocess.run(["defaults", "write", DOMAIN, "arr", "-array", "a", "b"], check=True)
+        subprocess.run(["defaults", "write", DOMAIN, "dct", "-dict", "k1", "v1", "k2", "v2"], check=True)
+        # A bystander the restore must NOT touch: this is the merge assumption
+        # `defaults import` is trusted with, asserted rather than assumed.
+        subprocess.run(["defaults", "write", DOMAIN, "keep", "-int", "7"], check=True)
+        want = {"d": b'["es"]', "arr": ["a", "b"], "dct": {"k1": "v1", "k2": "v2"}}
+        snap = ds.snapshot_plist(DOMAIN, ["d", "arr", "dct"])
+        ok("the snapshot holds parsed VALUES, not printed text", snap == want, repr(snap))
+        for k in ("d", "arr", "dct"):  # the harness clears its rows, as language_hover does
+            subprocess.run(["defaults", "delete", DOMAIN, k], capture_output=True)
+        ok("precondition: the rows really are gone",
+           ds.snapshot_plist(DOMAIN, ["d", "arr", "dct"]) == {"d": None, "arr": None, "dct": None})
+        landed = ds.restore_plist(DOMAIN, snap)
+        ok("restore reports success for every key", all(landed.values()), repr(landed))
+        ok("the DATA came back as data", read_type("d") == "data", read_type("d"))
+        ok("the ARRAY came back as an array", read_type("arr") == "array", read_type("arr"))
+        ok("the DICTIONARY came back as a dictionary", read_type("dct") == "dictionary", read_type("dct"))
+        ok("the values are structurally identical", ds.snapshot_plist(DOMAIN, ["d", "arr", "dct"]) == want)
+        ok("the bystander key survived the import (merge, not replace)",
+           ds.read_plist(DOMAIN, "keep") == 7, repr(ds.read_plist(DOMAIN, "keep")))
+        ok("the bystander is still an integer", read_type("keep") == "integer", read_type("keep"))
+
+        print("\na restore from PRINTED text is reported as NOT clean")
+        # Exactly what phase5_language_hover.py did before #2579: `defaults read`,
+        # then the printed blob back through `defaults write` as one argument.
+        for k in ("arr", "d"):
+            blob = subprocess.run(["defaults", "read", DOMAIN, k],
+                                  capture_output=True, text=True).stdout.strip()
+            subprocess.run(["defaults", "write", DOMAIN, k, blob], check=True)
+        checked = ds.check_plist(DOMAIN, snap)
+        ok("the mangled array is caught", checked["arr"] is False, repr(ds.read_plist(DOMAIN, "arr")))
+        ok("the mangled data is caught", checked["d"] is False, repr(ds.read_plist(DOMAIN, "d")))
+        ok("the untouched dictionary still reads clean", checked["dct"] is True)
+        landed = ds.restore_plist(DOMAIN, snap)
+        ok("a real restore repairs the mangling", all(landed.values()), repr(landed))
+
+        print("\nan ABSENT key on the plist path is restored to ABSENT, not to an empty container")
+        snap = ds.snapshot_plist(DOMAIN, ["never"])
+        ok("snapshot says absent", snap["never"] is None)
+        subprocess.run(["defaults", "write", DOMAIN, "never", "-array", "x"], check=True)
+        landed = ds.restore_plist(DOMAIN, snap)
+        ok("restore reports success", landed["never"] is True)
+        ok("the key is gone again", ds.read_plist(DOMAIN, "never") is None)
+        ok("the bystander is still there", ds.read_plist(DOMAIN, "keep") == 7)
     finally:
         subprocess.run(["defaults", "delete", DOMAIN], capture_output=True)
 


### PR DESCRIPTION
## Summary

`phase5_language_hover.py` parked `languageChipSuppressedLanguages` and `languageChipDismissalCounts` from `defaults read`'s printed text and handed that text back to `defaults write` as one positional argument, which does not put the value back. The restore check compared the same printed text on both sides, so it could not tell a faithful restore from a failed one. A run that began with either key populated never put it back.

Closes #2579.

`Tier: SMALL | Lane: Docs/dev-tooling | Modules: Tests/RuntimeUAT`

## The Mac run this PR was waiting for

`test_defaults_store.py` uses the real macOS `defaults` binary and has no fake, so it could not run on the Linux host this was authored on and CI does not execute it either. **It has now run on a Mac (macOS 26.7, 2026-09-05) and it changed the change.**

First run: every row passed up to the printed-text case, which CRASHED rather than asserting. Three things were measured there, and they correct a mechanism that the issue, this PR's own summary, the module docstring and the harness docstring all carried:

- `defaults write <domain> d '{length = 6, bytes = 0x5b226573225d}'` **exits 1** with `Could not parse: ... Try single-quoting it.` It does not store a string in place of the data. The write simply fails and whatever was there stays. The case ran that write under `check=True`, hence the crash.
- The printed text of an **array** (`( a, b )`) and of a **dictionary** (`{ k = v; }`) **parses straight back** on this macOS. `write` exits 0 and `read-type` still reports array and dictionary. So "handing the blob back mangles it" is false for those two types.
- Both language-chip keys are JSON-encoded `Data` on disk, which is exactly the type `defaults write` refuses. **So the #2579 defect is real and the fix is right; only the stated mechanism was wrong.**

The printed-text case now measures the DATA path: drive the key, attempt the old printed-text write, assert it is REFUSED, assert `check_plist` reports the key as not restored, then assert `restore_plist` puts the original bytes back. The array and dictionary rows are asserted CLEAN instead. Three docstrings corrected to say what was measured.

Also the first-ever execution of the two rows the author flagged to watch. The bystander written after the snapshot survives the import, and a missing domain exports as empty rather than raising. **Both pass.**

Final state: **39 rows pass, exit 0.**

## Finding that shaped the fix

The issue describes the two keys as an array and a dictionary. On disk they are JSON-encoded `Data`: `LanguageSuggestionPresenter.persistState` writes `JSONEncoder` output with `defaults.set(data, forKey:)`, so `defaults read` prints `{length = N, bytes = 0x…}` and `read-type` says `data`. A plist export/import handles `data`, arrays and dictionaries identically, so the fix is a general plist path rather than a container-only one. Absent keys are deleted on restore rather than written as an empty container, because an empty `Data` is a JSON decode failure to the presenter, not the fresh-install state.

## Changes

- `Tests/RuntimeUAT/defaults_store.py`: a second path beside the untouched typed one. `export_domain` (`defaults export <domain> -` parsed with `plistlib`; raises on a non-zero exit), `read_plist`, `snapshot_plist` (`{key: value or None}` as Python `bytes`/`list`/`dict`), `same_plist_value` + `check_plist` (value AND type, recursively), and `restore_plist` (deletes absent keys, then imports the domain as it stands with the parked keys overlaid, and returns `check_plist`). Module docstring describes both paths, the measured `defaults` behaviours, and why the import carries the whole domain.
- `Tests/RuntimeUAT/phase5_language_hover.py`: uses `snapshot_plist`/`restore_plist`; `restore_clean = all(landed.values())` plus `restore_failed_keys`, matching the geometry scripts' convention. The report shows parked values JSON-decoded through a `readable()` helper used only for the artifact, never for the check. The measured arms and verdict logic are unchanged.
- `Tests/RuntimeUAT/test_defaults_store.py`: rows for data, array and dict round-trips with `read-type` preserved; a bystander written after the snapshot surviving the import; a missing domain exporting as empty; the old harness's read-then-write loop refused on the data type and reported as not landed; a type swap reported as not landed; an absent key restored to absent.

## Review corrections

- **Import carries the whole domain (Codex P1, 23b4831).** The first draft imported a plist holding only the parked keys and assumed `defaults import` merges. A Mac measurement the same day showed it does merge, so the assumption held; rather than rest on an undocumented behaviour, `restore_plist` re-exports the domain after the deletes, overlays the parked keys, and imports the whole thing, which is correct under either semantics. The export is taken at restore time so keys a live instance wrote in between are kept. The control test's bystander sits after the snapshot so it proves this property rather than the merge assumption.
- **`export_domain` raises on failure (cloud review, 38ca473).** It returned `{}` on a non-zero exit, which turned "defaults could not answer" into "the domain has no keys": `snapshot_plist` would have parked `None` for keys that were really present and `restore_plist` would have deleted them with every check green. A missing domain never needed that branch: `defaults export` on one exits 0 with an empty `<dict/>`, so the fresh-install case still reads as `{}`, and a real failure now raises with the tool's stderr before any row is driven. **That control row has now executed on a Mac and passes.**
- **`check_plist` compared value without type (cloud review P2, 56c97007).** Python calls `True`, `1` and `1.0` equal, so a restore that put an integer where a boolean was would have been reported as landed: the check returning a pass for the class of defect it exists to catch. Two-way control on the same domain and values, after `defaults write -int 1` over a parked boolean:

  | check | `flag` (bool → int) | `row` (`[bool]` → `[int]`) |
  |---|---|---|
  | typed `check_plist` | `False` | `False` |
  | old `==` `check_plist` | `True` | `True` |

  Not reachable through this module's own restore today, since `restore_plist` writes the parked value back through `plistlib.dump`, which preserves the type, and the old printed-text write of a boolean stores the string `"1"` (measured), which `==` already rejects. Fixed anyway because the failure is a silent green in the one function whose whole job is to be exact. `same_plist_value` requires `type(got) is type(want)` — `bool` is its own type in Python, so no special case — and recurses into `list` and `dict`. An absent key compares against a sentinel rather than `None`, so "absent" and "holds nothing" stay distinct.

## Pre-Merge Checklist

### Build Verification
- [x] Dev build passes locally — N/A, no Swift touched; the whole diff is three `.py` files
- [x] Logic tests pass locally — `python3 Tests/RuntimeUAT/test_defaults_store.py` on macOS 26.7: **39 rows pass, exit 0**
- [x] CI `build-check` status is green on the current head

### Behavioral Testing (Local UAT)
- [ ] Live UAT (`phase5_language_hover.py`) not run. It needs a working microphone and the dev app, and **this machine's built-in microphone is currently parked at digital zero because the laptop is closed and running in clamshell** (founder is travelling). An independent capture reads `max_volume: -91.0 dB`, and the Swift receipt `AudioCaptureManagerLiveInputTests` fails for the same reason. That receipt PASSED at 15:53 EDT in a peer session's full Debug lane, so this is the lid, not a fault. Unrelated to this PR, which changes three `.py` files and no Swift.

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval
- N/A

### Review
- [x] Codex P1 (import replaces the domain): addressed in 23b4831; premise later measured false on a Mac, fix stays as belt-and-braces
- [x] Cloud review P1 (export failure read as empty domain): fixed in 38ca473, control row now executed on a Mac
- [x] Cloud review P2 (value-only comparison): fixed in f0fd432, with a two-way control against the old implementation

### Release Housekeeping
- N/A

## Noted, not changed

The harness restores while the dev app instance is still running, so `persistState` on the next chip event could overwrite the restore. `phase5_warning_morph.py` handles the same hazard with `stop_app` before restore. Out of scope for #2579; worth a follow-up.
