### PR TITLE
feat(whatsnew): let an entry carry sub-bullets, on all four surfaces at once (#2484)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -14,7 +14,44 @@ enum WhatsNewContent {
     let icon: String
     let title: String
     let description: String
+    /// Optional sub-points (#2484): a bulleted list beneath the description in the
+    /// app, and indented sub-bullets under the entry's line on the GitHub release
+    /// page. Empty for an entry with no list, which is every entry written before it.
+    ///
+    /// Spelled as a Swift array literal of direct double-quoted strings, between
+    /// `description:` and `version:`, because `scripts/ci/render-release-notes.py`
+    /// reads the SOURCE TEXT of this file, never a compiled value:
+    ///
+    ///     bullets: ["First point", "Second point"],
+    ///
+    /// A named constant, concatenation, interpolation or raw string inside the array
+    /// makes the renderer refuse the whole entry rather than ship a shorter list, and
+    /// `WhatsNewContentTests.releaseNoteRendererMatchesCompiledValues` fails the PR
+    /// that introduces one. Do NOT fake a list with `\n` and bullet characters inside
+    /// `description`: it renders in the app and ships the escapes visible on GitHub.
+    let bullets: [String]
     let version: String
+
+    /// Explicit so `bullets` can default to empty while staying a `let`: a `let`
+    /// with a default value is dropped from the synthesised memberwise initialiser
+    /// entirely, and `var` would make every entry mutable for no reason. The label
+    /// order is the memberwise order with `bullets` slotted before `version`, so
+    /// every existing entry, and one written without the field, compiles unchanged.
+    init(
+      id: String,
+      icon: String,
+      title: String,
+      description: String,
+      bullets: [String] = [],
+      version: String
+    ) {
+      self.id = id
+      self.icon = icon
+      self.title = title
+      self.description = description
+      self.bullets = bullets
+      self.version = version
+    }
   }
 
   static let entries: [Entry] = [

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewSettingsView.swift
@@ -33,8 +33,28 @@ struct WhatsNewSettingsView: View {
 
             BrandedSection {
               BrandedRow(showDivider: false) {
-                Text(entry.description)
-                  .settingsReadingCopy()
+                VStack(alignment: .leading, spacing: 8) {
+                  Text(entry.description)
+                    .settingsReadingCopy()
+
+                  // Sub-points beneath the paragraph (#2484), in the same reading
+                  // copy so the list reads as part of the description rather than
+                  // as a caption. Same shape as the numbered steps in the Globe key
+                  // popover; a bullet glyph instead of a number, since these are
+                  // points and not an order.
+                  if !entry.bullets.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                      ForEach(Array(entry.bullets.enumerated()), id: \.offset) { _, bullet in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                          Text("•")
+                            .foregroundStyle(.stTextTertiary)
+                            .accessibilityHidden(true)
+                          Text(bullet).settingsReadingCopy()
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -15,6 +15,10 @@ struct WhatsNewContentTests {
     let title: String
     let desc: String
     let version: String
+    /// Always present in `--dump-json` output, `[]` for an entry without the field,
+    /// so the comparison covers the list too (#2484): an array the renderer cannot
+    /// read dumps as `[]` and disagrees with the compiled bullets right here.
+    let bullets: [String]
   }
 
   private enum ReleaseNoteDrift: Error {
@@ -143,9 +147,56 @@ struct WhatsNewContentTests {
     let swiftFile = Self.repoRoot.appendingPathComponent(
       "Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift")
     let compiled = WhatsNewContent.entries.map {
-      ReleaseNoteEntry(title: $0.title, desc: $0.description, version: $0.version)
+      ReleaseNoteEntry(
+        title: $0.title, desc: $0.description, version: $0.version, bullets: $0.bullets)
     }
     try Self.requireRendererEquivalence(swiftFile: swiftFile, compiledEntries: compiled)
+  }
+
+  /// #2484: the same two-way control for `bullets`. The renderer reads the array
+  /// strictly, so one non-literal member makes it dump `[]` for the whole entry
+  /// rather than the readable prefix; the compiled value has both members, and only
+  /// the value comparison can tell a shorter list from the real one.
+  @Test("the renderer comparison rejects a bullets array it cannot fully read")
+  func releaseNoteRendererRejectsUnreadableBullets() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-2484-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let expected = [
+      ReleaseNoteEntry(
+        title: "Headline", desc: "Paragraph", version: "9.9.9",
+        bullets: ["Readable", "Second"])
+    ]
+    let readable = directory.appendingPathComponent("readable.swift")
+    try """
+    Entry(
+      title: "Headline",
+      description: "Paragraph",
+      bullets: ["Readable", "Second"],
+      version: "9.9.9"
+    )
+    """.write(to: readable, atomically: true, encoding: .utf8)
+    // Control for the control: the well-formed spelling must agree, or the
+    // rejection below proves nothing about the constant.
+    try Self.requireRendererEquivalence(swiftFile: readable, compiledEntries: expected)
+
+    let unreadable = directory.appendingPathComponent("unreadable.swift")
+    try """
+    Entry(
+      title: "Headline",
+      description: "Paragraph",
+      bullets: ["Readable", Copy.second],
+      version: "9.9.9"
+    )
+    """.write(to: unreadable, atomically: true, encoding: .utf8)
+    #expect(
+      throws: ReleaseNoteDrift.self,
+      "a constant inside bullets must disagree with the compiled value even though the entry still parses"
+    ) {
+      try Self.requireRendererEquivalence(swiftFile: unreadable, compiledEntries: expected)
+    }
   }
 
   /// Two-way control for the comparison itself. Both forms still parse as one
@@ -158,7 +209,9 @@ struct WhatsNewContentTests {
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: directory) }
 
-    let expected = [ReleaseNoteEntry(title: "Headline", desc: "First second", version: "9.9.9")]
+    let expected = [
+      ReleaseNoteEntry(title: "Headline", desc: "First second", version: "9.9.9", bullets: [])
+    ]
     for (name, description) in [
       ("concatenated", #""First " + "second""#),
       ("interpolated", #""First \(word)""#),
@@ -202,8 +255,9 @@ struct WhatsNewContentTests {
   // MARK: - Content sanity
 
   /// The title is now the ONLY header on the card, so an empty one leaves an entry
-  /// with no heading at all, and an empty description leaves an empty card.
-  @Test("no entry has an empty title, description, or icon")
+  /// with no heading at all, and an empty description leaves an empty card. A blank
+  /// bullet (#2484) leaves a bare glyph in the app and a bare `-` on the release page.
+  @Test("no entry has an empty title, description, icon, or bullet")
   func noEmptyFields() {
     for entry in WhatsNewContent.entries {
       #expect(!entry.title.trimmingCharacters(in: .whitespaces).isEmpty, "\(entry.id): empty title")
@@ -211,6 +265,11 @@ struct WhatsNewContentTests {
         !entry.description.trimmingCharacters(in: .whitespaces).isEmpty,
         "\(entry.id): empty description")
       #expect(!entry.icon.trimmingCharacters(in: .whitespaces).isEmpty, "\(entry.id): empty icon")
+      for (index, bullet) in entry.bullets.enumerated() {
+        #expect(
+          !bullet.trimmingCharacters(in: .whitespaces).isEmpty,
+          "\(entry.id): empty bullet at index \(index)")
+      }
     }
   }
 

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -19,6 +19,20 @@ silently captures only the first segment, and interpolation emits unresolved Swi
 NEITHER is caught by the count check, so both would ship wrong text. Validate by comparing
 parsed values against expected strings, not by counting items alone.
 
+The optional `bullets:` field (#2484) is a Swift array literal of the same direct
+double-quoted literals, written between `description:` and `version:` (the order the
+Swift initialiser fixes), on one line or one bullet per line:
+
+    bullets: ["First point", "Second point"],
+
+Absent means no list. Each bullet renders as an indented markdown sub-bullet under its
+entry's line and is normalised exactly like `description` (a backslash line-continuation
+or any run of whitespace becomes one space). The array is read STRICTLY: any token
+between `[` and `]` that is not a string literal, a comma or whitespace (a named constant,
+`+`, a raw string, a comment) makes the WHOLE array unreadable, which `empty_fields`
+turns into a hard failure. A partial read would be the silent failure this file exists
+to prevent: a list one item shorter than the one the app shows, with every count green.
+
 Used by .github/workflows/release.yml. Designed to fail SAFELY: if it cannot produce
 notes for the requested version, it exits non-zero and the workflow falls back to
 GitHub's auto-generated notes, so a release is never blocked or shipped blank.
@@ -58,14 +72,74 @@ def parse_entries(swift_path):
         v = re.search(r'version:\s*"([\d.]+)"', chunk)
         if not (t and d and v):
             continue
-        title = t.group(1).replace('\\"', '"')
-        title = re.sub(r"\s*\\\s*\n\s*", " ", title)
-        title = re.sub(r"\s+", " ", title).strip()
-        desc = d.group(1).replace('\\"', '"')
-        desc = re.sub(r"\s*\\\s*\n\s*", " ", desc)
-        desc = re.sub(r"\s+", " ", desc).strip()
-        entries.append({"title": title, "desc": desc, "version": v.group(1)})
+        # `bullets:` is looked for only BEFORE `version:`. That is where the Swift
+        # initialiser puts it, and bounding the search there keeps the parser inside
+        # the entry's own argument list: the chunk runs on to the next `Entry(`, so
+        # it also holds the comments above the NEXT entry, and a comment that merely
+        # mentions `bullets: [...]` must not become a phantom list on this one.
+        bullets = parse_bullets(chunk[: v.start()])
+        entries.append(
+            {
+                "title": normalise_literal(t.group(1)),
+                "desc": normalise_literal(d.group(1)),
+                "version": v.group(1),
+                # Absent in source is the same as `bullets: []`, so every entry
+                # written before #2484 parses and renders exactly as it did.
+                "bullets": bullets if bullets is not None else [],
+                # Parser state, not content: the field is in the source but could
+                # not be read (see `parse_bullets`). Consumed by `empty_fields` and
+                # never dumped, since the app compiles no such value to compare.
+                "bullets_unreadable": bullets is None,
+            }
+        )
     return entries
+
+
+def normalise_literal(raw):
+    """One literal's captured text as the reader sees it: an escaped quote becomes a
+    quote, a backslash line-continuation and any run of whitespace become one space,
+    both ends are trimmed. The same rule for title, description and each bullet."""
+    text = raw.replace('\\"', '"')
+    text = re.sub(r"\s*\\\s*\n\s*", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+BULLETS_OPEN = re.compile(r"bullets:\s*\[")
+STRING_LITERAL = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
+
+
+def parse_bullets(fields):
+    """The entry's `bullets:` array: `[]` when the field is absent, the normalised
+    bullets in source order when it reads cleanly, or `None` when the field is
+    present but this parser cannot read it.
+
+    Walks the array body token by token rather than regexing string literals out of
+    it, because the failure to avoid is a PARTIAL read: `["a", b]` must not become
+    `["a"]` with every assertion green. So anything between `[` and `]` that is not
+    a string literal, a comma or whitespace makes the whole array unreadable, and so
+    does a missing `]`. A `]` inside a bullet's text is fine: the literal is consumed
+    before the closer is looked for.
+    """
+    m = BULLETS_OPEN.search(fields)
+    if not m:
+        return []
+    pos = m.end()
+    bullets = []
+    while pos < len(fields):
+        ch = fields[pos]
+        if ch.isspace() or ch == ",":
+            pos += 1
+            continue
+        if ch == "]":
+            return bullets
+        if ch != '"':
+            return None
+        lit = STRING_LITERAL.match(fields, pos)
+        if not lit:
+            return None
+        bullets.append(normalise_literal(lit.group(1)))
+        pos = lit.end()
+    return None
 
 
 def version_key(v):
@@ -85,6 +159,8 @@ def render(entries, version):
         if title and title[-1] not in ".!?":
             title += "."
         out.append(f"- **{title}** {e['desc']}")
+        # Two-space indent nests each one under the entry's bullet on GitHub.
+        out.extend(f"  - {bullet}" for bullet in e["bullets"])
     rendered = "\n".join(out).strip()
     return rendered or None
 
@@ -100,22 +176,257 @@ def empty_fields(entries):
     An OUTCOME check rather than a syntax allow-list: the protocol's list of prohibited
     forms has been wrong twice about which forms exist, and "no entry renders empty"
     holds whatever syntax the next author reaches for.
+
+    Bullets (#2484) get the same outcome check for the same reason: a `bullets:` array
+    this parser cannot read would otherwise parse as NO bullets, the entry still parses,
+    the count check still passes, and the list the app shows is simply missing from the
+    release page. So an unreadable array, or any bullet that parsed blank, fails here.
     """
     return [
         f"{e['version']}: {e['title'][:60] or '(no title)'}"
         for e in entries
-        if not e["desc"].strip() or not e["title"].strip()
+        if not e["desc"].strip()
+        or not e["title"].strip()
+        or e["bullets_unreadable"]
+        or any(not b.strip() for b in e["bullets"])
     ]
 
 
 def empty_fields_message(empty):
     return (
-        "error: %d entr%s parsed with an empty title or description — the field is "
-        "present in the source but this parser could not read it (a multiline, "
-        "concatenated, interpolated or raw literal). Rewrite it as a single direct "
-        "double-quoted literal:\n  %s"
+        "error: %d entr%s parsed with an empty title, description or bullet, or a "
+        "bullets array this parser could not read — the field is present in the "
+        "source but its text is not (a multiline, concatenated, interpolated or raw "
+        "literal, or something other than a string literal inside `bullets: [...]`). "
+        "Rewrite it as direct double-quoted literals:\n  %s"
         % (len(empty), "y" if len(empty) == 1 else "ies", "\n  ".join(empty))
     )
+
+
+def public_values(entries):
+    """The parsed values the app also compiles, in source order: what `--dump-json`
+    emits and what `WhatsNewContentTests` compares against `WhatsNewContent.entries`
+    field by field. Parser state such as `bullets_unreadable` stays out."""
+    return [{k: e[k] for k in ("title", "desc", "version", "bullets")} for e in entries]
+
+
+# Two-way controls for the parser, run by `--self-test` before the real content.
+# Each case is (label, Swift source text, expected parse, expected render of 9.9.9,
+# expected `empty_fields` outcome). The expected parse pins VALUES rather than counts,
+# because a count is exactly what a zero-length capture satisfies. Each fixture is
+# written the way an author writes an entry, indentation included, and exercises one
+# spelling the parse contract allows or one it must refuse.
+FIXTURE_CASES = [
+    (
+        "no bullets field parses as an empty list and renders as before",
+        '''
+    Entry(
+      id: "plain",
+      icon: "sparkles",
+      title: "A plain entry",
+      description:
+        "One paragraph, no list.",
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "A plain entry", "desc": "One paragraph, no list.",
+          "version": "9.9.9", "bullets": []}],
+        "- **A plain entry.** One paragraph, no list.",
+        [],
+    ),
+    (
+        "two bullets render as two indented sub-bullets",
+        '''
+    Entry(
+      id: "listed",
+      icon: "list.bullet",
+      title: "An entry with a list",
+      description: "The paragraph above the list.",
+      bullets: [
+        "First point",
+        "Second point",
+      ],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "An entry with a list", "desc": "The paragraph above the list.",
+          "version": "9.9.9", "bullets": ["First point", "Second point"]}],
+        "- **An entry with a list.** The paragraph above the list.\n"
+        "  - First point\n"
+        "  - Second point",
+        [],
+    ),
+    (
+        "a one-line array, with an escaped quote and brackets inside a bullet",
+        r'''
+    Entry(
+      id: "inline",
+      icon: "sparkles",
+      title: "Inline",
+      description: "Desc.",
+      bullets: ["Say \"hi\"", "Keys [Option] and ]"],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Inline", "desc": "Desc.", "version": "9.9.9",
+          "bullets": ['Say "hi"', "Keys [Option] and ]"]}],
+        '- **Inline.** Desc.\n  - Say "hi"\n  - Keys [Option] and ]',
+        [],
+    ),
+    (
+        "a bullet literal spanning lines is normalised like a description",
+        r'''
+    Entry(
+      id: "wrapped",
+      icon: "sparkles",
+      title: "Wrapped",
+      description: "Desc.",
+      bullets: [
+        "A bullet   whose text \
+         continues on the next line",
+      ],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Wrapped", "desc": "Desc.", "version": "9.9.9",
+          "bullets": ["A bullet whose text continues on the next line"]}],
+        "- **Wrapped.** Desc.\n  - A bullet whose text continues on the next line",
+        [],
+    ),
+    (
+        "a named constant inside the array is refused, not partially read",
+        '''
+    Entry(
+      id: "constant",
+      icon: "sparkles",
+      title: "Constant",
+      description: "Desc.",
+      bullets: ["Readable", Copy.secondBullet],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Constant", "desc": "Desc.", "version": "9.9.9", "bullets": []}],
+        "- **Constant.** Desc.",
+        ["9.9.9: Constant"],
+    ),
+    (
+        "a concatenated bullet is refused",
+        '''
+    Entry(
+      id: "concat",
+      icon: "sparkles",
+      title: "Concat",
+      description: "Desc.",
+      bullets: ["First " + "second"],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Concat", "desc": "Desc.", "version": "9.9.9", "bullets": []}],
+        "- **Concat.** Desc.",
+        ["9.9.9: Concat"],
+    ),
+    (
+        "a raw-string bullet is refused",
+        '''
+    Entry(
+      id: "raw",
+      icon: "sparkles",
+      title: "Raw",
+      description: "Desc.",
+      bullets: [#"Raw text"#],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Raw", "desc": "Desc.", "version": "9.9.9", "bullets": []}],
+        "- **Raw.** Desc.",
+        ["9.9.9: Raw"],
+    ),
+    (
+        "an array with no closing bracket before version is refused",
+        '''
+    Entry(
+      id: "open",
+      icon: "sparkles",
+      title: "Open",
+      description: "Desc.",
+      bullets: ["Never closed",
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Open", "desc": "Desc.", "version": "9.9.9", "bullets": []}],
+        "- **Open.** Desc.",
+        ["9.9.9: Open"],
+    ),
+    (
+        "a blank bullet is refused",
+        '''
+    Entry(
+      id: "blank",
+      icon: "sparkles",
+      title: "Blank",
+      description: "Desc.",
+      bullets: ["Present", "   "],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Blank", "desc": "Desc.", "version": "9.9.9",
+          "bullets": ["Present", ""]}],
+        # `render` strips the whole body, so the blank last line loses its space.
+        "- **Blank.** Desc.\n  - Present\n  -",
+        ["9.9.9: Blank"],
+    ),
+    (
+        "bullets on one entry do not leak into the next, nor out of a comment",
+        '''
+    Entry(
+      id: "with",
+      icon: "sparkles",
+      title: "With",
+      description: "Desc.",
+      bullets: ["Only mine"],
+      version: "9.9.9"
+    ),
+
+    // MARK: - v9.9.8
+
+    // Written without bullets: ["Not a bullet"] on purpose.
+    Entry(
+      id: "without",
+      icon: "sparkles",
+      title: "Without",
+      description: "Desc.",
+      version: "9.9.8"
+    ),
+''',
+        [{"title": "With", "desc": "Desc.", "version": "9.9.9", "bullets": ["Only mine"]},
+         {"title": "Without", "desc": "Desc.", "version": "9.9.8", "bullets": []}],
+        "- **With.** Desc.\n  - Only mine",
+        [],
+    ),
+]
+
+
+def self_test_fixtures():
+    """Run FIXTURE_CASES; one line per failed assertion, empty when all pass."""
+    import tempfile
+
+    failures = []
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "fixture.swift")
+        for label, source, want_entries, want_body, want_empty in FIXTURE_CASES:
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(source)
+            entries = parse_entries(path)
+            got = public_values(entries)
+            if got != want_entries:
+                failures.append(f"[{label}] parsed {got!r}, wanted {want_entries!r}")
+            body = render(entries, "9.9.9")
+            if body != want_body:
+                failures.append(f"[{label}] rendered {body!r}, wanted {want_body!r}")
+            empty = empty_fields(entries)
+            if empty != want_empty:
+                failures.append(f"[{label}] empty_fields {empty!r}, wanted {want_empty!r}")
+    return failures
 
 
 def current_content_version():
@@ -147,7 +458,13 @@ def main():
         return 2
 
     if args.dump_json:
-        json.dump(entries, sys.stdout, ensure_ascii=False, separators=(",", ":"))
+        # Only the values the app compiles. An unreadable bullets array dumps as
+        # `[]`, which the compiled-value comparison in WhatsNewContentTests then
+        # rejects against the entry's real bullets, the same way a multiline
+        # description dumps as "" and is rejected against the real text.
+        json.dump(
+            public_values(entries), sys.stdout, ensure_ascii=False, separators=(",", ":")
+        )
         sys.stdout.write("\n")
         return 0
 
@@ -157,6 +474,20 @@ def main():
         return 0
 
     if args.self_test:
+        # Two-way controls on fixtures first: a parser only ever run on correct
+        # input has never been seen to refuse anything.
+        fixture_failures = self_test_fixtures()
+        if fixture_failures:
+            print(
+                "error: %d fixture case%s failed:\n  %s"
+                % (
+                    len(fixture_failures),
+                    "" if len(fixture_failures) == 1 else "s",
+                    "\n  ".join(fixture_failures),
+                ),
+                file=sys.stderr,
+            )
+            return 2
         # Integrity check: every entry has exactly one `version:` field, so the
         # number of parsed entries must equal the number of version fields in the
         # source. A mismatch means the parser dropped entries (e.g. the MARK-comment
@@ -193,7 +524,8 @@ def main():
             return 2
         print(
             f"self-test OK: {len(entries)} entries parsed (matches source); "
-            f"{cv} renders {body.count('- **')} item(s)"
+            f"{cv} renders {body.count('- **')} item(s); "
+            f"{len(FIXTURE_CASES)} fixture cases pass"
         )
         return 0
 

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -152,7 +152,13 @@ def parse_bullets(fields):
             pos += 1
             continue
         if ch == "]":
-            return bullets
+            # The closer must be the END of the argument: only whitespace, a comment and
+            # the argument's own comma may follow it before `version:` (where `fields`
+            # ends). `["First"] + ["Second"]` is a valid Swift expression, and returning
+            # at the first `]` read it as one bullet and let the release path exit 0 with
+            # half the list (Codex, #2680). Anything else there makes the array unreadable.
+            trailing = mask_literals_and_comments(fields[pos + 1:]).strip()
+            return bullets if trailing in ("", ",") else None
         if ch != '"':
             return None
         lit = STRING_LITERAL.match(fields, pos)
@@ -361,6 +367,38 @@ FIXTURE_CASES = [
         [{"title": "Raw", "desc": "Desc.", "version": "9.9.9", "bullets": []}],
         "- **Raw.** Desc.",
         ["9.9.9: Raw"],
+    ),
+    (
+        "an array extended by another expression after its closer is refused, not truncated",
+        '''
+    Entry(
+      id: "extended",
+      icon: "sparkles",
+      title: "Extended",
+      description: "Desc.",
+      bullets: ["First"] + ["Second"],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Extended", "desc": "Desc.", "version": "9.9.9", "bullets": []}],
+        "- **Extended.** Desc.",
+        ["9.9.9: Extended"],
+    ),
+    (
+        "a comment after the closer is not an extension of the array",
+        '''
+    Entry(
+      id: "commented",
+      icon: "sparkles",
+      title: "Commented",
+      description: "Desc.",
+      bullets: ["Only"], // + ["never"]
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Commented", "desc": "Desc.", "version": "9.9.9", "bullets": ["Only"]}],
+        "- **Commented.** Desc.\n  - Only",
+        [],
     ),
     (
         "an array with no closing bracket before version is refused",

--- a/scripts/ci/render-release-notes.py
+++ b/scripts/ci/render-release-notes.py
@@ -106,6 +106,22 @@ def normalise_literal(raw):
 
 BULLETS_OPEN = re.compile(r"bullets:\s*\[")
 STRING_LITERAL = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
+LINE_COMMENT = re.compile(r"//[^\n]*")
+
+
+def blank_out(match):
+    """The matched text as spaces of the same length, so positions found in the masked
+    text index the original."""
+    return " " * (match.end() - match.start())
+
+
+def mask_literals_and_comments(fields):
+    """`fields` with every string literal and `//` comment replaced by spaces, so a
+    search over it sees only the entry's own argument syntax. Literals go first: a
+    `//` inside a description is prose, not a comment, and blanking the literal
+    removes it before the comment pass looks."""
+    masked = STRING_LITERAL.sub(blank_out, fields)
+    return LINE_COMMENT.sub(blank_out, masked)
 
 
 def parse_bullets(fields):
@@ -120,7 +136,12 @@ def parse_bullets(fields):
     does a missing `]`. A `]` inside a bullet's text is fine: the literal is consumed
     before the closer is looked for.
     """
-    m = BULLETS_OPEN.search(fields)
+    # Found in the argument SYNTAX only. A description whose prose happens to contain
+    # `bullets: [one, two]` is a string literal, and searching the raw text would read
+    # the words inside it as a field that cannot be parsed, which `empty_fields` then
+    # turns into a refusal of the whole release's notes. The mask keeps every offset,
+    # so `m.end()` indexes the original text and the walk below reads the real array.
+    m = BULLETS_OPEN.search(mask_literals_and_comments(fields))
     if not m:
         return []
     pos = m.end()
@@ -374,6 +395,40 @@ FIXTURE_CASES = [
         # `render` strips the whole body, so the blank last line loses its space.
         "- **Blank.** Desc.\n  - Present\n  -",
         ["9.9.9: Blank"],
+    ),
+    (
+        "a description that mentions bullets: [...] in prose is not a bullets field",
+        '''
+    Entry(
+      id: "prose",
+      icon: "sparkles",
+      title: "Prose",
+      description: "Format bullets: [one, two] the way you like.",
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Prose", "desc": "Format bullets: [one, two] the way you like.",
+          "version": "9.9.9", "bullets": []}],
+        "- **Prose.** Format bullets: [one, two] the way you like.",
+        [],
+    ),
+    (
+        "a real bullets field after a description that mentions one is still read",
+        '''
+    Entry(
+      id: "both",
+      icon: "sparkles",
+      title: "Both",
+      description: "Mentions bullets: [not these].",
+      // bullets: ["not this either"]
+      bullets: ["The real one"],
+      version: "9.9.9"
+    ),
+''',
+        [{"title": "Both", "desc": "Mentions bullets: [not these].",
+          "version": "9.9.9", "bullets": ["The real one"]}],
+        "- **Both.** Mentions bullets: [not these].\n  - The real one",
+        [],
     ),
     (
         "bullets on one entry do not leak into the next, nor out of a comment",


### PR DESCRIPTION
## Summary

The What's New screen rendered each entry as a title above one paragraph, with no way to express a list. A fake list (`\n` and bullet characters inside `description`) renders in the app but ships the escapes visible on the GitHub release page, because `render-release-notes.py` reads the Swift source text and emits one markdown line per entry. This adds a real `bullets` field across all four surfaces the issue names, defaulting to empty so no existing entry changes. No real entry gains bullets here; this is the capability only.

Closes #2484.

`Tier: SMALL | Test: required (renderer + WhatsNewContentTests) | Modules: AppKit, ci scripts`

**Verification note:** authored on a Linux host with no Swift toolchain. The Python half (the renderer and its self-test fixtures) was fully verified there; the Swift half compiled for the first time in the macOS CI lanes on this PR, and all nine checks passed on `fe4447c`, including `build-debug`, which runs `WhatsNewContentTests`. The two later commits touch only the Python renderer.

## The field

```swift
      description:
        "The paragraph above the list.",
      bullets: [
        "First point",
        "Second point",
      ],
      version: "2.4.7"
```

A Swift array literal of direct double-quoted strings, written between `description:` and `version:`. A bullet may span lines with backslash continuation and is whitespace-normalised exactly like `description`. A named constant, concatenation, interpolation or raw string inside the array makes the renderer refuse the whole entry rather than ship a shorter list, and the Swift comparison test fails the PR that introduces one.

## The four surfaces

1. `WhatsNewContent.Entry`: `let bullets: [String]` plus an explicit init with `bullets: [String] = []` in memberwise order, so every existing entry (and #2678's new one, written without the field) compiles unchanged. A `let` with a default would vanish from the memberwise init; `var` would make entries mutable.
2. `WhatsNewSettingsView`: beneath the description, `if !entry.bullets.isEmpty`, a bullet glyph in `.stTextTertiary` beside `Text(bullet).settingsReadingCopy()`, copied from the Globe-key numbered-steps pattern in `KeybindsSettingsView`.
3. `scripts/ci/render-release-notes.py`: parses the optional array (absent means empty), emits `  - {bullet}` lines under the entry's line, extends the `--dump-json` output with `bullets` (always present, `[]` when absent), and extends the empty-fields outcome check so a non-empty `bullets:` in source that parsed to zero bullets is a hard failure with exit 2. The `bullets:` search is bounded to the entry's own argument list and sees only argument syntax: string literals and `//` comments are blanked to same-length spaces first, so neither a description whose prose says "bullets: [one, two]" nor a comment above the next entry can become a phantom list (Codex P2, d873d38). The closer must end the argument: only whitespace, a comment and the comma may follow `]` before `version:`, so `["First"] + ["Second"]` is refused rather than published as one bullet (Codex P2 round 2, cf1f2c4).
4. `WhatsNewContentTests`: `ReleaseNoteEntry` gains `bullets` so the compiled-vs-rendered comparison covers the list; `noEmptyFields` rejects a blank or whitespace bullet; new `releaseNoteRendererRejectsUnreadableBullets` proves a well-formed array agrees and a `Copy.second` member throws.

## Renderer verification

- `--version X` for all 26 versions, `--list`: 29 output files byte-identical before and after the change.
- `--dump-json`: 143 entries, identical apart from `"bullets": []` on each.
- `--self-test`: `143 entries parsed (matches source); 2.4.7 renders 3 item(s); 14 fixture cases pass` (before: no fixture cases). Fixtures cover two bullets, a multi-line bullet, an unreadable array refused with no stdout, the phantom-list guard for comments, prose mentioning the field, a real field after such prose, an array extended past its closer, a comment after the closer, and the Swift test's own fixtures replayed through `--dump-json`.
- End to end on a copy of the real file: two bullets on the 2.4.7 headline render as indented sub-bullets and dump on that entry only; `["Readable", Copy.other]` exits 2 for that version while other versions still render.

## Pre-Merge Checklist

### Build Verification
- [ ] Dev build passes locally — not possible on the authoring host
- [x] Logic tests pass — renderer self-test and fixtures locally; `WhatsNewContentTests` green in CI
- [ ] CI `build-check` status is green on the current head — all nine checks passed on `fe4447c`; re-running on `cf1f2c4`

### Behavioral Testing (Local UAT)
- [ ] App rebuilt and relaunched — worth a look at the What's New screen once an entry uses bullets; none does yet

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

### Polish Eval
- N/A

### Review
- [x] Codex P2 (prose containing `bullets: [` read as a field): fixed in d873d38, thread resolved
- [x] Codex P2 round 2 (array extended past its closer read as one bullet): fixed in cf1f2c4, thread resolved

### Release Housekeeping
- N/A; independent of the v2.4.7 release. #2678 (the Snippets entry) touches a different region of the same file and merges cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM