### PR TITLE
content(website): add S1-mini by Superwhisper to every marketing page that enumerates the polish engines (#2656)

### DIFF
--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -103,7 +103,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via EG-1, Ollama, or Apple Intelligence (macOS 26+). No internet required for the full pipeline."
+        "text": "Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+). No internet required for the full pipeline."
       }
     },
     {
@@ -119,7 +119,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can EnviousWispr remove filler words from dictation?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. EnviousWispr removes spoken noises like um, uh, and hmm automatically, on a fixed local list that works even with AI polish off. AI polish defaults to Apple Intelligence, which needs macOS 26+; on macOS 14-25 it silently falls back to the same deterministic cleanup unless you switch to EG-1, Ollama, or a cloud key. When AI polish does run, it goes further and also removes false starts and repeated words. Apple Dictation transcribes filler as-is."
+        "text": "Yes. EnviousWispr removes spoken noises like um, uh, and hmm automatically, on a fixed local list that works even with AI polish off. AI polish defaults to Apple Intelligence, which needs macOS 26+; on macOS 14-25 it silently falls back to the same deterministic cleanup unless you switch to EG-1, S1-mini by Superwhisper, Ollama, or a cloud key. When AI polish does run, it goes further and also removes false starts and repeated words. Apple Dictation transcribes filler as-is."
       }
     },
     {
@@ -419,7 +419,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">EG-1, Ollama</span> (on-device), <span class="table-highlight">Apple Intelligence</span> (on-device, macOS 26+), or BYO OpenAI/Gemini/Claude key</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Ollama</span> (on-device), <span class="table-highlight">Apple Intelligence</span> (on-device, macOS 26+), or BYO OpenAI/Gemini/Claude key</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
@@ -527,7 +527,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🧠</div>
         <div class="advantage-title">AI polish cleans your words</div>
-        <p class="advantage-desc">Apple Dictation gives you raw transcription. EnviousWispr pipes text through <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">AI polish</a> to remove filler words, fix grammar, and format paragraphs. Choose EG-1, Ollama, Apple Intelligence (macOS 26+), or your own OpenAI, Gemini, or Claude key.</p>
+        <p class="advantage-desc">Apple Dictation gives you raw transcription. EnviousWispr pipes text through <a href="/how-it-works/" style="color: var(--accent); text-decoration: underline;">AI polish</a> to remove filler words, fix grammar, and format paragraphs. Choose EG-1, S1-mini by Superwhisper, Ollama, Apple Intelligence (macOS 26+), or your own OpenAI, Gemini, or Claude key.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
@@ -613,7 +613,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-title">AI polish transforms raw speech</div>
         <div class="deep-dive-body">
           <p>Apple Dictation gives you exactly what you said, including every "um," "uh," "you know," and false start. For quick one-liners, that is fine. For anything longer, you end up editing the transcript to make it readable.</p>
-          <p>EnviousWispr pipes transcription through an AI polish step that removes filler words, fixes grammar, formats paragraphs, and adjusts tone. You can choose EG-1 (our own on-device model), Ollama (local open-source models), Apple Intelligence (on-device, requires macOS 26+), or bring your own OpenAI, Gemini, or Claude API key.</p>
+          <p>EnviousWispr pipes transcription through an AI polish step that removes filler words, fixes grammar, formats paragraphs, and adjusts tone. You can choose EG-1 (our own on-device model), S1-mini by Superwhisper (a lighter on-device model), Ollama (local open-source models), Apple Intelligence (on-device, requires macOS 26+), or bring your own OpenAI, Gemini, or Claude API key.</p>
           <p>The polish layer includes hallucination safeguards: short transcripts bypass the LLM entirely, output length is validated against input length, and preamble artifacts ("Certainly! Here is...") are stripped automatically. Your dictated text is wrapped in XML tags with explicit instructions to polish, not answer or rewrite.</p>
           <div class="deep-dive-detail">
             <strong>How it works:</strong> Context-aware prompts include the target app name, detected language, and ASR error patterns. Sandwich framing wraps the transcript in &lt;transcript&gt; tags to prevent prompt injection. Output exceeding 3x input length is rejected as probable hallucination, falling back to raw text.
@@ -693,7 +693,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr work offline?</div>
-        <p class="faq-a">Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via EG-1, Ollama, or Apple Intelligence (macOS 26+). No internet required for the full pipeline.</p>
+        <p class="faq-a">Transcription runs entirely on-device after a one-time model download. AI polish can also run locally via EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+). No internet required for the full pipeline.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">How accurate is EnviousWispr compared to Apple Dictation?</div>
@@ -701,7 +701,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can EnviousWispr remove filler words from dictation?</div>
-        <p class="faq-a">Yes. EnviousWispr removes spoken noises like "um," "uh," and "hmm" automatically, on a fixed local list that runs even with AI polish switched off. AI polish defaults to Apple Intelligence, which needs macOS 26+; below that it silently falls back to the same deterministic cleanup unless you switch to EG-1, Ollama, or a cloud key. When AI polish does run, it goes further and also removes false starts and repeated words. Apple Dictation transcribes them as-is. If you dictate longer passages, filler removal makes a noticeable difference in readability.</p>
+        <p class="faq-a">Yes. EnviousWispr removes spoken noises like "um," "uh," and "hmm" automatically, on a fixed local list that runs even with AI polish switched off. AI polish defaults to Apple Intelligence, which needs macOS 26+; below that it silently falls back to the same deterministic cleanup unless you switch to EG-1, S1-mini by Superwhisper, Ollama, or a cloud key. When AI polish does run, it goes further and also removes false starts and repeated words. Apple Dictation transcribes them as-is. If you dictate longer passages, filler removal makes a noticeable difference in readability.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr support voice commands like Apple Dictation?</div>

--- a/website/src/pages/compare/best-dictation-apps-for-mac.astro
+++ b/website/src/pages/compare/best-dictation-apps-for-mac.astro
@@ -63,7 +63,7 @@ const tableRows = [
   },
   {
     feature: "Polish / cleanup",
-    ew: "Yes, on-device with EG-1, Ollama, or Apple Intelligence (macOS 26+); optional cloud via your own key",
+    ew: "Yes, on-device with EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+); optional cloud via your own key",
     cells: ["Yes, but off until enabled; default provider is OpenAI so it expects an API key, and it runs on a second hotkey", "Yes, its own Fluid-1 model plus cloud providers; the Fluid-1 license and base model are not published", "Yes, cloud", "Local S1-mini or cloud writing models", "Optional add-on", "AI summaries (cloud)", "No", "Downloaded Gemma 4 for strictly local cleanup; Apple Intelligence also offered"],
   },
   {
@@ -222,7 +222,7 @@ const tableCols = ["Handy", "FluidVoice", "WisprFlow", "SuperWhisper", "MacWhisp
     <div class="pick reveal" id="best-free-private-mac-dictation">
       <div class="pick-label">Best for free, private, on-device dictation</div>
       <h2>EnviousWispr</h2>
-      <p>If you want to dictate into any Mac app without paying, signing in, or sending your voice to the cloud, EnviousWispr is the pick. Hold a keybind, speak, and transcription lands in well under a second; polished text follows shortly after, with the wait scaling to how much you said. Transcription runs entirely on your Mac's Apple Silicon, so your audio never leaves the device, and it works offline on a plane or in a basement. Cleanup runs on-device with EG-1, our own model, or Apple Intelligence (macOS 26+), so even the polish step can stay local; you can bring your own OpenAI, Gemini, or Claude key if you prefer a cloud model. Twenty-five European languages run on the fast Parakeet engine by default, and you can switch to WhisperKit for 99+ languages. The honest catch: it is macOS 14 and later on Apple Silicon only, with no Windows, Intel, or mobile version, and it is younger than the paid options.</p>
+      <p>If you want to dictate into any Mac app without paying, signing in, or sending your voice to the cloud, EnviousWispr is the pick. Hold a keybind, speak, and transcription lands in well under a second; polished text follows shortly after, with the wait scaling to how much you said. Transcription runs entirely on your Mac's Apple Silicon, so your audio never leaves the device, and it works offline on a plane or in a basement. Cleanup runs on-device with EG-1, our own model, S1-mini by Superwhisper, or Apple Intelligence (macOS 26+), so even the polish step can stay local; you can bring your own OpenAI, Gemini, or Claude key if you prefer a cloud model. Twenty-five European languages run on the fast Parakeet engine by default, and you can switch to WhisperKit for 99+ languages. The honest catch: it is macOS 14 and later on Apple Silicon only, with no Windows, Intel, or mobile version, and it is younger than the paid options.</p>
       <div class="pick-links">
         <a href="https://www.youtube.com/watch?v=srS5OgTj3O4" target="_blank" rel="noopener">Watch the 30-second demo</a>
         <a href="/compare/wisprflow/">Full EnviousWispr vs WisprFlow comparison</a>

--- a/website/src/pages/compare/dragon.astro
+++ b/website/src/pages/compare/dragon.astro
@@ -103,7 +103,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using EG-1, a local Ollama model, or Apple Intelligence (macOS 26+)."
+        "text": "Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using EG-1, S1-mini by Superwhisper, a local Ollama model, or Apple Intelligence (macOS 26+)."
       }
     },
     {
@@ -438,12 +438,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-highlight">Yes.</span> EG-1, local Ollama models, or Apple Intelligence (macOS 26+).</td>
+            <td><span class="table-highlight">Yes.</span> EG-1, S1-mini by Superwhisper, local Ollama models, or Apple Intelligence (macOS 26+).</td>
             <td><span class="table-cross">No AI polish at all</span></td>
           </tr>
           <tr>
             <td>AI polish / LLM providers</td>
-            <td><span class="table-highlight">6 providers:</span> EG-1, Ollama, Apple Intelligence (macOS 26+), OpenAI, Gemini, Claude</td>
+            <td><span class="table-highlight">7 providers:</span> EG-1, S1-mini by Superwhisper, Ollama, Apple Intelligence (macOS 26+), OpenAI, Gemini, Claude</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
@@ -556,7 +556,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">✨</div>
         <div class="advantage-title">AI polish built in</div>
-        <p class="advantage-desc">Dragon gives you a raw transcript. EnviousWispr can clean up filler words, fix punctuation, and restructure sentences using EG-1, a local Ollama model, or Apple Intelligence (macOS 26+). No extra software, no cloud dependency unless you choose it.</p>
+        <p class="advantage-desc">Dragon gives you a raw transcript. EnviousWispr can clean up filler words, fix punctuation, and restructure sentences using EG-1, S1-mini by Superwhisper, a local Ollama model, or Apple Intelligence (macOS 26+). No extra software, no cloud dependency unless you choose it.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">⚡</div>
@@ -601,7 +601,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>AI polish cleans up the transcript. Runs on-device with EG-1, Ollama, or Apple Intelligence (macOS 26+), or with your own cloud API key if you choose.</div>
+          <div>AI polish cleans up the transcript. Runs on-device with EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+), or with your own cloud API key if you choose.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -660,7 +660,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-title">Modern AI polish, not just raw transcript</div>
         <div class="deep-dive-body">
           <p>Dragon gives you a transcript and expects you to fix it. It has no concept of LLM-based post-processing. Dragon was built in an era before large language models existed, and Nuance has not retrofitted this capability.</p>
-          <p>EnviousWispr integrates six polish engines for Smart Polish: EG-1 (our own on-device model), Ollama (local models like Qwen or Gemma), Apple Intelligence (on-device, macOS 26+), and cloud options via OpenAI, Gemini, or Claude if you bring your own API key. The polish step removes filler words, fixes punctuation, restructures awkward phrasings, and adapts to the app you are dictating into.</p>
+          <p>EnviousWispr integrates seven polish engines for Smart Polish: EG-1 (our own on-device model), S1-mini by Superwhisper (a lighter on-device model), Ollama (local models like Qwen or Gemma), Apple Intelligence (on-device, macOS 26+), and cloud options via OpenAI, Gemini, or Claude if you bring your own API key. The polish step removes filler words, fixes punctuation, restructures awkward phrasings, and adapts to the app you are dictating into.</p>
           <p>The system is context-aware. Dictating into Slack? The polish keeps it conversational. Writing an email? It formalizes. And all cloud providers only receive the text transcript, never your audio.</p>
           <div class="deep-dive-detail">
             <strong>Technical detail:</strong> Smart Polish uses sandwich prompt framing with XML-tagged transcript boundaries to prevent hallucination. Output validation rejects responses longer than 3x the input. Short transcripts (3 words or fewer) bypass the LLM entirely. Preamble stripping removes "Certainly!" artifacts automatically.
@@ -765,7 +765,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr work offline?</div>
-        <p class="faq-a">Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using EG-1, a local Ollama model, or Apple Intelligence (macOS 26+). See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a> for setup.</p>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet after the initial model download. AI polish can also run offline using EG-1, S1-mini by Superwhisper, a local Ollama model, or Apple Intelligence (macOS 26+). See the <a href="/blog/getting-started-enviouswispr-under-2-minutes/" style="color: var(--accent); text-decoration: underline;">getting started guide</a> for setup.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can EnviousWispr do voice commands like Dragon?</div>

