### PR TITLE
docs(whatsnew): give Snippets its v2.4.7 entry, so the release body names it

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -83,6 +83,23 @@ enum WhatsNewContent {
         "S1-mini is a small open model for cleaning up dictation, and it is now an option beside EG-1 in AI Polish settings. It is a 484 MB download, runs on this Mac, and is free. Three writing style settings, Tone, Structure and Context, let you choose how it writes. EG-1 stays the recommended choice.",
       version: "2.4.7"
     ),
+
+    // #628. Snippets shipped on 2026-09-01 and had no entry, so the release
+    // body rendered from this file would have omitted a headline feature.
+    // Every clause checked against main: the default keyword is
+    // `VocabularyLanes.defaultKeyword` ("backslash"); "six working examples"
+    // is `SnippetStarters`; "exactly as you typed it" and "line breaks
+    // included" are the polish bypass and the multi-line delivery fix
+    // (#2639); the location is `SettingsSection.snippets`. Nothing is claimed
+    // about import, which has not shipped.
+    Entry(
+      id: "snippets",
+      icon: "text.badge.plus",
+      title: "Snippets: say a short phrase, paste the text you saved",
+      description:
+        "Save a piece of text once, then say your keyword and a short phrase to paste it: an email address, a sign-off, a link you send every week. The keyword is backslash unless you change it, so \"backslash my email\" pastes your address and \"my email\" on its own is left alone. What you saved is pasted exactly as you typed it, line breaks included, and AI Polish never rewrites it. A fresh install starts with six working examples you can edit or delete. Find them in Settings under Snippets.",
+      version: "2.4.7"
+    ),
     // MARK: - v2.4.6
 
     // Every title and every collapsed line in this group was written or edited by

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -87,7 +87,7 @@ enum WhatsNewContent {
     // #628. Snippets shipped on 2026-09-01 and had no entry, so the release
     // body rendered from this file would have omitted a headline feature.
     // Every clause checked against main: the default keyword is
-    // `VocabularyLanes.defaultKeyword` ("backslash"); "six working examples"
+    // `SnippetVocabulary.defaultKeyword` ("backslash"); "six working examples"
     // is `SnippetStarters`; "word for word" and "line breaks included" are
     // the polish bypass, the smart-insertion skip and the multi-line delivery
     // fix (#2639); the location is `SettingsSection.snippets`. NOT "exactly as

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -88,16 +88,20 @@ enum WhatsNewContent {
     // body rendered from this file would have omitted a headline feature.
     // Every clause checked against main: the default keyword is
     // `VocabularyLanes.defaultKeyword` ("backslash"); "six working examples"
-    // is `SnippetStarters`; "exactly as you typed it" and "line breaks
-    // included" are the polish bypass and the multi-line delivery fix
-    // (#2639); the location is `SettingsSection.snippets`. Nothing is claimed
-    // about import, which has not shipped.
+    // is `SnippetStarters`; "word for word" and "line breaks included" are
+    // the polish bypass, the smart-insertion skip and the multi-line delivery
+    // fix (#2639); the location is `SettingsSection.snippets`. NOT "exactly as
+    // you typed it": `CursorInsertionRepair.legacyPayload` appends a trailing
+    // space to every delivered dictation, snippets included (#2643 owns
+    // whether they should be exempt), so the copy says so instead of
+    // promising a byte-exact paste. Nothing is claimed about import, which
+    // has not shipped.
     Entry(
       id: "snippets",
       icon: "text.badge.plus",
       title: "Snippets: say a short phrase, paste the text you saved",
       description:
-        "Save a piece of text once, then say your keyword and a short phrase to paste it: an email address, a sign-off, a link you send every week. The keyword is backslash unless you change it, so \"backslash my email\" pastes your address and \"my email\" on its own is left alone. What you saved is pasted exactly as you typed it, line breaks included, and AI Polish never rewrites it. A fresh install starts with six working examples you can edit or delete. Find them in Settings under Snippets.",
+        "Save a piece of text once, then say your keyword and a short phrase to paste it: an email address, a sign-off, a link you send every week. The keyword is backslash unless you change it, so \"backslash my email\" pastes your address and \"my email\" on its own is left alone. What you saved is pasted word for word, line breaks included, with a space after it like any other dictation, and AI Polish never rewrites it. A fresh install starts with six working examples you can edit or delete. Find them in Settings under Snippets.",
       version: "2.4.7"
     ),
     // MARK: - v2.4.6


### PR DESCRIPTION
## Summary

Snippets shipped to `main` on 2026-09-01 (#628) and has no What's New entry. The GitHub release body is rendered from `WhatsNewContent.swift`, so v2.4.7 would have gone out today with a headline feature missing from its own notes, and the in-app What's New screen would never have introduced it. This adds one entry to the open 2.4.7 group, after S1-mini.

**Merge before cutting the v2.4.7 release**, since the release body is generated from this file.

`Tier: SMALL | Lane: Content | Modules: EnviousWisprAppKit`

## The entry

> **Snippets: say a short phrase, paste the text you saved.** Save a piece of text once, then say your keyword and a short phrase to paste it: an email address, a sign-off, a link you send every week. The keyword is backslash unless you change it, so "backslash my email" pastes your address and "my email" on its own is left alone. What you saved is pasted word for word, line breaks included, with a space after it like any other dictation, and AI Polish never rewrites it. A fresh install starts with six working examples you can edit or delete. Find them in Settings under Snippets.

Every clause checked against `main`: the default keyword is `SnippetVocabulary.defaultKeyword` ("backslash"); "six working examples" is `SnippetStarters`; "word for word, line breaks included" is the polish bypass, the smart-insertion skip and the multi-line delivery fix (#2639); the location is `SettingsSection.snippets`. Nothing is claimed about import, which has not shipped. The wording is a draft in the file's voice; edit it freely before release.

**Not "exactly as you typed it" (Codex P1, fixed in 83cb3ca):** `CursorInsertionRepair.legacyPayload` appends a trailing space to every delivered dictation, snippets included, and `KernelFinalizationWiringTests.multiLineSnippetIsDeliveredNotDivertedToTheClipboard` pins that. The first draft promised a byte-exact paste, which was false by one byte. #2643 owns whether snippets should be exempt. The same correction went to the README (#2677, 8ae95dc) and the help centre (#2681, 17e5451).

**Type name in the grounding comment (9c3fa29):** the comment cited `VocabularyLanes.defaultKeyword`, which is the file; the type is `SnippetVocabulary`. Comment only, no content change.

## Verification

- `python3 scripts/ci/render-release-notes.py --self-test`: 144 entries parsed, matching source (re-run on 9c3fa29).
- `python3 scripts/ci/render-release-notes.py --version 2.4.7`: renders four items, the new one last, with the corrected sentence.
- CI: all nine checks passed on `7e2d1a5`, including `build-debug`, which runs `WhatsNewContentTests` (unique ids, no empty fields, source order within a version, newest group equals `currentContentVersion`). Re-running on the current head.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — not possible on the authoring host
- [x] Logic tests pass — renderer self-test locally; Swift tests green in CI on the first commit
- [ ] CI `build-check` status is green on the current head — green on 7e2d1a5; re-running on 9c3fa29

### Behavioral Testing (Local UAT)
- N/A, content only

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval
- N/A

### Review
- [x] Codex P1 (byte-exact paste promise): copy corrected in 83cb3ca, thread resolved

### Release Housekeeping
- [ ] Land before the v2.4.7 release PR so the rendered release notes include it

## Note

#2484 (What's New list support) is in flight on another branch and adds a field to `Entry` in this file. Both changes touch different regions; whichever merges second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM