### PR TITLE
docs(help): bring 34 help-centre articles up to v2.4.7

### DIFF
--- a/website/src/content/help/adding-a-word-from-your-selection.md
+++ b/website/src/content/help/adding-a-word-from-your-selection.md
@@ -5,8 +5,8 @@ category: "custom-words"
 section: "Dictionary"
 order: 4
 keywords: ["quick add", "add selected word", "highlight a word", "selection", "shortcut", "whatsapp", "terminal", "menu bar", "clipboard", "add word from selection"]
-related: ["adding-custom-words", "clipboard-preservation", "how-custom-word-correction-works"]
-updated: 2026-09-01
+related: ["adding-custom-words", "clipboard-preservation", "how-custom-word-correction-works", "customizing-your-keybind"]
+updated: 2026-09-05
 ---
 When EnviousWispr writes a name the wrong way, you do not have to open settings to fix it. Highlight the word it should have written, press the Quick Add shortcut, and a small panel appears offering to attach that spelling to the word it keeps getting wrong.
 
@@ -14,10 +14,12 @@ When EnviousWispr writes a name the wrong way, you do not have to open settings 
 
 Both do the same thing, so use whichever is closer to hand.
 
-1. **The shortcut.** Highlight the word, then press your Quick Add keybind. You can see and change it in **Settings**, under your keybinds.
+1. **The shortcut.** Highlight the word, then press your Quick Add keybind. It is **Control Shift W** unless you have changed it. You can see and change it in **Settings** \> **Keybinds**, under **Add a Word**.
 2. **The menu bar.** Highlight the word, click the EnviousWispr icon, and choose **Add Selected Word**. The row names the word it found, so you can check it before you click.
 
 The panel shows you the word first and ranks the words already in your library, so you pick which one this spelling belongs to. Nothing is written until you choose.
+
+The shortcut moved to Control Shift W in version 2.4.7. Its old keys shared the Option key with the record key, so pressing them could start a recording instead of opening the panel. If you had chosen your own keys, yours are untouched.
 
 ### When an app will not say what you highlighted
 

--- a/website/src/content/help/adding-custom-words.md
+++ b/website/src/content/help/adding-custom-words.md
@@ -5,8 +5,8 @@ category: "custom-words"
 section: "Dictionary"
 order: 1
 keywords: ["custom words", "vocabulary", "add a word", "my name", "names", "jargon", "technical terms", "spells my name wrong", "dictionary", "teach it a word", "acronyms", "how do I add a name", "where is your words", "fix a misspelled name", "turn on vocabulary packs", "import my contacts"]
-related: ["why-is-my-dictation-inaccurate", "how-custom-word-correction-works"]
-updated: 2026-09-04
+related: ["why-is-my-dictation-inaccurate", "how-custom-word-correction-works", "using-snippets"]
+updated: 2026-09-05
 ---
 When EnviousWispr repeatedly misspells a name or a specialised word, you can teach it the exact spelling you want to use.
 
@@ -26,6 +26,8 @@ Building a reliable list saves you time editing afterwards. These are the catego
 - Names of people you write to regularly.
 - Your company name and your internal product names.
 - Technical vocabulary, acronyms, and jargon from your field that a general dictionary misses.
+
+A custom word is a spelling. If what you want is a whole block of text, such as your email address, a sign-off, or a link you send every week, that is a snippet rather than a custom word. See [_Using Snippets_](/help/using-snippets/).
 
 ### Using ready-made vocabulary packs
 

--- a/website/src/content/help/api-key-security.md
+++ b/website/src/content/help/api-key-security.md
@@ -6,9 +6,9 @@ section: "Privacy"
 order: 4
 keywords: ["api key", "where is my key stored", "keychain", "secret", "token", "is my key safe", "billing"]
 related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
-If you use OpenAI, Gemini, or Claude to polish your dictation, you bring your own API key. Here is where that key is kept and how to take it back out.
+If you use OpenAI, Gemini, or Claude to polish your dictation, you bring your own API key. Here is where that key is kept and how to take it back out. The on-device options, EG-1, Apple Intelligence and S1-mini, need no key at all.
 
 ### Stored in the macOS Keychain
 
@@ -24,6 +24,6 @@ If you used an early version of EnviousWispr, your key may have started out in a
 
 ### Removing a key
 
-**Clear the field.** Open **Settings**, select **AI Polish**, and clear the key field. The stored key goes with it.
+**Clear the key.** Open **Settings**, select **AI Polish**, choose your provider, and click **Clear** beside the key field. The stored key goes with it.
 
 You can also revoke the key from your provider's own dashboard at any time, which takes effect immediately regardless of what EnviousWispr does.

--- a/website/src/content/help/app-crashes-or-asr-engine-crashes.md
+++ b/website/src/content/help/app-crashes-or-asr-engine-crashes.md
@@ -5,13 +5,15 @@ category: "troubleshooting"
 section: "Recording Issues"
 order: 8
 keywords: ["crash", "crashes", "quits", "closes by itself", "keeps crashing", "stopped working", "disappeared", "not responding"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 EnviousWispr keeps its transcription engine separate from the rest of the app, so a failure in one does not take the other down with it.
 
 ### If the speech engine stops
 
 The transcription engine runs in its own process. If that process hits an error and stops, the rest of EnviousWispr stays open. EnviousWispr starts the engine again when you press your keybind for your next recording. There is nothing for you to do.
+
+If the engine was not ready at the moment you finished speaking, your recording is kept and given another go rather than lost.
 
 ### If the app itself quits
 

--- a/website/src/content/help/apple-intelligence-setup.md
+++ b/website/src/content/help/apple-intelligence-setup.md
@@ -5,10 +5,12 @@ category: "ai-polish"
 section: "Polish"
 order: 5
 keywords: ["apple intelligence", "apple ai", "on device ai", "free ai", "macos 26", "set up apple intelligence", "enable apple intelligence"]
-related: ["apple-intelligence-not-available"]
-updated: 2026-08-06
+related: ["apple-intelligence-not-available", "choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini", "s1-mini-by-superwhisper-and-writing-style"]
+updated: 2026-09-05
 ---
 Apple Intelligence is Apple's built-in system for processing language on your Mac, and EnviousWispr can use it to tidy up your dictation by removing filler words and fixing punctuation. This option is free to use, requires no API key, and keeps your text on your Mac.
+
+It is the option a fresh install starts with. It is not the only on-device choice: EG-1, our own model, is the recommended engine, and S1-mini by Superwhisper is a smaller third option. All three sit under **On this Mac** on the **AI Polish** page.
 
 ### What you need
 
@@ -24,7 +26,7 @@ Follow these steps to turn on Apple Intelligence polish inside EnviousWispr:
 
 1. **Open System Settings.** Open **System Settings**, click **Apple Intelligence & Siri**, and switch it on.
 2. **Open EnviousWispr settings.** Open EnviousWispr, go to **Settings**, and click **AI Polish**.
-3. **Select Apple Intelligence.** Choose **Apple Intelligence** from the list of polish options.
+3. **Select Apple Intelligence.** Choose **Apple Intelligence** under **On this Mac**.
 
 You will know the setup worked when your next dictation comes back with the filler words removed and the punctuation corrected.
 
@@ -33,3 +35,5 @@ You will know the setup worked when your next dictation comes back with the fill
 EnviousWispr checks your Mac and names the missing requirement directly on the **AI Polish** page. The usual reasons are an older version of macOS, Apple Intelligence not switched on yet, or the model still downloading in the background.
 
 Read [_Apple Intelligence Not Available_](/help/apple-intelligence-not-available/) if you run into any of those.
+
+If your Mac cannot run macOS 26, pick **EG-1** or **S1-mini** instead. Both polish on your Mac without Apple Intelligence, and neither needs a key.

--- a/website/src/content/help/bluetooth-and-airpods.md
+++ b/website/src/content/help/bluetooth-and-airpods.md
@@ -6,7 +6,7 @@ section: "Input Configuration"
 order: 2
 keywords: ["airpods", "air pods", "bluetooth", "wireless headphones", "headphones", "earbuds", "sounds muffled", "quality drops", "music stops", "beats", "headset"]
 related: ["choosing-your-microphone"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 AirPods and Bluetooth headsets work with EnviousWispr, and there are two things worth knowing before you rely on them.
 
@@ -25,6 +25,10 @@ That switch also takes a moment, which is why a first word can go missing if you
 **Wait a beat before speaking.** Hold your keybind for a moment before you start talking on the first recording after connecting.
 
 If that drop in audio quality bothers you, record from your Mac's built-in microphone instead. Your headset then stays in music mode the whole time.
+
+### The Bluetooth reminder
+
+EnviousWispr can show a short reminder of these tips once per launch. If you know them by now, switch off **Show Bluetooth tips** under **When using Bluetooth** on the **Microphone** page in **Settings**. The guide itself stays on that page.
 
 ### If it disconnects mid-recording
 

--- a/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
+++ b/website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md
@@ -5,8 +5,8 @@ category: "speech-engines"
 section: "Transcription"
 order: 1
 keywords: ["parakeet", "whisperkit", "whisper", "which engine", "engine", "speech engine", "model", "accuracy vs speed", "switch engine", "transcription engine", "which is better"]
-related: ["multi-language-dictation", "why-is-my-dictation-inaccurate"]
-updated: 2026-08-06
+related: ["multi-language-dictation", "why-is-my-dictation-inaccurate", "using-snippets"]
+updated: 2026-09-05
 ---
 You can choose between two speech engines for transcription, Parakeet or WhisperKit. Both run entirely on your Mac. Neither sends your audio anywhere, and neither needs an internet connection once its model has been downloaded.
 
@@ -27,11 +27,13 @@ To change your engine, follow these steps.
 
 **Open settings.** Click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **Transcription**.
 
-**Pick your engine.** Select either Parakeet or WhisperKit.
+**Pick your engine.** The **Fast** card is Parakeet, and the **All Languages** card is WhisperKit. Each card names the model it runs.
 
 **Download the model.** The first time you choose WhisperKit, click **Download WhisperKit Model**. The model does not download on its own, and it takes about 1.5 GB of storage.
 
 The change applies to your next recording.
+
+Setting your language under **Language** on the same page works on both engines. On Parakeet it stops the engine reaching for a different alphabet, such as Greek or Cyrillic turning up in a German dictation, though it cannot tell apart two languages that share one. Read [_Multi-Language Dictation_](/help/multi-language-dictation/).
 
 ### What happens when you dictate
 
@@ -41,7 +43,7 @@ Knowing the sequence helps you work out where a delay or an unexpected change ca
 
 **Transcribe the speech.** Your chosen engine reads the audio and writes out the text.
 
-**Clean up the text.** Your custom words are applied, filler words are removed, spoken emoji are converted, and numbers, dates and times are written the way you would type them. This stage always runs, whatever you have AI Polish set to, and each part of it has its own setting.
+**Clean up the text.** Any snippet you said is expanded first, then your custom words are applied, filler words are removed, spoken emoji are converted, and numbers, dates and times are written the way you would type them. This stage always runs, whatever you have AI Polish set to, and each part of it has its own setting.
 
 **Polish the text.** Any AI polish you have switched on runs against the cleaned-up text. This stage is optional, and setting AI Polish to None skips it entirely.
 

--- a/website/src/content/help/choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini.md
+++ b/website/src/content/help/choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini.md
@@ -6,7 +6,7 @@ section: "Polish"
 order: 2
 keywords: ["turn off ai", "turn ai off", "disable ai", "no ai", "provider", "openai", "chatgpt", "gemini", "claude", "apple intelligence", "ollama", "s1-mini", "superwhisper", "eg-1", "which ai", "api key", "change provider", "stop rewriting my words"]
 related: ["ai-polish-and-cloud-data", "api-key-security", "s1-mini-by-superwhisper-and-writing-style"]
-updated: 2026-09-04
+updated: 2026-09-05
 ---
 AI Polish is the step that tidies up your dictation after transcription, and you choose which provider does the work. Your transcription audio stays on your Mac on every one of these options. Open **Settings**, then select **AI Polish** to make your choice.
 
@@ -15,7 +15,7 @@ AI Polish is the step that tidies up your dictation after transcription, and you
 These options process your text entirely on your own machine.
 
 - **Apple Intelligence.** Free, with nothing to set up. It requires macOS 26 or later on a Mac that supports Apple Intelligence. This is the default when you install the app.
-- **EG-1.** The model Envious Labs built specifically for dictation. It is free. Download it from the AI Polish page, and it takes about 2.9 GB of storage once installed.
+- **EG-1.** The model Envious Labs built specifically for dictation, and the one marked **Recommended** on the AI Polish page. It is free. Download it from the AI Polish page, and it takes about 2.9 GB of storage once installed.
 - **S1-mini.** A small open model made by Superwhisper, and the lightest on-device option. It is free. Download it from the AI Polish page; it takes about 484 MB once installed and has three writing style settings you can adjust. See [_S1-mini by Superwhisper and Its Writing Style Settings_](/help/s1-mini-by-superwhisper-and-writing-style/).
 - **None.** No AI polish step runs at all. You still get filler-word removal and the benefit of your custom words.
 

--- a/website/src/content/help/choosing-your-microphone.md
+++ b/website/src/content/help/choosing-your-microphone.md
@@ -6,7 +6,7 @@ section: "Input Configuration"
 order: 1
 keywords: ["microphone", "mic", "input device", "which microphone", "headset", "usb mic", "external mic", "built in mic", "change microphone", "wrong microphone"]
 related: ["bluetooth-and-airpods", "empty-or-missing-transcription"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 EnviousWispr can follow whichever microphone your Mac is set to, or use a specific device you name yourself. Both choices live under **Settings** \> **Microphone**.
 
@@ -15,6 +15,8 @@ EnviousWispr can follow whichever microphone your Mac is set to, or use a specif
 Auto records from whatever input your Mac is currently set to, and follows that input as devices come and go. This is the default, and it suits most setups.
 
 To change what Auto follows, set your input in **System Settings** \> **Sound**.
+
+There is one exception. If the input your Mac is set to turns out not to be a real microphone, such as a virtual device installed by Krisp, Loopback, BlackHole, an aggregate device or a meeting app, EnviousWispr records from an available real microphone instead, because a virtual device delivers nothing but silence. If a virtual device is the only input on your Mac, it is still used. The **Microphone** page shows which device Auto is using.
 
 ### Choosing a specific microphone
 

--- a/website/src/content/help/clipboard-preservation.md
+++ b/website/src/content/help/clipboard-preservation.md
@@ -5,8 +5,8 @@ category: "pasting-your-text"
 section: "Paste System"
 order: 2
 keywords: ["clipboard", "copied text", "lost what i copied", "overwrites clipboard", "restore clipboard", "cmd v", "pasteboard"]
-related: ["how-text-gets-pasted-into-your-app"]
-updated: 2026-08-06
+related: ["how-text-gets-pasted-into-your-app", "adding-a-word-from-your-selection"]
+updated: 2026-09-05
 ---
 When you dictate, your text often has to travel through your clipboard to reach the app you are working in. EnviousWispr handles that by recording whatever is on your clipboard first, and putting it back immediately afterwards.
 
@@ -32,3 +32,11 @@ You control this under **Settings** \> **Clipboard**. Both options are on by def
 
 - **Restore clipboard after paste.** Puts what you had copied back onto the clipboard after your dictation lands. Switch this off if you would rather keep the dictation on your clipboard to paste again somewhere else.
 - **Auto-copy to clipboard.** Copies your dictation to the clipboard whenever EnviousWispr is not pasting it into an app for you.
+
+The same page holds **Smart insertion**, which matches spacing and capitals to the text around your cursor. Read [_How Text Gets Pasted Into Your App_](/help/how-text-gets-pasted-into-your-app/).
+
+### Quick Add and your clipboard
+
+Adding a word from a selection normally reads what you highlighted without touching your clipboard. Some apps will not say what you have selected, such as messaging apps built for iPad and some terminals. There, EnviousWispr briefly copies your selection, reads it, and puts your clipboard back. Your clipboard history will show both entries.
+
+The switch is **Read selections through the clipboard**, under **Quick Add** on the same **Clipboard** page. It is on by default, and it turns itself off in common remote desktop and virtual machine apps. Read [_Adding a Word From Your Selection_](/help/adding-a-word-from-your-selection/) for the detail.

--- a/website/src/content/help/customizing-your-keybind.md
+++ b/website/src/content/help/customizing-your-keybind.md
@@ -4,8 +4,9 @@ description: "Set the keys that start, stop, and cancel dictation."
 category: "recording-and-keybinds"
 section: "Recording"
 order: 4
-keywords: ["keybind", "keybinds", "hotkey", "shortcut", "keyboard shortcut", "change the key", "how do i change the key", "key combo", "keybinding", "remap", "different key", "globe key", "fn key", "caps lock", "conflicts with another app"]
-updated: 2026-09-01
+keywords: ["keybind", "keybinds", "hotkey", "shortcut", "keyboard shortcut", "change the key", "how do i change the key", "key combo", "keybinding", "remap", "different key", "globe key", "fn key", "caps lock", "conflicts with another app", "quick add shortcut", "control shift w"]
+related: ["adding-a-word-from-your-selection", "escape-recovery"]
+updated: 2026-09-05
 ---
 Your keybind is the key you hold or press to record, and you can change it to whatever suits your hands. EnviousWispr arrives set to the right Option key.
 
@@ -40,6 +41,12 @@ If holding a key down is uncomfortable, toggle mode asks less of your hand: one 
 Pressing Escape ends the current recording without pasting anything. You can change this cancel key on the same **Keybinds** page if you prefer a different one.
 
 The same page carries a setting called **Escape Recovery**, on unless you switch it off. With it on, your cancel keybind keeps the recording and offers to paste it back rather than discarding it, which is worth knowing before you reassign the key. See [Escape Recovery](/help/escape-recovery/).
+
+### The Quick Add key
+
+The same page has one more keybind, under **Add a Word**. Highlight a misheard word anywhere on your Mac, press it, and a small panel offers to add the right spelling to your dictionary. It is **Control Shift W** unless you change it.
+
+Version 2.4.7 moved it to those keys. The old ones shared the Option key with the record key, so pressing them could start a recording instead of opening the panel. If you had already chosen your own keys, yours are untouched. See [Adding a Word From Your Selection](/help/adding-a-word-from-your-selection/).
 
 ### If your keybind stops working
 

--- a/website/src/content/help/download-and-install.md
+++ b/website/src/content/help/download-and-install.md
@@ -5,9 +5,9 @@ category: "getting-started"
 section: "Basics"
 order: 3
 keywords: ["install", "download", "setup", "get started", "dmg", "first time", "where do i get it", "installation"]
-related: ["system-requirements", "granting-permissions-microphone-accessibility-and-automation"]
+related: ["system-requirements", "granting-permissions-microphone-accessibility-and-automation", "your-first-dictation"]
 seeAlso: "getting-started-enviouswispr-under-2-minutes"
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 EnviousWispr is a free, open-source dictation app for macOS. Installing it takes about two minutes, and there is no account to create and no subscription to start.
 
@@ -25,7 +25,7 @@ EnviousWispr is a free, open-source dictation app for macOS. Installing it takes
 
 macOS may show a security warning because you downloaded the application from the internet. Click **Open** to proceed.
 
-EnviousWispr then walks you through setup. You will choose a speech engine, pick the keybind you will hold down while dictating, and grant the macOS permissions it needs.
+EnviousWispr then walks you through setup. It downloads the speech model, sets up on-device AI polish, and lets you pick the keybind you will hold down while dictating, Right Option by default. It then asks for the two permissions it needs, Microphone and Accessibility, and ends with a practice box where you try your first dictation before you leave setup. You can skip the practice step if you would rather try it in a real app.
 
 ### How you know it worked
 

--- a/website/src/content/help/empty-or-missing-transcription.md
+++ b/website/src/content/help/empty-or-missing-transcription.md
@@ -6,13 +6,13 @@ section: "Transcription Issues"
 order: 3
 keywords: ["nothing happens", "no text", "empty", "microphone not working", "mic not working", "not hearing me", "no output", "blank", "nothing appears", "not transcribing", "not working at all", "silent", "no sound"]
 related: ["choosing-your-microphone", "granting-permissions-microphone-accessibility-and-automation"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 When a recording finishes and no text appears, something between your microphone and the speech model did not deliver. These checks run from the most common cause to the least, so work through them in order.
 
 ### 1. Is the app hearing you?
 
-Watch the recording bar on screen while you talk. Its meter moves with your voice. If the meter stays flat while you speak, your microphone is not reaching the app, and steps 2 to 4 are where to look.
+Watch the recording pill on screen while you talk. Its meter moves with your voice, and on a Mac that can show them, your words appear in the pill as you speak. If the meter stays flat and no words appear, your microphone is not reaching the app, and steps 2 to 4 are where to look.
 
 ### 2. Check the microphone permission
 
@@ -26,9 +26,11 @@ A physical mute switch stops your voice reaching the app even when everything el
 
 EnviousWispr needs to listen to the device you are actually speaking into. Open EnviousWispr settings and go to **Microphone**. When set to Auto, EnviousWispr records from whatever input your Mac is using, which may not be the device at your mouth. Pick a specific device from the list to remove the ambiguity.
 
+If your Mac's default input is a virtual device, such as one installed by Krisp, Loopback, BlackHole, an aggregate device or a meeting app, Auto skips it and records from a real microphone, because a virtual device delivers only silence. Versions before 2.4.5 recorded that silence, so if you gave up on EnviousWispr for this reason, it is worth another go. A virtual device is still used when it is the only input on your Mac.
+
 ### 5. Is the speech model ready?
 
-The app downloads its speech model on first launch. Until that download finishes, there is no model available to transcribe your voice. Progress is shown on screen.
+The app downloads its speech model on first launch. Until that download finishes, there is no model available to transcribe your voice. Progress is shown on screen. If the engine was not ready at the moment you finished speaking, your recording is kept and given another go rather than lost.
 
 ### 6. Was the recording very short?
 

--- a/website/src/content/help/filler-word-removal.md
+++ b/website/src/content/help/filler-word-removal.md
@@ -5,7 +5,7 @@ category: "features"
 section: "Text Processing"
 order: 2
 keywords: ["um", "uh", "filler", "filler words", "remove um", "you know", "like", "stop words", "cleaner speech"]
-updated: 2026-08-21
+updated: 2026-09-05
 ---
 EnviousWispr automatically removes spoken noises like "um", "uh", "hmm", and "er" from your dictated text before it reaches your app. This is on by default.
 
@@ -27,7 +27,9 @@ This runs on your Mac against a fixed list of noises, with no AI model involved.
 
 EnviousWispr only removes these noises when they stand on their own as separate words. The "um" inside the word "umbrella" is left alone.
 
-Some of these sounds are also real words in other languages. If your language is locked to German, Dutch, Danish, or Norwegian in **Settings → Transcription**, EnviousWispr keeps them instead of removing them: "er" (German for "he"; Dutch for "there"; Danish and Norwegian for "is") and "um" (German for "at [a time]" or "in order to") stay in your dictated text. This only applies when your language is locked; on Auto-detect, the fixed list above still applies to every dictation.
+Some of these sounds are also real words in other languages, and EnviousWispr keeps those instead of removing them. In German, Dutch, Danish and Norwegian, "er" stays: it means "he" in German, "there" in Dutch, and "is" in Danish and Norwegian. "um" stays in German, where it is an ordinary word, and in Portuguese, Slovenian and Croatian. "er" also stays in Swedish. Every other noise on the list is still removed.
+
+This works from the language of the dictation. That is the language you picked under **Settings** \> **Transcription**, or, on Auto-detect, the language the speech engine reports or the app recognises from the text. If the app can tell the dictation is not in English but cannot tell which language it is, it keeps every one of these words to be safe.
 
 ### If you want more than this
 

--- a/website/src/content/help/granting-permissions-microphone-accessibility-and-automation.md
+++ b/website/src/content/help/granting-permissions-microphone-accessibility-and-automation.md
@@ -6,15 +6,15 @@ section: "Basics"
 order: 5
 keywords: ["permissions", "permission", "allow", "access", "microphone access", "accessibility", "privacy settings", "system settings", "grant", "it is asking for permission", "blocked", "denied"]
 related: ["accessibility-permission-not-working", "paste-not-working"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
-Because EnviousWispr listens to your microphone and types into other apps, macOS requires you to grant specific permissions first. Two permissions are always needed, and a third is required only in rare cases. The **Permissions** page in EnviousWispr settings always shows the current status of each one.
+Because EnviousWispr listens to your microphone and types into other apps, macOS requires you to grant specific permissions first. Two permissions are always needed, and a third is required only in rare cases. Setup asks for the two before the practice dictation at the end, so most people grant both there. The **Permissions** page in EnviousWispr settings always shows the current status of each one.
 
 ### Microphone
 
 This permission allows EnviousWispr to hear your voice while you dictate.
 
-**Grant permission.** macOS asks the first time you record. If you missed the prompt, open **System Settings**, select **Privacy & Security**, click **Microphone**, and switch EnviousWispr on.
+**Grant permission.** Setup asks for it, and macOS asks again the first time you record if it was skipped. If you missed the prompt, open **System Settings**, select **Privacy & Security**, click **Microphone**, and switch EnviousWispr on.
 
 You will know it worked when you hold your keybind and the meter on the recording bar moves as you speak.
 
@@ -22,7 +22,7 @@ You will know it worked when you hold your keybind and the meter on the recordin
 
 This permission allows EnviousWispr to place the finished text directly into the app you are working in.
 
-**Grant permission.** Open **System Settings**, select **Privacy & Security**, click **Accessibility**, click the plus button, and add EnviousWispr from your Applications folder.
+**Grant permission.** Setup offers a **Grant** button for it. Otherwise open **System Settings**, select **Privacy & Security**, click **Accessibility**, click the plus button, and add EnviousWispr from your Applications folder.
 
 You will know it worked when your next dictation lands in the text box on its own.
 

--- a/website/src/content/help/how-custom-word-correction-works.md
+++ b/website/src/content/help/how-custom-word-correction-works.md
@@ -5,8 +5,8 @@ category: "custom-words"
 section: "Dictionary"
 order: 2
 keywords: ["how correction works", "why didnt my word work", "fuzzy match", "sounds like", "replacement rules"]
-related: ["adding-custom-words"]
-updated: 2026-09-01
+related: ["adding-custom-words", "using-snippets"]
+updated: 2026-09-05
 ---
 When you teach EnviousWispr a custom word, you give it one correct spelling, and it then recognises the many ways that word can come out wrong during transcription and corrects them for you.
 
@@ -20,7 +20,7 @@ Transcription errors on an unfamiliar word fall into three groups, and custom wo
 
 ### When custom word correction runs
 
-Custom word correction runs first, before anything else touches the text. Your words are therefore already right by the time filler removal and AI Polish see them.
+Custom word correction runs early. Only [snippet expansion](/help/using-snippets/) comes before it, and nothing else has touched the text by then. Your words are therefore already right by the time filler removal and AI Polish see them.
 
 ### If a word is not being caught
 

--- a/website/src/content/help/how-smart-polish-works-context-aware.md
+++ b/website/src/content/help/how-smart-polish-works-context-aware.md
@@ -5,7 +5,7 @@ category: "ai-polish"
 section: "Polish"
 order: 3
 keywords: ["smart polish", "context", "context aware", "knows what app", "different apps", "tone", "formal", "casual"]
-updated: 2026-09-04
+updated: 2026-09-05
 ---
 When EnviousWispr sends your dictation to an AI for polishing, it includes a small set of background facts along with your words. That extra context helps the AI make better corrections than it could by reading the transcript alone.
 
@@ -30,7 +30,7 @@ How much context is sent depends on the polish option you selected in settings.
 | **Ollama, except EG-1 and S1-mini** | Yes | Usually |
 | **Apple Intelligence, EG-1, and S1-mini** | No | No |
 
-Every Ollama model gets the app name, whichever one you picked and wherever it runs, with two exceptions: EG-1 and S1-mini, both of which you can also run through Ollama. Apple Intelligence, EG-1, and S1-mini get neither field. Both are compact on-device models that do better with short instructions, and EG-1 was trained without them.
+Every Ollama model gets the app name, whichever one you picked and wherever it runs, with two exceptions: EG-1 and S1-mini, both of which you can also run through Ollama. Apple Intelligence, EG-1, and S1-mini get neither field. All three are compact on-device models that do better with short instructions, and EG-1 was trained without them.
 
 Custom words say "usually" for a reason. When the app cannot tell with confidence which language you spoke, it holds your word list back for that dictation instead of risking English spellings being pushed onto text in another language. That applies to every option in the Yes rows, not just Ollama.
 

--- a/website/src/content/help/how-text-gets-pasted-into-your-app.md
+++ b/website/src/content/help/how-text-gets-pasted-into-your-app.md
@@ -28,7 +28,7 @@ Capital matching works in English, German, French, Italian, Spanish, Portuguese,
 
 You can turn this behaviour off under **Settings** \> **Clipboard**, where the setting is named **Smart insertion**.
 
-A dictation that expanded a snippet skips this tidy-up, so the text you saved arrives exactly as you typed it. Read [_Using Snippets_](/help/using-snippets/).
+A dictation that expanded a snippet skips this tidy-up, so the text you saved arrives word for word, with only the usual space after it. Read [_Using Snippets_](/help/using-snippets/).
 
 ### Web addresses in a browser
 

--- a/website/src/content/help/how-text-gets-pasted-into-your-app.md
+++ b/website/src/content/help/how-text-gets-pasted-into-your-app.md
@@ -5,8 +5,8 @@ category: "pasting-your-text"
 section: "Paste System"
 order: 1
 keywords: ["paste", "how does it type", "where does the text go", "delivery", "spacing", "capitals", "capitalisation", "capitalization", "stop capitalising", "stop capitalizing", "capital letters", "extra space", "no space", "jams words together", "smart insertion", "middle of a sentence", "cursor"]
-related: ["clipboard-preservation", "paste-not-working"]
-updated: 2026-08-06
+related: ["clipboard-preservation", "paste-not-working", "using-snippets"]
+updated: 2026-09-05
 ---
 EnviousWispr remembers the app and text field that were focused when you started recording, and delivers your text there. It works anywhere you can type, including native Mac apps, web browsers, and apps built on web technology such as VS Code, Slack, Discord, and Notion.
 
@@ -27,6 +27,12 @@ EnviousWispr looks at the text on either side of your cursor and matches it. Dic
 Capital matching works in English, German, French, Italian, Spanish, Portuguese, Dutch, Danish, Swedish, Finnish, Russian, and Turkish. German follows its own rules, so nouns keep the capital letters they are supposed to have. In every other language, EnviousWispr handles the spacing and leaves your capitals exactly as you spoke them.
 
 You can turn this behaviour off under **Settings** \> **Clipboard**, where the setting is named **Smart insertion**.
+
+A dictation that expanded a snippet skips this tidy-up, so the text you saved arrives exactly as you typed it. Read [_Using Snippets_](/help/using-snippets/).
+
+### Web addresses in a browser
+
+Dictating into the address bar of Safari, Chrome, Brave or Edge no longer adds a trailing space you have to delete. In Chrome and Brave, pressing Return after dictating an address goes there.
 
 ### Your clipboard contents are preserved
 

--- a/website/src/content/help/importing-and-exporting-custom-words.md
+++ b/website/src/content/help/importing-and-exporting-custom-words.md
@@ -5,8 +5,8 @@ category: "custom-words"
 section: "Dictionary"
 order: 3
 keywords: ["import", "export", "backup my words", "csv", "move to a new mac", "transfer", "share my word list"]
-related: ["adding-custom-words"]
-updated: 2026-09-01
+related: ["adding-custom-words", "using-snippets"]
+updated: 2026-09-05
 ---
 Your custom words are the names and specialised words you have taught EnviousWispr to recognise. You can move them to another Mac or bring them in from another dictation app. Every control mentioned on this page lives under **Settings** \> **Dictionary** \> **Your Words**.
 
@@ -24,7 +24,7 @@ Importing adds new words to your list without changing the words you already hav
 - **Juno** ships with around 400 built-in words of its own. Only the words you added are imported, so your list stays yours.
 - **Spokenly** can store find-and-replace rules written as patterns rather than plain words. Those are skipped, because a pattern is not a word.
 - **TypeWhisper** entries you have switched off stay off, and its case-sensitivity setting for each word comes across with it. Its match-strictness setting does not.
-- **Wispr Flow** text shortcuts are skipped. Those are text expansions rather than vocabulary.
+- **Wispr Flow** text shortcuts are skipped. Those are text expansions rather than vocabulary. EnviousWispr's own version of those is [Snippets](/help/using-snippets/), which you add by hand under **Settings** \> **Snippets**.
 
 If an app holds entries but none of them can come across, EnviousWispr tells you how many it found rather than saying it found nothing.
 

--- a/website/src/content/help/is-enviouswispr-free.md
+++ b/website/src/content/help/is-enviouswispr-free.md
@@ -6,7 +6,7 @@ section: "Cost"
 order: 1
 keywords: ["free", "is this free", "price", "cost", "pricing", "subscription", "pay", "trial", "how much", "premium", "hidden costs", "catch"]
 related: ["source-code-and-contributing", "choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
-updated: 2026-09-04
+updated: 2026-09-05
 ---
 EnviousWispr is a free dictation app for macOS, and free means all of it. There is no subscription, no trial period, and no account to create.
 
@@ -17,7 +17,7 @@ Every installation includes the complete feature set, with no hidden tiers and n
 - **Speech engines.** Both speech engines, and every language they cover.
 - **AI polish.** AI Polish, including the options that run entirely on your Mac.
 - **Recording modes.** Every recording mode, and keybinds you can set to anything.
-- **Custom vocabulary.** Your own dictionary of custom words, plus ready-made vocabulary packs.
+- **Custom vocabulary.** Your own dictionary of custom words, ready-made vocabulary packs, and snippets.
 - **History with no ceiling.** Unlimited dictation, and a History with no limit on how much it keeps.
 
 ### The one thing that can cost money

--- a/website/src/content/help/multi-language-dictation.md
+++ b/website/src/content/help/multi-language-dictation.md
@@ -5,10 +5,16 @@ category: "speech-engines"
 section: "Transcription"
 order: 2
 keywords: ["language", "languages", "spanish", "french", "german", "hindi", "not english", "foreign language", "bilingual", "multilingual", "change language", "accent"]
-related: ["choosing-a-speech-engine-parakeet-vs-whisperkit"]
-updated: 2026-08-06
+related: ["choosing-a-speech-engine-parakeet-vs-whisperkit", "filler-word-removal", "live-preview-words-on-screen"]
+updated: 2026-09-05
 ---
-EnviousWispr handles dozens of languages without asking you to change a setting before every session. Parakeet, the transcription engine you start with, recognises 25 European languages on its own, with nothing to configure.
+EnviousWispr handles dozens of languages without asking you to change a setting before every session. Parakeet, the transcription engine you start with, recognises 25 European languages and detects which one you are speaking on its own.
+
+### Telling it your language
+
+Both engines let you lock a language under **Settings** \> **Transcription** \> **Language**, or leave it on **Auto-detect language**.
+
+On Parakeet, locking a language narrows what the engine produces to your own alphabet, so a German dictation stops coming back with stray Greek or Cyrillic characters in it. It cannot separate two languages that share an alphabet, so it will not tell German from Dutch. On WhisperKit, locking a language gives higher accuracy than auto-detect.
 
 ### Switching to WhisperKit for more languages
 
@@ -27,3 +33,5 @@ You will know the setup is working when your next dictation comes back in the la
 - **Name your language rather than auto-detecting.** Choosing your language in settings gives higher accuracy than leaving it on auto-detect.
 - **Keep to one language per sentence.** Auto-detect handles one language at a time and struggles when you switch languages mid-sentence.
 - **Expect correction, not translation.** AI Polish cleans up grammar and filler words, but it does not translate. Dictating in French returns French text.
+- **Filler words are removed with your language in mind.** The step that strips ums and uhs reads the language you are dictating in. It leaves "er" alone in German, Dutch, Danish and Norwegian, and "um" in German, because those are real words there. Read [_Filler Word Removal_](/help/filler-word-removal/).
+- **Live Preview has its own language setting.** The words shown in the pill while you speak come from a separate engine, and you pick its language on the **Live Preview** page. Some languages need a language pack from macOS or the Universal engine. Read [_Live Preview_](/help/live-preview-words-on-screen/).

--- a/website/src/content/help/noise-suppression.md
+++ b/website/src/content/help/noise-suppression.md
@@ -5,13 +5,18 @@ category: "audio-and-microphone"
 section: "Audio Processing"
 order: 3
 keywords: ["noise", "background noise", "noisy room", "cafe", "fan", "noise cancelling", "suppression", "echo"]
-updated: 2026-08-06
+related: ["voice-activity-detection-and-auto-stop"]
+updated: 2026-09-05
 ---
 EnviousWispr has no noise suppression setting. It records your microphone as it is and lets the speech model handle the audio directly.
 
 ### Why noise suppression was removed
 
 Running the audio through a suppression filter before transcription hurt accuracy more than it helped, and it added a noticeable delay to every recording. The setting was removed in version 2.0.2, and switched off automatically when you updated.
+
+### What the app does do about rumble
+
+The step that finds where you were talking, so silence can be trimmed, works from a copy of your audio with the low rumble taken out, which is most of what a fan, an engine or an air conditioner produces. Your recording and the audio the speech engine transcribes are untouched. Read [_Voice Activity Detection and Auto-Stop_](/help/voice-activity-detection-and-auto-stop/).
 
 ### How to manage background noise
 

--- a/website/src/content/help/numbers-dates-and-times.md
+++ b/website/src/content/help/numbers-dates-and-times.md
@@ -5,9 +5,9 @@ category: "features"
 section: "Text Processing"
 order: 4
 keywords: ["numbers", "dates", "times", "money", "dollars", "percent", "phone number", "email address", "url", "formatting numbers", "writes out numbers", "spelled out"]
-related: ["spoken-punctuation-and-emoji"]
+related: ["spoken-punctuation-and-emoji", "how-text-gets-pasted-into-your-app"]
 seeAlso: "spoken-text-formatting-dates-numbers-emails"
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 Numbers, dates, and times are converted automatically from spoken words into the standard written forms. EnviousWispr writes numbers, money, dates, times, phone numbers, email addresses, and web addresses the way you would type them, rather than spelling out every word you said. It is switched on when you install the app, and there is nothing to configure.
 
@@ -23,6 +23,10 @@ Numbers, dates, and times are converted automatically from spoken words into the
 ### Small numbers stay as words
 
 Numbers below ten are written out as words, while numbers from ten upwards use digits. That follows the standard style used in most professional and general writing.
+
+### Web addresses
+
+A bare web address said out loud comes out ready to use. A stray period at the end of it is dropped, while a real sentence period is kept. A leftover "dot" sitting beside an address that has already been joined up is folded into it, and a garbled "h slash slash" from a half-heard "https" is repaired. Dictating into a browser's address bar is covered in [_How Text Gets Pasted Into Your App_](/help/how-text-gets-pasted-into-your-app/).
 
 ### When the formatting happens
 

--- a/website/src/content/help/push-to-talk-mode.md
+++ b/website/src/content/help/push-to-talk-mode.md
@@ -5,8 +5,8 @@ category: "recording-and-keybinds"
 section: "Recording"
 order: 1
 keywords: ["push to talk", "hold to talk", "hold the key", "ptt", "press and hold", "default mode", "recording mode"]
-related: ["customizing-your-keybind", "first-word-gets-cut-off"]
-updated: 2026-08-06
+related: ["customizing-your-keybind", "first-word-gets-cut-off", "escape-recovery"]
+updated: 2026-09-05
 ---
 Push-to-talk is the default recording mode. You hold your keybind down for as long as you are speaking. Letting go ends the recording, and your transcribed words appear at your cursor once EnviousWispr has worked out what you said.
 
@@ -19,6 +19,10 @@ Push-to-talk is the default recording mode. You hold your keybind down for as lo
 **Release it.** Let go when you finish your sentence. Your text appears at the cursor a moment later, once the audio has been transcribed.
 
 Recording stops the exact moment you release the key. Because of that, a cough, a deep breath, or a passing conversation after you finish speaking never reaches the transcript.
+
+A short sound confirms when recording starts and stops. Switch it off under **Settings** \> **Sounds**.
+
+If you press your cancel keybind by mistake, Escape by default, the dictation is kept and offered back to you rather than thrown away. Read [_Escape Recovery_](/help/escape-recovery/).
 
 ### Dictating for longer periods
 

--- a/website/src/content/help/s1-mini-by-superwhisper-and-writing-style.md
+++ b/website/src/content/help/s1-mini-by-superwhisper-and-writing-style.md
@@ -6,7 +6,7 @@ section: "Polish"
 order: 4
 keywords: ["s1-mini", "s1 mini", "superwhisper", "writing style", "tone", "casual", "formal", "lists", "prose", "email", "context", "lightweight", "small model", "8 gb mac", "on-device polish"]
 related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini", "model-downloads-and-management", "using-ollama-for-fully-offline-ai-polish"]
-updated: 2026-09-04
+updated: 2026-09-05
 ---
 S1-mini is a small open model made by Superwhisper for one job: tidying up dictated text. EnviousWispr offers it as a second on-device polish option beside EG-1. It runs entirely on your Mac, it is free, and there is no API key to manage. Open **Settings**, then **AI Polish**, and pick **S1-mini** to use it.
 
@@ -24,9 +24,9 @@ S1-mini was trained with three settings that you choose. They appear on the **Wr
 
 **Tone** sets the register.
 
-- **Casual** and **Semi-casual** write the way you would text: sentence starts stay lowercase and there is no final full stop.
+- **Casual** and **Semi-casual** write the way you would text.
 - **Semi-formal** keeps capitals and full stops. This is the default.
-- **Formal** keeps capitals and full stops and reads a little more buttoned up.
+- **Formal** keeps capitals and full stops and is the most formal of the four.
 
 **Structure** decides what happens to a spoken run of items.
 

--- a/website/src/content/help/sounds-and-appearance.md
+++ b/website/src/content/help/sounds-and-appearance.md
@@ -1,13 +1,13 @@
 ---
 title: "Sounds and Appearance"
-description: "Light and dark mode, where the recording bar sits, and recording sounds."
+description: "Light and dark mode, where the recording bar sits and how it looks, and recording sounds."
 category: "features"
 section: "Appearance and Sounds"
 order: 5
-keywords: ["sound", "sounds", "beep", "chime", "mute the sound", "turn off sound", "appearance", "theme", "dark mode", "pill", "overlay", "bar position", "move the bar", "menu bar icon"]
-updated: 2026-09-01
+keywords: ["sound", "sounds", "beep", "chime", "mute the sound", "turn off sound", "appearance", "theme", "dark mode", "pill", "pill design", "recording pill", "overlay", "bar position", "move the bar", "menu bar icon"]
+updated: 2026-09-05
 ---
-Three settings change how EnviousWispr looks and sounds while you use it. None of them affects what you dictate or how accurately it is transcribed.
+Four settings change how EnviousWispr looks and sounds while you use it. None of them affects what you dictate or how accurately it is transcribed.
 
 ### Light or dark
 
@@ -20,6 +20,10 @@ The recording bar shows you when EnviousWispr is listening, and you can put it w
 You can also move the bar during a dictation.
 
 **Drag the bar.** Click and drag the recording bar to any position on your screen while it is visible. That placement lasts for the current dictation only, and the next one returns to the position you chose in Settings.
+
+### The look of the recording bar
+
+The same **Appearance** page has a **Recording Pill** row with three designs: **Capsule**, **Reading Well** and **Level Rail**. Click one to use it. Reading Well is the design that shows your words as you speak, so it goes together with [Live Preview](/help/live-preview-words-on-screen/). If a design is greyed out, the line under the row says why.
 
 ### Recording sounds
 

--- a/website/src/content/help/source-code-and-contributing.md
+++ b/website/src/content/help/source-code-and-contributing.md
@@ -5,7 +5,7 @@ category: "updates-and-source"
 section: "Source Code"
 order: 2
 keywords: ["source code", "github", "open source", "license", "gpl", "contribute", "pull request", "build it myself", "repo"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 EnviousWispr is a free dictation app for macOS, and the entire application is open source under the GPLv3 license. You can inspect every part of the codebase at [github.com/saurabhav88/EnviousWispr](https://github.com/saurabhav88/EnviousWispr) and check every privacy claim on this site against the code that runs on your Mac.
 
@@ -16,6 +16,7 @@ EnviousWispr is distributed under the terms of the GNU General Public License v3
 - **Use freely.** You are free to use, study, change, and share the software, including for commercial purposes.
 - **Share modifications.** If you distribute a modified version of EnviousWispr, that version has to be open source under the same license terms.
 - **Trademarks are excluded.** The EnviousWispr name and logo belong to Envious Labs LLC and are not covered by the open source license.
+- **The models are licensed separately.** The GPLv3 covers the application code. The EG-1 polish model downloads separately under its own model license, and S1-mini by Superwhisper comes under its own license too. The speech models are third-party downloads as well.
 
 ### Helping out
 
@@ -27,4 +28,4 @@ Contributions make the project more stable and easier to trust. There are three 
 
 ### Building it yourself
 
-You can compile the application from source on your own machine. Building EnviousWispr needs a Mac with Apple Silicon and Xcode installed. The current compilation steps are kept up to date in the repository README.
+You can compile the application from source on your own machine. Building EnviousWispr needs a Mac with Apple Silicon and Xcode 26 or later installed. The current compilation steps are kept up to date in the repository README.

--- a/website/src/content/help/system-requirements.md
+++ b/website/src/content/help/system-requirements.md
@@ -5,7 +5,7 @@ category: "getting-started"
 section: "Basics"
 order: 2
 keywords: ["requirements", "supported macs", "will it run", "intel", "apple silicon", "m1", "m2", "m3", "m4", "macos version", "sonoma", "sequoia", "compatible", "does it work on my mac", "old mac"]
-updated: 2026-09-04
+updated: 2026-09-05
 ---
 EnviousWispr is a free dictation app for macOS. It runs on any Mac with Apple Silicon (M1 or later) running macOS 14 Sonoma or later. Intel Macs are not supported.
 
@@ -21,7 +21,7 @@ EnviousWispr is a free dictation app for macOS. It runs on any Mac with Apple Si
 AI polish is an optional feature that removes filler words and corrects grammar. Dictation works without it, so these requirements only apply if you choose to turn it on. Each polish option asks for something different:
 
 - **Apple Intelligence** requires macOS 26 or later, running on a Mac model that supports Apple Intelligence.
-- **EG-1**, the model built by Envious Labs, requires a one-time 2.9 GB download and around 6 GB of free disk space while it installs.
-- **S1-mini**, the small model made by Superwhisper, requires a one-time 484 MB download and around 1 GB of free disk space while it installs.
+- **EG-1**, the model built by Envious Labs, requires a one-time 2.9 GB download and around 6 GB of free disk space while it installs. It runs on macOS 14 or later, the same as the app. It works on a Mac with 8 GB of memory, but may run slower there.
+- **S1-mini**, the small model made by Superwhisper, requires a one-time 484 MB download and around 1 GB of free disk space while it installs. It runs on macOS 14 or later too, uses about a sixth of the memory EG-1 does, and is at its best in English.
 - **Ollama** running on your Mac requires enough free memory to load the model you choose. Ollama also offers models hosted on its own servers, which need an internet connection instead.
 - **OpenAI, Gemini, or Claude** require an internet connection and your own API key from that provider.

--- a/website/src/content/help/uninstalling-enviouswispr.md
+++ b/website/src/content/help/uninstalling-enviouswispr.md
@@ -6,7 +6,7 @@ section: "Basics"
 order: 6
 keywords: ["uninstall", "remove", "delete", "get rid of it", "clean up", "free up space", "leftover files", "models taking up space"]
 related: ["model-downloads-and-management"]
-updated: 2026-08-17
+updated: 2026-09-05
 ---
 Removing the app involves two parts: deleting the application itself, and deleting the support files it saved on your Mac.
 
@@ -18,7 +18,7 @@ Quit the application first, so macOS is not holding the program files open when 
 
 **Move it to the Trash.** Open your Applications folder in Finder and drag EnviousWispr to the Trash.
 
-The application is now gone, but your dictation history, custom words, and downloaded speech models remain on the Mac.
+The application is now gone, but your dictation history, custom words, snippets, and downloaded models remain on the Mac.
 
 ### Remove your data and settings
 
@@ -26,7 +26,7 @@ Those remaining files can add up to a few gigabytes of storage. Follow these ste
 
 **Open the Go to Folder box.** In Finder, press **Shift+Cmd+G** on your keyboard.
 
-**Delete the application support folder.** Paste `~/Library/Application Support/EnviousWispr` into the box, press Enter, and move that folder to the Trash. It holds your dictation history, your custom words, and the WhisperKit and EG-1 models. Any recording that Escape Recovery was still holding for you sits in there too, and goes with it.
+**Delete the application support folder.** Paste `~/Library/Application Support/EnviousWispr` into the box, press Enter, and move that folder to the Trash. It holds your dictation history, your custom words, your snippets, and the WhisperKit, EG-1 and S1-mini models. Any recording that Escape Recovery was still holding for you sits in there too, and goes with it.
 
 **Delete the preferences file.** Press **Shift+Cmd+G** again, paste `~/Library/Preferences`, press Enter, and move `com.enviouswispr.app.plist` to the Trash. That file stores your settings.
 
@@ -50,6 +50,6 @@ Revoking the key in that company's own dashboard is worth doing either way.
 
 ### If you come back
 
-If you plan to reinstall later, leave those support files in place. Reinstalling brings your history, custom words, models, and settings back on its own. Delete them first if you want to start fresh.
+If you plan to reinstall later, leave those support files in place. Reinstalling brings your history, custom words, snippets, models, and settings back on its own. Delete them first if you want to start fresh.
 
 Once you move those files to the Trash and empty it, they are gone for good. Envious Labs cannot restore them, because we never had a copy.

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -6,7 +6,7 @@ section: "Text Processing"
 order: 7
 keywords: ["snippets", "text expansion", "voice shortcut", "paste my email", "keyword", "backslash", "signature", "expand phrase", "saved text"]
 related: ["adding-custom-words", "ai-polish-and-cloud-data"]
-updated: 2026-09-01
+updated: 2026-09-05
 ---
 A snippet is a voice shortcut. You save a piece of text once, then say a short phrase to paste it. An email address, a sign-off, a link you send people every week.
 
@@ -66,7 +66,9 @@ Clearing the field puts the default back rather than switching snippets off.
 
 The text you save is pasted exactly as you typed it. AI Polish never rewrites it, so an email address, a web link or a signature arrives character for character. Everything else you dictate is still polished as normal.
 
-Line breaks are kept, so a two-line sign-off arrives as two lines.
+Line breaks are kept, so a two-line sign-off arrives as two lines, and a snippet with line breaks is inserted where you are typing like any other dictation.
+
+Your saved text also decides how it ends. Say nothing but the keyword and the trigger, into a search box or an empty field, and the full stop the speech engine adds to a complete sentence is dropped, so an email address does not arrive with a full stop welded on. The same happens when your saved text already ends a sentence, so a canned reply does not end in two full stops. In the middle of a sentence of your own, your own punctuation is kept.
 
 ### One thing worth knowing
 
@@ -82,4 +84,4 @@ Line breaks are kept, so a two-line sign-off arrives as two lines.
 
 **Export** writes your snippets and your keyword to a file you choose. Useful when you move to a new Mac. EnviousWispr will refuse to save over its own snippets file, because that would erase the snippets you were trying to back up.
 
-Import is coming soon.
+**Import** sits beside it but is greyed out. It is coming soon.

--- a/website/src/content/help/using-snippets.md
+++ b/website/src/content/help/using-snippets.md
@@ -64,7 +64,7 @@ Clearing the field puts the default back rather than switching snippets off.
 
 ### What EnviousWispr will not do to your snippet
 
-The text you save is pasted exactly as you typed it. AI Polish never rewrites it, so an email address, a web link or a signature arrives character for character. Everything else you dictate is still polished as normal.
+The text you save is pasted word for word, with a space after it like any other dictation. AI Polish never rewrites it, so an email address, a web link or a signature arrives as you saved it. Everything else you dictate is still polished as normal.
 
 Line breaks are kept, so a two-line sign-off arrives as two lines, and a snippet with line breaks is inserted where you are typing like any other dictation.
 

--- a/website/src/content/help/voice-activity-detection-and-auto-stop.md
+++ b/website/src/content/help/voice-activity-detection-and-auto-stop.md
@@ -6,7 +6,7 @@ section: "Audio Processing"
 order: 4
 keywords: ["auto stop", "stops on silence", "stops too early", "cuts me off", "pause", "silence", "vad", "keeps going after i stop", "waits too long"]
 related: ["hands-free-mode-long-dictation", "first-word-gets-cut-off"]
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 EnviousWispr can end a recording by itself once you stop talking, so you do not have to reach for your keybind again. This is off by default and has to be switched on before it does anything.
 
@@ -39,3 +39,5 @@ That recognition step now works from a copy of your audio with the low rumble ta
 ### If it stops at the wrong time
 
 Move the slider. If EnviousWispr keeps ending the recording while you are still thinking, raise the setting to three seconds, or switch the feature off and end every recording yourself.
+
+In a noisy room the timing moves. Since the trimming step stopped eating the start of sentences in noisy rooms, auto-stop usually stops sooner there, and on the half-second setting it sometimes waits longer or does not stop on its own at all. Raise the setting, or end the recording with your keybind.

--- a/website/src/content/help/what-is-ai-polish.md
+++ b/website/src/content/help/what-is-ai-polish.md
@@ -5,8 +5,8 @@ category: "ai-polish"
 section: "Polish"
 order: 1
 keywords: ["polish", "ai polish", "cleanup", "clean up my text", "grammar", "punctuation", "tidy", "what does ai do", "editing"]
-related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini"]
-updated: 2026-08-06
+related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini", "s1-mini-by-superwhisper-and-writing-style"]
+updated: 2026-09-05
 ---
 AI Polish is the optional step EnviousWispr runs after transcribing your speech, to tidy up what you said. It fixes grammar and punctuation, cuts filler words, and is instructed to keep your exact meaning and your language.
 
@@ -25,8 +25,16 @@ AI can still make mistakes. EnviousWispr checks the result and rejects the obvio
 
 If polish is unavailable, runs too slowly, or returns something unusable, EnviousWispr pastes the version of your dictation from immediately before the AI step. That version is not raw: your custom words, filler-word removal, and number and date formatting have already been applied to it. You never lose your dictation. How long the app waits before giving up depends on which polish option you chose.
 
+### Your polish options
+
+Every option is listed under **Settings** \> **AI Polish**, in three groups.
+
+- **On this Mac.** EG-1, our own model tuned for dictation, and the recommended choice. Apple Intelligence, built into macOS 26. S1-mini by Superwhisper, a small open model that is a 484 MB download. Nothing you dictate leaves your Mac with any of these.
+- **Your own setup.** Ollama, running an open model you choose, on your Mac or hosted.
+- **Cloud.** OpenAI, Google Gemini or Claude, with your own API key. These receive your transcribed text, never your audio.
+
 ### The default, and how to change it
 
-Apple Intelligence is the option you begin with, and it requires macOS 26 or later. On a Mac that cannot run macOS 26, the AI step is quietly skipped and you receive that same pre-polish version of your text.
+Apple Intelligence is the option you begin with, and it requires macOS 26 or later. On a Mac that cannot run macOS 26, the AI step is quietly skipped and you receive that same pre-polish version of your text. EG-1 and S1-mini do not need macOS 26, so either gives you on-device polish on an older Mac.
 
-EnviousWispr uses a single polish style, tuned for dictation. To change your polish option or switch polish off entirely, open **Settings** and select **AI Polish**.
+EnviousWispr uses a single polish style, tuned for dictation. The one exception is S1-mini, which has three writing style settings, Tone, Structure and Context. Read [_S1-mini by Superwhisper and Its Writing Style Settings_](/help/s1-mini-by-superwhisper-and-writing-style/). To change your polish option or switch polish off entirely, open **Settings** and select **AI Polish**.

--- a/website/src/content/help/what-is-enviouswispr.md
+++ b/website/src/content/help/what-is-enviouswispr.md
@@ -5,8 +5,8 @@ category: "getting-started"
 section: "Basics"
 order: 1
 keywords: ["what is it", "overview", "how does it work", "dictation app", "voice to text", "speech to text", "talk to type"]
-related: ["is-enviouswispr-free", "privacy-overview"]
-updated: 2026-08-06
+related: ["is-enviouswispr-free", "privacy-overview", "what-is-ai-polish", "live-preview-words-on-screen", "escape-recovery", "adding-a-word-from-your-selection", "using-snippets"]
+updated: 2026-09-05
 ---
 EnviousWispr is a free, open-source dictation application for macOS. You hold a keybind, speak into your microphone, and your spoken words appear as written text in whatever application you are currently using.
 
@@ -26,4 +26,11 @@ EnviousWispr gives you a full dictation setup on macOS without asking for paymen
 - **Your voice stays on your Mac.** Your speech is transcribed into text entirely on your own device. The audio recording never leaves your Mac.
 - **It works anywhere you can type.** You can dictate into Slack, Mail, Notion, VS Code, Google Docs, Terminal, or any other text field on your Mac.
 - **It lives in your menu bar.** The application runs quietly from your menu bar. There is no Dock icon and no separate window to keep open on your desktop.
-- **AI can tidy up what you said.** An optional polish step cuts filler words like "um" and fixes grammar and punctuation. This is enabled by default when you install the app, and you can switch which AI performs the polish or turn the feature off entirely.
+- **AI can tidy up what you said.** An optional polish step cuts filler words like "um" and fixes grammar and punctuation. It is on from the start. You can choose an engine that runs on your Mac (EG-1, Apple Intelligence, or S1-mini by Superwhisper), your own Ollama setup, or OpenAI, Gemini or Claude with your own key, or turn the step off entirely. Read [_What Is AI Polish?_](/help/what-is-ai-polish/).
+
+### What else it does
+
+- **See your words as you speak.** The recording pill shows a live preview of what it is hearing, on Macs that can show it. Read [_Live Preview_](/help/live-preview-words-on-screen/).
+- **Get a cancelled dictation back.** Pressing your cancel keybind keeps the dictation and offers it back instead of throwing it away. Read [_Escape Recovery_](/help/escape-recovery/).
+- **Teach it your words.** Names and jargon go in your **Dictionary**, and you can add a word from anything you have highlighted with one keybind. Read [_Adding a Word From Your Selection_](/help/adding-a-word-from-your-selection/).
+- **Paste saved text by voice.** Say a keyword, then the name of a snippet, and the text you saved lands in place. Read [_Using Snippets_](/help/using-snippets/).

--- a/website/src/content/help/your-first-dictation.md
+++ b/website/src/content/help/your-first-dictation.md
@@ -5,11 +5,13 @@ category: "getting-started"
 section: "Basics"
 order: 4
 keywords: ["first dictation", "how to use", "getting started", "try it", "how do i dictate", "speak", "record", "start"]
-related: ["push-to-talk-mode", "how-text-gets-pasted-into-your-app"]
+related: ["push-to-talk-mode", "how-text-gets-pasted-into-your-app", "live-preview-words-on-screen", "escape-recovery"]
 seeAlso: "getting-started-enviouswispr-under-2-minutes"
-updated: 2026-08-06
+updated: 2026-09-05
 ---
 You dictate by holding a key, speaking, and letting go. Your first attempt takes about ten seconds, and you can do it in whatever app you already have open.
+
+If you have just finished setup, you have already done one. The last setup screen is a practice box where you hold your keybind, say something, and watch it typed. This page is about doing the same in a real app.
 
 ### Try it now
 
@@ -25,7 +27,9 @@ You dictate by holding a key, speaking, and letting go. Your first attempt takes
 
 Three things happen while EnviousWispr works, and knowing them saves you wondering whether anything is happening at all.
 
-**A recording bar appears.** A small bar shows up while you are recording, with a meter that moves as you talk. It does not take focus away from the app you were typing in.
+**A recording pill appears.** A small pill shows up while you are recording, with a meter that moves as you talk. On a Mac that can show it, your words appear in the pill as you speak. That is only a preview: the text that gets pasted comes from the main engine after you let go. The pill does not take focus away from the app you were typing in. Read [_Live Preview_](/help/live-preview-words-on-screen/).
+
+**A short sound plays.** A quiet tick confirms when recording starts and stops. Switch it off under **Settings** \> **Sounds**.
 
 **The menu bar icon changes.** The icon goes from grey to colour while you record, then turns into a spinning wheel while EnviousWispr works out what you said.
 
@@ -36,3 +40,4 @@ Three things happen while EnviousWispr works, and knowing them saves you wonderi
 - Speak at your normal speed. Slowing down or over-enunciating does not help.
 - On your first dictation after opening the app, pause for a beat after pressing the key. Once the microphone has been used recently, EnviousWispr also captures the half second before you press, so later dictations do not need that pause.
 - Finished dictations are saved under **History**, which you reach from the menu bar icon, so you can go back and find one later. If saving fails, EnviousWispr tells you.
+- If you press your cancel keybind by mistake, Escape by default, the dictation is kept and offered back to you with an **Undo** button. Read [_Escape Recovery_](/help/escape-recovery/).


### PR DESCRIPTION
## Summary

A full audit of all 58 help-centre articles against the app as it exists on `main` today, ahead of the v2.4.7 rollout. Every checkable claim in every article (settings paths, switch names, defaults, engine lists, keybinds, macOS versions, behaviours) was verified against `WhatsNewContent.swift` and the Swift settings source. 34 articles were stale or missing a shipped feature and are updated in place; 24 were already correct and are untouched, with their dates left alone. The help centre deploys from `main`, so this can merge any time.

Three commits: one per half of the article set, then a two-sentence correction to the snippets wording.

`Tier: SMALL | Lane: Content | Modules: website/src/content/help`

## What was wrong, by theme

- **Older articles (last updated August 6) predated three releases.** The 27 articles from that batch missed Escape Recovery, Live Preview, Quick Add, the onboarding practice step, the recording pill picker, the virtual-microphone fix, language lock on Parakeet, URL cleanup, and language-aware filler removal. 20 of them are updated; 7 were still correct.
- **Engine lists were incomplete.** `what-is-ai-polish` and `apple-intelligence-setup` listed engines without EG-1 or S1-mini; `choosing-an-ai-provider` did not mark EG-1 as recommended; `system-requirements` did not say EG-1 and S1-mini run on macOS 14+.
- **Quick Add's chord had moved.** `adding-a-word-from-your-selection` named no chord and `customizing-your-keybind` never mentioned the third keybind. Both now state Control Shift W (verified against `ShortcutRole.quickAdd`) and the 2.4.7 move.
- **Snippets were not cross-referenced.** `adding-custom-words`, `how-custom-word-correction-works` (which wrongly said correction "runs first"; snippet expansion runs before it), `importing-and-exporting-custom-words`, `is-enviouswispr-free`, `what-is-enviouswispr` and `choosing-a-speech-engine` now point to snippets where relevant. `using-snippets` gains the September 4 fixes (multi-line snippets insert, the snippet's own ending wins) and keeps "Import is coming soon", which is still true in `SnippetsView`.
- **Snippets are pasted "word for word", not "exactly as you typed it"** (17e5451). Codex found on #2678 that `CursorInsertionRepair.legacyPayload` appends a trailing space to every delivered dictation, snippets included; the snippet path skips smart insertion but not that. `using-snippets` (which said "character for character" on `main`) and the new sentence in `how-text-gets-pasted-into-your-app` both now say word for word, with the usual space after it. The README (#2677) and What's New entry (#2678) carry the same correction.
- **Stale settings paths and names.** The engine picker is the Fast / All Languages cards, not literal engine buttons; onboarding no longer chooses an engine; the API key field has a Clear button; Auto microphone now skips virtual devices; the recording bar is a pill with live words; the Bluetooth tips switch exists; the uninstall folder list gains `snippets.json` and the S1-mini model.
- **One unverifiable claim removed.** `s1-mini-by-superwhisper-and-writing-style` claimed the Casual tone produces lowercase starts with no final full stop; nothing in source says so, so it is trimmed to the settings hint.
- **`filler-word-removal`** now describes the resolved-language rule from #2614 (locked, engine-reported, or text-recognised, with an English-veto fallback) rather than "only with a locked language".

The per-article table is in each commit body.

## Gaps reported, not filled

- No dedicated article for the three recording pill designs (Capsule, Reading Well, Level Rail); they are covered by a new row in `sounds-and-appearance`.
- The Keybinds page labels the row "Add-a-word keybind" while What's New and the articles say "Quick Add"; the articles use both terms rather than pick one.
- Snippets and Claude have no What's New entry of their own on `main`; the Snippets entry is #2678.

## Pre-Merge Checklist

### Build Verification
- [x] `node scripts/check-help-content.mjs`: 58 articles, 0 errors, 7 pre-existing warnings
- [x] `node scripts/check-language-count.mjs`: 42 claim sites, 0 failures
- [x] `npm run build`: 135 pages
- [x] `npm run check:help`: 71 routes built and in sitemap, 10,433 internal links, 0 dead; search 47 passed
- [ ] CI `website-check` is green on the current head — all seven checks passed on `3387649`; re-running on `17e5451`

### Behavioral Testing (Local UAT)
- N/A

### Code Quality
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets

### Polish Eval
- N/A

### Release Housekeeping
- N/A; the help centre deploys from `main` on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GAWT1a6iSiauP3g3w3whM