--- a/website/src/pages/compare/fluidvoice.astro
+++ b/website/src/pages/compare/fluidvoice.astro
@@ -88,7 +88,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use EnviousWispr completely offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
       }
     },
     {
@@ -427,12 +427,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish (cleanup after transcription)</td>
-            <td><span class="table-highlight">EG-1</span> (our own tuned model), Apple Intelligence, Ollama, or your own OpenAI, Claude, or Gemini key</td>
+            <td><span class="table-highlight">EG-1</span> (our own tuned model), S1-mini by Superwhisper, Apple Intelligence, Ollama, or your own OpenAI, Claude, or Gemini key</td>
             <td><span class="table-check">Fluid-1 plus broad provider choice</span>: OpenAI, Anthropic, xAI, Groq, Cerebras, Google, OpenRouter, Ollama, LM Studio, or a custom endpoint</td>
           </tr>
           <tr>
             <td>Needs a prompt to be written</td>
-            <td><span class="table-check">No</span>: EG-1 and Apple Intelligence ship with a working default</td>
+            <td><span class="table-check">No</span>: EG-1, S1-mini by Superwhisper, and Apple Intelligence ship with a working default</td>
             <td><span class="table-check">No</span>: a working default ships with the app, and prompt profiles can be edited or routed by app</td>
           </tr>
           <tr>
@@ -713,7 +713,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
-        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source like FluidVoice?</div>

--- a/website/src/pages/compare/google-docs-voice-typing.astro
+++ b/website/src/pages/compare/google-docs-voice-typing.astro
@@ -345,12 +345,12 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">EG-1, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> (EG-1, Ollama, or Apple Intelligence on macOS 26+)</td>
+            <td><span class="table-check">Yes</span> (EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence on macOS 26+)</td>
             <td><span class="table-cross">No.</span> Entire tool requires internet.</td>
           </tr>
           <tr>
@@ -458,7 +458,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">✨</div>
         <div class="advantage-title">AI polish and cleanup</div>
-        <p class="advantage-desc">EnviousWispr removes filler words, fixes grammar, and polishes your text with AI. Use EG-1 or Ollama on-device (or Apple Intelligence on macOS 26+), or bring your own OpenAI, Gemini, or Claude API key. Google's voice typing gives you raw dictation only.</p>
+        <p class="advantage-desc">EnviousWispr removes filler words, fixes grammar, and polishes your text with AI. Use EG-1, S1-mini by Superwhisper, or Ollama on-device (or Apple Intelligence on macOS 26+), or bring your own OpenAI, Gemini, or Claude API key. Google's voice typing gives you raw dictation only.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📝</div>
@@ -557,7 +557,7 @@ const breadcrumbJsonLd = JSON.stringify({
         <div class="deep-dive-title">Privacy: on-device vs cloud</div>
         <div class="deep-dive-body">
           <p>Google Docs Voice Typing requires a constant internet connection. Your audio is streamed to Google's servers, processed by their speech recognition API, and the text result is sent back. Google's <a href="https://policies.google.com/privacy" style="color: var(--accent); text-decoration: underline;">privacy policy</a> governs how that audio data is handled.</p>
-          <p>EnviousWispr processes audio entirely on your Mac using the Apple Silicon Neural Engine. The audio buffer never leaves your device. After transcription, the audio is discarded. If you use on-device AI polish (EG-1, Ollama, or Apple Intelligence on macOS 26+), the entire pipeline is local. No audio or text is uploaded anywhere.</p>
+          <p>EnviousWispr processes audio entirely on your Mac using the Apple Silicon Neural Engine. The audio buffer never leaves your device. After transcription, the audio is discarded. If you use on-device AI polish (EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence on macOS 26+), the entire pipeline is local. No audio or text is uploaded anywhere.</p>
           <p>If you opt into a cloud LLM for polish (OpenAI, Gemini, or Claude), only the text transcript is sent, never the audio, and you provide your own API key. You control the relationship with the provider directly.</p>
           <div class="deep-dive-detail">
             <strong>Privacy by architecture:</strong> EnviousWispr does not have a server. There is no account system, no cloud backend, and no telemetry on your dictated content. The app sends anonymous usage analytics (PostHog) and crash reports (Sentry). Your audio never leaves your Mac; your text stays local too, unless you opt into cloud polish, in which case only the transcript goes directly to your chosen provider under your own API key.

--- a/website/src/pages/compare/handy.astro
+++ b/website/src/pages/compare/handy.astro
@@ -88,7 +88,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use EnviousWispr completely offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
       }
     },
     {
@@ -442,7 +442,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish (cleanup after transcription)</td>
-            <td><span class="table-highlight">EG-1, Apple Intelligence, or a local Ollama model on-device;</span> OpenAI, Claude, or Gemini with your own key, or Ollama's hosted models with your Ollama sign-in</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Apple Intelligence, or a local Ollama model on-device;</span> OpenAI, Claude, or Gemini with your own key, or Ollama's hosted models with your Ollama sign-in</td>
             <td><span class="table-check">Yes</span>: OpenAI, OpenRouter, Anthropic, Groq, Cerebras, Apple Intelligence, Custom, Z.AI, or AWS Bedrock through Mantle</td>
           </tr>
           <tr>
@@ -600,7 +600,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>AI polish runs locally by default (EG-1, Apple Intelligence, or a downloaded Ollama model). If you choose a cloud provider instead (your own key for OpenAI, Claude, or Gemini, or your Ollama sign-in for Ollama's hosted models), your transcript, custom words, and the app you're dictating into are sent. Audio is never sent, either way.</div>
+          <div>AI polish runs locally by default (EG-1, S1-mini by Superwhisper, Apple Intelligence, or a downloaded Ollama model). If you choose a cloud provider instead (your own key for OpenAI, Claude, or Gemini, or your Ollama sign-in for Ollama's hosted models), your transcript, custom words, and the app you're dictating into are sent. Audio is never sent, either way.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -690,7 +690,7 @@ const faqJsonLd = JSON.stringify({
           <p>EnviousWispr's polish runs on the same hotkey as transcription, automatically once it is on, and never needs a second hotkey the way Handy's does. Deterministic filler-word removal (um, uh, hmm, and similar) runs first and always, whatever language you're dictating in; spoken numbers, dates, and times convert to digits automatically too, when you're dictating in English. EG-1, our own model fine-tuned specifically for dictation, then handles the harder cases: turning a spoken list into a real one, keeping only what you meant when you talk yourself into a correction mid-sentence. That LLM step is guarded against hallucination: short transcripts skip the model entirely, and output beyond roughly three times the input's length (with a floor around 200 characters, so a short dictation isn't flagged the instant polish adds a sentence) is rejected as probable fabrication and the raw transcript is used instead.</p>
           <p>In our own testing on the latest release, EG-1 builds a real bulleted list out of a spoken list 83% of the time (up from under 1%), and correctly keeps only what you meant when you self-correct mid-sentence 78% of the time. That is a measured result from a model built and tested for this one job. Handy's cleanup quality with its default prompt, or your own, has not been benchmarked publicly, and will vary further if you write your own instructions or switch providers.</p>
           <div class="deep-dive-detail">
-            <strong>How it works:</strong> Deterministic filler-word removal (um, uh, hmm, and similar) runs first and always, whatever language you're dictating in; number/date/time formatting joins it for English dictation. AI polish (EG-1, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
+            <strong>How it works:</strong> Deterministic filler-word removal (um, uh, hmm, and similar) runs first and always, whatever language you're dictating in; number/date/time formatting joins it for English dictation. AI polish (EG-1, S1-mini by Superwhisper, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
           </div>
         </div>
       </div>
@@ -764,7 +764,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
-        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source like Handy?</div>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -304,7 +304,7 @@ const itemListJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish (cleanup)</td>
-            <td class="col-ew"><span class="yes">Yes, on-device EG-1, Ollama, or Apple Intelligence (macOS 26+); BYOK cloud optional</span></td>
+            <td class="col-ew"><span class="yes">Yes, on-device EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+); BYOK cloud optional</span></td>
             <td><span class="yes">Yes, cloud</span></td>
             <td><span class="partial">S1-mini for local basic cleanup; Pro cloud writing modes also available</span></td>
             <td><span class="no">No</span></td>

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -96,7 +96,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use EnviousWispr completely offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
       }
     },
     {
@@ -431,7 +431,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish (cleanup after transcription)</td>
-            <td><span class="table-highlight">EG-1</span> (measured, purpose-built for dictation), Apple Intelligence, Ollama, or your own key</td>
+            <td><span class="table-highlight">EG-1</span> (measured, purpose-built for dictation), S1-mini by Superwhisper, Apple Intelligence, Ollama, or your own key</td>
             <td><span class="table-check">Yes</span>, on-device: Qwen3 0.6B for live correction, Qwen3 4B Instruct for smart formatting, both separate downloads; no published benchmark</td>
           </tr>
           <tr>
@@ -653,7 +653,7 @@ const faqJsonLd = JSON.stringify({
           <p>Juno is a local voice layer for writing, rewriting, and taking actions. After dictation begins, Voice Actions for creating a Note, setting a Reminder, or adding a one-shot alarm start with "Hey Juno." Its separate Voice Commands and Writer commands can rewrite text without a wake phrase.</p>
           <p>EnviousWispr does not create Notes, Reminders, or alarms. It turns speech into text and pastes it where you were working. If you want a broader local assistant, Juno covers ground we do not.</p>
           <div class="deep-dive-detail">
-            <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
+            <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, S1-mini by Superwhisper, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
           </div>
         </div>
       </div>
@@ -721,7 +721,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
-        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source like Juno?</div>

--- a/website/src/pages/compare/macwhisper.astro
+++ b/website/src/pages/compare/macwhisper.astro
@@ -79,7 +79,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does EnviousWispr work offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via EG-1, Ollama, or Apple Intelligence (macOS 26+). Cloud polish with your own API key is optional."
+        "text": "Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+). Cloud polish with your own API key is optional."
       }
     },
     {
@@ -429,7 +429,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">EG-1, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
             <td>AI Assistant add-on ($9.99/mo), cloud-based</td>
           </tr>
           <tr>
@@ -522,7 +522,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">EG-1 and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. MacWhisper's AI Assistant is a separate $9.99/mo subscription.</p>
+        <p class="advantage-desc">EG-1, S1-mini by Superwhisper, and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. MacWhisper's AI Assistant is a separate $9.99/mo subscription.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📝</div>
@@ -651,7 +651,7 @@ const faqJsonLd = JSON.stringify({
         <div class="deep-dive-body">
           <p>MacWhisper gives you Whisper output. That is already useful for file transcription, where you can review and edit at your leisure. For real-time dictation, raw ASR output is not good enough. You need text that is ready to use the moment it appears.</p>
           <p>EnviousWispr runs a 6-pass fuzzy word correction pipeline on every transcription. Your custom vocabulary (names, technical terms, acronyms) is matched against the ASR output using phonetic similarity, edit distance, and context-aware scoring. Filler words like "um", "uh", and "you know" are stripped automatically.</p>
-          <p>On top of that, optional AI polish reformats the text for grammar, punctuation, and readability. It runs on-device with EG-1, Ollama, or Apple Intelligence (macOS 26+), or via your own OpenAI, Gemini, or Claude key. The result is polished, ready-to-send text, not a rough transcript that needs manual cleanup.</p>
+          <p>On top of that, optional AI polish reformats the text for grammar, punctuation, and readability. It runs on-device with EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+), or via your own OpenAI, Gemini, or Claude key. The result is polished, ready-to-send text, not a rough transcript that needs manual cleanup.</p>
           <div class="deep-dive-detail">
             <strong>How it works:</strong> Post-processing pipeline applies custom word correction (phonetic matching, Levenshtein distance, bigram context), filler removal, and optional LLM polish. AI polish uses sandwich framing with XML tags to prevent hallucination, plus output length validation to reject fabricated responses. Short transcripts bypass LLM entirely.
           </div>
@@ -723,7 +723,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does EnviousWispr work offline?</div>
-        <p class="faq-a">Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via EG-1, Ollama, or Apple Intelligence (macOS 26+). Cloud polish with your own API key is optional.</p>
+        <p class="faq-a">Transcription runs entirely on-device and works without internet after models download. AI polish can also run locally via EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+). Cloud polish with your own API key is optional.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use MacWhisper for dictation?</div>

--- a/website/src/pages/compare/notta.astro
+++ b/website/src/pages/compare/notta.astro
@@ -433,12 +433,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">EG-1, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
             <td>AI summaries and action items from meetings</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> - EG-1, Ollama, or Apple Intelligence (macOS 26+) run locally</td>
+            <td><span class="table-check">Yes</span> - EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+) run locally</td>
             <td><span class="table-cross">No</span> - AI features require cloud</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -449,7 +449,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish / AI features</td>
-            <td><span class="table-highlight">EG-1, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
             <td>AI summaries, action items, chat with transcripts (cloud)</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/spokenly.astro
+++ b/website/src/pages/compare/spokenly.astro
@@ -96,7 +96,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use EnviousWispr completely offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
       }
     },
     {
@@ -634,7 +634,7 @@ const faqJsonLd = JSON.stringify({
           <p>Spokenly's Modes and Agentic Actions turn it into more than dictation: switch profiles per app, and let a spoken command search the web, open an app, or run a Shortcut. Its MCP tool gives Claude Code or Codex a specific way to ask a question and receive your spoken answer.</p>
           <p>EnviousWispr does one thing: it turns your speech into clean, finished text wherever your cursor is, every time, the same way. If you want the broader automation layer, Spokenly covers ground we do not attempt.</p>
           <div class="deep-dive-detail">
-            <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
+            <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, S1-mini by Superwhisper, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
           </div>
         </div>
       </div>
@@ -702,7 +702,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
-        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I import my Spokenly custom words into EnviousWispr?</div>

--- a/website/src/pages/compare/superwhisper.astro
+++ b/website/src/pages/compare/superwhisper.astro
@@ -88,7 +88,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use EnviousWispr completely offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud AI providers like OpenAI, Gemini, or Claude are optional and require your own API key."
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud AI providers like OpenAI, Gemini, or Claude are optional and require your own API key."
       }
     },
     {
@@ -96,7 +96,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does Superwhisper have offline AI polish?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Superwhisper can transcribe offline with a downloaded local speech model, and it now has an on-device polish option too: a Local mode powered by S1-mini, its own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition and a lighter cleanup pass than the cloud writing modes, which still need an internet connection. EnviousWispr's EG-1 and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+."
+        "text": "Superwhisper can transcribe offline with a downloaded local speech model, and it now has an on-device polish option too: a Local mode powered by S1-mini, its own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition and a lighter cleanup pass than the cloud writing modes, which still need an internet connection. EnviousWispr's EG-1, S1-mini by Superwhisper, and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+."
       }
     },
     {
@@ -430,12 +430,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">EG-1, Ollama on-device, Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Ollama on-device, Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
             <td>Cloud AI via GPT-5, Claude, Llama 4, Grok, Gemini, Ministral (requires Pro); or S1-mini on-device for basic cleanup (experimental, free)</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> (EG-1, Apple Intelligence, or Ollama, fully on-device)</td>
+            <td><span class="table-check">Yes</span> (EG-1, S1-mini by Superwhisper, Apple Intelligence, or Ollama, fully on-device)</td>
             <td><span class="table-check">Yes</span>, for basic cleanup: Local mode with S1-mini (experimental, 0.6B, on-device); full writing modes still need GPT, Claude, or Llama over the internet</td>
           </tr>
           <tr>
@@ -573,7 +573,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">EG-1 and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. You control which services touch your text. Superwhisper's cloud AI requires a Pro subscription.</p>
+        <p class="advantage-desc">EG-1, S1-mini by Superwhisper, and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. You control which services touch your text. Superwhisper's cloud AI requires a Pro subscription.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>
@@ -608,7 +608,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>AI polish runs locally (EG-1, Ollama, or Apple Intelligence on macOS 26+) or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
+          <div>AI polish runs locally (EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence on macOS 26+) or with your own API key. If you use a cloud provider, only the text transcript is sent; you control the key.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -773,11 +773,11 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
-        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud AI providers like OpenAI, Gemini, or Claude are optional and require your own API key.</p>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud AI providers like OpenAI, Gemini, or Claude are optional and require your own API key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does Superwhisper have offline AI polish?</div>
-        <p class="faq-a">Superwhisper can transcribe offline with a downloaded local speech model, and it now has an on-device polish option too: a Local mode powered by S1-mini, its own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition and a lighter cleanup pass than the cloud writing modes, which still need an internet connection. EnviousWispr's EG-1 and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+.</p>
+        <p class="faq-a">Superwhisper can transcribe offline with a downloaded local speech model, and it now has an on-device polish option too: a Local mode powered by S1-mini, its own 0.6B open-weights model that cleans up fillers, punctuation, and numbers without sending anything off your Mac. It is a newer, experimental addition and a lighter cleanup pass than the cloud writing modes, which still need an internet connection. EnviousWispr's EG-1, S1-mini by Superwhisper, and Ollama integrations run entirely on your Mac, and so does Apple Intelligence on macOS 26+.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr really free?</div>

--- a/website/src/pages/compare/typewhisper.astro
+++ b/website/src/pages/compare/typewhisper.astro
@@ -88,7 +88,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use EnviousWispr completely offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
+        "text": "Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key."
       }
     },
     {
@@ -639,7 +639,7 @@ const faqJsonLd = JSON.stringify({
           <p>TypeWhisper's Workflows are a genuine automation system: cleanup, translation, extraction, and formatting steps, referencing providers like OpenAI and Groq in its own changelog. The installed build also includes presets for Action Items, Create Table, email drafting, lists, JSON, Meeting Notes, Reply, and Translate.</p>
           <p>EG-1 is a single model, fine-tuned by us specifically for the problem of turning spoken dictation into clean text, shipped with the app, with results we measure and publish. It runs on the same hotkey as transcription with nothing to configure.</p>
           <div class="deep-dive-detail">
-            <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
+            <strong>How it works:</strong> Deterministic filler and number cleanup runs first and always. AI polish (EG-1, S1-mini by Superwhisper, Apple Intelligence, Ollama, or your own cloud key) runs after, with output-length validation to catch fabrication. If any step fails, you still get the last successful text, never nothing.
           </div>
         </div>
       </div>
@@ -703,7 +703,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use EnviousWispr completely offline?</div>
-        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
+        <p class="faq-a">Yes. After the one-time model download, transcription runs entirely on-device with no internet required. AI polish can also run offline using EG-1 (our own model, macOS 14+), S1-mini by Superwhisper, Apple Intelligence (macOS 26+), or Ollama with a local model. Cloud providers like OpenAI, Claude, or Gemini are optional and require your own API key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source like TypeWhisper?</div>

--- a/website/src/pages/compare/voiceink.astro
+++ b/website/src/pages/compare/voiceink.astro
@@ -135,7 +135,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does VoiceInk have AI text enhancement?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 6 AI polish engines including EG-1 (our own on-device model), Ollama (on-device), Apple Intelligence (on-device, macOS 26+), and cloud providers (OpenAI, Gemini, Claude) with your own API key, plus built-in hallucination safeguards."
+        "text": "Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 7 AI polish engines including EG-1 (our own on-device model), S1-mini by Superwhisper (on-device), Ollama (on-device), Apple Intelligence (on-device, macOS 26+), and cloud providers (OpenAI, Gemini, Claude) with your own API key, plus built-in hallucination safeguards."
       }
     }
   ]
