### PR TITLE
refactor(llm): read every provider display name from LLMProvider.displayName, and freeze the owner (#2650)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -39,12 +39,14 @@ final class BackendMetadata {
   /// success — a configured-but-unreachable provider still shows its
   /// model name; per-dictation outcomes surface on the transcript.
   /// Apple Intelligence is named directly: its model id never varies
-  /// and discovery only runs when the settings pane is visited.
+  /// and discovery only runs when the settings pane is visited. The fixed
+  /// names are READ from `LLMProvider.displayName`, never restated here
+  /// (#2650): this arm was one of four sites spelling the same string.
   var polishLabel: String {
     switch settings.llmProvider {
     case .none: "Off"
-    case .appleIntelligence: "Apple Intelligence"
-    case .egOne: "EG-1"  // #1271: fixed name, like Apple Intelligence above
+    case .appleIntelligence: LLMProvider.appleIntelligence.displayName
+    case .egOne: LLMProvider.egOne.displayName  // #1271: fixed name, like Apple Intelligence above
     // #2649 (cloud review): falling through to `llmLabel` rendered the model id
     // `s1-mini`, and the licence requires the exact spelling wherever the
     // model is identified. One owner for that string.

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -1203,7 +1203,8 @@ private struct ChecklistPhaseView: View {
 
   private static let items: [(title: String, subtitle: String)] = [
     ("Setting up speech model", "One-time setup"),
-    ("Configuring on-device AI", "Apple Intelligence"),
+    // #2650: the provider's display name has one owner.
+    ("Configuring on-device AI", LLMProvider.appleIntelligence.displayName),
     ("Setting your keybind", "Default: ⌥ Option"),
   ]
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishProviderRail.swift
@@ -235,12 +235,17 @@ struct PolishRailProvider: Identifiable, Equatable {
 enum PolishRailCatalog {
   /// Flattened in render order. `providers(in:)` derives group membership from
   /// this list, and the current rail renders those results.
+  ///
+  /// Every `name` that IS the provider's display name reads
+  /// `LLMProvider.displayName` (#2650) rather than restating it; the one row
+  /// whose name deliberately differs says so where it does.
   static let all: [PolishRailProvider] = [
     PolishRailProvider(
-      provider: .egOne, name: "EG-1", tagline: "Our tuned model",
+      provider: .egOne, name: LLMProvider.egOne.displayName, tagline: "Our tuned model",
       group: .onThisMac, recommended: true),
     PolishRailProvider(
-      provider: .appleIntelligence, name: "Apple Intelligence", tagline: "Built into macOS",
+      provider: .appleIntelligence, name: LLMProvider.appleIntelligence.displayName,
+      tagline: "Built into macOS",
       group: .onThisMac, recommended: false),
     // #2649. Founder placement: beside EG-1 on this Mac, never above it. EG-1
     // keeps `recommended`; Apple Intelligence remains what a fresh install
@@ -257,16 +262,20 @@ enum PolishRailCatalog {
       tagline: "by Superwhisper",
       group: .onThisMac, recommended: false),
     PolishRailProvider(
-      provider: .ollama, name: "Ollama", tagline: "Any open model, local or hosted",
+      provider: .ollama, name: LLMProvider.ollama.displayName,
+      tagline: "Any open model, local or hosted",
       group: .yourOwnSetup, recommended: false),
     PolishRailProvider(
-      provider: .openAI, name: "OpenAI", tagline: "Your API key",
+      provider: .openAI, name: LLMProvider.openAI.displayName, tagline: "Your API key",
       group: .cloud, recommended: false),
+    // Intentionally NOT `LLMProvider.gemini.displayName` ("Gemini"): the rail
+    // carries the vendor so the row reads as a cloud service beside OpenAI and
+    // Claude. `PolishRailCatalogTests` pins this exact copy.
     PolishRailProvider(
       provider: .gemini, name: "Google Gemini", tagline: "Your API key",
       group: .cloud, recommended: false),
     PolishRailProvider(
-      provider: .claude, name: "Claude", tagline: "Your API key",
+      provider: .claude, name: LLMProvider.claude.displayName, tagline: "Your API key",
       group: .cloud, recommended: false),
   ]
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/LocalEngineStatusCard.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LocalEngineStatusCard.swift
@@ -44,8 +44,8 @@ struct LocalEngineDescriptor: Equatable {
   }
 
   static let egOne = LocalEngineDescriptor(
-    name: "EG-1", downloadSize: "2.9 GB", installHeadroom: "6 GB", showsLowMemoryNote: true,
-    contextTokens: 16384)
+    name: LLMProvider.egOne.displayName, downloadSize: "2.9 GB", installHeadroom: "6 GB",
+    showsLowMemoryNote: true, contextTokens: 16384)
 
   static let s1Mini = LocalEngineDescriptor(
     // 484,219,808 bytes. Stated DECIMAL, because that is what EG-1's "2.9 GB"

--- a/Sources/EnviousWisprLLM/OllamaSetupService.swift
+++ b/Sources/EnviousWisprLLM/OllamaSetupService.swift
@@ -348,8 +348,10 @@ public final class OllamaSetupService {
   /// suggestion row would render a dead Download button. EG-1 distribution ships
   /// separately (see the tuned-polish-provider wiring plan).
   public nonisolated static let curatedPrivateCatalog: [OllamaModelCatalogEntry] = [
+    // The display name is the EG-1 provider's, read from its one owner (#2650):
+    // this row and the polish rail must agree on what the model is called.
     OllamaModelCatalogEntry(
-      name: "eg-1", displayName: "EG-1", parameterCount: "4B",
+      name: "eg-1", displayName: LLMProvider.egOne.displayName, parameterCount: "4B",
       downloadSize: "~2.9 GB")
   ]
 

--- a/Tests/EnviousWisprTests/Architecture/LLMProviderDisplayNameFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/LLMProviderDisplayNameFreezeTests.swift
@@ -1,0 +1,153 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+/// #2650 — a provider's display name has ONE owner, `LLMProvider.displayName`,
+/// and every site that shows it reads it from there.
+///
+/// Before this freeze the same string was typed out in four places: the sidebar
+/// polish label, the settings rail catalog, the onboarding checklist, and the
+/// local-engine descriptor, each restating "EG-1" or "Apple Intelligence" as a
+/// literal. Nothing was wrong on screen; the defect was structural, and #2649
+/// showed the shape of the failure it invites. That change added S1-mini under
+/// a licence that requires one exact spelling wherever the model is identified,
+/// and a fifth restatement would have been a licence breach that compiled
+/// cleanly and read fine to a reviewer who did not know the term existed.
+///
+/// So this is a STRUCTURAL freeze on the class rather than a check of the
+/// instances: a new site that restates a display name fails the build instead
+/// of waiting for a rename or a licence audit to find it.
+///
+/// The rule: no non-comment line under `Sources/` outside the owner file may
+/// contain a quoted literal equal to any `LLMProvider.displayName` value. The
+/// literal is matched exactly — `"EG-1"` including both quotes — so a longer
+/// sentence that MENTIONS a provider ("EG-1 is not installed") is not a
+/// restatement of its name and does not fire.
+///
+/// Drift Guard: when this fails, no user sees anything — every site still
+/// shows the right string today. What is at risk is the next rename, and the
+/// licence-bound spelling the next third-party model will bring.
+@Suite("LLMProvider display-name owner freeze (#2650)", .tags(.driftGuard))
+struct LLMProviderDisplayNameFreezeTests {
+
+  /// The one file allowed to spell the names: it is where `displayName` lives.
+  private static let owner = "Sources/EnviousWisprCore/LLMResult.swift"
+
+  /// Lines outside the owner that legitimately carry one of the strings, keyed
+  /// by repo-relative file, each with the literal it is allowed and the reason
+  /// it is NOT a restatement of the provider's display name. Adding an entry
+  /// is a deliberate act: state what else the string is doing there.
+  private static let permitted: [String: [(literal: String, reason: String)]] = [
+    // Built-in dictionary corrections. The string is a VOCABULARY entry — the
+    // canonical spelling a recogniser's mishearing is corrected to, keyed by a
+    // stable `id` and bound to its own alias list — in a table that also holds
+    // brands with no provider at all ("EnviousWispr"). Tying it to the settings
+    // enum would couple the spoken-word dictionary to the polish picker.
+    "Sources/EnviousWisprPostProcessing/CustomWordsManager.swift": [
+      ("EG-1", "built-in dictionary canonical spelling, a vocabulary entry"),
+      ("OpenAI", "built-in dictionary canonical spelling, a vocabulary entry"),
+      ("Claude", "built-in dictionary canonical spelling, a vocabulary entry"),
+    ],
+    // A log CATEGORY. It names the subsystem a diagnostic line belongs to, is an
+    // observability key rather than anything a user reads, and matches the
+    // display name by coincidence of both being the product's name.
+    "Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift": [
+      ("Ollama", "diagnostic log category, an observability key")
+    ],
+    "Sources/EnviousWisprPipeline/LLMPolishStep.swift": [
+      ("Ollama", "diagnostic log category, an observability key")
+    ],
+  ]
+
+  /// Every name the owner defines, quoted the way a Swift literal restating it
+  /// would appear. Derived from the enum so a new case is guarded the moment it
+  /// exists, without anyone remembering to extend a list here.
+  private static var quotedDisplayNames: [(name: String, quoted: String)] {
+    LLMProvider.allCases.map { ($0.displayName, "\"\($0.displayName)\"") }
+  }
+
+  @Test("no source file outside the owner restates a provider display name")
+  func onlyTheOwnerSpellsADisplayName() throws {
+    let root = RepoRoot.url
+    let sources = root.appendingPathComponent("Sources")
+    let names = Self.quotedDisplayNames
+
+    var offenders: [String] = []
+    let files = FileManager.default.enumerator(
+      at: sources, includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles, .skipsPackageDescendants])
+    while let item = files?.nextObject() as? URL {
+      guard item.pathExtension == "swift" else { continue }
+      let relative = item.path.replacingOccurrences(of: root.path + "/", with: "")
+      guard relative != Self.owner else { continue }
+      let allowed = Set((Self.permitted[relative] ?? []).map { $0.literal })
+      let source = try String(contentsOf: item, encoding: .utf8)
+      for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
+        .enumerated()
+      {
+        let text = String(line)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        // Comment-only lines may mention a name in prose; the freeze is about
+        // code that would show it, so those are skipped the way the other
+        // source-scanning freezes in this directory skip them.
+        if trimmed.hasPrefix("//") { continue }
+        for entry in names where !allowed.contains(entry.name) {
+          if text.contains(entry.quoted) {
+            offenders.append("\(relative):\(idx + 1): \(trimmed)")
+          }
+        }
+      }
+    }
+
+    #expect(
+      offenders.isEmpty,
+      """
+      These lines restate a provider display name that `LLMProvider.displayName` \
+      already owns. Read it from there (`LLMProvider.egOne.displayName`, or \
+      `provider.displayName`) so a rename or a licence-bound spelling changes in \
+      one place, or add the file to `permitted` with the reason the string is \
+      something other than the provider's name:
+      \(offenders.sorted().joined(separator: "\n"))
+      """)
+  }
+
+  /// The two-way control. A freeze whose pattern matches nothing is
+  /// indistinguishable from a clean repo, and would keep passing after the
+  /// owner moved or the names were rewritten as something the scan cannot see.
+  @Test("the owner file still spells every display name the scan looks for")
+  func ownerStillSpellsEveryName() throws {
+    let text = try String(contentsOf: RepoRoot.sourceURL(Self.owner), encoding: .utf8)
+    for entry in Self.quotedDisplayNames {
+      #expect(
+        text.contains(entry.quoted),
+        """
+        \(Self.owner) no longer contains \(entry.quoted). Either `displayName` \
+        moved — point `owner` at its new home — or the name is no longer a plain \
+        literal there and this freeze is checking a spelling it cannot find.
+        """)
+    }
+  }
+
+  /// Every permitted exception must still name a real file that still carries
+  /// the literal, so a rename or a cleanup turns into a failure here rather
+  /// than silently widening the allow-list to cover nothing.
+  @Test("every permitted exception still names a real file carrying its literal")
+  func permittedEntriesAreLive() throws {
+    let known = Set(Self.quotedDisplayNames.map { $0.name })
+    for (path, entries) in Self.permitted {
+      let url = RepoRoot.sourceURL(path)
+      #expect(
+        FileManager.default.fileExists(atPath: url.path),
+        "permitted exception no longer exists: \(path)")
+      let text = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+      for entry in entries {
+        #expect(
+          known.contains(entry.literal),
+          "permitted literal \(entry.literal) is not a display name (\(entry.reason)): \(path)")
+        #expect(
+          text.contains("\"\(entry.literal)\""),
+          "permitted exception no longer carries \"\(entry.literal)\" (\(entry.reason)): \(path)")
+      }
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Architecture/LLMProviderDisplayNameFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/LLMProviderDisplayNameFreezeTests.swift
@@ -34,28 +34,33 @@ struct LLMProviderDisplayNameFreezeTests {
   private static let owner = "Sources/EnviousWisprCore/LLMResult.swift"
 
   /// Lines outside the owner that legitimately carry one of the strings, keyed
-  /// by repo-relative file, each with the literal it is allowed and the reason
-  /// it is NOT a restatement of the provider's display name. Adding an entry
-  /// is a deliberate act: state what else the string is doing there.
-  private static let permitted: [String: [(literal: String, reason: String)]] = [
+  /// by repo-relative file. Each exception is bound to the exact construct that
+  /// carries the literal — the argument label and the quoted name together, as
+  /// they appear on the line — with the reason it is NOT a restatement of the
+  /// provider's display name. Binding the whole construct rather than the bare
+  /// name is deliberate: `"EG-1"` is allowed in the dictionary file only as a
+  /// `canonical:` vocabulary spelling, so a NEW `"EG-1"` in the same file that
+  /// is anything else (a label, a description, an alert) still fails. Adding an
+  /// entry is a deliberate act: state what else the string is doing there.
+  private static let permitted: [String: [(construct: String, reason: String)]] = [
     // Built-in dictionary corrections. The string is a VOCABULARY entry — the
     // canonical spelling a recogniser's mishearing is corrected to, keyed by a
     // stable `id` and bound to its own alias list — in a table that also holds
     // brands with no provider at all ("EnviousWispr"). Tying it to the settings
     // enum would couple the spoken-word dictionary to the polish picker.
     "Sources/EnviousWisprPostProcessing/CustomWordsManager.swift": [
-      ("EG-1", "built-in dictionary canonical spelling, a vocabulary entry"),
-      ("OpenAI", "built-in dictionary canonical spelling, a vocabulary entry"),
-      ("Claude", "built-in dictionary canonical spelling, a vocabulary entry"),
+      ("canonical: \"EG-1\"", "built-in dictionary canonical spelling, a vocabulary entry"),
+      ("canonical: \"OpenAI\"", "built-in dictionary canonical spelling, a vocabulary entry"),
+      ("canonical: \"Claude\"", "built-in dictionary canonical spelling, a vocabulary entry"),
     ],
     // A log CATEGORY. It names the subsystem a diagnostic line belongs to, is an
     // observability key rather than anything a user reads, and matches the
     // display name by coincidence of both being the product's name.
     "Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift": [
-      ("Ollama", "diagnostic log category, an observability key")
+      ("category: \"Ollama\"", "diagnostic log category, an observability key")
     ],
     "Sources/EnviousWisprPipeline/LLMPolishStep.swift": [
-      ("Ollama", "diagnostic log category, an observability key")
+      ("category: \"Ollama\"", "diagnostic log category, an observability key")
     ],
   ]
 
@@ -80,7 +85,7 @@ struct LLMProviderDisplayNameFreezeTests {
       guard item.pathExtension == "swift" else { continue }
       let relative = item.path.replacingOccurrences(of: root.path + "/", with: "")
       guard relative != Self.owner else { continue }
-      let allowed = Set((Self.permitted[relative] ?? []).map { $0.literal })
+      let allowed = (Self.permitted[relative] ?? []).map { $0.construct }
       let source = try String(contentsOf: item, encoding: .utf8)
       for (idx, line) in source.split(separator: "\n", omittingEmptySubsequences: false)
         .enumerated()
@@ -91,8 +96,13 @@ struct LLMProviderDisplayNameFreezeTests {
         // code that would show it, so those are skipped the way the other
         // source-scanning freezes in this directory skip them.
         if trimmed.hasPrefix("//") { continue }
-        for entry in names where !allowed.contains(entry.name) {
-          if text.contains(entry.quoted) {
+        for entry in names where text.contains(entry.quoted) {
+          // An exception covers THIS line only when the line carries the whole
+          // permitted construct, not merely the name it contains.
+          let excused = allowed.contains { construct in
+            construct.contains(entry.quoted) && text.contains(construct)
+          }
+          if !excused {
             offenders.append("\(relative):\(idx + 1): \(trimmed)")
           }
         }
@@ -105,8 +115,8 @@ struct LLMProviderDisplayNameFreezeTests {
       These lines restate a provider display name that `LLMProvider.displayName` \
       already owns. Read it from there (`LLMProvider.egOne.displayName`, or \
       `provider.displayName`) so a rename or a licence-bound spelling changes in \
-      one place, or add the file to `permitted` with the reason the string is \
-      something other than the provider's name:
+      one place, or add the exact construct on that line to `permitted` with the \
+      reason the string is something other than the provider's name:
       \(offenders.sorted().joined(separator: "\n"))
       """)
   }
@@ -129,11 +139,13 @@ struct LLMProviderDisplayNameFreezeTests {
   }
 
   /// Every permitted exception must still name a real file that still carries
-  /// the literal, so a rename or a cleanup turns into a failure here rather
-  /// than silently widening the allow-list to cover nothing.
-  @Test("every permitted exception still names a real file carrying its literal")
+  /// the exact construct, and the construct must quote a real display name, so
+  /// a rename or a cleanup turns into a failure here rather than silently
+  /// widening the allow-list to cover nothing — or narrowing it to a construct
+  /// the scan would never match.
+  @Test("every permitted exception still names a real file carrying its construct")
   func permittedEntriesAreLive() throws {
-    let known = Set(Self.quotedDisplayNames.map { $0.name })
+    let quoted = Self.quotedDisplayNames.map { $0.quoted }
     for (path, entries) in Self.permitted {
       let url = RepoRoot.sourceURL(path)
       #expect(
@@ -142,11 +154,14 @@ struct LLMProviderDisplayNameFreezeTests {
       let text = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
       for entry in entries {
         #expect(
-          known.contains(entry.literal),
-          "permitted literal \(entry.literal) is not a display name (\(entry.reason)): \(path)")
+          quoted.contains { entry.construct.contains($0) },
+          """
+          permitted construct \(entry.construct) quotes no display name \
+          (\(entry.reason)): \(path)
+          """)
         #expect(
-          text.contains("\"\(entry.literal)\""),
-          "permitted exception no longer carries \"\(entry.literal)\" (\(entry.reason)): \(path)")
+          text.contains(entry.construct),
+          "permitted exception no longer carries \(entry.construct) (\(entry.reason)): \(path)")
       }
     }
   }


### PR DESCRIPTION
## Summary

A provider's display name was typed out as a literal in several files instead of read from its owner, `LLMProvider.displayName`. Every copy agreed, which is why nobody noticed; they drift when one is edited, and #2649 showed the real cost: S1-mini's licence requires one exact spelling wherever the model is identified, so every restatement is a chance to get a licence-bound string wrong. Every display-name lookup now reads the owner, and a source-scanning freeze test stops it coming back.

Closes #2650.

`Tier: SMALL | Test: required (Core, AppKit) | Modules: EnviousWisprCore, EnviousWisprAppKit, EnviousWisprLLM`

**Verification note:** authored on a Linux host with no Swift toolchain; the macOS CI lanes were the first compile, and all nine checks passed on the first commit, including `build-debug`, which runs the new freeze test and the existing `PolishRailCatalogTests` and `TestInventoryFreezeTests`. Before that, the scan logic was ported to Python and run: against `main` it reports exactly the ten lines this PR removes, against this branch it reports none. The second commit (Codex review fix, below) was checked the same way and is on its CI run now.

## What was consolidated, and what was deliberately not

Lookups of the display name (consolidated, strings on screen unchanged):
- `BackendMetadata.polishLabel`: the `.appleIntelligence` and `.egOne` arms. Switch shape kept.
- `PolishRailCatalog.all`: the EG-1, Apple Intelligence, Ollama, OpenAI and Claude rows' `name:`.
- `OnboardingV2View` checklist subtitle "Apple Intelligence".
- `LocalEngineDescriptor.egOne` `name:`.
- `OllamaSetupService.curatedPrivateCatalog` `displayName:` for the EG-1 row.

Left alone, each with a reason in code or in the freeze's allowlist:
- `"Google Gemini"` in the rail: intentionally differs from `displayName` ("Gemini") so the row reads as a cloud service beside OpenAI and Claude; `PolishRailCatalogTests` pins it. Not a restatement, so the freeze does not fire on it.
- `CustomWordsManager` canonicals `"EG-1"`, `"OpenAI"`, `"Claude"`: vocabulary entries in the built-in correction dictionary, keyed by stable id and bound to alias lists, in a table that also holds brands with no provider. Coupling the spoken-word dictionary to the settings enum would be the wrong axis.
- `category: "Ollama"` in two log sites: an observability key.
- `"eg-1"` model-id strings in `OllamaSetupService`: those restate `egOneModelName`, not the display name, and are outside this issue's scope.
- Per-provider `switch` statements that make decisions (polish deadline, token policy, discovery, canonicalisation) are untouched, per the issue's load-bearing half.

## The freeze

`Tests/EnviousWisprTests/Architecture/LLMProviderDisplayNameFreezeTests.swift`, tagged `.driftGuard`, mirroring `AutoInputDeviceAuthorityFreezeTests` and `EngineIdentityFreezeTests`:
1. No non-comment line under `Sources/*.swift` outside `LLMResult.swift` contains `"<displayName>"` for any `LLMProvider.allCases` value, minus the allowlist above. Derived from the enum, so a new case is guarded the moment it exists.
2. Two-way control: the owner file still spells every name the scan looks for.
3. Every allowlisted exception names a file that exists and still carries its construct, and the construct quotes a real display name.

**Allowlist scope (Codex review, dadb1575):** each exception is bound to the exact construct on the line (`canonical: "EG-1"`, `category: "Ollama"`), not to the bare name anywhere in the file. A line is excused only when it carries the whole construct, so a new `"EG-1"` label typed into `CustomWordsManager.swift` for any other reason still fails the freeze.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — not possible on the authoring host
- [ ] Logic tests pass locally — not possible on the authoring host; Python port of the scan run as described
- [ ] CI `build-check` status is green on the current head — green on bd57fbf; re-running on dadb1575
- [x] `scripts/check-dependency-direction.sh` passes (23 modules)

### Behavioral Testing (Local UAT)
- N/A, no behaviour change; same strings on screen

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval (touches `Sources/EnviousWisprLLM/`)
- [x] `polish-eval-smoke` CI check is green (`polish-quality-gate` passed)
- [x] Swift → Python sync: N/A, no prompt, vocab or threshold change
- [x] No new polish capability, no baseline change

### Review
- [x] Codex P2 (allowlist scoped per file, not per construct): fixed in dadb1575, thread resolved

### Release Housekeeping
- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM