### PR TITLE
feat(audio): pick which input of a multi-input interface the microphone is on (#2664)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -134,6 +134,17 @@ enum DictationNarrator {
     }
   }
 
+  /// #2664. The same advisory when the take came from a multi-input audio
+  /// interface: it names the device and points at the one setting that fixes
+  /// the common cause (the microphone is on a socket other than Input 1). Sentence
+  /// FOUNDER-LOCKED at Gate 2, 2026-09-05; no dashes. A nil hint is the locked
+  /// seventh sentence above, byte for byte, so every existing caller is unchanged.
+  static func copy(for reason: TerminalAdvisoryReason, hint: MultiInputAdvisoryHint?) -> String {
+    guard let hint else { return copy(for: reason) }
+    return
+      "Audio isn't capturing from \(hint.deviceName). Try a different input under Settings > Microphone."
+  }
+
   // MARK: - Post-completion + advisory warnings (E3, #1567)
 
   /// Founder-LOCKED 2026-07-15. Unchanged from today EXCEPT two approved
@@ -187,7 +198,11 @@ enum DictationNarrator {
   /// The single authority for every VoiceOver announcement the recording overlay
   /// posts. The panel keeps choosing the AX priority + target element; the words
   /// live here. Words byte-identical to today (founder-locked 2026-07-15).
-  static func announcement(for intent: OverlayIntent) -> String {
+  /// #2664: `hint` reaches only the `.advisory` arm; every other intent ignores it,
+  /// and a nil hint keeps every spoken string byte-identical.
+  static func announcement(for intent: OverlayIntent, hint: MultiInputAdvisoryHint? = nil)
+    -> String
+  {
     switch intent {
     case .hidden: return "Recording complete"
     case .recording(audioLevel: _): return "Recording started"
@@ -199,7 +214,7 @@ enum DictationNarrator {
     // #1891: NO "Error: " prefix. A screen-reader user would otherwise hear
     // the exact opposite of what the sentence says. This arm is the reason the
     // advisory is a separate intent rather than a suppression flag on `.error`.
-    case .advisory(let reason): return copy(for: reason)
+    case .advisory(let reason): return copy(for: reason, hint: hint)
     case .interruption(let reason): return "Interruption: \(copy(for: reason))"
     case .passiveChip(let payload): return "Detected \(payload.displayName)"
     case .cachingModel(engineLabel: _): return "Getting dictation ready, one moment"

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationCompletedReporting.swift
@@ -46,6 +46,9 @@ enum DictationCompletedReporting {
       // #1523: bound device's native channel count (nil omits; 0 emits as an
       // anomaly). Not gated on positivity — 1 and 2 are both meaningful.
       captureNativeChannelCount: health?.nativeChannelCount,
+      // #2664: which input channel the capture took; same optionality (nil omits,
+      // 0 is the measured default and travels).
+      captureInputChannel: health?.inputChannel,
       salvagedLeadTrimMs: driver.lastSalvagedLeadTrimMs,
       // #1408: which interruption cut this dictation short. `stop_reason` already
       // says one did; this names it. Absent on an uninterrupted completion.

--- a/Sources/EnviousWisprAppKit/App/MultiInputAdvisoryHint.swift
+++ b/Sources/EnviousWisprAppKit/App/MultiInputAdvisoryHint.swift
@@ -1,0 +1,52 @@
+import CoreAudio
+import EnviousWisprAudio
+import EnviousWisprCore
+
+/// #2664. Facts the silent-take advisory needs to name a multi-input device.
+///
+/// Built at PRESENT time from settings + the device list, and it carries the
+/// device NAME only (founder, Gate 2, 2026-09-05). It makes no claim about which
+/// input is configured or was recorded, so present-time evaluation, a later
+/// settings change, or a refused channel map cannot make the sentence false: the
+/// device named is the one the user will find selected in Settings, and "no
+/// audio came through" is what the take established. Presentation-only; never
+/// enters telemetry.
+struct MultiInputAdvisoryHint: Equatable, Sendable {
+  let deviceName: String
+
+  /// nil for `.noTransport` (no device was ever opened, so there is no socket to
+  /// try), nil when no device is known (including an empty device list), and nil
+  /// for a one-input device — in every nil case the locked seventh sentence
+  /// shows, byte-identical to today.
+  static func make(reason: TerminalAdvisoryReason, socketDevice: AudioInputDevice?) -> Self? {
+    switch reason {
+    case .noTransport:
+      return nil
+    case .zeroSignal, .vadGateNoSpeech:
+      break
+    }
+    guard let socketDevice, socketDevice.inputChannelCount > 1 else { return nil }
+    return Self(deviceName: socketDevice.name)
+  }
+}
+
+/// #2664. The ONE rule for "which device would the Microphone settings row
+/// describe right now": the pinned device when one is set, else the device Auto
+/// would actually OPEN (not the raw system default — since #2022 those differ
+/// when the default is a virtual or aggregate device the ladder refuses). The
+/// settings row and the advisory hint both call this, so they can never name
+/// two different devices for one state.
+enum InputSocket {
+  static func socketDevice(
+    preferredInputDeviceIDOverride: String,
+    devices: [AudioInputDevice],
+    resolvedAutoInputDeviceID: () -> AudioDeviceID?
+  ) -> AudioInputDevice? {
+    if !preferredInputDeviceIDOverride.isEmpty {
+      // Same rule as the picker's own lookup: first match by UID.
+      return devices.first { $0.uid == preferredInputDeviceIDOverride }
+    }
+    guard let resolvedID = resolvedAutoInputDeviceID() else { return nil }
+    return devices.first { $0.id == resolvedID }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayDirector.swift
@@ -307,6 +307,13 @@ final class OverlayDirector {
   /// compile rather than shipping a button that reaches nobody.
   private let openMicrophoneSettings: () -> Void
 
+  /// #2664: the facts a silent-take advisory needs to name a multi-input
+  /// device, resolved at ADMISSION time from settings + the device list. Same
+  /// no-default reasoning as the two closures above: a caller that forgets to
+  /// wire it fails to compile rather than shipping an advisory that can never
+  /// name the box.
+  private let advisoryHint: @MainActor (TerminalAdvisoryReason) -> MultiInputAdvisoryHint?
+
   init(
     host: any OverlayWindowHosting,
     position: @escaping () -> OverlayPillPosition = { .top },
@@ -323,6 +330,8 @@ final class OverlayDirector {
     grantAccessibility: @escaping () -> Void,
     // #2549: same no-default reasoning as `grantAccessibility` above.
     openMicrophoneSettings: @escaping () -> Void,
+    // #2664: same no-default reasoning again.
+    advisoryHint: @escaping @MainActor (TerminalAdvisoryReason) -> MultiInputAdvisoryHint?,
     // **No default either, for the reason directly above** (#2375 C3a). This is
     // the seam Phase 4 replaces: a settings-backed snapshot at this same
     // construction point, changing this closure's BODY and nothing else. A
@@ -350,6 +359,7 @@ final class OverlayDirector {
     self.livePreview = livePreview
     self.grantAccessibility = grantAccessibility
     self.openMicrophoneSettings = openMicrophoneSettings
+    self.advisoryHint = advisoryHint
     self.position = position
     self.model = model
     self.expiryClock = PillExpiryClock(
@@ -1406,8 +1416,14 @@ extension OverlayDirector: OverlayPresenting {
       } else {
         handle(.pipeline(.error(reason: reason)), binding: .none, relay: relay)
       }
-    case .advisory(let reason):
-      handle(.pipeline(.advisory(reason: reason)), binding: .none, relay: relay)
+    case .advisory(let reason, let hint):
+      // #2664: a supplied hint wins; otherwise ask the composition root NOW, so
+      // the sentence names the device the user would find selected in Settings.
+      if let hint = hint ?? advisoryHint(reason) {
+        handle(.advisory(reason: reason, hint: hint), binding: .none, relay: relay)
+      } else {
+        handle(.pipeline(.advisory(reason: reason)), binding: .none, relay: relay)
+      }
     case .interruption(let reason):
       handle(.pipeline(.interruption(reason: reason)), binding: .none, relay: relay)
     case .cachingModel(let engineLabel):

--- a/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/OverlayReducer.swift
@@ -19,6 +19,11 @@ import Foundation
 enum OverlayEvent: Equatable {
   /// The dictation pipeline. Outranks every feature.
   case pipeline(OverlayIntent)
+  /// #2664: a pipeline advisory carrying a presentation-only fact the intent
+  /// vocabulary must not learn (the multi-input device's name). Reduced through
+  /// the SAME arm as `.pipeline(.advisory(reason:))` — same admission, same
+  /// priority, same dedup — with the hint threaded to the catalog request.
+  case advisory(reason: TerminalAdvisoryReason, hint: MultiInputAdvisoryHint)
   /// A bulk-import progress pill. A feature, so it takes the slot only while
   /// the pipeline is idle, and only from ITSELF.
   case importStatus(message: String)
@@ -223,6 +228,8 @@ struct OverlayReducer {
     switch event {
     case .pipeline(let intent):
       return reducePipeline(intent)
+    case .advisory(let reason, let hint):
+      return reducePipeline(.advisory(reason: reason), advisoryHint: hint)
     case .importStatus(let message):
       return reduceImportStatus(message: message)
     case .bluetoothAwareness:
@@ -376,7 +383,9 @@ struct OverlayReducer {
 
   // MARK: - Pipeline
 
-  private mutating func reducePipeline(_ intent: OverlayIntent) -> OverlayPlan {
+  private mutating func reducePipeline(
+    _ intent: OverlayIntent, advisoryHint: MultiInputAdvisoryHint? = nil
+  ) -> OverlayPlan {
     // **Announce on a CHANGE of intent, which is the shipped dedup guard's own
     // condition.** The shipped post sits after `guard intent != currentIntent`,
     // so a repeated push is silent — and every production `.recording` push
@@ -390,7 +399,18 @@ struct OverlayReducer {
     // and re-announcing a recording that never stopped is not behaviour worth
     // porting.
     let isNewIntent = state.pipelineIntent != intent
-    let announcement = isNewIntent ? PillCatalog.announcement(for: intent) : nil
+    // #2664: a hinted advisory must be SPOKEN with the device name too, and the
+    // intent alone cannot say it — so the announcement comes from the hinted
+    // catalog request on that one path. Every other intent is unchanged.
+    let announcement: OverlayAnnouncement?
+    if !isNewIntent {
+      announcement = nil
+    } else if case .advisory(let reason) = intent, let advisoryHint {
+      announcement = PillCatalog.announcement(
+        for: PillCatalogRequest.advisory(reason: reason, hint: advisoryHint))
+    } else {
+      announcement = PillCatalog.announcement(for: intent)
+    }
 
     // **The shipped dedup DROPS a repeated intent, it does not merely silence
     // it.** The first version returned a fresh presentation with a new ID and
@@ -441,7 +461,9 @@ struct OverlayReducer {
       return .noChange
     }
 
-    guard var presentation = Self.presentation(for: intent, id: makeID()) else {
+    guard
+      var presentation = Self.presentation(for: intent, id: makeID(), advisoryHint: advisoryHint)
+    else {
       // `.hidden`, and anything with no presentation, empties the slot.
       // `didChange` is read BEFORE the mutation: emptying an already-empty slot
       // is a genuine no-op and must not make the host re-apply nothing.
@@ -780,18 +802,25 @@ struct OverlayReducer {
   ///
   /// Listing the other fifteen rather than writing `default` is deliberate: a new
   /// pipeline intent must fail to compile here as well as in the catalog.
-  private static func presentation(for intent: OverlayIntent, id: PresentationID)
+  private static func presentation(
+    for intent: OverlayIntent, id: PresentationID, advisoryHint: MultiInputAdvisoryHint? = nil
+  )
     -> PillDefinition?
   {
     switch intent {
     case .hidden, .processing, .clipboardFallback, .accessibilityToast, .warning,
       .error, .advisory, .interruption, .passiveChip, .cachingModel, .engineReady,
       .recoveringLastRecording, .recoverySucceeded, .bluetoothAwareness, .escapeRecovery:
-      guard let request = PillCatalogRequest(nonRecording: intent) else {
+      guard var request = PillCatalogRequest(nonRecording: intent) else {
         // Unreachable: the initialiser refuses `.recording` only, and that arm
         // returns above without reaching here.
         assertionFailure("PillCatalogRequest(nonRecording:) refused a non-recording intent")
         return nil
+      }
+      // #2664: the intent conversion supplies no hint by design; re-attach the
+      // one the event carried. Only an advisory can carry one.
+      if let advisoryHint, case .advisory(let reason, _) = request {
+        request = .advisory(reason: reason, hint: advisoryHint)
       }
       return PillCatalog.entry(for: request, id: id).definition
 

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillCatalog.swift
@@ -35,7 +35,11 @@ enum PillCatalogRequest: Equatable, Sendable {
   case accessibilityToast
   case warning(reason: RecordingWarningReason)
   case error(reason: TerminalNoticeReason)
-  case advisory(reason: TerminalAdvisoryReason)
+  /// #2664: `hint` is a presentation-only fact `OverlayIntent` never carries.
+  /// The intent conversions below drop it (`matchingIntent`) and supply nil
+  /// (`init?(nonRecording:)`) BY DESIGN; the reducer re-attaches it from the
+  /// `OverlayEvent.advisory(reason:hint:)` event.
+  case advisory(reason: TerminalAdvisoryReason, hint: MultiInputAdvisoryHint? = nil)
   case interruption(reason: TerminalNoticeReason)
   case passiveChip(payload: LanguageChipPayload)
   case cachingModel(engineLabel: String)
@@ -126,6 +130,12 @@ enum PillCatalog {
   /// assert on identity. There is still exactly one implementation: `entry`
   /// calls this.
   static func announcement(for request: PillCatalogRequest) -> OverlayAnnouncement? {
+    // #2664: a hinted advisory would lose its hint through `matchingIntent`, so
+    // VoiceOver reads the same sentence the pill shows. Same priority as the
+    // `.advisory` arm below.
+    if case .advisory(let reason, let hint?) = request {
+      return .high(DictationNarrator.announcement(for: .advisory(reason: reason), hint: hint))
+    }
     guard let intent = request.matchingIntent else {
       // **Import status announces NOTHING, and that is preserved rather than
       // omitted.** It is the one presentation with no matching `OverlayIntent`,
@@ -227,7 +237,7 @@ enum PillCatalog {
         width: .fixed(280), fixedHeight: 44,
         expiry: .after(seconds: 3), severity: .error)  // NotificationStyle 3.0
 
-    case .advisory(let reason):
+    case .advisory(let reason, let hint):
       // #1891. A user-setup advisory draws the mic-slash glyph in the secondary
       // colour, not the red failure treatment, and `NotificationStyle` owns both
       // — so it needs a severity of its own rather than inheriting the helper's
@@ -237,7 +247,7 @@ enum PillCatalog {
       // called with `fitToContent: style.isMultiline` and this is the one style
       // where that is true. No `fixedHeight` here is deliberate, not an omission.
       return notice(
-        id: id, kind: .notification, text: DictationNarrator.copy(for: reason),
+        id: id, kind: .notification, text: DictationNarrator.copy(for: reason, hint: hint),
         width: .fixed(360),  // RecordingOverlayPanel.advisoryWidth
         // **The 8 seconds is READING TIME, and the reason moved here from the
         // dead table it used to live in** (#2376 C3). `NotificationStyle`
@@ -418,7 +428,8 @@ extension PillCatalogRequest {
     case .accessibilityToast: return .accessibilityToast
     case .warning(let reason): return .warning(reason: reason)
     case .error(let reason): return .error(reason: reason)
-    case .advisory(let reason): return .advisory(reason: reason)
+    // #2664: the hint is dropped here by design — `OverlayIntent` is reason-only.
+    case .advisory(let reason, _): return .advisory(reason: reason)
     case .interruption(let reason): return .interruption(reason: reason)
     case .passiveChip(let payload): return .passiveChip(payload: payload)
     case .cachingModel(let engineLabel): return .cachingModel(engineLabel: engineLabel)

--- a/Sources/EnviousWisprAppKit/App/Overlay/PillRequest.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/PillRequest.swift
@@ -142,7 +142,11 @@ enum PillRequest {
   case clipboardFallback
   case warning(reason: RecordingWarningReason)
   case error(reason: TerminalNoticeReason)
-  case advisory(reason: TerminalAdvisoryReason)
+  /// #2664: `hint` is presentation-only (the device name for a multi-input
+  /// interface). nil means "resolve it at admission through the director's
+  /// `advisoryHint` closure"; a supplied hint wins, so a test can present a
+  /// hinted advisory without a device list.
+  case advisory(reason: TerminalAdvisoryReason, hint: MultiInputAdvisoryHint? = nil)
   case interruption(reason: TerminalNoticeReason)
   case cachingModel(engineLabel: String)
   case engineReady

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -136,6 +136,7 @@ final class PipelineSettingsSync {
 
     audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
     audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+    audioCapture.inputChannelByDeviceUID = settings.inputChannelByDeviceUID
     audioCapture.warmEnginePolicy = settings.warmEnginePolicy
     audioCapture.configureVAD(
       autoStop: settings.vadAutoStop,
@@ -251,6 +252,11 @@ final class PipelineSettingsSync {
       audioCapture.selectedInputDeviceUID = settings.selectedInputDeviceUID
     case .preferredInputDeviceIDOverride:
       audioCapture.preferredInputDeviceIDOverride = settings.preferredInputDeviceIDOverride
+    case .inputChannelByDeviceUID:
+      // #2664: same contract as `.selectedInputDeviceUID` — rebuilds the next
+      // recording's capture source (the manager's warm-reuse check reads this
+      // map live); an in-flight recording is unaffected.
+      audioCapture.inputChannelByDeviceUID = settings.inputChannelByDeviceUID
     case .warmEnginePolicy:
       audioCapture.warmEnginePolicy = settings.warmEnginePolicy
     case .autoCopyToClipboard, .vadAutoStop, .vadSilenceTimeout, .vadSensitivity,

--- a/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
+++ b/Sources/EnviousWisprAppKit/App/SettingsChangeTelemetry.swift
@@ -138,6 +138,10 @@ enum SettingsProjection {
     case .selectedBackend, .onboardingState, .hasCompletedOnboarding,
       .isDebugModeEnabled, .isDictationAudioArchiveEnabled, .debugLogLevel, .whisperKitLanguage,
       .selectedInputDeviceUID, .preferredInputDeviceIDOverride,
+      // #2664: a UID-keyed map is device identity, which never leaves the Mac;
+      // the effective channel is already carried per take by
+      // `capture_input_channel`, so a settings delta would add nothing.
+      .inputChannelByDeviceUID,
       // #1480: the popover's own lifecycle telemetry (`bt_awareness.*`) owns this
       // signal, incl. `suppressed_by_setting`; no separate settings.changed delta.
       .showBluetoothTips,

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -626,6 +626,18 @@ package final class WisprBootstrapper {
       openMicrophoneSettings: {
         Task { await permissions.requestMicrophoneAccessOrOpenSettings() }
       },
+      // #2664: the silent-take advisory names the multi-input device the user
+      // would find selected in Settings right now. Same device rule as the
+      // settings row (`InputSocket.socketDevice`), same strong captures as the
+      // closures beside it — the bootstrapper owns both for the app's lifetime.
+      advisoryHint: { reason in
+        MultiInputAdvisoryHint.make(
+          reason: reason,
+          socketDevice: InputSocket.socketDevice(
+            preferredInputDeviceIDOverride: settings.preferredInputDeviceIDOverride,
+            devices: audioDeviceList.availableInputDevices,
+            resolvedAutoInputDeviceID: AudioDeviceEnumerator.resolvedAutoInputDeviceID))
+      },
       // **THE SEAM PHASE 3 LEFT, NOW SPENT** (#2376 Phase 4, C6). It is a closure
       // so that it can be: the director lives for the app's lifetime, so a stored
       // pair would freeze the user's choice at launch — a picker would appear to

--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -53,7 +53,18 @@ struct AudioSettingsView: View {
           + "device selected in macOS. If that device turns out not to be a real "
           + "microphone, recording uses an available microphone instead."
       ) {
-        VStack(alignment: .leading, spacing: 12) {
+        // #2664: the socket control sits on the SAME line as the device picker,
+        // sized to its own text (founder, 2026-09-05: a full-width segmented bar
+        // for two options read as a giant purple slab). Only for a device
+        // reporting more than one input, and never for one whose UID could not
+        // be read (nothing to key a choice on, and an empty key would be shared
+        // by every such device). The DISPLAYED selection goes through the same
+        // pure rule HAL applies, so a saved index the device no longer has shows
+        // as Input 1. Stored 0-based; labelled from 1 like the sockets on the box.
+        let multiInputDevice = socketDevice.flatMap { device in
+          device.inputChannelCount > 1 && !device.uid.isEmpty ? device : nil
+        }
+        VStack(alignment: .leading, spacing: 6) {
           HStack(spacing: 10) {
             Picker("", selection: inputDeviceSelection) {
               Text("Auto").tag("")
@@ -68,56 +79,50 @@ struct AudioSettingsView: View {
               StatusPill(text: "Using \(socketDevice.name)")
             }
 
+            if let device = multiInputDevice {
+              let socketSelection = Binding<Int>(
+                get: {
+                  InputChannelPreference.effectiveChannel(
+                    requested: InputChannelPreference.requested(
+                      for: device.uid, in: settingsManager.inputChannelByDeviceUID),
+                    availableChannels: device.inputChannelCount)
+                },
+                set: { newValue in
+                  settingsManager.inputChannelByDeviceUID[device.uid] = newValue
+                }
+              )
+              HStack(spacing: 8) {
+                Text(InputSocketCopy.label).settingsHelperCopy()
+                if device.inputChannelCount <= 6 {
+                  BrandedSegmentedPicker(
+                    options: (0..<device.inputChannelCount).map { index in
+                      (
+                        label: InputSocketCopy.optionLabel(index: index), systemImage: nil,
+                        value: index
+                      )
+                    },
+                    selection: socketSelection
+                  )
+                  // Content-sized: the picker's segments stretch to fill whatever
+                  // width they are given, and here they are given only their own.
+                  .fixedSize(horizontal: true, vertical: false)
+                } else {
+                  Picker("", selection: socketSelection) {
+                    ForEach(0..<device.inputChannelCount, id: \.self) { index in
+                      Text(InputSocketCopy.optionLabel(index: index)).tag(index)
+                    }
+                  }
+                  .labelsHidden()
+                  .fixedSize()
+                }
+              }
+            }
+
             Spacer(minLength: 0)
           }
 
-          // #2664: "Microphone socket" — only for a device reporting more than
-          // one input. The DISPLAYED selection goes through the same pure rule
-          // HAL applies, so a saved index the device no longer has shows as
-          // Input 1 rather than as a socket that does not exist. Stored 0-based;
-          // labelled from 1 like the sockets on the box.
-          // A device whose UID could not be read has nothing to key a choice on,
-          // so the row stays hidden for it rather than saving under an empty key
-          // that every such device would share.
-          if let device = socketDevice, device.inputChannelCount > 1, !device.uid.isEmpty {
-            let socketSelection = Binding<Int>(
-              get: {
-                InputChannelPreference.effectiveChannel(
-                  requested: InputChannelPreference.requested(
-                    for: device.uid, in: settingsManager.inputChannelByDeviceUID),
-                  availableChannels: device.inputChannelCount)
-              },
-              set: { newValue in
-                settingsManager.inputChannelByDeviceUID[device.uid] = newValue
-              }
-            )
-            VStack(alignment: .leading, spacing: 8) {
-              Text(InputSocketCopy.header).settingsRowLabel()
-              if device.inputChannelCount <= 6 {
-                BrandedSegmentedPicker(
-                  options: (0..<device.inputChannelCount).map { index in
-                    (
-                      label: InputSocketCopy.optionLabel(index: index), systemImage: nil,
-                      value: index
-                    )
-                  },
-                  selection: socketSelection
-                )
-              } else {
-                Picker("", selection: socketSelection) {
-                  ForEach(0..<device.inputChannelCount, id: \.self) { index in
-                    Text(InputSocketCopy.optionLabel(index: index)).tag(index)
-                  }
-                }
-                .labelsHidden()
-                .frame(maxWidth: 200, alignment: .leading)
-              }
-              Text(
-                InputSocketCopy.helper(
-                  inputCount: device.inputChannelCount, deviceName: device.name)
-              )
-              .settingsHelperCopy()
-            }
+          if let device = multiInputDevice {
+            Text(InputSocketCopy.helper(deviceName: device.name)).settingsHelperCopy()
           }
         }
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -12,23 +12,20 @@ struct AudioSettingsView: View {
   @Environment(SettingsManager.self) private var settings
   @Environment(AudioDeviceList.self) private var audioDeviceList
 
-  /// Names the device Auto would actually OPEN, not the system default.
-  ///
-  /// Since #2022 those differ when the default is a virtual or aggregate device
-  /// the ladder refuses. Reading the default here would print "Using Krisp"
-  /// while the microphone we actually record from is the built-in one — the
-  /// pill's only job is to say what is in use, so naming the refused device is
-  /// the one thing it must not do.
-  private var autoInputDeviceName: String? {
-    guard settings.preferredInputDeviceIDOverride.isEmpty,
-      let resolvedID = AudioDeviceEnumerator.resolvedAutoInputDeviceID()
-    else { return nil }
-    return audioDeviceList.availableInputDevices.first { $0.id == resolvedID }?.name
-  }
-
   var body: some View {
     let settingsManager = settings
     @Bindable var settings = settings
+    // #2664: the device this page describes, computed ONCE per body (the Auto
+    // branch runs the resolver ladder, so two computed properties would pay for
+    // it twice). Since #2022 Auto names the device the ladder would actually
+    // OPEN, not the raw system default: printing "Using Krisp" while recording
+    // from the built-in microphone is the one thing the pill must not do. The
+    // "Using X" pill and the socket row both read this local, and the advisory
+    // hint uses the same rule, so the three can never disagree about one state.
+    let socketDevice = InputSocket.socketDevice(
+      preferredInputDeviceIDOverride: settingsManager.preferredInputDeviceIDOverride,
+      devices: audioDeviceList.availableInputDevices,
+      resolvedAutoInputDeviceID: AudioDeviceEnumerator.resolvedAutoInputDeviceID)
     let inputDeviceSelection = Binding<String>(
       get: { settingsManager.preferredInputDeviceIDOverride },
       set: { newValue in
@@ -56,21 +53,68 @@ struct AudioSettingsView: View {
           + "device selected in macOS. If that device turns out not to be a real "
           + "microphone, recording uses an available microphone instead."
       ) {
-        HStack(spacing: 10) {
-          Picker("", selection: inputDeviceSelection) {
-            Text("Auto").tag("")
-            ForEach(audioDeviceList.availableInputDevices) { device in
-              Text(device.name).tag(device.uid)
+        VStack(alignment: .leading, spacing: 12) {
+          HStack(spacing: 10) {
+            Picker("", selection: inputDeviceSelection) {
+              Text("Auto").tag("")
+              ForEach(audioDeviceList.availableInputDevices) { device in
+                Text(device.name).tag(device.uid)
+              }
+            }
+            .labelsHidden()
+            .frame(maxWidth: 340, alignment: .leading)
+
+            if settingsManager.preferredInputDeviceIDOverride.isEmpty, let socketDevice {
+              StatusPill(text: "Using \(socketDevice.name)")
+            }
+
+            Spacer(minLength: 0)
+          }
+
+          // #2664: "Microphone socket" — only for a device reporting more than
+          // one input. The DISPLAYED selection goes through the same pure rule
+          // HAL applies, so a saved index the device no longer has shows as
+          // Input 1 rather than as a socket that does not exist. Stored 0-based;
+          // labelled from 1 like the sockets on the box.
+          if let device = socketDevice, device.inputChannelCount > 1 {
+            let socketSelection = Binding<Int>(
+              get: {
+                InputChannelPreference.effectiveChannel(
+                  requested: settingsManager.inputChannelByDeviceUID[device.uid],
+                  availableChannels: device.inputChannelCount)
+              },
+              set: { newValue in
+                settingsManager.inputChannelByDeviceUID[device.uid] = newValue
+              }
+            )
+            VStack(alignment: .leading, spacing: 8) {
+              Text(InputSocketCopy.header).settingsRowLabel()
+              if device.inputChannelCount <= 6 {
+                BrandedSegmentedPicker(
+                  options: (0..<device.inputChannelCount).map { index in
+                    (
+                      label: InputSocketCopy.optionLabel(index: index), systemImage: nil,
+                      value: index
+                    )
+                  },
+                  selection: socketSelection
+                )
+              } else {
+                Picker("", selection: socketSelection) {
+                  ForEach(0..<device.inputChannelCount, id: \.self) { index in
+                    Text(InputSocketCopy.optionLabel(index: index)).tag(index)
+                  }
+                }
+                .labelsHidden()
+                .frame(maxWidth: 200, alignment: .leading)
+              }
+              Text(
+                InputSocketCopy.helper(
+                  inputCount: device.inputChannelCount, deviceName: device.name)
+              )
+              .settingsHelperCopy()
             }
           }
-          .labelsHidden()
-          .frame(maxWidth: 340, alignment: .leading)
-
-          if let autoInputDeviceName {
-            StatusPill(text: "Using \(autoInputDeviceName)")
-          }
-
-          Spacer(minLength: 0)
         }
       }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AudioSettingsView.swift
@@ -76,11 +76,15 @@ struct AudioSettingsView: View {
           // HAL applies, so a saved index the device no longer has shows as
           // Input 1 rather than as a socket that does not exist. Stored 0-based;
           // labelled from 1 like the sockets on the box.
-          if let device = socketDevice, device.inputChannelCount > 1 {
+          // A device whose UID could not be read has nothing to key a choice on,
+          // so the row stays hidden for it rather than saving under an empty key
+          // that every such device would share.
+          if let device = socketDevice, device.inputChannelCount > 1, !device.uid.isEmpty {
             let socketSelection = Binding<Int>(
               get: {
                 InputChannelPreference.effectiveChannel(
-                  requested: settingsManager.inputChannelByDeviceUID[device.uid],
+                  requested: InputChannelPreference.requested(
+                    for: device.uid, in: settingsManager.inputChannelByDeviceUID),
                   availableChannels: device.inputChannelCount)
               },
               set: { newValue in

--- a/Sources/EnviousWisprAppKit/Views/Settings/InputSocketCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/InputSocketCopy.swift
@@ -1,16 +1,17 @@
-/// #2664. Every string the "Microphone socket" row shows, in one place, frozen
-/// by `InputSocketCopyTests`. Shown only for a device reporting more than one
-/// input. Stored values are 0-based; the labels count from 1 the way the
+/// #2664. Every string the microphone socket control shows, in one place,
+/// frozen by `InputSocketCopyTests`. Shown only for a device reporting more than
+/// one input. Stored values are 0-based; the labels count from 1 the way the
 /// sockets on the box do. No dashes anywhere (content rule).
 enum InputSocketCopy {
-  static let header = "Microphone socket"
+  /// The short label in front of the control, on the device picker's own line.
+  static let label = "Mic is on"
 
   static func optionLabel(index: Int) -> String {
     "Input \(index + 1)"
   }
 
-  static func helper(inputCount: Int, deviceName: String) -> String {
-    "This device has \(inputCount) inputs. Pick the one your microphone is plugged into. "
-      + "EnviousWispr remembers this for \(deviceName)."
+  /// The one quiet line under the row: the choice is per device.
+  static func helper(deviceName: String) -> String {
+    "Remembered for \(deviceName)."
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/InputSocketCopy.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/InputSocketCopy.swift
@@ -1,0 +1,16 @@
+/// #2664. Every string the "Microphone socket" row shows, in one place, frozen
+/// by `InputSocketCopyTests`. Shown only for a device reporting more than one
+/// input. Stored values are 0-based; the labels count from 1 the way the
+/// sockets on the box do. No dashes anywhere (content rule).
+enum InputSocketCopy {
+  static let header = "Microphone socket"
+
+  static func optionLabel(index: Int) -> String {
+    "Input \(index + 1)"
+  }
+
+  static func helper(inputCount: Int, deviceName: String) -> String {
+    "This device has \(inputCount) inputs. Pick the one your microphone is plugged into. "
+      + "EnviousWispr remembers this for \(deviceName)."
+  }
+}

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -167,6 +167,10 @@ public protocol AudioCaptureInterface: AnyObject {
   // Configuration properties (read-write)
   var selectedInputDeviceUID: String { get set }
   var preferredInputDeviceIDOverride: String { get set }
+  /// #2664: per-device input-channel preference (device UID -> 0-based channel).
+  /// Mirrored from settings like the two device fields above; the manager reads
+  /// it at source construction and at every warm-reuse decision.
+  var inputChannelByDeviceUID: [String: Int] { get set }
   var warmEnginePolicy: WarmEnginePolicy { get set }
 
   // Core lifecycle

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -207,6 +207,14 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// User override for input device. Empty string means "Auto" (smart selection enabled).
   public var preferredInputDeviceIDOverride: String = ""
 
+  /// #2664: per-device input-channel preference (device UID -> 0-based channel),
+  /// mirrored from settings by `PipelineSettingsSync` exactly as the two device
+  /// fields above are. Missing UID means channel 0. Copied onto every HAL source
+  /// at construction for its cold prepare, and read LIVE by `resolveSource()`'s
+  /// warm-reuse check, so changing the socket for the bound device rebuilds the
+  /// next recording's capture source instead of reusing a unit on the old one.
+  public var inputChannelByDeviceUID: [String: Int] = [:]
+
   /// Hard emergency recording-duration ceiling in seconds. Prevents unbounded
   /// memory growth. MUST stay strictly above the graceful soft cap
   /// (`TimingConstants.maxRecordingDuration`, 3600s) so the graceful stop+transcribe
@@ -1014,6 +1022,22 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       buildSource(for: decision)
     }
 
+    /// #2664 test seam: replace the route resolver with one whose two hardware
+    /// reads are injected, so `resolveSource()` can run on a machine with no
+    /// audio output device. Production never calls this.
+    func installRouteResolverForTesting(_ resolver: CaptureRouteResolver) {
+      routeResolver = resolver
+    }
+
+    /// #2664 test seam: run the REAL `resolveSource()` — warm-reuse decision
+    /// included — and return the source it settled on, so a test can assert
+    /// identity (`===` the installed warm source means reused; anything else
+    /// means rebuilt) without going on to `prepare()` real hardware. Install the
+    /// warm source with `installCapturedSourceForTesting` first.
+    func resolveSourceForTesting() -> any AudioInputSource {
+      resolveSource()
+    }
+
     /// Test seam (heartpath 5b): drop the live active source while KEEPING the
     /// retained capture-session source, so `retireCapturingSource` reaches the
     /// `.activeSourceGone` branch. The installer's optional `active` argument
@@ -1207,12 +1231,25 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// DEBUG arming tests can exercise construction from a given decision without
   /// running `CaptureRouteResolver.resolve()`, which reads live output hardware.
   private func buildSource(for decision: CaptureRouteDecision) -> any AudioInputSource {
+    let source: any AudioInputSource
     #if DEBUG
       if let debugSourceFactory {
-        return debugSourceFactory(decision)  // #1844/#1714 seam; nil in production
+        source = debugSourceFactory(decision)  // #1844/#1714 seam; nil in production
+      } else {
+        source = Self.makeSource(for: decision)
       }
+    #else
+      source = Self.makeSource(for: decision)
     #endif
-    return Self.makeSource(for: decision)
+    // #2664: hand EVERY freshly built HAL source the manager's CURRENT channel
+    // map — the production path and the DEBUG factories alike — here rather than
+    // inside each constructor, so no construction route can build a source that
+    // cold-prepares on a stale or empty map. A source that is not HAL-typed has
+    // no channel to choose.
+    if let halSource = source as? HALDeviceInputSource {
+      halSource.inputChannelByDeviceUID = inputChannelByDeviceUID
+    }
+    return source
   }
 
   private func resolveSource() -> any AudioInputSource {
@@ -1239,13 +1276,17 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       // Device changes between recordings must trigger rebuild.
       var configMatch = existingSourceType == decision.sourceType
       // A warm HAL source must not be reused once the resolved target device
-      // changes (or the bound device drifts from the resolved target).
+      // changes (or the bound device drifts from the resolved target), nor
+      // (#2664) once the user's socket choice for the bound device no longer
+      // matches the channel the warm unit takes — compared against the MANAGER's
+      // live map, because the source's own copy is what it prepared on.
       if configMatch, let halSource = existing as? HALDeviceInputSource {
         let wantsTarget = decision.effectiveDeviceUID
         let normalize: (String?) -> String = { ($0?.isEmpty ?? true) ? "" : $0! }
         configMatch =
           normalize(halSource.targetDeviceUID) == normalize(wantsTarget)
           && halSource.boundDeviceMatchesResolvedTargetForReuse()
+          && halSource.boundInputChannelMatches(preference: inputChannelByDeviceUID)
       }
 
       if configMatch {

--- a/Sources/EnviousWisprAudio/AudioDeviceManager.swift
+++ b/Sources/EnviousWisprAudio/AudioDeviceManager.swift
@@ -6,6 +6,18 @@ public struct AudioInputDevice: Sendable, Identifiable, Hashable {
   public let id: AudioDeviceID
   public let name: String
   public let uid: String
+  /// #2664: total native input channels, from the single channel-count
+  /// authority (`AudioDeviceEnumerator.inputChannelCount`). Always > 0 here —
+  /// `allInputDevices()` drops a device reporting none. The settings row shows
+  /// a per-device socket picker only when this exceeds 1.
+  public let inputChannelCount: Int
+
+  public init(id: AudioDeviceID, name: String, uid: String, inputChannelCount: Int) {
+    self.id = id
+    self.name = name
+    self.uid = uid
+    self.inputChannelCount = inputChannelCount
+  }
 }
 
 /// One input-device candidate, frozen during a SINGLE enumeration pass (#1714).
@@ -115,7 +127,8 @@ public enum AudioDeviceEnumerator {
       return AudioInputDevice(
         id: deviceID,
         name: name,
-        uid: uid
+        uid: uid,
+        inputChannelCount: channelCount
       )
     }
   }

--- a/Sources/EnviousWisprAudio/BoundInputDevice.swift
+++ b/Sources/EnviousWisprAudio/BoundInputDevice.swift
@@ -9,9 +9,9 @@ import CoreAudio
 /// could describe a microphone the session never recorded from. Returning the
 /// bind makes "read it before it exists" unexpressible rather than merely tested.
 ///
-/// All four fields are read together in HAL's single all-succeeded commit block
+/// All five fields are read together in HAL's single all-succeeded commit block
 /// and cleared together in its single teardown, so they are ONE fact with one
-/// lifetime, not four accessors that could drift apart.
+/// lifetime, not five accessors that could drift apart.
 ///
 /// **Visibility.** `public` is the NARROWEST WORKING visibility, not a default.
 /// `AudioCaptureInterface` is already `public` (`AudioCaptureInterface.swift:7`)
@@ -52,12 +52,26 @@ public struct BoundInputDevice: Equatable, Sendable {
   /// is `public`, and a public requirement cannot expose a package type.
   public let resolutionSource: String
 
+  /// #2664: the device input channel (0-based) the mono capture ACTUALLY took.
+  /// 0 is the default (no channel map set). Set only in HAL's committed block,
+  /// from the channel-map property set's own result, so a map the unit refused
+  /// reads 0 here — never the channel the user asked for. The warm-reuse
+  /// predicate compares this to the CURRENT preference; a mismatch rebuilds.
+  ///
+  /// **Undefaulted, deliberately** — the `resolutionSource` reasoning above
+  /// applies unchanged: a defaulted field would let a conformer commit a bind
+  /// without saying which channel it recorded, and a reuse decision built on
+  /// that silence would keep a stale channel warm across a settings change.
+  public let inputChannel: Int
+
   public init(
-    deviceID: AudioDeviceID, deviceUID: String?, transportLabel: String?, resolutionSource: String
+    deviceID: AudioDeviceID, deviceUID: String?, transportLabel: String?, resolutionSource: String,
+    inputChannel: Int
   ) {
     self.deviceID = deviceID
     self.deviceUID = deviceUID
     self.transportLabel = transportLabel
     self.resolutionSource = resolutionSource
+    self.inputChannel = inputChannel
   }
 }

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -399,6 +399,9 @@ final class HALDeviceInputSource: AudioInputSource {
 
   private(set) var isCapturing = false
   var isRunning: Bool {
+    #if DEBUG
+      if let isRunningOverrideForTesting { return isRunningOverrideForTesting }
+    #endif
     guard let audioUnit else { return false }
     var running: UInt32 = 0
     var size = UInt32(MemoryLayout<UInt32>.size)
@@ -409,6 +412,14 @@ final class HALDeviceInputSource: AudioInputSource {
 
   /// Target capture device UID. Nil means follow the live system default input.
   var targetDeviceUID: String?
+
+  /// #2664: per-device input-channel preference (device UID -> 0-based channel),
+  /// copied from `AudioCaptureManager` at construction. Read ONCE, at cold
+  /// `prepare()`, to choose the channel map; nothing else reads it. The
+  /// warm-reuse predicate deliberately takes the MANAGER's current map as an
+  /// argument instead, because this copy is stale by definition once the user
+  /// changes the setting while the unit is warm.
+  var inputChannelByDeviceUID: [String: Int] = [:]
 
   /// The single capture device-selection authority (#1714). Injected so the
   /// whole ladder — and the warm-compatibility projection below — is testable
@@ -482,33 +493,51 @@ final class HALDeviceInputSource: AudioInputSource {
   /// is cleared only in `teardownUnit()`. AUHAL down-mixes to mono by taking
   /// channel 0; this records how many channels the device actually exposed.
   private var boundNativeChannelCount: Int?
+  /// #2664: the device input channel the committed unit ACTUALLY takes. 0 when
+  /// no channel map was set (the default path, byte-for-byte today's behaviour)
+  /// or when the map set was refused; otherwise the applied channel. Committed
+  /// and cleared with the other bound fields, and carried on `BoundInputDevice`
+  /// so the warm-reuse predicate can compare it to the current preference.
+  private var boundInputChannel: Int?
 
   var actualBoundTransport: String? { boundTransport }
 
+  #if DEBUG
+    /// #2664 test seam: when non-nil, `isRunning` reports this instead of asking
+    /// the real unit, so `AudioCaptureManager.resolveSource()`'s warm-reuse
+    /// branch — which is HAL-typed and gated on `existing.isRunning` — can be
+    /// driven with a committed bind and no `AudioUnit`. Production never sets it.
+    var isRunningOverrideForTesting: Bool?
+  #endif
+
   /// #1844: the committed bind, or nil before `prepare()` succeeded / after
-  /// teardown. All four fields are assigned together in the cold commit block
-  /// and cleared together in `teardownUnit()`, so this reads one fact, not four
+  /// teardown. All five fields are assigned together in the cold commit block
+  /// and cleared together in `teardownUnit()`, so this reads one fact, not five
   /// that could drift.
   private var currentBoundInputDevice: BoundInputDevice? {
-    guard let boundDeviceID, let boundResolutionSource else { return nil }
+    guard let boundDeviceID, let boundResolutionSource, let boundInputChannel else { return nil }
     return BoundInputDevice(
       deviceID: boundDeviceID, deviceUID: boundUID, transportLabel: boundTransport,
-      resolutionSource: boundResolutionSource)
+      resolutionSource: boundResolutionSource, inputChannel: boundInputChannel)
   }
 
-  /// #1844: sets or clears ALL FOUR committed bind fields together, the way the
-  /// cold commit block and `teardownUnit()` each do.
+  /// #1844: sets or clears ALL FIVE committed bind fields together, the way the
+  /// cold commit block and `teardownUnit()` each do. `nativeChannelCount` is the
+  /// prepare-time constant beside them (#2664: the warm-reuse channel predicate
+  /// reads it), so a test staging a multi-input bind supplies it here too.
   ///
   /// This is the ONLY bind-setting seam. A partial-bind setter used to sit
   /// beside it, moving just the numeric id; #1714 deleted it once the warm
   /// predicate started reading the whole bind, because a test could otherwise
   /// pass on a correct id with a stale UID — and the UID is exactly what the
   /// health check's identity re-check depends on. Do not reintroduce one.
-  func setBoundInputDeviceForTesting(_ bound: BoundInputDevice?) {
+  func setBoundInputDeviceForTesting(_ bound: BoundInputDevice?, nativeChannelCount: Int? = nil) {
     boundDeviceID = bound?.deviceID
     boundUID = bound?.deviceUID
     boundTransport = bound?.transportLabel
     boundResolutionSource = bound?.resolutionSource
+    boundInputChannel = bound?.inputChannel
+    boundNativeChannelCount = nativeChannelCount
   }
 
   /// #1844: the warm-reuse DECISION, split from the hardware that answers
@@ -553,6 +582,20 @@ final class HALDeviceInputSource: AudioInputSource {
     return inputDeviceResolver.isWarmBindCompatible(bound, preferredUID: targetDeviceUID)
   }
 
+  /// #2664: does the committed unit take the channel the CURRENT preference
+  /// asks for? `preference` is the manager's live map, never this source's own
+  /// construction-time copy. Resolved through the same pure function cold
+  /// prepare applies, against the bound device's own channel count, so a
+  /// preference the device cannot honour compares equal to the channel-0 bind
+  /// it produced rather than forcing a rebuild that would land on channel 0
+  /// again. False with no committed bind, like the device predicate above.
+  func boundInputChannelMatches(preference: [String: Int]) -> Bool {
+    guard let bound = currentBoundInputDevice else { return false }
+    let wanted = InputChannelPreference.effectiveChannel(
+      requested: preference[bound.deviceUID ?? ""], availableChannels: boundNativeChannelCount)
+    return wanted == bound.inputChannel
+  }
+
   /// #1523: the last live stop-metadata, cached in `teardownUnit()` right before
   /// the render context + bound-device state are cleared. The device-vanish path
   /// (`handleDeviceMayHaveVanished`) tears the unit down BEFORE the manager reads
@@ -580,7 +623,8 @@ final class HALDeviceInputSource: AudioInputSource {
       preRollGapCount: preRollGapCount,
       lostChunkCount: snap.lostChunks,
       rateDivergenceDetected: formatDivergenceObserved,
-      nativeChannelCount: boundNativeChannelCount
+      nativeChannelCount: boundNativeChannelCount,
+      inputChannel: boundInputChannel
     )
   }
 
@@ -699,6 +743,23 @@ final class HALDeviceInputSource: AudioInputSource {
       throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.set_device")
     }
 
+    // #2664: the bound device's identity and channel count, read into LOCALS
+    // here (both are plain property reads with no device-configuration side
+    // effect) and committed to `self` only in the all-succeeded block below.
+    // Which channel the mono capture should take is decided by the one pure
+    // authority; an unusable preference falls to channel 0, today's behaviour,
+    // and says so in the route log.
+    let deviceUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
+    let nativeChannelCount = AudioDeviceEnumerator.inputChannelCount(for: deviceID)
+    let requestedChannel = inputChannelByDeviceUID[deviceUID ?? ""]
+    let channel = InputChannelPreference.effectiveChannel(
+      requested: requestedChannel, availableChannels: nativeChannelCount)
+    if let requestedChannel, requestedChannel != channel {
+      AudioCaptureManager.btRouteLog(
+        "HALDeviceInputSource: channel_pref_out_of_range requested=\(requestedChannel) "
+          + "available=\(nativeChannelCount) — capturing channel 0")
+    }
+
     // AUHAL input does NOT resample (Apple QA1777: "does not provide sample
     // rate conversion" for input on macOS) — query the HARDWARE's actual
     // native rate and set the client format to MATCH it (mono/Float32 is
@@ -734,6 +795,30 @@ final class HALDeviceInputSource: AudioInputSource {
     guard status == noErr else {
       AudioComponentInstanceDispose(unit)
       throw AudioError.formatCreationFailed(source: "HALDeviceInputSource.prepare.stream_format")
+    }
+
+    // #2664: the ONE capture change. With a mono client format AUHAL takes
+    // device channel 0 and nothing else, so a microphone on any other input of a
+    // multi-input interface recorded silence. `kAudioOutputUnitProperty_ChannelMap`
+    // on the input element's OUTPUT scope is an `Int32` per client channel naming
+    // the device channel it should carry (Apple TN2091), and it must be set AFTER
+    // the client format and BEFORE `AudioUnitInitialize`. Channel 0 sets nothing,
+    // so the default path is byte-for-byte what shipped before. A refused set is
+    // a LIMB failure: log it, keep channel 0, and let the take proceed — the
+    // committed `boundInputChannel` then says 0, never the channel asked for.
+    var appliedChannel = 0
+    if channel != 0 {
+      var channelMap: [Int32] = [Int32(channel)]
+      let mapStatus = AudioUnitSetProperty(
+        unit, kAudioOutputUnitProperty_ChannelMap, kAudioUnitScope_Output, 1,
+        &channelMap, UInt32(MemoryLayout<Int32>.size))
+      if mapStatus == noErr {
+        appliedChannel = channel
+      } else {
+        AudioCaptureManager.btRouteLog(
+          "HALDeviceInputSource: channel_map_set_failed status=\(mapStatus) requested=\(channel) "
+            + "— capturing channel 0")
+      }
     }
 
     // Scratch/ring capacity scales with the native rate — a fixed 4096-frame
@@ -828,7 +913,7 @@ final class HALDeviceInputSource: AudioInputSource {
     registerFormatChangeListeners(deviceID: deviceID)
 
     boundDeviceID = deviceID
-    boundUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
+    boundUID = deviceUID
     boundTransport = AudioDeviceEnumerator.transportLabel(for: deviceID)
     // #1714: the fourth committed field, taken from the same switch that chose
     // the device — so there is no defaulted or optional path by which a bind
@@ -839,10 +924,14 @@ final class HALDeviceInputSource: AudioInputSource {
     // channels: 1 above) and AUHAL down-mixes by TAKING CHANNEL 0 — so a device
     // whose meaningful audio is on a later channel would be captured as silence.
     // This value makes a >1-channel fleet population measurable; it does NOT
-    // change what we capture (measure-only, #1523). Do not build a channel
-    // selector until this telemetry shows both a >1-channel population and a
-    // buried-audio report.
-    boundNativeChannelCount = AudioDeviceEnumerator.inputChannelCount(for: deviceID)
+    // change what we capture; the SELECTOR #1523 deferred is the channel map
+    // above (#2664), built once this telemetry showed both a >1-channel
+    // population and a buried-audio report.
+    boundNativeChannelCount = nativeChannelCount
+    // #2664: the sixth committed field — what the unit actually takes, from the
+    // property set's own result, so telemetry and warm reuse never read the
+    // requested channel as the recorded one.
+    boundInputChannel = appliedChannel
     // #1434: the native rate + ratio in the prepare line is the per-recording
     // rate evidence D4 flagged as the highest-value instrumentation gap.
     let ratio = Self.targetFormat.sampleRate / nativeFormat.sampleRate
@@ -850,7 +939,8 @@ final class HALDeviceInputSource: AudioInputSource {
       "HALDeviceInputSource: prepared with device \(deviceID) (uid=\(boundUID ?? "unknown")) "
         + "nativeRate=\(Int(nativeFormat.sampleRate)) targetRate=\(Int(Self.targetFormat.sampleRate)) "
         + "ratio=\(String(format: "%.3f", ratio)) "
-        + "nativeChannels=\(boundNativeChannelCount.map(String.init) ?? "nil")"
+        + "nativeChannels=\(boundNativeChannelCount.map(String.init) ?? "nil") "
+        + "inputChannel=\(appliedChannel)"
     )
 
     // #1844: the bind this attempt established, handed straight back to the
@@ -861,7 +951,7 @@ final class HALDeviceInputSource: AudioInputSource {
     attemptState.recordPrepareSucceeded()
     return BoundInputDevice(
       deviceID: deviceID, deviceUID: boundUID, transportLabel: boundTransport,
-      resolutionSource: selectedSource.rawValue)
+      resolutionSource: selectedSource.rawValue, inputChannel: appliedChannel)
   }
 
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
@@ -993,7 +1083,8 @@ final class HALDeviceInputSource: AudioInputSource {
       // not exist yet. (The XPC proxy's host-side watchdog leaves these nil.)
       nativeRateHz: renderContext?.nativeFormat.sampleRate,
       rateDivergenceDetected: formatDivergenceObserved,
-      nativeChannelCount: boundNativeChannelCount
+      nativeChannelCount: boundNativeChannelCount,
+      inputChannel: boundInputChannel
     )
     onCaptureStalled?(ctx)
   }
@@ -1246,6 +1337,7 @@ final class HALDeviceInputSource: AudioInputSource {
     boundTransport = nil
     boundResolutionSource = nil
     boundNativeChannelCount = nil
+    boundInputChannel = nil
   }
 
   /// Read the device's OWN native stream format directly from the HAL device

--- a/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
+++ b/Sources/EnviousWisprAudio/HALDeviceInputSource.swift
@@ -592,7 +592,8 @@ final class HALDeviceInputSource: AudioInputSource {
   func boundInputChannelMatches(preference: [String: Int]) -> Bool {
     guard let bound = currentBoundInputDevice else { return false }
     let wanted = InputChannelPreference.effectiveChannel(
-      requested: preference[bound.deviceUID ?? ""], availableChannels: boundNativeChannelCount)
+      requested: InputChannelPreference.requested(for: bound.deviceUID, in: preference),
+      availableChannels: boundNativeChannelCount)
     return wanted == bound.inputChannel
   }
 
@@ -751,7 +752,8 @@ final class HALDeviceInputSource: AudioInputSource {
     // and says so in the route log.
     let deviceUID = AudioDeviceEnumerator.inputDeviceUID(for: deviceID)
     let nativeChannelCount = AudioDeviceEnumerator.inputChannelCount(for: deviceID)
-    let requestedChannel = inputChannelByDeviceUID[deviceUID ?? ""]
+    let requestedChannel = InputChannelPreference.requested(
+      for: deviceUID, in: inputChannelByDeviceUID)
     let channel = InputChannelPreference.effectiveChannel(
       requested: requestedChannel, availableChannels: nativeChannelCount)
     if let requestedChannel, requestedChannel != channel {

--- a/Sources/EnviousWisprAudio/InputChannelPreference.swift
+++ b/Sources/EnviousWisprAudio/InputChannelPreference.swift
@@ -1,0 +1,19 @@
+/// #2664. Which device input channel (0-based) the mono capture should take.
+///
+/// The one authority for the channel INDEX: HAL prepare applies it, the
+/// warm-reuse predicate compares against it, and the settings row displays it.
+/// Pure: (requested, available) -> effective. Never throws; a stale, absent or
+/// out-of-range preference is channel 0, which is exactly today's behaviour
+/// (AUHAL's mono client format takes device channel 0 when no map is set).
+///
+/// `public` because AppKit's settings row calls it too, so a saved index the
+/// device no longer has is SHOWN as Input 1 rather than as a socket that does
+/// not exist.
+public enum InputChannelPreference {
+  public static func effectiveChannel(requested: Int?, availableChannels: Int?) -> Int {
+    guard let requested, requested > 0,
+      let availableChannels, requested < availableChannels
+    else { return 0 }
+    return requested
+  }
+}

--- a/Sources/EnviousWisprAudio/InputChannelPreference.swift
+++ b/Sources/EnviousWisprAudio/InputChannelPreference.swift
@@ -16,4 +16,14 @@ public enum InputChannelPreference {
     else { return 0 }
     return requested
   }
+
+  /// The ONE way a device's saved choice is looked up. A device whose UID could
+  /// not be read (nil, or the empty string `AudioDeviceEnumerator` substitutes)
+  /// has NO saved choice: an empty key would otherwise be shared by every such
+  /// device, and a choice made on one would be applied to another. Every reader
+  /// (cold prepare, warm reuse, the settings row) goes through here.
+  public static func requested(for deviceUID: String?, in preference: [String: Int]) -> Int? {
+    guard let deviceUID, !deviceUID.isEmpty else { return nil }
+    return preference[deviceUID]
+  }
 }

--- a/Sources/EnviousWisprCore/CaptureStallContext.swift
+++ b/Sources/EnviousWisprCore/CaptureStallContext.swift
@@ -60,6 +60,9 @@ public struct CaptureStallContext: Sendable {
   /// at watchdog-fire time (direct HAL stalls populate it; the XPC proxy's
   /// host-side watchdog leaves it nil). Preserved through `enrichedWithStabilizationFlags`.
   public let nativeChannelCount: Int?
+  /// #2664: the device input channel the stalled capture was bound to (0 =
+  /// default). Source-stamped beside `nativeChannelCount`, nil on the same paths.
+  public let inputChannel: Int?
 
   public init(
     sessionID: UInt64,
@@ -84,7 +87,8 @@ public struct CaptureStallContext: Sendable {
     rateDivergenceDetected: Bool? = nil,
     formatStabilized: Bool? = nil,
     captureRebuiltForFormat: Bool? = nil,
-    nativeChannelCount: Int? = nil
+    nativeChannelCount: Int? = nil,
+    inputChannel: Int? = nil
   ) {
     self.sessionID = sessionID
     self.armedAtUptimeNs = armedAtUptimeNs
@@ -109,6 +113,7 @@ public struct CaptureStallContext: Sendable {
     self.formatStabilized = formatStabilized
     self.captureRebuiltForFormat = captureRebuiltForFormat
     self.nativeChannelCount = nativeChannelCount
+    self.inputChannel = inputChannel
   }
 
   /// #1543 in-process forward enrichment: the capture MANAGER owns the
@@ -156,7 +161,8 @@ public struct CaptureStallContext: Sendable {
       rateDivergenceDetected: rateDivergenceDetected,
       formatStabilized: formatStabilized,
       captureRebuiltForFormat: captureRebuiltForFormat,
-      nativeChannelCount: nativeChannelCount
+      nativeChannelCount: nativeChannelCount,
+      inputChannel: inputChannel
     )
   }
 
@@ -190,7 +196,8 @@ public struct CaptureStallContext: Sendable {
       rateDivergenceDetected: rateDivergenceDetected,
       formatStabilized: formatStabilized,
       captureRebuiltForFormat: captureRebuiltForFormat,
-      nativeChannelCount: nativeChannelCount
+      nativeChannelCount: nativeChannelCount,
+      inputChannel: inputChannel
     )
   }
 }

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -127,6 +127,12 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
   /// device exposed so a >1-channel population is measurable). Nil when the
   /// source doesn't read a channel count (e.g. proxy-origin stalls).
   public let nativeChannelCount: Int?
+  /// #2664: the device input channel (0-based) the mono capture ACTUALLY took.
+  /// 0 is the default channel (no channel map set, today's behaviour for every
+  /// device); a positive value means the user's per-device socket choice was
+  /// applied. Nil means "not measured" (a source that binds no HAL unit), never
+  /// 0 — the same absent-vs-zero rule `nativeChannelCount` follows.
+  public let inputChannel: Int?
 
   /// Every way the captured stream can lose frames between the microphone and
   /// the pipeline, summed. THE point of this property is to be the one place
@@ -175,7 +181,8 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     preRollGapCount: Int = 0,
     lostChunkCount: Int = 0,
     rateDivergenceDetected: Bool = false,
-    nativeChannelCount: Int? = nil
+    nativeChannelCount: Int? = nil,
+    inputChannel: Int? = nil
   ) {
     self.nativeRateHz = nativeRateHz
     self.ringDropCount = ringDropCount
@@ -187,6 +194,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     self.lostChunkCount = lostChunkCount
     self.rateDivergenceDetected = rateDivergenceDetected
     self.nativeChannelCount = nativeChannelCount
+    self.inputChannel = inputChannel
   }
 
   /// Counters decode as ABSENT-MEANS-ZERO rather than as required keys, so a stop
@@ -208,6 +216,7 @@ public struct CaptureStopMetadata: Sendable, Codable, Equatable {
     rateDivergenceDetected =
       try c.decodeIfPresent(Bool.self, forKey: .rateDivergenceDetected) ?? false
     nativeChannelCount = try c.decodeIfPresent(Int.self, forKey: .nativeChannelCount)
+    inputChannel = try c.decodeIfPresent(Int.self, forKey: .inputChannel)
   }
 }
 

--- a/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
+++ b/Sources/EnviousWisprPipeline/ASREmptyResultDiagnostics.swift
@@ -45,6 +45,8 @@ internal struct ASREmptyResultDiagnostics {
   var captureRebuiltForFormat: Bool?
   // #1523 bound device's total native input channel count at the empty terminal.
   var captureNativeChannelCount: Int?
+  // #2664 the device input channel the capture took (0 = default).
+  var captureInputChannel: Int?
 
   var incrementalAccepted: Bool?
   var incrementalResultChars: Int?
@@ -123,6 +125,7 @@ internal struct ASREmptyResultDiagnostics {
     put(captureFormatStabilized, key: "capture.format_stabilized", into: &extra)
     put(captureRebuiltForFormat, key: "capture.rebuilt_for_format", into: &extra)
     put(captureNativeChannelCount, key: "capture.native_channel_count", into: &extra)
+    put(captureInputChannel, key: "capture.input_channel", into: &extra)
 
     put(incrementalAccepted, key: "asr.incremental_accepted", into: &extra)
     put(incrementalResultChars, key: "asr.incremental_result_chars", into: &extra)

--- a/Sources/EnviousWisprPipeline/CaptureHealthTransports.swift
+++ b/Sources/EnviousWisprPipeline/CaptureHealthTransports.swift
@@ -14,6 +14,8 @@ public struct CaptureHealthTransports: Sendable, Equatable {
   public let captureRebuiltForFormat: Bool?
   /// #1523: the bound device's total native input channel count.
   public let nativeChannelCount: Int?
+  /// #2664: the device input channel the capture actually took (0 = default).
+  public let inputChannel: Int?
 
   public init(
     nativeRateHz: Double?,
@@ -23,7 +25,8 @@ public struct CaptureHealthTransports: Sendable, Equatable {
     rateDivergenceDetected: Bool?,
     formatStabilized: Bool?,
     captureRebuiltForFormat: Bool?,
-    nativeChannelCount: Int? = nil
+    nativeChannelCount: Int? = nil,
+    inputChannel: Int? = nil
   ) {
     self.nativeRateHz = nativeRateHz
     self.ringDropCount = ringDropCount
@@ -33,5 +36,6 @@ public struct CaptureHealthTransports: Sendable, Equatable {
     self.formatStabilized = formatStabilized
     self.captureRebuiltForFormat = captureRebuiltForFormat
     self.nativeChannelCount = nativeChannelCount
+    self.inputChannel = inputChannel
   }
 }

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryContexts.swift
@@ -35,6 +35,8 @@ struct NoAudioContext: Sendable {
   var captureRebuiltForFormat: Bool? = nil
   // #1523: bound device's total native input channel count at the no-audio terminal.
   var captureNativeChannelCount: Int? = nil
+  // #2664: the device input channel the capture took (0 = default).
+  var captureInputChannel: Int? = nil
 }
 
 /// Per-call context for `HeartPathTelemetryEmitter.zombieZeroPeakIfNeeded(...)`.

--- a/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
+++ b/Sources/EnviousWisprPipeline/HeartPathTelemetryEmitter.swift
@@ -222,6 +222,7 @@ final class HeartPathTelemetryEmitter {
     if let channels = ctx.captureNativeChannelCount {
       extras["capture.native_channel_count"] = channels
     }
+    if let channel = ctx.captureInputChannel { extras["capture.input_channel"] = channel }
     captureError(err, .audioCaptureFailed, "recording", extras)
   }
 

--- a/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
+++ b/Sources/EnviousWisprPipeline/KernelLifecycleTelemetrySink.swift
@@ -60,7 +60,7 @@ final class KernelLifecycleTelemetrySink {
     _ wholeBufferRMS: Float?, _ maxWindowRMS: Float?, _ durationMs: Int?,
     _ effectiveTransport: String?, _ selectedTransport: String?, _ inputSelectionMode: String?,
     _ inputDeviceKind: String?, _ captureNativeRateHz: Double?, _ captureNativeChannelCount: Int?,
-    _ takeID: String?
+    _ captureInputChannel: Int?, _ takeID: String?
   ) -> Void
 
   /// #1884 `dictation.started` — the denominator. Deliberately minimal: this
@@ -79,6 +79,8 @@ final class KernelLifecycleTelemetrySink {
     _ inputSelectionMode: String?, _ wholeBufferRMS: Float?, _ maxWindowRMS: Float?,
     _ peakAudioLevel: Float?, _ durationMs: Int?, _ captureNativeRateHz: Double?,
     _ captureNativeChannelCount: Int?,
+    // #2664: the device input channel the capture took (0 = default), beside the count.
+    _ captureInputChannel: Int?,
     // #2184: what the VAD's segments did to this take's audio. All four are nil
     // when the take concluded before the conditioner ran, which is the reading
     // rather than a gap. Owner: `KernelVADConditioningTelemetry`.
@@ -219,7 +221,7 @@ final class KernelLifecycleTelemetrySink {
     vadGateNoSpeech: @escaping VADGateNoSpeechSink = {
       backend, mode, rawSampleCount, peakAudioLevel, wholeBufferRMS, maxWindowRMS, durationMs,
       effectiveTransport, selectedTransport, inputSelectionMode, inputDeviceKind,
-      captureNativeRateHz, captureNativeChannelCount, takeID in
+      captureNativeRateHz, captureNativeChannelCount, captureInputChannel, takeID in
       TelemetryService.shared.vadGateNoSpeech(
         backend: backend, mode: mode, rawSampleCount: rawSampleCount,
         peakAudioLevel: peakAudioLevel, wholeBufferRMS: wholeBufferRMS,
@@ -227,7 +229,8 @@ final class KernelLifecycleTelemetrySink {
         effectiveTransport: effectiveTransport, selectedTransport: selectedTransport,
         inputSelectionMode: inputSelectionMode, inputDeviceKind: inputDeviceKind,
         captureNativeRateHz: captureNativeRateHz,
-        captureNativeChannelCount: captureNativeChannelCount, takeID: takeID)
+        captureNativeChannelCount: captureNativeChannelCount,
+        captureInputChannel: captureInputChannel, takeID: takeID)
     },
     dictationStarted: @escaping DictationStartedSink = { takeID, backend in
       TelemetryService.shared.dictationStarted(takeID: takeID, backend: backend)
@@ -235,8 +238,8 @@ final class KernelLifecycleTelemetrySink {
     dictationTerminal: @escaping DictationTerminalSink = {
       takeID, backend, result, reason, inputDeviceKind, effectiveTransport, selectedTransport,
       inputSelectionMode, wholeBufferRMS, maxWindowRMS, peakAudioLevel, durationMs,
-      captureNativeRateHz, captureNativeChannelCount, vadRawSampleCount, vadFilteredSampleCount,
-      vadRetainedRatio, vadConditioningReason, deliveryDisposition in
+      captureNativeRateHz, captureNativeChannelCount, captureInputChannel, vadRawSampleCount,
+      vadFilteredSampleCount, vadRetainedRatio, vadConditioningReason, deliveryDisposition in
       TelemetryService.shared.dictationTerminal(
         takeID: takeID, backend: backend, result: result, reason: reason,
         inputDeviceKind: inputDeviceKind, effectiveTransport: effectiveTransport,
@@ -245,6 +248,7 @@ final class KernelLifecycleTelemetrySink {
         peakAudioLevel: peakAudioLevel, durationMs: durationMs,
         captureNativeRateHz: captureNativeRateHz,
         captureNativeChannelCount: captureNativeChannelCount,
+        captureInputChannel: captureInputChannel,
         deliveryDisposition: deliveryDisposition,
         vadRawSampleCount: vadRawSampleCount,
         vadFilteredSampleCount: vadFilteredSampleCount,
@@ -377,6 +381,7 @@ final class KernelLifecycleTelemetrySink {
       attribution?.wholeBufferRMS, attribution?.maxWindowRMS,
       attribution?.peakAudioLevel, attribution?.durationMs,
       attribution?.captureNativeRateHz, attribution?.captureNativeChannelCount,
+      attribution?.captureInputChannel,
       conditioning?.rawSampleCount, conditioning?.filteredSampleCount,
       conditioning?.retainedRatio, conditioning?.conditioningReason,
       snapshot.deliveryDisposition.rawValue)
@@ -568,7 +573,7 @@ final class KernelLifecycleTelemetrySink {
           facts.wholeBufferRMS, facts.maxWindowRMS, facts.durationMs,
           facts.effectiveTransport, facts.selectedTransport, facts.inputSelectionMode,
           facts.inputDeviceKind, facts.captureNativeRateHz, facts.captureNativeChannelCount,
-          facts.takeID)
+          facts.captureInputChannel, facts.takeID)
       case .asrEmptyNoSpeech:
         breadcrumb(
           "asr", "ASR empty (no speech detected)",
@@ -831,6 +836,7 @@ final class KernelLifecycleTelemetrySink {
     let inputDeviceKind: String?
     let captureNativeRateHz: Double?
     let captureNativeChannelCount: Int?
+    let captureInputChannel: Int?
     let takeID: String?
   }
 
@@ -851,6 +857,7 @@ final class KernelLifecycleTelemetrySink {
       inputDeviceKind: noSpeech?.inputDeviceKind,
       captureNativeRateHz: health?.stopMetadata?.nativeRateHz,
       captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount,
+      captureInputChannel: health?.stopMetadata?.inputChannel,
       // Read BEFORE the generic terminal postamble clears the take key. The
       // postamble deliberately runs after the event-specific arm for exactly
       // this reason; if it is ever moved above the switch, the §11.2 take-key
@@ -875,6 +882,7 @@ final class KernelLifecycleTelemetrySink {
     if let v = facts.inputDeviceKind { payload["input_device_kind"] = v }
     if let v = facts.captureNativeRateHz { payload["capture_native_rate_hz"] = v }
     if let v = facts.captureNativeChannelCount { payload["capture_native_channel_count"] = v }
+    if let v = facts.captureInputChannel { payload["capture_input_channel"] = v }
     return payload
   }
 
@@ -1118,7 +1126,8 @@ final class KernelLifecycleTelemetrySink {
         captureRateDivergenceDetected: health?.stopMetadata?.rateDivergenceDetected,
         captureFormatStabilized: health?.formatStabilized,
         captureRebuiltForFormat: health?.captureRebuiltForFormat,
-        captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount
+        captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount,
+        captureInputChannel: health?.stopMetadata?.inputChannel
       )
       if let noAudioCapturedRich {
         noAudioCapturedRich(ctx)

--- a/Sources/EnviousWisprPipeline/KernelTerminalTelemetrySnapshot.swift
+++ b/Sources/EnviousWisprPipeline/KernelTerminalTelemetrySnapshot.swift
@@ -39,6 +39,9 @@ struct KernelSignalAttributionTelemetry: Sendable, Equatable {
   let durationMs: Int?
   let captureNativeRateHz: Double?
   let captureNativeChannelCount: Int?
+  /// #2664: the device input channel the capture took (0 = default), so a
+  /// signal-free terminal can say whether a non-default socket was in effect.
+  let captureInputChannel: Int?
 }
 
 /// #2184 — what the VAD's segments did to this take's audio, frozen at the

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1922,7 +1922,8 @@ final class RecordingSessionKernel {
       rateDivergenceDetected: captureResult.metadata?.rateDivergenceDetected,
       formatStabilized: formatStabilizedThisSession,
       captureRebuiltForFormat: captureRebuiltForFormatThisSession,
-      nativeChannelCount: captureResult.metadata?.nativeChannelCount
+      nativeChannelCount: captureResult.metadata?.nativeChannelCount,
+      inputChannel: captureResult.metadata?.inputChannel
     )
     recordingStoppedTelemetry(captureResult.samples.count)
     await (vad as? CaptureVADSignalSource)?.finalizeAtStop(
@@ -4022,7 +4023,10 @@ final class RecordingSessionKernel {
         // terminal. This is the near-silent-capture event §3a correlates a
         // >1-channel count against (voice on a later channel → AUHAL takes
         // channel 0 → silence), so the count belongs precisely here.
-        nativeChannelCount: captureResult.metadata?.nativeChannelCount
+        nativeChannelCount: captureResult.metadata?.nativeChannelCount,
+        // #2664: and which channel the capture actually took, so the fleet
+        // question "did the socket setting reach this take" is answerable.
+        inputChannel: captureResult.metadata?.inputChannel
       ))
   }
 
@@ -4102,7 +4106,8 @@ final class RecordingSessionKernel {
       peakAudioLevel: peak,
       durationMs: telemetryState.recordingSnapshot?.durationMs,
       captureNativeRateHz: health?.stopMetadata?.nativeRateHz,
-      captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount
+      captureNativeChannelCount: health?.stopMetadata?.nativeChannelCount,
+      captureInputChannel: health?.stopMetadata?.inputChannel
     )
   }
 
@@ -4493,6 +4498,7 @@ final class RecordingSessionKernel {
     diagnostics.captureFormatStabilized = health.formatStabilized
     diagnostics.captureRebuiltForFormat = health.captureRebuiltForFormat
     diagnostics.captureNativeChannelCount = health.stopMetadata?.nativeChannelCount
+    diagnostics.captureInputChannel = health.stopMetadata?.inputChannel
     telemetryState.asrEmptyDiagnostics = diagnostics
   }
 

--- a/Sources/EnviousWisprServices/SentryAudioExtras.swift
+++ b/Sources/EnviousWisprServices/SentryAudioExtras.swift
@@ -74,6 +74,7 @@ public enum SentryAudioExtras {
       if let channels = ctx.nativeChannelCount {
         extras["capture.native_channel_count"] = channels
       }
+      if let channel = ctx.inputChannel { extras["capture.input_channel"] = channel }
     }
 
     if let swap = polishModelSwapMs {

--- a/Sources/EnviousWisprServices/SettingsDefaultValues.swift
+++ b/Sources/EnviousWisprServices/SettingsDefaultValues.swift
@@ -122,6 +122,9 @@ enum SettingsDefaultValues {
 
   static let selectedInputDeviceUID = ""
   static let preferredInputDeviceIDOverride = ""
+  /// #2664: no per-device socket choice on a fresh install; every device
+  /// records from its first input, as before.
+  static let inputChannelByDeviceUID: [String: Int] = [:]
 
   static let useStreamingASR = false
   static let warmEnginePolicy: WarmEnginePolicy = .seconds30

--- a/Sources/EnviousWisprServices/SettingsManager.swift
+++ b/Sources/EnviousWisprServices/SettingsManager.swift
@@ -49,6 +49,8 @@ public final class SettingsManager {
     case languageMode
     case selectedInputDeviceUID
     case preferredInputDeviceIDOverride
+    /// #2664: per-device "Microphone socket" choice, keyed by device UID.
+    case inputChannelByDeviceUID
     case useStreamingASR
     case livePreviewEnabled
     case livePreviewEngine
@@ -98,7 +100,7 @@ public final class SettingsManager {
     "crashRecoveryEnabled", "contactsSyncOnLaunchEnabled",
     "isDebugModeEnabled", "isDictationAudioArchiveEnabled", "debugLogLevel",
     "whisperKitLanguage", "languageMode",
-    "selectedInputDeviceUID", "preferredInputDeviceIDOverride",
+    "selectedInputDeviceUID", "preferredInputDeviceIDOverride", "inputChannelByDeviceUID",
     "useStreamingASR", "livePreviewEnabled", "livePreviewEngine",
     "warmEnginePolicy", "appearancePreference",
     "overlayPillPosition",
@@ -730,6 +732,22 @@ public final class SettingsManager {
     }
   }
 
+  /// #2664: which input of a multi-input audio interface the microphone is on,
+  /// per device UID, stored 0-based (the UI shows `Input \(index + 1)`). A
+  /// missing UID means channel 0, today's behaviour. Persisted as JSON `Data`
+  /// under one key, the `languageMode` shape above; an undecodable or absent
+  /// value loads as `[:]` (no earlier shape exists to migrate from). Keyed by
+  /// UID rather than `AudioDeviceID` because a replug recycles the numeric
+  /// handle and keeps the UID.
+  public var inputChannelByDeviceUID: [String: Int] {
+    didSet {
+      if let data = try? JSONEncoder().encode(inputChannelByDeviceUID) {
+        defaults.set(data, forKey: "inputChannelByDeviceUID")
+      }
+      onChange?(.inputChannelByDeviceUID)
+    }
+  }
+
   #if DEBUG
     /// DEV-ONLY per-build knob (AFM adapter PoC): when ON and EW_AFM_ADAPTER_PATH
     /// is set, on-device Apple Intelligence polish runs through the local
@@ -797,6 +815,17 @@ public final class SettingsManager {
   ///   default) for production (resolves to `SettingsDefaults.store`, the
   ///   build-shared suite); tests inject a private suite. `nil` (not a direct
   ///   `SettingsDefaults.store` default arg) keeps the accessor Services-internal.
+  /// #2664: decode the per-device socket map, or `[:]` when the key is absent
+  /// or undecodable. Fails OPEN to the default on purpose: a corrupt blob must
+  /// cost the user one re-pick, never a launch that cannot read its settings.
+  nonisolated static func loadInputChannelByDeviceUID(from defaults: UserDefaults) -> [String: Int]
+  {
+    guard let data = defaults.data(forKey: "inputChannelByDeviceUID"),
+      let decoded = try? JSONDecoder().decode([String: Int].self, from: data)
+    else { return SettingsDefaultValues.inputChannelByDeviceUID }
+    return decoded
+  }
+
   public init(defaults: UserDefaults? = nil) {
     let defaults = defaults ?? SettingsDefaults.store
     self.defaults = defaults
@@ -984,6 +1013,7 @@ public final class SettingsManager {
     preferredInputDeviceIDOverride =
       defaults.string(forKey: "preferredInputDeviceIDOverride")
       ?? SettingsDefaultValues.preferredInputDeviceIDOverride
+    inputChannelByDeviceUID = Self.loadInputChannelByDeviceUID(from: defaults)
     #if DEBUG
       // PER-BUILD EXCEPTION (#923): AFM adapter PoC dev knob, read from the
       // build's own store, default ON. Stays out of unifiedDefaultsKeys + the

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -212,6 +212,7 @@ public final class TelemetryService {
     captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
     captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
     captureRebuiltForFormat: Bool? = nil, captureNativeChannelCount: Int? = nil,
+    captureInputChannel: Int? = nil,
     salvagedLeadTrimMs: Int? = nil,
     // #1408: present only on a salvaged completion — WHICH interruption cut the
     // recording short. `stop_reason` already says an interruption ended it; this
@@ -281,6 +282,7 @@ public final class TelemetryService {
       captureFormatStabilized: captureFormatStabilized,
       captureRebuiltForFormat: captureRebuiltForFormat,
       captureNativeChannelCount: captureNativeChannelCount,
+      captureInputChannel: captureInputChannel,
       salvagedLeadTrimMs: salvagedLeadTrimMs,
       interruptedBy: interruptedBy,
       asrSalvageOutcome: asrSalvageOutcome,
@@ -1068,6 +1070,7 @@ public final class TelemetryService {
     inputDeviceKind: String?,
     captureNativeRateHz: Double?,
     captureNativeChannelCount: Int?,
+    captureInputChannel: Int?,
     takeID: String?
   ) {
     let event = "audio.vad_gate_no_speech"
@@ -1090,6 +1093,7 @@ public final class TelemetryService {
     if let captureNativeChannelCount {
       props["capture_native_channel_count"] = captureNativeChannelCount
     }
+    if let captureInputChannel { props["capture_input_channel"] = captureInputChannel }
     if let takeID { props["take_id"] = takeID }
     #if DEBUG
       // Read BACK OUT of the emitted payload so a test observes what PostHog
@@ -1102,7 +1106,7 @@ public final class TelemetryService {
         if let value = props[key] as? String { stringProps[key] = value }
       }
       var intProps: [String: Int] = ["raw_sample_count": rawSampleCount]
-      for key in ["duration_ms", "capture_native_channel_count"] {
+      for key in ["duration_ms", "capture_native_channel_count", "capture_input_channel"] {
         if let value = props[key] as? Int { intProps[key] = value }
       }
       var doubleProps: [String: Double] = [:]
@@ -1207,6 +1211,9 @@ public final class TelemetryService {
     durationMs: Int? = nil,
     captureNativeRateHz: Double? = nil,
     captureNativeChannelCount: Int? = nil,
+    // #2664: the device input channel the capture took (0 = default). Additive,
+    // defaulted, omit-when-nil like the count beside it.
+    captureInputChannel: Int? = nil,
     // #2087: ADDITIVE and defaulted, so every existing call site and every
     // existing query keeps working. An Escape Recovery session concludes
     // `.completed`, so without this the ordinary terminal row would report it as
@@ -1245,6 +1252,7 @@ public final class TelemetryService {
     if let captureNativeChannelCount {
       props["capture_native_channel_count"] = captureNativeChannelCount
     }
+    if let captureInputChannel { props["capture_input_channel"] = captureInputChannel }
     if let vadRawSampleCount { props["vad_raw_sample_count"] = vadRawSampleCount }
     if let vadFilteredSampleCount { props["vad_filtered_sample_count"] = vadFilteredSampleCount }
     if let vadRetainedRatio { props["vad_retained_ratio"] = vadRetainedRatio }
@@ -1262,8 +1270,8 @@ public final class TelemetryService {
       }
       var intProps: [String: Int] = [:]
       for key in [
-        "duration_ms", "capture_native_channel_count", "vad_raw_sample_count",
-        "vad_filtered_sample_count",
+        "duration_ms", "capture_native_channel_count", "capture_input_channel",
+        "vad_raw_sample_count", "vad_filtered_sample_count",
       ] {
         if let value = props[key] as? Int { intProps[key] = value }
       }
@@ -1434,6 +1442,7 @@ public final class TelemetryService {
     captureConverterErrorCount: Int? = nil, captureZeroOutputCount: Int? = nil,
     captureRateDivergenceDetected: Bool? = nil, captureFormatStabilized: Bool? = nil,
     captureRebuiltForFormat: Bool? = nil, captureNativeChannelCount: Int? = nil,
+    captureInputChannel: Int? = nil,
     salvagedLeadTrimMs: Int? = nil,
     interruptedBy: String? = nil,
     asrSalvageOutcome: String? = nil,
@@ -1472,6 +1481,9 @@ public final class TelemetryService {
     if let stab = captureFormatStabilized { props["capture_format_stabilized"] = stab }
     if let rebuilt = captureRebuiltForFormat { props["capture_rebuilt_for_format"] = rebuilt }
     if let channels = captureNativeChannelCount { props["capture_native_channel_count"] = channels }
+    // #2664: which device input channel the capture took (0 = default). Omit when
+    // nil (not measured); 0 is a real measurement and travels.
+    if let channel = captureInputChannel { props["capture_input_channel"] = channel }
     if let trim = salvagedLeadTrimMs { props["salvaged_lead_trim_ms"] = trim }
     if let p = llmProvider { props["llm_provider"] = p }
     if let a = targetApp { props["target_app"] = a }

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -37,6 +37,7 @@ final class RouterTestAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "hal_device_input"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
   var preWarmError: Error?
   /// #1063 PR1: counts `abortPreWarm()` so the release-during-recovery-arm guard

--- a/Tests/EnviousWisprTests/App/InputDevicePreferenceReconcilerTests.swift
+++ b/Tests/EnviousWisprTests/App/InputDevicePreferenceReconcilerTests.swift
@@ -19,7 +19,7 @@ struct InputDevicePreferenceReconcilerTests {
   }
 
   private static func device(_ uid: String) -> AudioInputDevice {
-    AudioInputDevice(id: 1, name: uid, uid: uid)
+    AudioInputDevice(id: 1, name: uid, uid: uid, inputChannelCount: 1)
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/App/InputSocketCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/InputSocketCopyTests.swift
@@ -1,0 +1,33 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+// #2664: the "Microphone socket" row's copy, frozen. Drift guard: changing a
+// string here is a deliberate product decision, not a side effect.
+@Suite("InputSocketCopy is frozen — #2664", .tags(.driftGuard))
+struct InputSocketCopyTests {
+
+  @Test("the row header, option labels and helper are byte-exact")
+  func copyIsFrozen() {
+    #expect(InputSocketCopy.header == "Microphone socket")
+    #expect(InputSocketCopy.optionLabel(index: 0) == "Input 1")
+    #expect(InputSocketCopy.optionLabel(index: 1) == "Input 2")
+    #expect(InputSocketCopy.optionLabel(index: 5) == "Input 6")
+    #expect(
+      InputSocketCopy.helper(inputCount: 2, deviceName: "Scarlett 2i2 USB")
+        == "This device has 2 inputs. Pick the one your microphone is plugged into. "
+        + "EnviousWispr remembers this for Scarlett 2i2 USB.")
+  }
+
+  @Test("no dashes anywhere in the row's copy (content rule)")
+  func noDashes() {
+    let all = [
+      InputSocketCopy.header, InputSocketCopy.optionLabel(index: 3),
+      InputSocketCopy.helper(inputCount: 8, deviceName: "Any Box"),
+    ]
+    for s in all {
+      #expect(s.contains("\u{2014}") == false, "em dash in: \(s)")
+      #expect(s.contains("\u{2013}") == false, "en dash in: \(s)")
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/InputSocketCopyTests.swift
+++ b/Tests/EnviousWisprTests/App/InputSocketCopyTests.swift
@@ -7,23 +7,21 @@ import Testing
 @Suite("InputSocketCopy is frozen — #2664", .tags(.driftGuard))
 struct InputSocketCopyTests {
 
-  @Test("the row header, option labels and helper are byte-exact")
+  @Test("the row label, option labels and helper are byte-exact")
   func copyIsFrozen() {
-    #expect(InputSocketCopy.header == "Microphone socket")
+    #expect(InputSocketCopy.label == "Mic is on")
     #expect(InputSocketCopy.optionLabel(index: 0) == "Input 1")
     #expect(InputSocketCopy.optionLabel(index: 1) == "Input 2")
     #expect(InputSocketCopy.optionLabel(index: 5) == "Input 6")
     #expect(
-      InputSocketCopy.helper(inputCount: 2, deviceName: "Scarlett 2i2 USB")
-        == "This device has 2 inputs. Pick the one your microphone is plugged into. "
-        + "EnviousWispr remembers this for Scarlett 2i2 USB.")
+      InputSocketCopy.helper(deviceName: "Scarlett 2i2 USB") == "Remembered for Scarlett 2i2 USB.")
   }
 
   @Test("no dashes anywhere in the row's copy (content rule)")
   func noDashes() {
     let all = [
-      InputSocketCopy.header, InputSocketCopy.optionLabel(index: 3),
-      InputSocketCopy.helper(inputCount: 8, deviceName: "Any Box"),
+      InputSocketCopy.label, InputSocketCopy.optionLabel(index: 3),
+      InputSocketCopy.helper(deviceName: "Any Box"),
     ]
     for s in all {
       #expect(s.contains("\u{2014}") == false, "em dash in: \(s)")

--- a/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/LivePreviewCoordinatorTests.swift
@@ -2197,6 +2197,7 @@ private final class CountingAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "hal_device_input"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   func startEnginePhase() async throws {}

--- a/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
+++ b/Tests/EnviousWisprTests/App/LiveRecordingStateTests.swift
@@ -175,6 +175,7 @@ private final class SettableAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "hal_device_input"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   func startEnginePhase() async throws {}
@@ -223,6 +224,7 @@ private final class ObservableAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "hal_device_input"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   func startEnginePhase() async throws {}

--- a/Tests/EnviousWisprTests/App/MultiInputAdvisoryHintTests.swift
+++ b/Tests/EnviousWisprTests/App/MultiInputAdvisoryHintTests.swift
@@ -1,0 +1,109 @@
+import CoreAudio
+import EnviousWisprAudio
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+
+// #2664: the silent-take notice names the multi-input box the user would find
+// selected in Settings, and ONLY that box. When this fails, the user sees the
+// wrong device named, or the "try a different input" hint on a one-input
+// microphone that has no other input to try.
+@Suite("MultiInputAdvisoryHint and the shared socket-device rule — #2664", .tags(.productOutcome))
+struct MultiInputAdvisoryHintTests {
+
+  private static let scarlett = AudioInputDevice(
+    id: 42, name: "Scarlett 2i2 USB", uid: "scarlett-2i2-uid", inputChannelCount: 2)
+  private static let builtIn = AudioInputDevice(
+    id: 7, name: "MacBook Pro Microphone", uid: "builtin-uid", inputChannelCount: 1)
+
+  // MARK: - The hint
+
+  @Test("a two-input device on a silent take names the device")
+  func multiInputDeviceProducesHint() {
+    let hint = MultiInputAdvisoryHint.make(reason: .zeroSignal, socketDevice: Self.scarlett)
+    #expect(hint == MultiInputAdvisoryHint(deviceName: "Scarlett 2i2 USB"))
+    #expect(
+      MultiInputAdvisoryHint.make(reason: .vadGateNoSpeech, socketDevice: Self.scarlett)
+        == MultiInputAdvisoryHint(deviceName: "Scarlett 2i2 USB"))
+  }
+
+  @Test("a one-input device never gets the hint: there is no other input to try")
+  func oneInputDeviceHasNoHint() {
+    #expect(MultiInputAdvisoryHint.make(reason: .zeroSignal, socketDevice: Self.builtIn) == nil)
+  }
+
+  @Test("no known device (empty list, nothing resolved) means the locked sentence")
+  func noDeviceHasNoHint() {
+    #expect(MultiInputAdvisoryHint.make(reason: .zeroSignal, socketDevice: nil) == nil)
+  }
+
+  @Test("noTransport never hints: no device was opened, so there is no socket to try")
+  func noTransportHasNoHint() {
+    #expect(MultiInputAdvisoryHint.make(reason: .noTransport, socketDevice: Self.scarlett) == nil)
+  }
+
+  // MARK: - The shared device rule (settings row and hint read the same one)
+
+  @Test("a pinned device is found by UID, whatever Auto would resolve")
+  func pinnedDeviceWinsByUID() {
+    var resolverCalls = 0
+    let device = InputSocket.socketDevice(
+      preferredInputDeviceIDOverride: "scarlett-2i2-uid",
+      devices: [Self.builtIn, Self.scarlett],
+      resolvedAutoInputDeviceID: {
+        resolverCalls += 1
+        return 7
+      })
+    #expect(device == Self.scarlett)
+    #expect(resolverCalls == 0, "a pinned choice must not pay for the Auto ladder")
+  }
+
+  @Test("a pinned device that is not connected yields nothing, never a substitute")
+  func pinnedDeviceMissingYieldsNil() {
+    let device = InputSocket.socketDevice(
+      preferredInputDeviceIDOverride: "unplugged-uid",
+      devices: [Self.builtIn, Self.scarlett],
+      resolvedAutoInputDeviceID: { 7 })
+    #expect(device == nil)
+  }
+
+  @Test("Auto names the device the ladder would OPEN, matched by runtime id")
+  func autoResolvesByID() {
+    let device = InputSocket.socketDevice(
+      preferredInputDeviceIDOverride: "",
+      devices: [Self.builtIn, Self.scarlett],
+      resolvedAutoInputDeviceID: { 42 })
+    #expect(device == Self.scarlett)
+  }
+
+  @Test("Auto with nothing resolved, or an empty device list, yields nothing")
+  func autoUnresolvedYieldsNil() {
+    #expect(
+      InputSocket.socketDevice(
+        preferredInputDeviceIDOverride: "", devices: [Self.builtIn, Self.scarlett],
+        resolvedAutoInputDeviceID: { nil }) == nil)
+    #expect(
+      InputSocket.socketDevice(
+        preferredInputDeviceIDOverride: "", devices: [], resolvedAutoInputDeviceID: { 42 })
+        == nil)
+    #expect(
+      InputSocket.socketDevice(
+        preferredInputDeviceIDOverride: "scarlett-2i2-uid", devices: [],
+        resolvedAutoInputDeviceID: { 42 }) == nil)
+  }
+
+  @Test("Auto flipping between a one-input and a two-input device hints only on the second")
+  func autoFlipHintsOnlyForMultiInput() {
+    let onBuiltIn = InputSocket.socketDevice(
+      preferredInputDeviceIDOverride: "", devices: [Self.builtIn, Self.scarlett],
+      resolvedAutoInputDeviceID: { 7 })
+    let onScarlett = InputSocket.socketDevice(
+      preferredInputDeviceIDOverride: "", devices: [Self.builtIn, Self.scarlett],
+      resolvedAutoInputDeviceID: { 42 })
+    #expect(MultiInputAdvisoryHint.make(reason: .zeroSignal, socketDevice: onBuiltIn) == nil)
+    #expect(
+      MultiInputAdvisoryHint.make(reason: .zeroSignal, socketDevice: onScarlett)?.deviceName
+        == "Scarlett 2i2 USB")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/AdvisoryHintRoutingTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/AdvisoryHintRoutingTests.swift
@@ -1,0 +1,92 @@
+import EnviousWisprCore
+import Testing
+
+@testable import EnviousWisprAppKit
+
+// #2664: the hinted advisory reaches the pill and VoiceOver with the device
+// named, while the pipeline's own vocabulary (`OverlayIntent`) never learns the
+// hint. When this fails, the user sees the generic sentence after a silent take
+// on their interface, or hears a different sentence than the one on screen.
+@MainActor
+@Suite("Advisory hint routing through the overlay — #2664", .tags(.productOutcome))
+struct AdvisoryHintRoutingTests {
+
+  private static let hint = MultiInputAdvisoryHint(deviceName: "Scarlett 2i2 USB")
+  private static let hinted =
+    "Audio isn't capturing from Scarlett 2i2 USB. Try a different input under Settings > Microphone."
+
+  @Test(
+    "the catalog renders the hinted sentence, at the same width and dwell as the plain advisory")
+  func catalogRendersHintedSentence() throws {
+    let plain = try #require(
+      PillCatalog.entry(for: .advisory(reason: .zeroSignal), id: PresentationID()).definition)
+    let hinted = try #require(
+      PillCatalog.entry(for: .advisory(reason: .zeroSignal, hint: Self.hint), id: PresentationID())
+        .definition)
+    guard case .notice(let plainNotice) = plain.content,
+      case .notice(let hintedNotice) = hinted.content
+    else {
+      Issue.record("the advisory is no longer a notice")
+      return
+    }
+    #expect(hintedNotice.text == Self.hinted)
+    #expect(plainNotice.text == DictationNarrator.copy(for: TerminalAdvisoryReason.zeroSignal))
+    #expect(hinted.requestedWidth == plain.requestedWidth)
+    #expect(hinted.expiry == plain.expiry)
+  }
+
+  @Test("VoiceOver reads the sentence the pill shows, with no Error prefix")
+  func announcementMatchesPill() throws {
+    let spoken = try #require(
+      PillCatalog.announcement(for: .advisory(reason: .zeroSignal, hint: Self.hint)))
+    #expect(spoken == .high(Self.hinted))
+    // Two-way control: the plain request still speaks the locked sentence.
+    let plain = try #require(PillCatalog.announcement(for: .advisory(reason: .zeroSignal)))
+    #expect(plain == .high(DictationNarrator.copy(for: TerminalAdvisoryReason.zeroSignal)))
+  }
+
+  @Test("the intent conversion DROPS the hint and the reverse conversion supplies none, by design")
+  func intentConversionsAreHintFree() {
+    let request = PillCatalogRequest.advisory(reason: .vadGateNoSpeech, hint: Self.hint)
+    #expect(request.matchingIntent == .advisory(reason: .vadGateNoSpeech))
+    let back = PillCatalogRequest(nonRecording: .advisory(reason: .vadGateNoSpeech))
+    #expect(back == .advisory(reason: .vadGateNoSpeech, hint: nil))
+    #expect(back != request, "a hint cannot survive a trip through OverlayIntent")
+  }
+
+  @Test("the reducer's advisory event presents the hinted sentence through the pipeline arm")
+  func reducerPresentsHintedSentence() throws {
+    var reducer = OverlayReducer()
+    let plan = reducer.reduce(.advisory(reason: .zeroSignal, hint: Self.hint))
+    let presentation = try #require(plan.presentation)
+    guard case .notice(let notice) = presentation.content else {
+      Issue.record("the advisory is no longer a notice")
+      return
+    }
+    #expect(notice.text == Self.hinted)
+    #expect(plan.didChange)
+    // VoiceOver hears the device name too: the announcement comes from the
+    // hinted request, not from the reason-only intent.
+    #expect(plan.announcement == .high(Self.hinted))
+    // It occupies the slot as a PIPELINE advisory: a repeated plain advisory for
+    // the same reason is the dedup'd no-op the pipeline arm has always produced.
+    let repeat_ = reducer.reduce(.pipeline(.advisory(reason: .zeroSignal)))
+    #expect(repeat_.presentation == nil)
+    #expect(repeat_.didChange == false)
+    #expect(repeat_.announcement == nil)
+  }
+
+  @Test("a director resolves the hint at admission from its composition-root closure")
+  func directorResolvesHintAtAdmission() throws {
+    let (director, host) = OverlayTestDouble.headlessDirectorWithHost(
+      advisoryHint: { reason in reason == .zeroSignal ? Self.hint : nil })
+    director.present(.advisory(reason: .zeroSignal))
+    let shown = try #require(director.renderModel.state.presentation)
+    guard case .notice(let notice) = shown.content else {
+      Issue.record("the advisory is no longer a notice")
+      return
+    }
+    #expect(notice.text == Self.hinted)
+    _ = host
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/LanguageChipExpiryOwnershipTests.swift
@@ -70,7 +70,8 @@ struct LanguageChipExpiryOwnershipTests {
       scheduler: .manual { armed.work = $0 },
       announce: { _ in },
       livePreview: .disabled,
-      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, advisoryHint: { _ in nil },
+      selections: { .shipped },
       firstRenderSchedule: { $0() })
 
     d.present(

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTestSupport.swift
@@ -1,4 +1,5 @@
 import EnviousWisprAppKitTestSupport
+import EnviousWisprCore
 import Foundation
 import Testing
 
@@ -36,18 +37,27 @@ enum OverlayTestDouble {
       // Announcements go nowhere: a test that has not asked for a screen has not
       // asked for VoiceOver either, and the real post reaches the system.
       announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
-      openMicrophoneSettings: {}, selections: { .shipped },
+      openMicrophoneSettings: {}, advisoryHint: { _ in nil }, selections: { .shipped },
       firstRenderSchedule: { $0() })
   }
 
   /// The same director, with its fake host in hand for a test that needs to
   /// assert on what the host was ASKED for.
-  static func headlessDirectorWithHost() -> (OverlayDirector, WindowlessOverlayHost) {
+  ///
+  /// `advisoryHint` defaults to "no device known", the composition root's answer
+  /// for a one-input microphone; a #2664 test hands in a resolver to prove the
+  /// director asks it at admission.
+  static func headlessDirectorWithHost(
+    advisoryHint: @escaping @MainActor (TerminalAdvisoryReason) -> MultiInputAdvisoryHint? = {
+      _ in nil
+    }
+  ) -> (OverlayDirector, WindowlessOverlayHost) {
     let host = WindowlessOverlayHost()
     return (
       OverlayDirector(
         host: host, announce: { _ in },
         livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+        advisoryHint: advisoryHint,
         selections: { .shipped }, firstRenderSchedule: { $0() }),
       host
     )

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayDirectorTests.swift
@@ -117,6 +117,7 @@ struct OverlayDirectorTests {
         display: { preview.display() }),
       grantAccessibility: { sink.appActions.append(.grantAccessibility) },
       openMicrophoneSettings: { sink.appActions.append(.openMicrophoneSettings) },
+      advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     return (d, host, sink)
@@ -189,7 +190,8 @@ struct OverlayDirectorTests {
       scheduler: .manual { _ in },
       announce: { _ in },
       livePreview: .disabled,
-      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, advisoryHint: { _ in nil },
+      selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
   }
 
@@ -285,6 +287,7 @@ struct OverlayDirectorTests {
         display: { preview.display() }),
       grantAccessibility: { sink.appActions.append(.grantAccessibility) },
       openMicrophoneSettings: { sink.appActions.append(.openMicrophoneSettings) },
+      advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     hosts.append(host)
@@ -316,7 +319,8 @@ struct OverlayDirectorTests {
       scheduler: .manual { armed.work = $0 },
       announce: { _ in },
       livePreview: .disabled,
-      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, advisoryHint: { _ in nil },
+      selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
 
     d.present(.warning(reason: .polishFailed))
@@ -957,7 +961,8 @@ struct OverlayDirectorTests {
         isEnabledForGeometry: { recordingStarted },
         wordsCapability: { recordingStarted ? .available : .previewOff },
         display: { .off }),
-      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, advisoryHint: { _ in nil },
+      selections: { .shipped },
       firstRenderSchedule: { $0() })
     Self.hosts.append(host)
     defer { Self.closeAllWindows() }
@@ -1429,7 +1434,8 @@ struct OverlayDirectorTests {
     let deferral = Deferral()
     let d = OverlayDirector(
       host: host, scheduler: .manual { _ in }, announce: { _ in }, livePreview: .disabled,
-      grantAccessibility: {}, openMicrophoneSettings: {}, selections: { .shipped },
+      grantAccessibility: {}, openMicrophoneSettings: {}, advisoryHint: { _ in nil },
+      selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
     defer { recorder.panel?.orderOut() }
 
@@ -1460,6 +1466,7 @@ struct OverlayDirectorTests {
     let d = OverlayDirector(
       host: host, scheduler: .manual { _ in }, announce: { announcements.append($0) },
       livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
 
@@ -1489,6 +1496,7 @@ struct OverlayDirectorTests {
     let d = OverlayDirector(
       host: host, scheduler: .manual { _ in }, announce: { _ in },
       livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { deferral.block = $0 })
 
@@ -1697,6 +1705,7 @@ struct OverlayDirectorTests {
     let d = OverlayDirector(
       host: host, announce: { _ in },
       livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: { .shipped })
 
     d.present(.warning(reason: .polishFailed))
@@ -1724,6 +1733,7 @@ struct OverlayDirectorTests {
     let d = OverlayDirector(
       host: host, announce: { _ in },
       livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: { .shipped })
 
     // First request, deferred. A second replaces it before the run loop turns,
@@ -1749,6 +1759,7 @@ struct OverlayDirectorTests {
     let d = OverlayDirector(
       host: host, announce: { _ in },
       livePreview: .disabled, grantAccessibility: {}, openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: { .shipped })
     d.present(.warning(reason: .polishFailed))
     await withCheckedContinuation { c in DispatchQueue.main.async { c.resume() } }
@@ -1929,6 +1940,7 @@ struct OverlayDirectorTests {
       livePreview: .disabled,
       grantAccessibility: { sink.appActions.append(.grantAccessibility) },
       openMicrophoneSettings: { sink.appActions.append(.openMicrophoneSettings) },
+      advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     hosts.append(host)

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingContractTests.swift
@@ -50,7 +50,7 @@ struct OverlayHostingContractTests {
     let host = WindowlessOverlayHost()
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
-      openMicrophoneSettings: {},
+      openMicrophoneSettings: {}, advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
 

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayHostingParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayHostingParityTests.swift
@@ -50,7 +50,7 @@ struct OverlayHostingParityTests {
   private static func director(on host: any OverlayWindowHosting) -> OverlayDirector {
     OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
-      openMicrophoneSettings: {},
+      openMicrophoneSettings: {}, advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
   }

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayRetainedWindowTests.swift
@@ -233,7 +233,7 @@ struct OverlayRetainedWindowBehaviourTests {
     let host = OverlayWindowHost(effects: recorder.makeEffects())
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
-      openMicrophoneSettings: {},
+      openMicrophoneSettings: {}, advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     defer { recorder.panel?.orderOut() }
@@ -265,7 +265,7 @@ struct OverlayRetainedWindowBehaviourTests {
     let host = OverlayWindowHost(effects: recorder.makeEffects())
     let d = OverlayDirector(
       host: host, announce: { _ in }, livePreview: .disabled, grantAccessibility: {},
-      openMicrophoneSettings: {},
+      openMicrophoneSettings: {}, advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
     defer { recorder.panel?.orderOut() }

--- a/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/PillRequestParityTests.swift
@@ -93,6 +93,7 @@ struct PillRequestParityTests {
           appActions.append(.openMicrophoneSettings)
           openMicrophoneSettingsSawPresentation = director.renderModel.state.presentation != nil
         },
+        advisoryHint: { _ in nil },
         selections: { .shipped },
         firstRenderSchedule: { $0() })
     }

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingDirectorCaptureTests.swift
@@ -65,6 +65,7 @@ struct RecordingDirectorCaptureTests {
         }),
       grantAccessibility: {},
       openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: {
         counts.selections += 1
         return selections
@@ -327,6 +328,7 @@ struct RecordingDirectorCaptureTests {
         display: { .off }),
       grantAccessibility: {},
       openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: { .shipped },
       firstRenderSchedule: { $0() })
 

--- a/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RecordingReconciliationTests.swift
@@ -78,6 +78,7 @@ struct RecordingReconciliationTests {
         display: { .off }),
       grantAccessibility: {},
       openMicrophoneSettings: {},
+      advisoryHint: { _ in nil },
       selections: selections,
       firstRenderSchedule: { $0() },
       scheduleReconciliation: { queue.schedule($0) })

--- a/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/RenderedPillFreezeTests.swift
@@ -58,6 +58,13 @@ struct RenderedPillFreezeTests {
       // unwrapped line — which is the reading two earlier capture rounds took
       // and the reason the harness proposes a width at all.
       ("advisory.zeroSignal", .advisory(reason: .zeroSignal), 360, 68),
+      // #2664: the hinted variant names the device; one line shorter than the
+      // seventh sentence, same requested width. Measured 2026-09-05.
+      (
+        "advisory.zeroSignal.hinted",
+        .advisory(reason: .zeroSignal, hint: MultiInputAdvisoryHint(deviceName: "Scarlett 2i2 USB")),
+        360, 52
+      ),
       ("interruption.deviceRemoved", .interruption(reason: .deviceRemoved), 225.5, 44),
       ("cachingModel", .cachingModel(engineLabel: "Parakeet"), 259.5, 51),
       ("engineReady", .engineReady, 213, 40),

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureInterfaceZeroSignalDefaultsTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureInterfaceZeroSignalDefaultsTests.swift
@@ -164,6 +164,7 @@ private final class DefaultsOnlyAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "defaults_only_stub"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   func startEnginePhase() async throws {}

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerRetireFenceTests.swift
@@ -60,7 +60,7 @@ import Testing
       /// could have derived from settings.
       var boundToReturn = BoundInputDevice(
         deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       /// #1714: the undefaulted protocol witness. This suite is about retire
       /// behaviour and never fires it; declaring it explicitly is exactly what
       /// the undefaulted requirement is for.

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
@@ -78,7 +78,6 @@ import Testing
       ).terminationReason
     }
 
-
     /// Barrier on a writer's serial write queue. `finalize` is idempotent and
     /// ALWAYS invokes `completion` — including on the already-finalized path — so
     /// this cannot hang; it simply queues behind whatever the manager already
@@ -204,7 +203,8 @@ import Testing
       await Self.drain(writer)
 
       let recovered = try RecoverySpoolStore(directory: dir).recover(
-        recoverySessionID: "tail", cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key()))
+        recoverySessionID: "tail",
+        cipher: RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key()))
       #expect(recovered.terminationReason == .interrupted, "marked superseded, not clean")
       #expect(
         recovered.samples == [0.5, -0.5, 0.25, -0.25],
@@ -332,7 +332,7 @@ import Testing
     var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
     var boundToReturn = BoundInputDevice(
       deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub",
-      resolutionSource: "system_default")
+      resolutionSource: "system_default", inputChannel: 0)
     func prepare() async throws -> BoundInputDevice { boundToReturn }
     func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
       AsyncStream { $0.finish() }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerStopFenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerStopFenceTests.swift
@@ -62,7 +62,7 @@ import Testing
       var onInputResolutionAttemptFinalized: ((FinalizedInputResolutionAttempt) -> Void)?
       var boundToReturn = BoundInputDevice(
         deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       private(set) var prepareCallCount = 0
 
       func prepare() async throws -> BoundInputDevice {

--- a/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioInputSourceConformanceFreezeTests.swift
@@ -115,7 +115,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
   ) -> BoundInputDevice {
     BoundInputDevice(
       deviceID: deviceID, deviceUID: "uid-\(deviceID)", transportLabel: "built_in",
-      resolutionSource: source)
+      resolutionSource: source, inputChannel: 0)
   }
 
   @Test("warm automatic source is reusable while bound to current system default")
@@ -123,7 +123,10 @@ struct HALDeviceInputSourceDeviceTargetTests {
     let source = HALDeviceInputSource()
     source.inputDeviceResolver = InputDeviceResolver(
       defaultInputDeviceID: { 42 },
-      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .complete([]) }
+      inputDeviceSnapshot: {
+        Issue.record("Auto must not enumerate")
+        return .complete([])
+      }
     )
     source.setBoundInputDeviceForTesting(committedBind(42))
 
@@ -136,7 +139,10 @@ struct HALDeviceInputSourceDeviceTargetTests {
     nonisolated(unsafe) var currentDefault: AudioDeviceID = 42
     source.inputDeviceResolver = InputDeviceResolver(
       defaultInputDeviceID: { currentDefault },
-      inputDeviceSnapshot: { Issue.record("Auto must not enumerate"); return .complete([]) }
+      inputDeviceSnapshot: {
+        Issue.record("Auto must not enumerate")
+        return .complete([])
+      }
     )
     source.setBoundInputDeviceForTesting(committedBind(42))
 
@@ -179,7 +185,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
       deviceID: 121,
       deviceUID: "BC-87-FA-9C-7E-71:input",
       transportLabel: "bluetooth",
-      resolutionSource: "system_default"
+      resolutionSource: "system_default", inputChannel: 0
     )
     source.setBoundInputDeviceForTesting(committed)
 
@@ -198,7 +204,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
     source.setBoundInputDeviceForTesting(
       BoundInputDevice(
         deviceID: 121, deviceUID: "BC-87-FA-9C-7E-71:input", transportLabel: "bluetooth",
-        resolutionSource: "system_default"))
+        resolutionSource: "system_default", inputChannel: 0))
 
     #expect(source.warmReuseBindForTesting(hasLiveUnit: false) == nil)
   }
@@ -217,7 +223,7 @@ struct HALDeviceInputSourceDeviceTargetTests {
       deviceID: 121,
       deviceUID: "BC-87-FA-9C-7E-71:input",
       transportLabel: "bluetooth",
-      resolutionSource: "system_default"
+      resolutionSource: "system_default", inputChannel: 0
     )
     source.setBoundInputDeviceForTesting(committed)
     #expect(source.warmReuseBindForTesting(hasLiveUnit: true) == committed)
@@ -336,7 +342,7 @@ struct HALInputResolutionFinalizationTests {
     source.setBoundInputDeviceForTesting(
       BoundInputDevice(
         deviceID: 121, deviceUID: "uid-121", transportLabel: "bluetooth",
-        resolutionSource: "list_fallback"))
+        resolutionSource: "list_fallback", inputChannel: 0))
 
     nonisolated(unsafe) var finalised: [FinalizedInputResolutionAttempt] = []
     source.onInputResolutionAttemptFinalized = { finalised.append($0) }

--- a/Tests/EnviousWisprTests/Audio/BoundDeviceAdoptionTests.swift
+++ b/Tests/EnviousWisprTests/Audio/BoundDeviceAdoptionTests.swift
@@ -60,7 +60,7 @@ import Testing
       /// model a retry that lands on a different device.
       var boundToReturn = BoundInputDevice(
         deviceID: 99, deviceUID: "stub-uid-99", transportLabel: "usb",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       /// When set, `prepare()` throws this instead of returning a bind.
       var prepareError: Error?
       private(set) var prepareCallCount = 0
@@ -118,7 +118,7 @@ import Testing
       let stub = StubSource()
       stub.boundToReturn = BoundInputDevice(
         deviceID: 99, deviceUID: "stub-uid-99", transportLabel: "usb",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       let manager = Self.makeManager(stub)
 
       try await manager.startEnginePhase()
@@ -136,7 +136,7 @@ import Testing
       let stub = StubSource()
       stub.boundToReturn = BoundInputDevice(
         deviceID: 7, deviceUID: "actually-bound-uid", transportLabel: "built_in",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       let manager = Self.makeManager(
         stub, rememberedSelection: "remembered-but-never-opened-uid")
 
@@ -172,7 +172,7 @@ import Testing
       let stub = StubSource()
       stub.boundToReturn = BoundInputDevice(
         deviceID: 99, deviceUID: "first-attempt-uid", transportLabel: "usb",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       let manager = Self.makeManager(stub)
 
       try await manager.startEnginePhase()
@@ -182,7 +182,7 @@ import Testing
       manager.rebuildEngine()
       stub.boundToReturn = BoundInputDevice(
         deviceID: 42, deviceUID: "final-attempt-uid", transportLabel: "built_in",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       try await manager.startEnginePhase()
 
       #expect(manager.zeroSignalDiscriminatorDevice == stub.boundToReturn)
@@ -237,7 +237,7 @@ import Testing
       stub.finalizedAttemptToFire = nil
       stub.boundToReturn = BoundInputDevice(
         deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
-        resolutionSource: "list_fallback")
+        resolutionSource: "list_fallback", inputChannel: 0)
       let manager = Self.makeManager(stub)
 
       try await manager.startEnginePhase()
@@ -254,7 +254,7 @@ import Testing
       stub.finalizedAttemptToFire = Self.finalizedAttempt(.systemDefault)
       stub.boundToReturn = BoundInputDevice(
         deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
-        resolutionSource: "list_fallback")
+        resolutionSource: "list_fallback", inputChannel: 0)
       let manager = Self.makeManager(stub)
 
       try await manager.startEnginePhase()
@@ -268,7 +268,7 @@ import Testing
       // First attempt succeeds on the system default.
       stub.boundToReturn = BoundInputDevice(
         deviceID: 42, deviceUID: "default-uid", transportLabel: "built_in",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       let manager = Self.makeManager(stub)
       try await manager.startEnginePhase()
       #expect(manager.currentInputResolutionSource == "system_default")
@@ -291,7 +291,7 @@ import Testing
       let stub = StubSource()
       stub.boundToReturn = BoundInputDevice(
         deviceID: 42, deviceUID: "default-uid", transportLabel: "built_in",
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
       let manager = Self.makeManager(stub)
       try await manager.startEnginePhase()
       #expect(manager.currentInputResolutionSource == "system_default")
@@ -312,7 +312,7 @@ import Testing
       stub.finalizedAttemptToFire = Self.finalizedAttempt(.listFallback)
       stub.boundToReturn = BoundInputDevice(
         deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
-        resolutionSource: "list_fallback")
+        resolutionSource: "list_fallback", inputChannel: 0)
       let manager = Self.makeManager(stub)
 
       try await manager.preWarm()
@@ -344,7 +344,7 @@ import Testing
       stub.finalizedAttemptToFire = Self.finalizedAttempt(.listFallback)
       stub.boundToReturn = BoundInputDevice(
         deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
-        resolutionSource: "list_fallback")
+        resolutionSource: "list_fallback", inputChannel: 0)
       let manager = Self.makeManager(stub)
 
       var forwarded: [InputResolutionAttemptTelemetry] = []
@@ -365,7 +365,7 @@ import Testing
       stub.finalizedAttemptToFire = nil
       stub.boundToReturn = BoundInputDevice(
         deviceID: 30, deviceUID: "fallback-uid", transportLabel: "built_in",
-        resolutionSource: "list_fallback")
+        resolutionSource: "list_fallback", inputChannel: 0)
       let manager = Self.makeManager(stub)
 
       var forwarded: [InputResolutionAttemptTelemetry] = []

--- a/Tests/EnviousWisprTests/Audio/DebugInputFallbackArmingTests.swift
+++ b/Tests/EnviousWisprTests/Audio/DebugInputFallbackArmingTests.swift
@@ -55,7 +55,7 @@ import Testing
       func prepare() async throws -> BoundInputDevice {
         BoundInputDevice(
           deviceID: 1, deviceUID: "stub", transportLabel: "built_in",
-          resolutionSource: "system_default")
+          resolutionSource: "system_default", inputChannel: 0)
       }
       func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
         AsyncStream { $0.finish() }

--- a/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
+++ b/Tests/EnviousWisprTests/Audio/HALFormatStabilizationTests.swift
@@ -169,6 +169,24 @@ struct CaptureStopMetadataTransportTests {
     #expect(decoded.nativeChannelCount == 4)
   }
 
+  @Test("#2664: the applied input channel survives the round trip and is absent-means-nil")
+  func inputChannelRoundTripAndAbsence() throws {
+    let original = CaptureStopMetadata(
+      nativeRateHz: 48000, rateDivergenceDetected: false, nativeChannelCount: 2, inputChannel: 1)
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(CaptureStopMetadata.self, from: data)
+    #expect(decoded == original)
+    #expect(decoded.inputChannel == 1)
+    // A blob from a build before #2664: no `inputChannel` key. Nil, never 0 — nil
+    // means "not measured", 0 means "the default channel was measured".
+    let preFieldJSON = """
+      {"nativeRateHz":48000,"rateDivergenceDetected":false,"nativeChannelCount":2}
+      """
+    let older = try JSONDecoder().decode(CaptureStopMetadata.self, from: Data(preFieldJSON.utf8))
+    #expect(older.inputChannel == nil)
+    #expect(older.nativeChannelCount == 2)
+  }
+
   @Test("#1523: a pre-field JSON blob (no channel key) decodes to a nil count")
   func preFieldBlobDecodesToNilChannelCount() throws {
     // A stop-reply blob encoded before #1523 shipped — no `nativeChannelCount`
@@ -243,6 +261,7 @@ struct CaptureStopMetadataGapTests {
           "lostChunkCount",
           "rateDivergenceDetected",
           "nativeChannelCount",
+          "inputChannel",
         ]))
     #expect(!fields.contains("drainedPreRollSampleCount"))
   }

--- a/Tests/EnviousWisprTests/Audio/InputChannelPreferenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputChannelPreferenceTests.swift
@@ -1,0 +1,58 @@
+import Testing
+
+@testable import EnviousWisprAudio
+
+// #2664: the ONE authority for which device input channel the mono capture
+// takes. When this fails, the user sees either their chosen socket NOT being
+// the one recorded (silence from a microphone that works everywhere else), or a
+// stale choice for a device that shrank breaking a microphone that used to work.
+@Suite("InputChannelPreference — #2664", .tags(.productOutcome))
+struct InputChannelPreferenceTests {
+
+  @Test("no preference means channel 0, today's behaviour for every device")
+  func absentPreferenceIsChannelZero() {
+    #expect(InputChannelPreference.effectiveChannel(requested: nil, availableChannels: 2) == 0)
+    #expect(InputChannelPreference.effectiveChannel(requested: nil, availableChannels: nil) == 0)
+  }
+
+  @Test("Input 1 (stored as 0) is channel 0 whatever the device exposes")
+  func explicitZeroIsChannelZero() {
+    #expect(InputChannelPreference.effectiveChannel(requested: 0, availableChannels: 2) == 0)
+    #expect(InputChannelPreference.effectiveChannel(requested: 0, availableChannels: 1) == 0)
+  }
+
+  @Test("a socket the device has is taken as asked")
+  func inRangeChoiceIsHonoured() {
+    // Scarlett 2i2: Input 2 is device channel 1.
+    #expect(InputChannelPreference.effectiveChannel(requested: 1, availableChannels: 2) == 1)
+    // A six-input interface, last socket.
+    #expect(InputChannelPreference.effectiveChannel(requested: 5, availableChannels: 6) == 5)
+  }
+
+  @Test("a socket the device does not have falls back to channel 0, never traps or throws")
+  func outOfRangeFallsToZero() {
+    // Saved for a 2-input box, now plugged into a 1-input microphone with the same UID class.
+    #expect(InputChannelPreference.effectiveChannel(requested: 1, availableChannels: 1) == 0)
+    // Index == count is one past the last socket.
+    #expect(InputChannelPreference.effectiveChannel(requested: 2, availableChannels: 2) == 0)
+    // Channel count unreadable: fail closed to today's behaviour.
+    #expect(InputChannelPreference.effectiveChannel(requested: 1, availableChannels: nil) == 0)
+    // A read that collapsed to 0 channels.
+    #expect(InputChannelPreference.effectiveChannel(requested: 1, availableChannels: 0) == 0)
+    // A corrupt negative index.
+    #expect(InputChannelPreference.effectiveChannel(requested: -1, availableChannels: 2) == 0)
+  }
+
+  @Test("Auto flipping between a 1-input and a 2-input device applies each device's OWN value")
+  func perDeviceValuesAreIndependent() {
+    // The preference is keyed by device UID; the built-in microphone has no entry
+    // and the interface has Input 2 chosen. Each resolves on its own count.
+    let preference = ["scarlett-2i2-uid": 1]
+    #expect(
+      InputChannelPreference.effectiveChannel(
+        requested: preference["builtin-mic-uid"], availableChannels: 1) == 0)
+    #expect(
+      InputChannelPreference.effectiveChannel(
+        requested: preference["scarlett-2i2-uid"], availableChannels: 2) == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/Audio/InputChannelPreferenceTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputChannelPreferenceTests.swift
@@ -43,6 +43,17 @@ struct InputChannelPreferenceTests {
     #expect(InputChannelPreference.effectiveChannel(requested: -1, availableChannels: 2) == 0)
   }
 
+  @Test("a device with no readable UID has NO saved choice, so two such devices never share one")
+  func unreadableUIDHasNoChoice() {
+    // `AudioDeviceEnumerator` substitutes "" for a UID it could not read; a map
+    // entry under "" (however it got there) must never reach a capture.
+    let preference = ["": 1, "real-uid": 1]
+    #expect(InputChannelPreference.requested(for: "", in: preference) == nil)
+    #expect(InputChannelPreference.requested(for: nil, in: preference) == nil)
+    #expect(InputChannelPreference.requested(for: "real-uid", in: preference) == 1)
+    #expect(InputChannelPreference.requested(for: "unknown-uid", in: preference) == nil)
+  }
+
   @Test("Auto flipping between a 1-input and a 2-input device applies each device's OWN value")
   func perDeviceValuesAreIndependent() {
     // The preference is keyed by device UID; the built-in microphone has no entry

--- a/Tests/EnviousWisprTests/Audio/InputChannelReuseTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputChannelReuseTests.swift
@@ -1,0 +1,148 @@
+import CoreAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprAudio
+
+// Drives `AudioCaptureManager`'s `#if DEBUG` seams, so the whole suite is
+// DEBUG-only (`swift-testing-debug-seam-needs-if-debug`).
+#if DEBUG
+
+  // #2664: changing the socket must reach the NEXT recording. The capture unit
+  // stays warm for up to 30 s between takes and `resolveSource()` reuses it when
+  // the route is unchanged, so without a channel conjunct in that decision a user
+  // who picks Input 2 after a silent take would dictate again into the SAME unit
+  // still wired to Input 1 — and see the same silence, now with the fix applied.
+  //
+  // These cases drive the REAL `resolveSource()` against a real
+  // `HALDeviceInputSource` carrying a committed bind, with every hardware read
+  // injected: the route resolver's output-device reads, the input resolver's
+  // default-device read, and the unit's own liveness. Source type, target UID and
+  // device compatibility are held CONSTANT across every arm; only the manager's
+  // channel preference changes. When this fails, the user sees a socket change
+  // do nothing until the warm engine times out.
+  @MainActor
+  @Suite("AudioCaptureManager warm reuse honours the socket choice — #2664", .tags(.productOutcome))
+  struct InputChannelReuseTests {
+
+    private static let boundDeviceID: AudioDeviceID = 42
+    private static let boundUID = "scarlett-2i2-uid"
+
+    /// A warm HAL source bound to a two-input device on `channel`, Auto-selected
+    /// (`targetDeviceUID` nil), whose device predicate answers "still the default"
+    /// through an injected resolver. No `AudioUnit` exists; liveness is forced.
+    private static func warmSource(channel: Int, deviceID: AudioDeviceID = boundDeviceID)
+      -> HALDeviceInputSource
+    {
+      let source = HALDeviceInputSource()
+      source.targetDeviceUID = nil
+      source.inputDeviceResolver = InputDeviceResolver(
+        defaultInputDeviceID: { deviceID },
+        inputDeviceSnapshot: { .success(candidates: [], complete: true) },
+        transportForDevice: { _ in nil })
+      source.setBoundInputDeviceForTesting(
+        BoundInputDevice(
+          deviceID: deviceID, deviceUID: boundUID, transportLabel: "usb",
+          resolutionSource: "system_default", inputChannel: channel),
+        nativeChannelCount: 2)
+      source.isRunningOverrideForTesting = true
+      return source
+    }
+
+    /// A manager on Auto with `warm` installed as its live source and both
+    /// output-route reads injected, so `resolveSource()` runs with no hardware.
+    private static func makeManager(warm: HALDeviceInputSource, preference: [String: Int])
+      -> AudioCaptureManager
+    {
+      let manager = AudioCaptureManager()
+      manager.preferredInputDeviceIDOverride = ""
+      manager.installRouteResolverForTesting(
+        CaptureRouteResolver(
+          defaultOutputDeviceID: { nil }, isBluetoothOutputDevice: { _ in false }))
+      manager.installCapturedSourceForTesting(warm, sessionID: 1)
+      manager.inputChannelByDeviceUID = preference
+      return manager
+    }
+
+    // MARK: - The two arms the plan names
+
+    @Test("unchanged preference: the warm unit on Input 2 is REUSED")
+    func unchangedPreferenceReuses() {
+      let warm = Self.warmSource(channel: 1)
+      let manager = Self.makeManager(warm: warm, preference: [Self.boundUID: 1])
+
+      let resolved = manager.resolveSourceForTesting()
+
+      #expect(resolved === warm, "an unchanged socket must not force a rebuild")
+    }
+
+    @Test(
+      "changed preference: the warm unit on Input 2 is REBUILT when the user goes back to Input 1")
+    func changedPreferenceRebuilds() {
+      let warm = Self.warmSource(channel: 1)
+      // The user cleared the choice (or picked Input 1): the map no longer names
+      // this device, so the effective channel is 0 and the warm unit is on 1.
+      let manager = Self.makeManager(warm: warm, preference: [:])
+
+      let resolved = manager.resolveSourceForTesting()
+
+      #expect(resolved !== warm, "a changed socket must tear the warm unit down")
+      // The replacement is a fresh production HAL source carrying the manager's
+      // CURRENT map, so its cold prepare reads the new choice — not the copy the
+      // torn-down source prepared on.
+      let rebuilt = resolved as? HALDeviceInputSource
+      #expect(rebuilt != nil, "the rebuilt source is the production HAL type")
+      #expect(rebuilt?.inputChannelByDeviceUID == [:])
+    }
+
+    @Test(
+      "changed preference the other way: a warm unit on Input 1 is rebuilt when Input 2 is chosen")
+    func choosingInputTwoRebuildsAChannelZeroUnit() {
+      // This is the customer's exact path: silent take on the default, pick
+      // Input 2 in Settings, dictate again inside the warm window.
+      let warm = Self.warmSource(channel: 0)
+      let manager = Self.makeManager(warm: warm, preference: [Self.boundUID: 1])
+
+      let resolved = manager.resolveSourceForTesting()
+
+      #expect(resolved !== warm)
+      #expect((resolved as? HALDeviceInputSource)?.inputChannelByDeviceUID == [Self.boundUID: 1])
+    }
+
+    // MARK: - Held constant: everything that is NOT the channel
+
+    @Test("a preference for a DIFFERENT device leaves the warm unit alone")
+    func otherDevicePreferenceIsIrrelevant() {
+      let warm = Self.warmSource(channel: 0)
+      let manager = Self.makeManager(warm: warm, preference: ["some-other-interface": 1])
+
+      #expect(manager.resolveSourceForTesting() === warm)
+    }
+
+    @Test("a preference the bound device cannot honour compares equal to its channel-0 bind")
+    func unusablePreferenceDoesNotForceAPointlessRebuild() {
+      // Input 6 chosen for a two-input box: cold prepare would land on channel 0
+      // again, so rebuilding every take would only cost the warm engine.
+      let warm = Self.warmSource(channel: 0)
+      let manager = Self.makeManager(warm: warm, preference: [Self.boundUID: 5])
+
+      #expect(manager.resolveSourceForTesting() === warm)
+    }
+
+    // MARK: - The predicate itself, keyed by UID
+
+    @Test("same UID, new device ID keeps the choice (a replug recycles the numeric handle)")
+    func sameUIDNewDeviceIDKeepsTheChoice() {
+      let source = Self.warmSource(channel: 1, deviceID: 7)
+      #expect(source.boundInputChannelMatches(preference: [Self.boundUID: 1]))
+      #expect(source.boundInputChannelMatches(preference: [:]) == false)
+    }
+
+    @Test("no committed bind answers false, like the device predicate beside it")
+    func noBindIsNotAMatch() {
+      let source = HALDeviceInputSource()
+      #expect(source.boundInputChannelMatches(preference: [:]) == false)
+    }
+  }
+
+#endif

--- a/Tests/EnviousWisprTests/Audio/InputChannelReuseTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputChannelReuseTests.swift
@@ -138,6 +138,19 @@ import Testing
       #expect(source.boundInputChannelMatches(preference: [:]) == false)
     }
 
+    @Test("a bind whose UID could not be read ignores a choice saved under the empty key")
+    func emptyUIDIgnoresEmptyKey() {
+      let source = HALDeviceInputSource()
+      source.setBoundInputDeviceForTesting(
+        BoundInputDevice(
+          deviceID: 9, deviceUID: "", transportLabel: "usb",
+          resolutionSource: "system_default", inputChannel: 0),
+        nativeChannelCount: 2)
+      // No choice applies, so the channel-0 unit matches and is not rebuilt in
+      // pursuit of a choice that belongs to no device.
+      #expect(source.boundInputChannelMatches(preference: ["": 1]))
+    }
+
     @Test("no committed bind answers false, like the device predicate beside it")
     func noBindIsNotAMatch() {
       let source = HALDeviceInputSource()

--- a/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
+++ b/Tests/EnviousWisprTests/Audio/InputDeviceResolverTests.swift
@@ -689,7 +689,7 @@ struct InputDeviceResolverTests {
   private func bind(_ id: AudioDeviceID, _ source: InputResolutionSource) -> BoundInputDevice {
     BoundInputDevice(
       deviceID: id, deviceUID: "uid-\(id)", transportLabel: "built_in",
-      resolutionSource: source.rawValue)
+      resolutionSource: source.rawValue, inputChannel: 0)
   }
 
   /// `defaultTransport` is injected here for the same reason as the cold helper:

--- a/Tests/EnviousWisprTests/Audio/PreRollCeilingTests.swift
+++ b/Tests/EnviousWisprTests/Audio/PreRollCeilingTests.swift
@@ -50,7 +50,7 @@ import Testing
       func prepare() async throws -> BoundInputDevice {
         BoundInputDevice(
           deviceID: 1, deviceUID: "stub-uid", transportLabel: "stub",
-          resolutionSource: "system_default")
+          resolutionSource: "system_default", inputChannel: 0)
       }
       func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer> {
         AsyncStream { $0.finish() }

--- a/Tests/EnviousWisprTests/Audio/ZeroSignalDeviceIdentityTests.swift
+++ b/Tests/EnviousWisprTests/Audio/ZeroSignalDeviceIdentityTests.swift
@@ -26,7 +26,7 @@ struct ZeroSignalDeviceIdentityTests {
     deviceID: 121,
     deviceUID: "BC-87-FA-9C-7E-71:input",
     transportLabel: "bluetooth",
-    resolutionSource: "system_default"
+    resolutionSource: "system_default", inputChannel: 0
   )
 
   /// Counts hardware classifications so a test can prove a guard short-circuited
@@ -130,7 +130,7 @@ struct ZeroSignalDeviceIdentityTests {
     let counter = ReadCounter()
     let bindWithoutUID = BoundInputDevice(
       deviceID: 121, deviceUID: nil, transportLabel: "bluetooth",
-      resolutionSource: "system_default")
+      resolutionSource: "system_default", inputChannel: 0)
 
     let eligible = Self.evaluate(bound: bindWithoutUID, counter: counter)
 
@@ -254,7 +254,7 @@ struct ZeroSignalDeviceIdentityTests {
   func booleanWrapperMatchesClassificationForEveryOutcome() {
     let bindWithoutUID = BoundInputDevice(
       deviceID: 121, deviceUID: nil, transportLabel: "bluetooth",
-      resolutionSource: "system_default")
+      resolutionSource: "system_default", inputChannel: 0)
 
     // (bind, uidNow, liveness, mute) → the outcome each row is here to cover.
     let rows: [(BoundInputDevice, String??, DeviceLiveness, DeviceMuteState)] = [

--- a/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
+++ b/Tests/EnviousWisprTests/Core/HeartPathContextsTests.swift
@@ -41,13 +41,16 @@ struct HeartPathContextsTests {
       inputDeviceUIDPreferred: nil,
       inputDeviceUIDSystemDefault: nil,
       failureMode: .noBuffers,
-      nativeChannelCount: 6
+      nativeChannelCount: 6,
+      inputChannel: 1
     )
     // The kernel merges its stabilization observations without reconstructing
     // the context from scratch, so the source-stamped channel count must survive.
     let enriched = source.enrichedWithStabilizationFlags(
       formatStabilized: true, captureRebuiltForFormat: false)
     #expect(enriched.nativeChannelCount == 6)
+    // #2664: the applied input channel rides beside it, same lifetime.
+    #expect(enriched.inputChannel == 1)
     #expect(enriched.formatStabilized == true)
     // A source that never stamps a count leaves it nil through enrichment.
     #expect(
@@ -63,6 +66,10 @@ struct HeartPathContextsTests {
       unstamped.enrichedWithStabilizationFlags(
         formatStabilized: nil, captureRebuiltForFormat: nil
       ).nativeChannelCount == nil)
+    #expect(
+      unstamped.enrichedWithStabilizationFlags(
+        formatStabilized: nil, captureRebuiltForFormat: nil
+      ).inputChannel == nil)
   }
 
   @Test("#1543: enrichedWithManagerRoute overlays session id + route, preserves source fields")
@@ -83,7 +90,8 @@ struct HeartPathContextsTests {
       failureMode: .noBuffers,
       nativeRateHz: 48_000,
       rateDivergenceDetected: true,
-      nativeChannelCount: 2
+      nativeChannelCount: 2,
+      inputChannel: 1
     )
     let enriched = halBuilt.enrichedWithManagerRoute(
       sessionID: 7,  // manager's app-lifetime id
@@ -104,6 +112,7 @@ struct HeartPathContextsTests {
     #expect(enriched.nativeRateHz == 48_000)
     #expect(enriched.rateDivergenceDetected == true)
     #expect(enriched.nativeChannelCount == 2)
+    #expect(enriched.inputChannel == 1)
     #expect(enriched.inputDeviceUIDPreferred == "BuiltInMicrophoneDevice")
     #expect(enriched.failureMode == .noBuffers)
     #expect(enriched.armedAtUptimeNs == 100)

--- a/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ASREmptyResultDiagnosticsTests.swift
@@ -66,6 +66,10 @@ struct ASREmptyResultDiagnosticsTests {
 
     diagnostics.captureNativeChannelCount = 2
     #expect(diagnostics.sentryExtra()["capture.native_channel_count"] as? Int == 2)
+    // #2664: the applied input channel rides beside the count, nil omits.
+    #expect(diagnostics.sentryExtra()["capture.input_channel"] == nil)
+    diagnostics.captureInputChannel = 1
+    #expect(diagnostics.sentryExtra()["capture.input_channel"] as? Int == 1)
   }
 
   @Test("WhisperKit diagnostics keep comparable base fields and worker subset")

--- a/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/AudioCaptureFailureExtrasTests.swift
@@ -135,6 +135,7 @@ private final class ExtrasAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "hal_device_input"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   func startEnginePhase() async throws {}

--- a/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/DictationTerminalTelemetryTests.swift
@@ -24,6 +24,8 @@ struct DictationTerminalTelemetryTests {
     /// conditioner ran, so this records absence as data rather than skipping it.
     var conditionings: [(raw: Int?, filtered: Int?, ratio: Double?, reason: String?)] = []
     var starts: [(takeID: String, backend: String)] = []
+    /// #2664. The applied input channel per terminal; nil is "not measured".
+    var inputChannels: [Int?] = []
   }
 
   private func makeSink(_ recorder: Recorder) -> KernelLifecycleTelemetrySink {
@@ -38,9 +40,10 @@ struct DictationTerminalTelemetryTests {
       },
       dictationTerminal: {
         takeID, backend, result, reason, kind, effectiveTransport, _, _, _, _, peak, _, _, _,
-        vadRaw, vadFiltered, vadRatio, vadReason, disposition in
+        inputChannel, vadRaw, vadFiltered, vadRatio, vadReason, disposition in
         recorder.terminals.append((takeID, backend, result, reason))
         recorder.attributions.append((kind, peak, effectiveTransport))
+        recorder.inputChannels.append(inputChannel)
         recorder.dispositions.append(disposition)
         recorder.conditionings.append((vadRaw, vadFiltered, vadRatio, vadReason))
       }
@@ -178,8 +181,11 @@ struct DictationTerminalTelemetryTests {
           inputDeviceKind: "built_in_mic", effectiveTransport: "builtin",
           selectedTransport: nil, inputSelectionMode: "auto",
           wholeBufferRMS: 0.0001, maxWindowRMS: 0.0002, peakAudioLevel: 0.0007,
-          durationMs: 3200, captureNativeRateHz: 48000, captureNativeChannelCount: 1)))
+          durationMs: 3200, captureNativeRateHz: 48000, captureNativeChannelCount: 1,
+          captureInputChannel: 0)))
     #expect(recorder.attributions.first?.kind == "built_in_mic")
+    // #2664: the applied channel rides the row; 0 is a measurement, not an omission.
+    #expect(recorder.inputChannels == [0])
     #expect(recorder.attributions.first?.peak == 0.0007)
     #expect(recorder.attributions.first?.transport == "builtin")
   }
@@ -208,8 +214,10 @@ struct DictationTerminalTelemetryTests {
           inputDeviceKind: nil, effectiveTransport: nil, selectedTransport: nil,
           inputSelectionMode: nil, wholeBufferRMS: nil, maxWindowRMS: nil,
           peakAudioLevel: nil, durationMs: nil, captureNativeRateHz: nil,
-          captureNativeChannelCount: nil)))
+          captureNativeChannelCount: nil, captureInputChannel: nil)))
     #expect(missing.attributions.first?.peak == nil, "a missing reading must never become 0")
+    // `[Int?]`: the row is present and carries nil, so compare the array, not `.first`.
+    #expect(missing.inputChannels == [nil], "an unmeasured channel must never become 0")
 
     let measuredZero = Recorder()
     makeSink(measuredZero).emitTerminal(
@@ -219,7 +227,8 @@ struct DictationTerminalTelemetryTests {
           inputDeviceKind: nil, effectiveTransport: nil, selectedTransport: nil,
           inputSelectionMode: nil, wholeBufferRMS: nil, maxWindowRMS: nil,
           peakAudioLevel: 0.0, durationMs: nil, captureNativeRateHz: nil,
-          captureNativeChannelCount: nil)))
+          captureNativeChannelCount: nil, captureInputChannel: 1)))
+    #expect(measuredZero.inputChannels == [1], "a chosen Input 2 (channel 1) travels")
     #expect(
       measuredZero.attributions.first?.peak == 0.0,
       "a MEASURED zero is the diagnostic finding and must survive")

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -514,6 +514,7 @@ internal final class FixtureAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "fixture_mock"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   private let loadedSamples: [Float]

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryEmitterTests.swift
@@ -204,6 +204,8 @@ struct HeartPathTelemetryEmitterTests {
     #expect(captured.extra["capture.failure_mode"] as? String == "no_audio_captured")
     // #1523: an unstamped no-audio terminal omits the channel-count key.
     #expect(captured.extra["capture.native_channel_count"] == nil)
+    // #2664: and the applied input channel key.
+    #expect(captured.extra["capture.input_channel"] == nil)
   }
 
   @Test("#1523: a stamped channel count rides the no-audio captureError extras")
@@ -213,10 +215,13 @@ struct HeartPathTelemetryEmitterTests {
 
     var ctx = Self.noAudioContext(sessionID: 5)
     ctx.captureNativeChannelCount = 8
+    ctx.captureInputChannel = 3
     emitter.noAudioCaptured(ctx: ctx)
 
     #expect(recorder.errors.count == 1)
     #expect(recorder.errors[0].extra["capture.native_channel_count"] as? Int == 8)
+    // #2664: the applied input channel rides beside the count.
+    #expect(recorder.errors[0].extra["capture.input_channel"] as? Int == 3)
   }
 
   @Test("noAudioCaptured dedups to a breadcrumb after a stall in the same session")

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -520,6 +520,7 @@ struct HeartPathTelemetryWiringTests {
     var captureSourceType: String = "hal_device_input"
     var selectedInputDeviceUID: String = ""
     var preferredInputDeviceIDOverride: String = ""
+    var inputChannelByDeviceUID: [String: Int] = [:]
     var warmEnginePolicy: WarmEnginePolicy = .off
 
     func startEnginePhase() async throws {}
@@ -582,6 +583,7 @@ private final class NoOpAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "hal_device_input"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   func startEnginePhase() async throws {}

--- a/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFrozenBindGuardTests.swift
@@ -39,7 +39,7 @@ struct KernelFrozenBindGuardTests {
     deviceID: 121,
     deviceUID: "synthetic-uid-no-real-device-carries-this",
     transportLabel: "bluetooth",
-    resolutionSource: "system_default"
+    resolutionSource: "system_default", inputChannel: 0
   )
 
   private struct Context {
@@ -94,7 +94,7 @@ struct KernelFrozenBindGuardTests {
       // widening of `AudioDeviceEnumerator.inputDeviceUID(for:)`, which is internal.
       return BoundInputDevice(
         deviceID: device.id, deviceUID: device.uid, transportLabel: nil,
-        resolutionSource: "system_default")
+        resolutionSource: "system_default", inputChannel: 0)
     }
     return nil
   }

--- a/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelLifecycleTelemetrySinkTests.swift
@@ -80,6 +80,7 @@ import Testing
       let inputDeviceKind: String?
       let captureNativeRateHz: Double?
       let captureNativeChannelCount: Int?
+      let captureInputChannel: Int?
       let takeID: String?
     }
 
@@ -160,7 +161,7 @@ import Testing
       vadGateNoSpeech: {
         backend, mode, rawSampleCount, peak, wholeRMS, maxWindowRMS, durationMs,
         effectiveTransport, selectedTransport, inputSelectionMode, deviceKind, nativeRate,
-        nativeChannels, takeID in
+        nativeChannels, inputChannel, takeID in
         recorder.vadGateNoSpeechCalls.append(
           Recorder.VADGateNoSpeechCall(
             backend: backend, mode: mode, rawSampleCount: rawSampleCount,
@@ -169,6 +170,7 @@ import Testing
             selectedTransport: selectedTransport, inputSelectionMode: inputSelectionMode,
             inputDeviceKind: deviceKind,
             captureNativeRateHz: nativeRate, captureNativeChannelCount: nativeChannels,
+            captureInputChannel: inputChannel,
             takeID: takeID))
         recorder.timeline.append("vadGateNoSpeech")
       },
@@ -895,7 +897,7 @@ import Testing
       vadGateNoSpeech: {
         backend, mode, rawSampleCount, peak, wholeRMS, maxWindowRMS, durationMs,
         effectiveTransport, selectedTransport, inputSelectionMode, deviceKind, nativeRate,
-        nativeChannels, takeID in
+        nativeChannels, inputChannel, takeID in
         recorder.vadGateNoSpeechCalls.append(
           Recorder.VADGateNoSpeechCall(
             backend: backend, mode: mode, rawSampleCount: rawSampleCount,
@@ -904,6 +906,7 @@ import Testing
             selectedTransport: selectedTransport, inputSelectionMode: inputSelectionMode,
             inputDeviceKind: deviceKind,
             captureNativeRateHz: nativeRate, captureNativeChannelCount: nativeChannels,
+            captureInputChannel: inputChannel,
             takeID: takeID))
       })
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -204,6 +204,7 @@ final class FakeAudioCapture: AudioCaptureInterface {
 
   var selectedInputDeviceUID = ""
   var preferredInputDeviceIDOverride = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   init() {}

--- a/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TerminalAdvisoryTests.swift
@@ -67,6 +67,33 @@ import Testing
     }
   }
 
+  @Test("#2664: the hinted sentence is byte-exact, and a nil hint is the seventh sentence itself")
+  func hintedSentenceIsFrozen() {
+    let hint = MultiInputAdvisoryHint(deviceName: "Scarlett 2i2 USB")
+    let expected =
+      "Audio isn't capturing from Scarlett 2i2 USB. Try a different input under Settings > Microphone."
+    for reason in TerminalAdvisoryReason.allCases {
+      #expect(DictationNarrator.copy(for: reason, hint: hint) == expected)
+      #expect(DictationNarrator.copy(for: reason, hint: nil) == DictationNarrator.copy(for: reason))
+    }
+    // Rule 6: no em-dashes or en-dashes in user-facing copy.
+    #expect(expected.contains("\u{2014}") == false)
+    #expect(expected.contains("\u{2013}") == false)
+    #expect(expected.contains("Try again.") == false)
+  }
+
+  @Test("#2664: VoiceOver speaks the hinted sentence with no Error prefix")
+  func hintedAnnouncementHasNoErrorPrefix() {
+    let hint = MultiInputAdvisoryHint(deviceName: "Scarlett 2i2 USB")
+    let spoken = DictationNarrator.announcement(for: .advisory(reason: .zeroSignal), hint: hint)
+    #expect(spoken == DictationNarrator.copy(for: .zeroSignal, hint: hint))
+    #expect(spoken.hasPrefix("Error:") == false)
+    // The hint reaches ONLY the advisory arm: an error with a hint is unchanged.
+    #expect(
+      DictationNarrator.announcement(for: .error(reason: .asrFailed), hint: hint)
+        == DictationNarrator.announcement(for: .error(reason: .asrFailed)))
+  }
+
   @Test("the advisory is a plain sentence, never the our-fault retry form")
   func advisoryNeverClaimsOurBug() {
     // The house rule (#1558): "[Category] error. Try again." means OUR bug.

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -150,6 +150,7 @@ private final class NeverFinishingAudioCapture: AudioCaptureInterface {
   var captureSourceType: String = "fixture_mock"
   var selectedInputDeviceUID: String = ""
   var preferredInputDeviceIDOverride: String = ""
+  var inputChannelByDeviceUID: [String: Int] = [:]
   var warmEnginePolicy: WarmEnginePolicy = .off
 
   /// Hold the continuation indefinitely so the AsyncStream never completes.

--- a/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Services/DictationCompletedRouteFieldsTests.swift
@@ -286,6 +286,30 @@ struct DictationCompletedRouteFieldsTests {
       #expect(box.event?.intProps["capture_native_channel_count"] == nil)
     }
 
+    @Test("#2664: the applied input channel threads into dictation.completed; 0 travels, nil omits")
+    func inputChannelThreadedAsIntProp() {
+      let box = Box()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { box.event = event }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt",
+        captureNativeChannelCount: 2, captureInputChannel: 1)
+      #expect(box.event?.intProps["capture_input_channel"] == 1)
+
+      // 0 is the measured default channel and must travel (it is the reading
+      // that says "the setting was not applied on this take").
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt", captureInputChannel: 0)
+      #expect(box.event?.intProps["capture_input_channel"] == 0)
+
+      TelemetryService.shared.reportDictationCompleted(
+        transcript: Transcript(text: "hello"), inputMode: "ptt")
+      #expect(box.event?.intProps["capture_input_channel"] == nil)
+    }
+
     @Test("#1707: asrSalvageOutcome threads into dictation.completed when a salvage was attempted")
     func asrSalvageOutcomeThreaded() {
       let box = Box()

--- a/Tests/EnviousWisprTests/Services/InputChannelSettingsTests.swift
+++ b/Tests/EnviousWisprTests/Services/InputChannelSettingsTests.swift
@@ -1,0 +1,71 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #2664: the per-device "Microphone socket" choice must survive a relaunch and
+/// must never take the app down when the stored blob is unreadable. When this
+/// fails, the user sees their chosen socket forgotten after a restart, or every
+/// device silently back on Input 1. Every case uses an ephemeral suite so nothing
+/// touches the real store.
+@MainActor
+@Suite("SettingsManager inputChannelByDeviceUID — #2664", .tags(.productOutcome))
+struct InputChannelSettingsTests {
+  init() { _ = NSApplication.shared }  // @MainActor AppKit-touching SUT (swift-patterns)
+
+  private static func freshSuite() -> UserDefaults {
+    let name = "ew.inputChannelTest." + UUID().uuidString
+    let d = UserDefaults(suiteName: name)!
+    d.removePersistentDomain(forName: name)
+    return d
+  }
+
+  @Test("a fresh install has no socket choices: every device records from Input 1")
+  func freshInstallIsEmpty() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    #expect(settings.inputChannelByDeviceUID == [:])
+    #expect(settings.inputChannelByDeviceUID == SettingsDefaultValues.inputChannelByDeviceUID)
+  }
+
+  @Test("a saved map survives relaunch, keyed by device UID")
+  func savedMapSurvivesRelaunch() {
+    let suite = Self.freshSuite()
+    let first = SettingsManager(defaults: suite)
+    first.inputChannelByDeviceUID = ["scarlett-2i2-uid": 1, "six-input-uid": 4]
+
+    // The write lands as JSON Data under the one key, in the injected store.
+    let stored = suite.data(forKey: "inputChannelByDeviceUID")
+    #expect(stored != nil)
+
+    let relaunched = SettingsManager(defaults: suite)
+    #expect(relaunched.inputChannelByDeviceUID == ["scarlett-2i2-uid": 1, "six-input-uid": 4])
+  }
+
+  @Test("an undecodable stored blob loads as an empty map, never a crash or a stale value")
+  func undecodableBlobLoadsEmpty() {
+    let suite = Self.freshSuite()
+    suite.set(Data("not json at all".utf8), forKey: "inputChannelByDeviceUID")
+    let settings = SettingsManager(defaults: suite)
+    #expect(settings.inputChannelByDeviceUID == [:])
+
+    // A JSON value of the wrong SHAPE is undecodable too.
+    suite.set(Data("[1, 2, 3]".utf8), forKey: "inputChannelByDeviceUID")
+    #expect(SettingsManager(defaults: suite).inputChannelByDeviceUID == [:])
+  }
+
+  @Test("changing the map emits its own SettingKey exactly once")
+  func changeEmitsKeyOnce() {
+    let settings = SettingsManager(defaults: Self.freshSuite())
+    var seen: [SettingsManager.SettingKey] = []
+    settings.onChange = { seen.append($0) }
+    settings.inputChannelByDeviceUID = ["scarlett-2i2-uid": 1]
+    #expect(seen.filter { $0 == .inputChannelByDeviceUID }.count == 1)
+  }
+
+  @Test("the key belongs to the unified defaults set exactly once")
+  func keyIsUnified() {
+    #expect(
+      SettingsManager.unifiedDefaultsKeys.filter { $0 == "inputChannelByDeviceUID" }.count == 1)
+  }
+}

--- a/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
+++ b/Tests/EnviousWisprTests/Services/SentryAudioExtrasTests.swift
@@ -127,6 +127,8 @@ struct SentryAudioExtrasTests {
     #expect(extras["polish.recent_model_swap_ms"] as? Int == 4500)
     // #1523: a source that never stamped a channel count omits the key.
     #expect(extras["capture.native_channel_count"] == nil)
+    // #2664: same for the applied input channel.
+    #expect(extras["capture.input_channel"] == nil)
   }
 
   @Test("#1523: a source-stamped channel count rides the stall extras")
@@ -143,7 +145,8 @@ struct SentryAudioExtrasTests {
       inputDeviceUIDPreferred: nil,
       inputDeviceUIDSystemDefault: nil,
       failureMode: .noBuffers,
-      nativeChannelCount: 2
+      nativeChannelCount: 2,
+      inputChannel: 1
     )
     let extras = SentryAudioExtras.buildCaptureExtras(
       route: ctx.route,
@@ -156,6 +159,8 @@ struct SentryAudioExtrasTests {
       stallContext: ctx
     )
     #expect(extras["capture.native_channel_count"] as? Int == 2)
+    // #2664: the applied input channel rides beside the count.
+    #expect(extras["capture.input_channel"] as? Int == 1)
   }
 
   @Test("nil polish swap omits the key entirely")

--- a/website/src/content/help/choosing-your-microphone.md
+++ b/website/src/content/help/choosing-your-microphone.md
@@ -30,6 +30,16 @@ To select a specific device:
 
 **Select your device.** Choose your microphone from the list.
 
+### If your microphone box has more than one input
+
+Audio interfaces such as a Focusrite Scarlett have two or more inputs, and EnviousWispr records from one of them. It uses Input 1 unless you tell it otherwise. When the selected device reports more than one input, a **Microphone socket** row appears under the device picker. Pick the input your microphone is plugged into, and EnviousWispr remembers that choice for that box.
+
+If your microphone is on the wrong input, a recording ends with a notice that names the device and points you to this setting. If the input numbers do not match the sockets on your device, try the next one.
+
+**Scarlett Solo 4th Gen:** the XLR microphone socket is Input 2, so pick Input 2. If you have enabled "Combine inputs", Input 1 already carries your microphone and no change is needed. On Scarlett Solo 3rd Gen, the XLR microphone socket is Input 1.
+
+**Two microphones at once:** this setting listens to one input. To record two people through one interface, use the mix your interface itself provides. Combining devices with a macOS Aggregate Device is not recommended.
+
 ### If your microphone is unplugged mid-recording
 
 EnviousWispr keeps what it recorded up to that point and transcribes it, rather than losing the entire recording.

--- a/website/src/content/help/choosing-your-microphone.md
+++ b/website/src/content/help/choosing-your-microphone.md
@@ -32,7 +32,7 @@ To select a specific device:
 
 ### If your microphone box has more than one input
 
-Audio interfaces such as a Focusrite Scarlett have two or more inputs, and EnviousWispr records from one of them. It uses Input 1 unless you tell it otherwise. When the selected device reports more than one input, a **Microphone socket** row appears under the device picker. Pick the input your microphone is plugged into, and EnviousWispr remembers that choice for that box.
+Audio interfaces such as a Focusrite Scarlett have two or more inputs, and EnviousWispr records from one of them. It uses Input 1 unless you tell it otherwise. When the selected device reports more than one input, a **Mic is on** control appears next to the device picker. Pick the input your microphone is plugged into, and EnviousWispr remembers that choice for that box.
 
 If your microphone is on the wrong input, a recording ends with a notice that names the device and points you to this setting. If the input numbers do not match the sockets on your device, try the next one.
 

--- a/website/src/content/help/empty-or-missing-transcription.md
+++ b/website/src/content/help/empty-or-missing-transcription.md
@@ -28,6 +28,8 @@ EnviousWispr needs to listen to the device you are actually speaking into. Open 
 
 If your Mac's default input is a virtual device, such as one installed by Krisp, Loopback, BlackHole, an aggregate device or a meeting app, Auto skips it and records from a real microphone, because a virtual device delivers only silence. Versions before 2.4.5 recorded that silence, so if you gave up on EnviousWispr for this reason, it is worth another go. A virtual device is still used when it is the only input on your Mac.
 
+If you record through an audio interface with more than one input (a Focusrite Scarlett, for example), also check the **Microphone socket** row under the device picker. EnviousWispr listens to Input 1 unless you pick another, and a microphone plugged into Input 2 records silence until you do. Read [_Choosing Your Microphone_](/help/choosing-your-microphone/) for the details.
+
 ### 5. Is the speech model ready?
 
 The app downloads its speech model on first launch. Until that download finishes, there is no model available to transcribe your voice. Progress is shown on screen. If the engine was not ready at the moment you finished speaking, your recording is kept and given another go rather than lost.

--- a/website/src/content/help/empty-or-missing-transcription.md
+++ b/website/src/content/help/empty-or-missing-transcription.md
@@ -28,7 +28,7 @@ EnviousWispr needs to listen to the device you are actually speaking into. Open 
 
 If your Mac's default input is a virtual device, such as one installed by Krisp, Loopback, BlackHole, an aggregate device or a meeting app, Auto skips it and records from a real microphone, because a virtual device delivers only silence. Versions before 2.4.5 recorded that silence, so if you gave up on EnviousWispr for this reason, it is worth another go. A virtual device is still used when it is the only input on your Mac.
 
-If you record through an audio interface with more than one input (a Focusrite Scarlett, for example), also check the **Microphone socket** row under the device picker. EnviousWispr listens to Input 1 unless you pick another, and a microphone plugged into Input 2 records silence until you do. Read [_Choosing Your Microphone_](/help/choosing-your-microphone/) for the details.
+If you record through an audio interface with more than one input (a Focusrite Scarlett, for example), also check the **Mic is on** control next to the device picker. EnviousWispr listens to Input 1 unless you pick another, and a microphone plugged into Input 2 records silence until you do. Read [_Choosing Your Microphone_](/help/choosing-your-microphone/) for the details.
 
 ### 5. Is the speech model ready?
 


### PR DESCRIPTION
## What this changes for the user

A microphone plugged into any input other than the first of a multi-input USB audio interface (a Focusrite Scarlett 2i2, a Scarlett Solo 4th Gen with its XLR on Input 2) used to record silence, because the mono capture always took device channel 0. Five people in the fleet had never had one successful take on such a device; a customer emailed about it on 2026-09-05.

- **Settings > Microphone** gains a small **Mic is on: Input 1 | Input 2** control on the device picker's own line, shown only when the selected device reports more than one input (a menu above six inputs). Pick the input the microphone is on; the choice is remembered per device and applied on the next recording, even inside the 30 second warm-engine window.
- The silent-take notice names the device when it has more than one input: *"Audio isn't capturing from Scarlett 2i2 USB. Try a different input under Settings > Microphone."* One-input microphones keep today's sentence, byte for byte. VoiceOver reads the same sentence the pill shows.
- Help centre: a new section in *Choosing Your Microphone* and a pointer in *Empty or Missing Transcription*.
- Telemetry: `capture_input_channel` (PostHog) / `capture.input_channel` (Sentry) beside the existing channel count, on every payload that carries it, so the 30-day re-measure can split the never-succeeded cohort by whether a non-default socket was ever applied.

Nothing changes for anyone who does not touch the setting: with no saved choice the channel map is not set and the capture path is byte-identical.

## How

`Tier: MEDIUM | Test: required (Audio, AppKit) | Modules: Core, Audio, Services, Pipeline, AppKit, website`
Lane: Code, `mixed_pr: true` (Content twin: two help articles).

Plan: `docs/feature-requests/issue-2664-2026-09-05-input-channel-picker.md` (Gate 2 approved 2026-09-05). Built in four Codex-orchestrated chunks, each CHUNK-CLEAN, then an independent whole-diff `codex review` (clean) and the behavioural second pass (one finding adopted, three recorded below).

1. **Audio.** `InputChannelPreference.effectiveChannel(requested:availableChannels:)` is the one authority for the index; `HALDeviceInputSource.prepare()` sets `kAudioOutputUnitProperty_ChannelMap` (output scope, element 1, one `Int32`) after the client format and before `AudioUnitInitialize` (Apple TN2091); a refused set logs and proceeds on channel 0. `BoundInputDevice.inputChannel` carries what the unit actually takes; `AudioCaptureManager.resolveSource()` gains a warm-reuse conjunct comparing the manager's live map to the bound channel.
2. **Settings.** `SettingsManager.inputChannelByDeviceUID: [String: Int]` (JSON `Data`, absent or undecodable loads as `[:]`), mirrored to the capture manager by `PipelineSettingsSync`.
3. **Telemetry parity** across the 13 files that carry `nativeChannelCount`.
4. **UI.** `InputSocket.socketDevice` is the one rule the settings row and the advisory hint share; `OverlayEvent.advisory(reason:hint:)` carries the presentation-only hint through the reducer while `OverlayIntent` stays reason-only; `OverlayDirector` takes a required `advisoryHint` closure.

## Known limits (recorded, not fixed)

- The advisory names the device selected in Settings at the moment the notice renders, not the device the take used. A device switch inside the 8 second dwell can name the new device. Deliberate: the sentence points at the setting the user will find selected.
- A channel map the audio unit refuses logs `channel_map_set_failed` and records on channel 0 while Settings still shows the chosen input; the next take retries. The heart path never fails on a preference.
- A channel-count read that fails at cold prepare falls back to channel 0 for that warm unit's lifetime (30 second idle policy, extended by repeated takes); the next cold prepare re-reads.
- Multi-stream input devices are not verified on hardware (plan §14).

## Validation

- `scripts/xcode-test.sh` full Debug lane on the final commit: 7378 + 7 + 206 = **7591 tests, PASS** (3 pre-existing known issues). New suites: `InputChannelPreferenceTests` (6), `InputChannelReuseTests` (8, drives the real `resolveSource()` through DEBUG seams with every hardware read injected), `InputChannelSettingsTests` (5), `MultiInputAdvisoryHintTests` (8), `InputSocketCopyTests` (2), `AdvisoryHintRoutingTests` (5), plus rows in `TerminalAdvisoryTests`, `RenderedPillFreezeTests` (hinted advisory 360 x 52 on the dev Mac), `HALFormatStabilizationTests`, `HeartPathContextsTests`, the terminal/lifecycle/emitter/diagnostics/Sentry-extras telemetry suites and `DictationCompletedRouteFieldsTests`.
- Website: `npm run build` (content check 58 articles, 0 errors) and `npm run check:help` (routes 71/71, 0 dead links; search 47 passed).
- **Live UAT** (plan §11.1) on the dev build with BlackHole 2ch pinned, the sentence on channel 2 only and a faint noise floor on the other channel (a digitally silent virtual input is retired by the existing dead-mic guard, which a real interface never triggers): **A** Input 1 → no words, pill *"Audio isn't capturing from BlackHole 2ch. Try a different input under Settings > Microphone."*, `vad_gate_no_speech` peak 0.0001, `inputChannel=0`; **B** Input 2 → *"The quick brown fox jumps over the lazy dog."*, `inputChannel=1`; **B2** second take 8 s later → transcript again, `Reusing warm HALDeviceInput source`; **C** back to Input 1 inside the warm window → `Route changed while warm — tearing down old source`, cold prepare `inputChannel=0`, the hinted pill; **D** built-in mic pinned → socket control absent, forced all-zero take shows the byte-exact seventh sentence. Evidence: `.validation/runs/2664-live-uat/live-uat.json` (main checkout, gitignored), driver and screenshot beside it.
- Telemetry from the dev build under `environment=development`: **PostHog observed live** (`capture_input_channel` on `audio.vad_gate_no_speech` = 0, `dictation.completed` = 1 with native count 2, `dictation.terminal` failed/no_speech = 0). **Sentry not observed live**: the extras key `capture.input_channel` rides only Sentry error events (capture stall, no-audio, ASR-empty-with-speech), none of which the rig produces; the zero-signal terminal deliberately emits no Sentry error. The Sentry side is bound by `SentryAudioExtrasTests`, `HeartPathTelemetryEmitterTests` and `ASREmptyResultDiagnosticsTests`, which read the emitted extras dictionary.
- Codex: four build chunks CHUNK-CLEAN (chunk 4 after two adopted P2s: the spoken sentence had lost the hint through the reason-only intent; the Solo help note applied 4th Gen wiring to every generation); independent whole-diff `codex review` clean; behavioural second pass: one finding adopted (empty-UID devices must not share a saved choice), three recorded above as known limits; confirming round CLEAN. Transcripts under `.codex/2026-09-05-issue-2664-*`.

### One test is red on the dev machine right now, and it is the lid

`AudioCaptureManagerLiveInputTests` opens the REAL built-in microphone and requires non-zero samples. It passed on this exact commit at 15:48 and fails at 16:01 with the machine's lid closed (laptop in a bag, still running). A closed lid parks the built-in microphone, which is the first cause the advisory sentence itself names. Independent control: `ffmpeg -f avfoundation -i ":MacBook Pro Microphone"` recorded `max_volume: -91.0 dB` (digital zero) in the same window, with the dev app stopped and input volume at 27. The feature cannot reach this path: the built-in microphone reports ONE input channel, no preference is saved for it, `effectiveChannel` returns 0, and no channel map is set. Hosted CI reports this case SKIPPED (no audio device), so the dev-machine receipt is the one that counts and it will be re-run with the lid open before merge.

## Follow-ups

- #2682 per-input level meters (deferred at Gate 2).
- 30-day re-measure of the never-succeeded multi-input cohort with `capture_input_channel` (comment on #2664 at wind-down).
- Test-hardening issue with the mutation recipes for the new suites.

Closes #2664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zAmugEKNYw1gPcuCKETS2