@@ -481,12 +481,12 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">6 providers:</span> EG-1, Ollama (on-device), Apple Intelligence (on-device, macOS 26+), OpenAI, Gemini, Claude (BYO key)</td>
+            <td><span class="table-highlight">7 providers:</span> EG-1, S1-mini by Superwhisper, Ollama (on-device), Apple Intelligence (on-device, macOS 26+), OpenAI, Gemini, Claude (BYO key)</td>
             <td>AI formatting via system prompts with LLM providers</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> (EG-1, Ollama, or Apple Intelligence on macOS 26+, no API key needed)</td>
+            <td><span class="table-check">Yes</span> (EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence on macOS 26+, no API key needed)</td>
             <td><span class="table-cross">Requires cloud LLM</span> for AI formatting</td>
           </tr>
           <tr>
@@ -604,7 +604,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#129504;</div>
         <div class="advantage-title">6 on-device + cloud polish engines</div>
-        <p class="advantage-desc">EG-1 and Ollama run fully on-device with no API key, and so does Apple Intelligence on macOS 26+. Or bring your own OpenAI, Gemini, or Claude key. VoiceInk offers AI formatting through system prompts with cloud LLMs.</p>
+        <p class="advantage-desc">EG-1, S1-mini by Superwhisper, and Ollama run fully on-device with no API key, and so does Apple Intelligence on macOS 26+. Or bring your own OpenAI, Gemini, or Claude key. VoiceInk offers AI formatting through system prompts with cloud LLMs.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">&#128295;</div>
@@ -649,7 +649,7 @@ const faqJsonLd = JSON.stringify({
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">3</div>
-          <div>AI polish runs locally (EG-1, Ollama, or Apple Intelligence on macOS 26+) or with your own API key. If you use a cloud provider, only the text transcript is sent.</div>
+          <div>AI polish runs locally (EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence on macOS 26+) or with your own API key. If you use a cloud provider, only the text transcript is sent.</div>
         </div>
         <div class="privacy-step">
           <div class="privacy-step-num">4</div>
@@ -818,7 +818,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">What is AI polish and does VoiceInk have it?</div>
-        <p class="faq-a">AI polish is a post-transcription step that fixes grammar, removes filler words, and formats your text using a language model. EnviousWispr supports EG-1, Ollama, and Apple Intelligence (all on-device, Apple Intelligence needs macOS 26+), and cloud providers (OpenAI, Gemini, Claude) with your own API key. VoiceInk offers AI formatting through system prompts with cloud LLM providers.</p>
+        <p class="faq-a">AI polish is a post-transcription step that fixes grammar, removes filler words, and formats your text using a language model. EnviousWispr supports EG-1, S1-mini by Superwhisper, Ollama, and Apple Intelligence (all on-device, Apple Intelligence needs macOS 26+), and cloud providers (OpenAI, Gemini, Claude) with your own API key. VoiceInk offers AI formatting through system prompts with cloud LLM providers.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Which app is better for non-English languages?</div>
@@ -826,7 +826,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does VoiceInk have AI text enhancement?</div>
-        <p class="faq-a">Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 6 AI polish engines including EG-1 (our own on-device model), Ollama (on-device), Apple Intelligence (on-device, macOS 26+), OpenAI, Gemini, and Claude, plus built-in hallucination safeguards that reject fabricated output.</p>
+        <p class="faq-a">Yes. VoiceInk offers AI formatting through system prompts with LLM providers. EnviousWispr supports 7 AI polish engines including EG-1 (our own on-device model), S1-mini by Superwhisper (on-device), Ollama (on-device), Apple Intelligence (on-device, macOS 26+), OpenAI, Gemini, and Claude, plus built-in hallucination safeguards that reject fabricated output.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I switch from VoiceInk easily?</div>
@@ -838,7 +838,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is there a free alternative to VoiceInk?</div>
-        <p class="faq-a">Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline with 6 providers. No account or payment required.</p>
+        <p class="faq-a">Yes. EnviousWispr is a free, on-device dictation app for Apple Silicon Macs. It uses Parakeet TDT for fast English transcription and includes an AI polish pipeline with 7 providers. No account or payment required.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Is EnviousWispr open source?</div>

--- a/website/src/pages/compare/vox.astro
+++ b/website/src/pages/compare/vox.astro
@@ -45,7 +45,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Do EnviousWispr and Vox both work offline?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes, when using downloaded local models. Vox can transcribe locally and use downloaded Gemma 4 for local cleanup. Vox also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. EnviousWispr can use local EG-1, Apple Intelligence, or downloaded Ollama models, plus optional cloud providers with your own key."
+        "text": "Yes, when using downloaded local models. Vox can transcribe locally and use downloaded Gemma 4 for local cleanup. Vox also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. EnviousWispr can use local EG-1, S1-mini by Superwhisper, Apple Intelligence, or downloaded Ollama models, plus optional cloud providers with your own key."
       }
     },
     {
@@ -53,7 +53,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Does Vox have AI cleanup like EnviousWispr's EG-1?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Vox can clean up text locally with a downloaded Gemma 4 model. It also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. Vox's built-in and custom Voice Modes control how cleanup behaves. EnviousWispr offers EG-1, Apple Intelligence, or a downloaded Ollama model locally, plus optional cloud providers with your own key."
+        "text": "Yes. Vox can clean up text locally with a downloaded Gemma 4 model. It also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. Vox's built-in and custom Voice Modes control how cleanup behaves. EnviousWispr offers EG-1, S1-mini by Superwhisper, Apple Intelligence, or a downloaded Ollama model locally, plus optional cloud providers with your own key."
       }
     },
     {
@@ -326,7 +326,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI cleanup</td>
-            <td>EG-1, Apple Intelligence, or a downloaded Ollama model</td>
+            <td>EG-1, S1-mini by Superwhisper, Apple Intelligence, or a downloaded Ollama model</td>
             <td>Downloaded Gemma 4 stays local; Apple Intelligence may use Apple's Private Cloud Compute</td>
           </tr>
           <tr>
@@ -428,11 +428,11 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Do EnviousWispr and Vox both work offline?</div>
-        <p class="faq-a">Yes, when using downloaded local models. Vox can transcribe locally and use downloaded Gemma 4 for local cleanup. Vox also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. EnviousWispr can use local EG-1, Apple Intelligence, or downloaded Ollama models, plus optional cloud providers with your own key.</p>
+        <p class="faq-a">Yes, when using downloaded local models. Vox can transcribe locally and use downloaded Gemma 4 for local cleanup. Vox also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. EnviousWispr can use local EG-1, S1-mini by Superwhisper, Apple Intelligence, or downloaded Ollama models, plus optional cloud providers with your own key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Does Vox have AI cleanup like EnviousWispr's EG-1?</div>
-        <p class="faq-a">Yes. Vox can clean up text locally with a downloaded Gemma 4 model. It also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. Vox's built-in and custom Voice Modes control how cleanup behaves. EnviousWispr offers EG-1, Apple Intelligence, or a downloaded Ollama model locally, plus optional cloud providers with your own key.</p>
+        <p class="faq-a">Yes. Vox can clean up text locally with a downloaded Gemma 4 model. It also offers Apple Intelligence, which may route text through Apple's Private Cloud Compute. Vox's built-in and custom Voice Modes control how cleanup behaves. EnviousWispr offers EG-1, S1-mini by Superwhisper, Apple Intelligence, or a downloaded Ollama model locally, plus optional cloud providers with your own key.</p>
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">What is VoxNotch?</div>

--- a/website/src/pages/compare/whisper-cpp.astro
+++ b/website/src/pages/compare/whisper-cpp.astro
@@ -345,12 +345,12 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">6 providers</span>: EG-1, Ollama, Apple Intelligence (macOS 26+), OpenAI, Gemini, Claude</td>
+            <td><span class="table-highlight">7 providers</span>: EG-1, S1-mini by Superwhisper, Ollama, Apple Intelligence (macOS 26+), OpenAI, Gemini, Claude</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span>. EG-1 and Ollama run fully on-device, and so does Apple Intelligence on macOS 26+.</td>
+            <td><span class="table-check">Yes</span>. EG-1, S1-mini by Superwhisper, and Ollama run fully on-device, and so does Apple Intelligence on macOS 26+.</td>
             <td><span class="table-cross">None</span></td>
           </tr>
           <tr>

--- a/website/src/pages/compare/willow-voice.astro
+++ b/website/src/pages/compare/willow-voice.astro
@@ -341,12 +341,12 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>AI polish</td>
-            <td><span class="table-highlight">EG-1, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
+            <td><span class="table-highlight">EG-1, S1-mini by Superwhisper, Ollama</span> on-device, <span class="table-highlight">Apple Intelligence</span> on-device (macOS 26+); OpenAI, Gemini, or Claude with your own key</td>
             <td>AI rewrite and style matching (cloud)</td>
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-check">Yes</span> via EG-1, local Ollama models, or Apple Intelligence (macOS 26+)</td>
+            <td><span class="table-check">Yes</span> via EG-1, S1-mini by Superwhisper, local Ollama models, or Apple Intelligence (macOS 26+)</td>
             <td><span class="table-cross">No</span> (cloud-dependent)</td>
           </tr>
           <tr>
@@ -366,7 +366,7 @@ const breadcrumbJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td><span class="table-check">Yes</span> (six AI providers: EG-1, Ollama, Apple Intelligence on macOS 26+, OpenAI, Gemini, Claude; voice-preserving polish)</td>
+            <td><span class="table-check">Yes</span> (seven AI providers: EG-1, S1-mini by Superwhisper, Ollama, Apple Intelligence on macOS 26+, OpenAI, Gemini, Claude; voice-preserving polish)</td>
             <td><span class="table-check">Yes</span> (style matching, AI mode)</td>
           </tr>
           <tr>
@@ -459,7 +459,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">EG-1 and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. You control which services touch your text, if any.</p>
+        <p class="advantage-desc">EG-1, S1-mini by Superwhisper, and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. You control which services touch your text, if any.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -428,7 +428,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Offline AI polish</td>
-            <td><span class="table-highlight">Yes.</span> Transcription + AI polish can both run fully offline via EG-1, Ollama, or Apple Intelligence (macOS 26+). Cloud options (OpenAI, Gemini, Claude) available with your own key.</td>
+            <td><span class="table-highlight">Yes.</span> Transcription + AI polish can both run fully offline via EG-1, S1-mini by Superwhisper, Ollama, or Apple Intelligence (macOS 26+). Cloud options (OpenAI, Gemini, Claude) available with your own key.</td>
             <td><span class="table-cross">No.</span> Requires internet for both transcription and AI editing.</td>
           </tr>
           <tr>
@@ -468,7 +468,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Writing style control</td>
-            <td>Voice-preserving AI polish across six engines (EG-1, Ollama on-device; Apple Intelligence on-device, macOS 26+; OpenAI, Gemini, Claude with your own key).</td>
+            <td>Voice-preserving AI polish across seven engines (EG-1, S1-mini by Superwhisper, Ollama on-device; Apple Intelligence on-device, macOS 26+; OpenAI, Gemini, Claude with your own key).</td>
             <td>Auto-adjusts tone per app (English, desktop only).</td>
           </tr>
           <tr>
@@ -586,7 +586,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔑</div>
         <div class="advantage-title">Your choice of AI polish</div>
-        <p class="advantage-desc">EG-1 and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. You control which services touch your text, if any.</p>
+        <p class="advantage-desc">EG-1, S1-mini by Superwhisper, and Ollama run entirely on-device, and so does Apple Intelligence on macOS 26+. Want cloud speed? Bring your own OpenAI, Gemini, or Claude key. You control which services touch your text, if any.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📖</div>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -385,9 +385,9 @@ const breadcrumbJsonLd = JSON.stringify({
         <div class="stat-detail">WhisperKit + Parakeet</div>
       </div>
       <div class="stat-card reveal">
-        <div class="stat-value">5</div>
+        <div class="stat-value">6</div>
         <div class="stat-label">Polish engines</div>
-        <div class="stat-detail">EG-1, Apple, Ollama, OpenAI, Gemini</div>
+        <div class="stat-detail">EG-1, S1-mini by Superwhisper, Apple, Ollama, OpenAI, Gemini</div>
       </div>
       <div class="stat-card reveal">
         <div class="stat-value">0</div>
@@ -426,12 +426,18 @@ const breadcrumbJsonLd = JSON.stringify({
         <div class="engine-meta">On-device &middot; macOS 14+ &middot; One-time download &middot; Free</div>
       </div>
       <div class="engine-card reveal" style="--i:2">
+        <span class="engine-badge">Lightest</span>
+        <h3>S1-mini by Superwhisper</h3>
+        <p>A small open model built for tidying up dictated text. About a sixth the size of EG-1, with Tone, Structure, and Context settings you choose. English first. Runs fully on your Mac. EG-1 stays our recommendation.</p>
+        <div class="engine-meta">On-device &middot; macOS 14+ &middot; 484 MB download &middot; Free</div>
+      </div>
+      <div class="engine-card reveal" style="--i:3">
         <span class="engine-badge">Your call</span>
         <h3>Your own local model</h3>
         <p>Run any local model through Ollama, fully offline, if you would rather bring your own.</p>
         <div class="engine-meta">On-device &middot; Bring your own model</div>
       </div>
-      <div class="engine-card reveal" style="--i:3">
+      <div class="engine-card reveal" style="--i:4">
         <span class="engine-badge">Your call</span>
         <h3>Your OpenAI or Gemini key</h3>
         <p>Prefer a cloud model? The transcript, cleanup instructions, custom words, target app name, and your account credential go directly to that provider. Audio never does.</p>
@@ -482,7 +488,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="feat-card reveal">
         <div class="feat-icon">✏️</div>
         <div class="feat-title">Smart polish</div>
-        <p class="feat-desc">Filler words removed, grammar corrected, your meaning preserved. Runs on-device with EG-1 or Apple Intelligence, or with your own OpenAI or Gemini key.</p>
+        <p class="feat-desc">Filler words removed, grammar corrected, your meaning preserved. Runs on-device with EG-1, S1-mini by Superwhisper, or Apple Intelligence, or with your own OpenAI or Gemini key.</p>
       </div>
       <div class="feat-card reveal">
         <div class="feat-icon">🎯</div>
@@ -502,7 +508,7 @@ const breadcrumbJsonLd = JSON.stringify({
       <div class="feat-card reveal">
         <div class="feat-icon">🔌</div>
         <div class="feat-title">Multiple AI providers</div>
-        <p class="feat-desc">Use on-device polish with EG-1 (our own model), Apple Intelligence, or Ollama, or bring your own OpenAI or Gemini key. Cloud polish requests include <code>store: false</code> so providers are asked not to retain the text.</p>
+        <p class="feat-desc">Use on-device polish with EG-1 (our own model), S1-mini by Superwhisper, Apple Intelligence, or Ollama, or bring your own OpenAI or Gemini key. Cloud polish requests include <code>store: false</code> so providers are asked not to retain the text.</p>
       </div>
       <div class="feat-card reveal">
         <div class="feat-icon">🔤</div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -387,7 +387,7 @@ const jsonLdWebSite = JSON.stringify({
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="2" stroke-linecap="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
           </div>
           <h3>Your AI, Your Choice</h3>
-          <p>Polish on-device with EG-1, our own model and the one we recommend, or Apple's built-in AI. Prefer to bring your own? Run a local model with Ollama, or add your own OpenAI or Google Gemini key. The on-device options need no internet at all.</p>
+          <p>Polish on-device with EG-1, our own model and the one we recommend, with S1-mini by Superwhisper, or with Apple's built-in AI. Prefer to bring your own? Run a local model with Ollama, or add your own OpenAI or Google Gemini key. The on-device options need no internet at all.</p>
         </div>
         <div class="benefit-card reveal" style="--i:5">
           <div class="benefit-icon orange" aria-hidden="true">

--- a/website/src/pages/speech-to-text-mac.astro
+++ b/website/src/pages/speech-to-text-mac.astro
@@ -193,7 +193,7 @@ const faqJsonLd = JSON.stringify({
             <li>Numbers, dates, money, emails, URLs, and spoken punctuation formatted correctly, when you are dictating in English. These share one step and it is skipped for other languages</li>
             <li>Spoken emoji</li>
             <li>Custom vocabulary correction</li>
-            <li>Cleanup with our own on-device model, or with Apple Intelligence on macOS 26 and later, or with a local Ollama model</li>
+            <li>Cleanup with our own on-device model, or with S1-mini by Superwhisper, or with Apple Intelligence on macOS 26 and later, or with a local Ollama model</li>
           </ul>
         </div>
         <div class="offline-col reveal">
@@ -219,7 +219,7 @@ const faqJsonLd = JSON.stringify({
         <ul>
           <li><strong>Apple Silicon only.</strong> M1 or later. There is no Intel build and there will not be one; the speed comes from the Neural Engine.</li>
           <li><strong>macOS 14 Sonoma or later.</strong> Core dictation works across that whole range.</li>
-          <li><strong>Apple Intelligence cleanup needs macOS 26.</strong> Third-party apps could not call the on-device model before that. Apple Intelligence is also the shipped default, so on macOS 14 to 25 the cleanup step is skipped silently and you get the deterministically cleaned text rather than raw output. There is no automatic fallback: to get AI cleanup below macOS 26 you pick EG-1, a local Ollama model, or your own provider key yourself.</li>
+          <li><strong>Apple Intelligence cleanup needs macOS 26.</strong> Third-party apps could not call the on-device model before that. Apple Intelligence is also the shipped default, so on macOS 14 to 25 the cleanup step is skipped silently and you get the deterministically cleaned text rather than raw output. There is no automatic fallback: to get AI cleanup below macOS 26 you pick EG-1, S1-mini by Superwhisper, a local Ollama model, or your own provider key yourself.</li>
           <li><strong>No Windows, Linux, iOS, or Android version.</strong> If you need those, <a href="/compare/handy/">Handy</a> is free, open source, and cross-platform.</li>
           <li><strong>Dictation, not file transcription.</strong> For turning existing recordings into transcripts, <a href="/compare/macwhisper/">MacWhisper</a> is built for that job.</li>
         </ul>


### PR DESCRIPTION
## Summary

v2.4.7 ships today with S1-mini by Superwhisper as a second bundled on-device polish engine. The help centre already carried it; the marketing surface still listed "EG-1, Apple, Ollama, OpenAI, Gemini" wherever it enumerated the engines. Every enumeration now includes S1-mini, placed after EG-1, which stays the recommended engine. The website deploys from `main`, so merge this with or right after the release, not before.

Closes #2656.

`Tier: SMALL | Lane: Content | Modules: website`

## Sweep

Every "EG-1" mention under `website/src/pages` outside `blog/` (158 hits, 21 files), classified as: an engine enumeration (changed); EG-1 alone as our model, its benchmark, licence or training (left); a latency note naming the engine measured (left); a description of the defaults, which S1-mini is not (left). Blog posts are dated and out of scope per the issue.

## Changed, 22 pages

- `index`: the on-device polish paragraph.
- `how-it-works`: the engine stat (5 → 6 and its list), a new S1-mini engine card after EG-1 (484 MB, macOS 14+, free, Tone/Structure/Context, English first, "EG-1 stays our recommendation"; no claim about speed or quality, since none was measured), and the two feature blurbs that list engines.
- `speech-to-text-mac`: the offline cleanup bullet and the below-macOS-26 note.
- `compare/`: apple-dictation, best-dictation-apps-for-mac, dragon, fluidvoice, google-docs-voice-typing, handy, index, juno, macwhisper, notta, otter-ai, spokenly, superwhisper, typewhisper, voiceink, vox, whisper-cpp, willow-voice, wisprflow. Engine cells, prose, and FAQ answers, each FAQ changed in both its JSON-LD and visible copy; engine counts of six become seven. Eight of these pages were not on the issue's list and enumerated engines too.

Facts as the app states them: exactly "S1-mini" by "Superwhisper" (the licence term; a re-sweep finds no camel-cased spelling anywhere under `website/src`), 484 MB decimal, on-device, free, English first, three writing style settings. `dateModified` and "Last reviewed" fields are untouched, matching prior content fixes.

## Verification

- `npm run build`: 135 pages, no errors.
- For every compare page with a changed FAQ, the built HTML carries the S1-mini sentence in both the JSON-LD and the visible answer (counted per page: 2 where the FAQ is duplicated, 1 on pages with a single copy).
- Stale counts (`six polish engines`, `six engines`, `six AI providers`, `6 providers`, stat `5`): none remain.

## Left for a separate pass

`website/src/pages/privacy-policy.astro` line 78 also enumerates the on-device options as "(Apple Intelligence, EG-1, or Ollama)". It is a legal document with its own "Last updated July 5, 2026" stamp, so it is not in this content commit; it wants its own pass that also bumps that date.

## Pre-Merge Checklist

### Build Verification
- [x] `npm run build` passes locally
- [x] CI `website-check` is green — all seven checks passed on `1e028d8`

### Behavioral Testing (Local UAT)
- N/A

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets

### Polish Eval
- N/A

### Release Housekeeping
- [ ] Merge with the v2.4.7 release so the site never describes an engine the shipped app lacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM