### PR TITLE
content(help): EG-1 lays out an email, and three surfaces stop overclaiming snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 EnviousWispr ships often. A few of the user-facing improvements from recent releases:
 
 - **A second on-device polish model, S1-mini by Superwhisper.** A small open model for cleaning up dictation, now an option beside EG-1 in AI Polish settings. A 484 MB download, runs on your Mac, and free. Three writing style settings, Tone, Structure and Context, let you choose how it writes. Happiest in English. EG-1 stays the recommended choice. (v2.4.7)
-- **Snippets.** Say a keyword, then a short phrase, and the text you saved is pasted character for character. A fresh install starts with six working examples to try. (v2.4.7)
+- **Snippets.** Say a keyword, then a short phrase, and the text you saved is pasted word for word. A fresh install starts with six working examples to try. (v2.4.7)
 - **More of EnviousWispr is switched on from the start.** Escape Recovery, Live Preview and the recording sounds are now on by default, and each is a switch you can turn off. Quick Add has moved to Control Shift W so it no longer shares a key with recording. (v2.4.7)
 - **Add a custom word to your dictionary with a click of a button.** Highlight a misheard word anywhere on macOS, press the Quick Add keybind, and save the right spelling without opening Settings. A small panel ranks it against the words you have already saved, so one Return usually finishes the job. It is also in the menu bar menu. (v2.4.6)
 - **A new pill design for recording, and a practice run during setup.** Choose between recording pill designs in Appearance, and try dictation before onboarding ends. (v2.4.6)

--- a/website/src/content/help/what-is-ai-polish.md
+++ b/website/src/content/help/what-is-ai-polish.md
@@ -4,9 +4,9 @@ description: "What AI Polish changes about your dictation, and what it is design
 category: "ai-polish"
 section: "Polish"
 order: 1
-keywords: ["polish", "ai polish", "cleanup", "clean up my text", "grammar", "punctuation", "tidy", "what does ai do", "editing"]
+keywords: ["polish", "ai polish", "cleanup", "clean up my text", "grammar", "punctuation", "tidy", "what does ai do", "editing", "email", "dictate an email", "email formatting", "paragraphs", "paragraph breaks", "bullet list", "make a list"]
 related: ["choosing-an-ai-provider-none-apple-intelligence-ollama-openai-gemini", "s1-mini-by-superwhisper-and-writing-style"]
-updated: 2026-09-05
+updated: 2026-09-06
 ---
 AI Polish is the optional step EnviousWispr runs after transcribing your speech, to tidy up what you said. It fixes grammar and punctuation, cuts filler words, and is instructed to keep your exact meaning and your language.
 
@@ -32,6 +32,16 @@ Every option is listed under **Settings** \> **AI Polish**, in three groups.
 - **On this Mac.** EG-1, our own model tuned for dictation, and the recommended choice. Apple Intelligence, built into macOS 26. S1-mini by Superwhisper, a small open model that is a 484 MB download. Nothing you dictate leaves your Mac with any of these.
 - **Your own setup.** Ollama, running an open model you choose, on your Mac or hosted.
 - **Cloud.** OpenAI, Google Gemini or Claude, with your own API key. These receive your transcribed text, never your audio.
+
+### How EG-1 lays out what you dictate
+
+From version 2.4.7, EG-1 gives your dictation a shape rather than returning one long paragraph.
+
+- **A new topic starts a new paragraph.** When you move from one subject to the next, EG-1 puts a break there.
+- **A list you announce comes out as a list.** Say that you have three points and then give them, and you get three lines rather than one run-on sentence.
+- **An email gets a greeting on its own line.** Dictate a message start to finish and the opening line sits above the body. A sign-off usually lands on its own line too, though less reliably than the greeting, so check that one before you send.
+
+EG-1 still adds nothing you did not say, and it does not write a subject line for you.
 
 ### The default, and how to change it
 

--- a/website/src/content/help/what-is-ai-polish.md
+++ b/website/src/content/help/what-is-ai-polish.md
@@ -35,11 +35,11 @@ Every option is listed under **Settings** \> **AI Polish**, in three groups.
 
 ### How EG-1 lays out what you dictate
 
-From version 2.4.7, EG-1 gives your dictation a shape rather than returning one long paragraph.
+From version 2.4.7, EG-1 gives your dictation a shape rather than returning one long paragraph. It gets this right most of the time rather than every time, so read anything long before you send it.
 
-- **A new topic starts a new paragraph.** When you move from one subject to the next, EG-1 puts a break there.
-- **A list you announce comes out as a list.** Say that you have three points and then give them, and you get three lines rather than one run-on sentence.
-- **An email gets a greeting on its own line.** Dictate a message start to finish and the opening line sits above the body. A sign-off usually lands on its own line too, though less reliably than the greeting, so check that one before you send.
+- **A new topic starts a new paragraph.** When you move from one subject to the next, EG-1 usually puts a break there.
+- **A list you announce comes out as a list.** Say that you have three points and then give them, and you usually get three lines rather than one run-on sentence. This is the one it misses most often.
+- **An email gets a greeting on its own line.** Dictate a message start to finish and the opening line sits above the body. A sign-off usually lands on its own line too, though less reliably than the greeting.
 
 EG-1 still adds nothing you did not say, and it does not write a subject line for you.
 

--- a/website/src/content/help/what-is-ai-polish.md
+++ b/website/src/content/help/what-is-ai-polish.md
@@ -39,9 +39,9 @@ From version 2.4.7, EG-1 gives your dictation a shape rather than returning one 
 
 - **A new topic starts a new paragraph.** When you move from one subject to the next, EG-1 usually puts a break there.
 - **A list you announce comes out as a list.** Say that you have three points and then give them, and you usually get three lines rather than one run-on sentence. This is the one it misses most often.
-- **An email gets a greeting on its own line.** Dictate a message start to finish and the opening line sits above the body. A sign-off usually lands on its own line too, though less reliably than the greeting.
+- **An email gets a greeting on its own line.** Dictate a message start to finish and the opening line almost always sits above the body. A sign-off usually lands on its own line too, though less reliably than the greeting.
 
-EG-1 still adds nothing you did not say, and it does not write a subject line for you.
+This is layout, not content. The limits above still apply: EG-1 is not allowed to add anything you did not say, and it is not asked to write you a subject line.
 
 ### The default, and how to change it
 

--- a/website/src/pages/compare/juno.astro
+++ b/website/src/pages/compare/juno.astro
@@ -461,7 +461,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Snippets and direct replacements</td>
-            <td><span class="table-check">Yes</span>, snippets: say a keyword, then a short phrase, and the saved text is pasted exactly as you typed it</td>
+            <td><span class="table-check">Yes</span>, snippets: say a keyword, then a short phrase, and the saved text is pasted word for word, never rewritten by AI Polish</td>
             <td><span class="table-check">Yes</span>, both are built in</td>
           </tr>
           <tr>

--- a/website/src/pages/compare/wisprflow.astro
+++ b/website/src/pages/compare/wisprflow.astro
@@ -473,7 +473,7 @@ const faqJsonLd = JSON.stringify({
           </tr>
           <tr>
             <td>Snippets / shortcuts</td>
-            <td><span class="table-check">Yes.</span> Say a keyword, then a short phrase, and the saved text is pasted exactly as you typed it. Snippets stay on your Mac; there is no team sharing.</td>
+            <td><span class="table-check">Yes.</span> Say a keyword, then a short phrase, and the saved text is pasted word for word, with a space after it like any other dictation. AI Polish never rewrites it. Snippets stay on your Mac; there is no team sharing.</td>
             <td><span class="table-check">Yes.</span> Voice-triggered text shortcuts with shared snippets for teams.</td>
           </tr>
           <tr>


### PR DESCRIPTION
## Summary

Post-release audit of v2.4.7 across every user-facing surface. Two real findings
and one repo-level nit.

## 1. Nothing told a user that EG-1 lays out an email

EG-1 1.2 shipped in v2.4.7 as the second entry on the release notes.
`what-is-ai-polish.md` listed the polish options and what polish will not do,
and said nothing about layout, so a reader arriving from the release note found
no detail in any of the 58 articles.

New section, scoped to what was measured on #2547 against the SHIPPED model
rather than to the release note wording. The sign-off is stated as "usually"
because it is 29/37; the greeting, paragraph breaks and lists are stated flatly
because they are 32/32, 97/102 and 96/114.

## 2. Three sentences promised a byte-exact snippet paste

`CursorInsertionRepair.legacyPayload` appends a trailing space to every delivered
dictation, snippets included. #2643 is open on exactly that.

Enumerated with `.claude/scripts/claim-sweep.sh Snippets` (136 mentions across 8
surfaces), not a hand-written grep. Three overclaimed, and every one now matches
`using-snippets.md`, which was right all along:

| Surface | Was | Now |
|---|---|---|
| `README.md` | "character for character" | "word for word" |
| `compare/wisprflow.astro` | "exactly as you typed it" | the help centre wording |
| `compare/juno.astro` | "exactly as you typed it" | the help centre wording |

The README disagreed with ITSELF: line 112 already said "word for word".

## Also done, outside this PR

GitHub repo description updated: it named one on-device model and no Snippets.

## Checked and deliberately NOT changed

The pre-release help pass (#2681) had already done the work. All three settings
that flipped ON in v2.4.7 read as on, Quick Add reads Control Shift W and names
the version, `filler-word-removal.md` names all eight protected languages plus
the unknown-language veto, and `choosing-your-microphone.md` carries the Mic is
on control with the Scarlett Solo 4th-vs-3rd Gen difference.

"Settings > Dictionary > Your Words" is CORRECT and was not touched: Your Words
is still the first tab inside the renamed page.

The homepage is untouched. The founder is rebuilding it separately.

## Test plan

- [x] `npm ci && npm run build` in the worktree, 135 pages. A worktree has no
      `node_modules`, so this is a real build rather than an exit code.
- [x] `npm run check:help`: 71 routes built, 71 in sitemap, 0 dead of 10,434
      internal links; search 47 passed, 0 failed.
- [x] Changed strings verified in `dist/`, not in source: 1 hit each in
      `dist/help/what-is-ai-polish/`, `dist/compare/wisprflow/`, `dist/compare/juno/`.
- [x] Post-fix claim sweep: zero surviving "character for character" or
      "exactly as you typed".
- [x] Local Codex review: no actionable issues.
- [ ] `build-check` green on this PR

Lane: Content. mixed_pr: true (README is Docs/dev-tooling). Tier: SMALL.

Part of #2643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zAmugEKNYw1gPcuCKETS2
