### PR TITLE
refactor(llm): stop retrying the bare LLMError.rateLimited nobody throws (#2641)

### DIFF
--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -31,7 +31,16 @@ enum LLMRetryPolicy {
   static func isRetryable(_ error: Error) -> Bool {
     if let llmError = error as? LLMError {
       switch llmError {
-      case .rateLimited: return true
+      case .rateLimited:
+        // EXPLICIT (#2641): nothing in the repository constructs
+        // `LLMError.rateLimited`. Every connector that recognises a 429
+        // throws `.classified(.rateLimited)` (OpenAI, Claude) or
+        // `.classified(.rateLimitedOrQuota)` (Gemini, Ollama), and those are
+        // decided by the catalog arm below. The case itself stays for the
+        // public `LLMError` surface and its pinned Sentry identity (#10),
+        // but a retry nobody can reach is not a policy; a future producer
+        // must opt into retrying on purpose rather than inherit it.
+        return false
       case .requestFailed(let msg):
         return msg.contains("server error")
       case .classified(let reason):

--- a/Tests/EnviousWisprTests/LLM/LLMRetryPolicyTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMRetryPolicyTests.swift
@@ -38,9 +38,14 @@ struct LLMRetryPolicyTests {
 
   // MARK: - LLMError retryable cases
 
-  @Test("rateLimited is retryable")
-  func rateLimitedRetryable() {
-    #expect(LLMRetryPolicy.isRetryable(LLMError.rateLimited))
+  /// #2641: `LLMError.rateLimited` has no producer — the connectors classify a
+  /// 429 into `.classified(.rateLimited)` (retried, asserted below) or
+  /// `.classified(.rateLimitedOrQuota)` (fail-fast). The bare case used to
+  /// carry a retry that nothing could reach; it is pinned non-retryable so a
+  /// future producer has to choose to retry rather than inherit it.
+  @Test("bare rateLimited has no producer and is not retryable")
+  func bareRateLimitedNotRetryable() {
+    #expect(!LLMRetryPolicy.isRetryable(LLMError.rateLimited))
   }
 
   @Test("requestFailed with server error is retryable")


### PR DESCRIPTION
## Summary

Item 2 of #2641 only: the retry policy's `case .rateLimited: return true` has no producer. Nothing in the repository constructs `LLMError.rateLimited`; OpenAI and Claude throw `.classified(.rateLimited)` for a 429 and Gemini and Ollama throw `.classified(.rateLimitedOrQuota)`, both decided by the catalog arm. The bare arm was a retry nobody could reach, and it would have become a real behaviour change the moment someone added a producer. It is now an explicit non-retry, so a future producer has to opt into retrying on purpose.

Item 1 (Retry-After telemetry and budget-aware retry) is untouched and stays open; the issue's own sequencing note says item 1 may reshape this later, which is fine.

Refs #2641.

`Tier: SMALL | Lane: Code | Modules: EnviousWisprLLM`

**Verification note:** authored on a Linux host with no Swift toolchain; the macOS CI lanes on this PR were the first compile, and all nine checks passed on `1846ee2`, including `build-debug`, which runs `LLMRetryPolicyTests`.

## Why the enum case stays

Deleting `LLMError.rateLimited` outright was considered and rejected: `LLMError` is public, the case carries a pinned Sentry fingerprint (`EnviousWisprLLM.LLMError#10`) under a doc block that says shipped values never change, and `LLMErrorSentryIdentityTests` pin-locks it and asserts all fourteen descriptors are unique. Removing the case would have touched five exhaustive switches and that contract for a change that is behaviourally identical today.

## Hit classification (re-verified on `main`)

`git grep "\.rateLimited"` over `Sources/`, `Tests/`, `scripts/`, `workers/`, `website/` gives 50 hits. The `LLMError.rateLimited` ones are all consumers: the enum case, `errorDescription`, `==`, the Sentry fingerprint, the semantic id, the retry arm, the Sentry identity fixture, and the one retry-policy test that constructed it. Everything else is a different type (`PolishFailureReason`, `AFMGenerationSentryError`, FluidAudio's `DownloadError`).

## Changes

- `Sources/EnviousWisprLLM/LLMRetryPolicy.swift`: the `.rateLimited` arm returns `false` with a comment stating why and citing #2641. Delays, the `.classified` arm and every connector are untouched.
- `Tests/EnviousWisprTests/LLM/LLMRetryPolicyTests.swift`: `rateLimitedRetryable` becomes `bareRateLimitedNotRetryable`, asserting the non-retry. The existing `classifiedRateLimitedRetryable` still asserts the real 429 path retries.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — not possible on the authoring host
- [ ] Logic tests pass locally — not possible on the authoring host
- [x] CI `build-check` status is green — all nine checks passed on `1846ee2`

### Behavioral Testing (Local UAT)
- N/A, no reachable behaviour changes

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval (touches `Sources/EnviousWisprLLM/`)
- [x] `polish-eval-smoke` CI check is green (`polish-quality-gate` passed)
- [x] Swift → Python sync: N/A, no prompt, vocab or threshold change
- [x] No new polish capability, no baseline change

### Release Housekeeping
- N/A

## Noted, not changed

The Sentry doc block in `LLMProtocol.swift` says "13 descriptors" while there are fourteen. Pre-existing and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM