### PR TITLE
fix(delivery): Parakeet stops writing and deleting in FluidAudio's shared model cache (#2483)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -30,6 +30,9 @@ public final class ASRManager: ASRManagerInterface {
   /// #1348 Phase 2: delivery-managed Parakeet loads are cache-only (see
   /// `ASRManagerInterface.parakeetCacheOnly`).
   public var parakeetCacheOnly = false
+  /// #2483 chunk 1: see `ASRManagerProxy.parakeetModelDirectory` — same
+  /// contract, same temporary default, replaced by injection in chunk 2.
+  public var parakeetModelDirectory: URL = ParakeetBackend.defaultModelDirectory
   private var idleTimer: Timer?
   private var lastTranscriptionTime: Date?
   /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.
@@ -156,7 +159,9 @@ public final class ASRManager: ASRManagerInterface {
         // not a kernel-side identity gate (capability rule applies to
         // adapters/kernel; injected test mocks keep the legacy path).
         if self.parakeetCacheOnly, let parakeet = self.parakeetBackend as? ParakeetBackend {
-          try await parakeet.prepare(cacheOnly: true, progressCallback: progress)
+          try await parakeet.prepare(
+            cacheOnly: true, modelDirectory: self.parakeetModelDirectory,
+            progressCallback: progress)
         } else {
           try await self.parakeetBackend.prepare(progressCallback: progress)
         }

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -30,9 +30,11 @@ public final class ASRManager: ASRManagerInterface {
   /// #1348 Phase 2: delivery-managed Parakeet loads are cache-only (see
   /// `ASRManagerInterface.parakeetCacheOnly`).
   public var parakeetCacheOnly = false
-  /// #2483 chunk 1: see `ASRManagerProxy.parakeetModelDirectory` — same
-  /// contract, same temporary default, replaced by injection in chunk 2.
-  public var parakeetModelDirectory: URL = ParakeetBackend.defaultModelDirectory
+  /// #2483: see `ASRManagerProxy.parakeetModelDirectory`. The default is OUR
+  /// directory, never the vendor's, so an entry point that loads without going
+  /// through `ParakeetEngineAdapter` — `ActiveEngineOperation.load` does exactly
+  /// that — cannot reach FluidAudio's shared tree by omission.
+  public var parakeetModelDirectory: URL = ParakeetInstallLocation.live
   private var idleTimer: Timer?
   private var lastTranscriptionTime: Date?
   /// Single-flight guard: if a load is already in progress, callers await it instead of starting a new one.

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -158,9 +158,19 @@ public final class ASRManager: ASRManagerInterface {
         // downcasts to the concrete backend this manager itself constructed —
         // not a kernel-side identity gate (capability rule applies to
         // adapters/kernel; injected test mocks keep the legacy path).
-        if self.parakeetCacheOnly, let parakeet = self.parakeetBackend as? ParakeetBackend {
+        //
+        // #2483 second-pass finding 1/2/5: the downcast is no longer gated on
+        // `parakeetCacheOnly`. It used to be, and the `else` then reached
+        // `prepare(progressCallback:)`, whose convenience overload resolves
+        // FluidAudio's SHARED directory — so switching delivery off sent the
+        // in-process path straight back to the tree this whole change exists to
+        // stop touching, with downloading enabled. The XPC path never had that
+        // hole because the proxy passes the directory on every load. Only a
+        // non-`ParakeetBackend` backend (an injected mock, which loads nothing)
+        // takes the protocol overload now.
+        if let parakeet = self.parakeetBackend as? ParakeetBackend {
           try await parakeet.prepare(
-            cacheOnly: true, modelDirectory: self.parakeetModelDirectory,
+            cacheOnly: self.parakeetCacheOnly, modelDirectory: self.parakeetModelDirectory,
             progressCallback: progress)
         } else {
           try await self.parakeetBackend.prepare(progressCallback: progress)

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -122,6 +122,12 @@ public protocol ASRManagerInterface: AnyObject {
   /// download). Set by `ParakeetEngineAdapter` from the delivery flag before
   /// each warm-up. Both conformers honor it on their Parakeet prepare path.
   var parakeetCacheOnly: Bool { get set }
+  /// #2483: the Parakeet install directory the HOST selected. Set by
+  /// `ParakeetEngineAdapter` alongside `parakeetCacheOnly` before each warm-up.
+  /// Both conformers pass it to their Parakeet prepare path; neither resolves a
+  /// directory of its own, because every default they could reach is
+  /// FluidAudio's shared cache, which EnviousWispr does not own.
+  var parakeetModelDirectory: URL { get set }
   func loadModel() async throws
   func unloadModel() async  // periphery:ignore - called via existential type (ASRManager idle timer)
   func setInitialBackendType(_ type: ASRBackendType)
@@ -185,6 +191,15 @@ extension ASRManagerInterface {
   /// (mocks never download).
   public var parakeetCacheOnly: Bool {
     get { false }
+    set {}
+  }
+
+  /// #2483 safe default for test doubles, same shape as `parakeetCacheOnly`
+  /// above and safe for the same reason: BOTH production conformers declare
+  /// real storage, so their witnesses win, and a mock never loads a model, so
+  /// the value it reports is never used to touch the filesystem.
+  public var parakeetModelDirectory: URL {
+    get { ParakeetBackend.defaultModelDirectory }
     set {}
   }
 }

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -199,7 +199,7 @@ extension ASRManagerInterface {
   /// real storage, so their witnesses win, and a mock never loads a model, so
   /// the value it reports is never used to touch the filesystem.
   public var parakeetModelDirectory: URL {
-    get { ParakeetBackend.defaultModelDirectory }
+    get { ParakeetInstallLocation.live }
     set {}
   }
 }

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -126,13 +126,17 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// warm-up; false = legacy in-service download path, bit-for-bit.
   public var parakeetCacheOnly = false
 
-  /// #2483 chunk 1: the install directory sent to the helper on every load.
-  /// Defaults to today's value so this chunk changes no behaviour; chunk 2
-  /// injects the app-owned directory from the delivery registration and this
-  /// default goes away. Not optional on purpose — a nil here would have to be
-  /// resolved somewhere, and every place that could resolve it picks the
-  /// shared tree.
-  public var parakeetModelDirectory: URL = ParakeetBackend.defaultModelDirectory
+  /// #2483: the install directory sent to the helper on every load.
+  ///
+  /// **Defaults to OUR directory, not the vendor's.** `ParakeetEngineAdapter`
+  /// injects the registration's exact location before each warm-up, which is what
+  /// keeps a test-redirected root honest — but it is not the only entry point.
+  /// `ActiveEngineOperation.load` calls `loadModel()` directly for launch recovery
+  /// and Diagnostics, and with a vendor default here that load sent the shared
+  /// path to the helper. Not optional on purpose: a nil would have to be resolved
+  /// somewhere, and the only thing available to resolve it with is the vendor's
+  /// own answer.
+  public var parakeetModelDirectory: URL = ParakeetInstallLocation.live
 
   /// #1348 Phase 2 (grounded r2 blocker 1 — forced helper recycle): after a
   /// proxy-level error on the load path (nil connection, interface/selector

--- a/Sources/EnviousWisprASR/ASRManagerProxy.swift
+++ b/Sources/EnviousWisprASR/ASRManagerProxy.swift
@@ -126,6 +126,14 @@ public final class ASRManagerProxy: ASRManagerInterface {
   /// warm-up; false = legacy in-service download path, bit-for-bit.
   public var parakeetCacheOnly = false
 
+  /// #2483 chunk 1: the install directory sent to the helper on every load.
+  /// Defaults to today's value so this chunk changes no behaviour; chunk 2
+  /// injects the app-owned directory from the delivery registration and this
+  /// default goes away. Not optional on purpose — a nil here would have to be
+  /// resolved somewhere, and every place that could resolve it picks the
+  /// shared tree.
+  public var parakeetModelDirectory: URL = ParakeetBackend.defaultModelDirectory
+
   /// #1348 Phase 2 (grounded r2 blocker 1 — forced helper recycle): after a
   /// proxy-level error on the load path (nil connection, interface/selector
   /// mismatch, remote-proxy failure), drop the connection so the NEXT call
@@ -292,7 +300,10 @@ public final class ASRManagerProxy: ASRManagerInterface {
         let callEraID = self.connection.map(ObjectIdentifier.init)
         self.serviceProxy { proxy in
           let cacheOnly = self.parakeetCacheOnly && self.activeBackendType == .parakeet
-          proxy.loadModel(backendType: self.activeBackendType.rawValue, cacheOnly: cacheOnly) {
+          proxy.loadModel(
+            backendType: self.activeBackendType.rawValue, cacheOnly: cacheOnly,
+            modelDirectoryPath: self.parakeetModelDirectory.path
+          ) {
             nsError in
             // #1525 PR I-B: reconstruct the typed, conforming error from the
             // surviving NSError domain/code before throwing to the adapter.

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -33,29 +33,28 @@ public actor ParakeetBackend: ASRBackend {
 
   public init() {}
 
-  /// The directory FluidAudio would pick for itself.
+  /// FluidAudio's SHARED per-repo cache — the directory EnviousWispr does NOT
+  /// own and must never write in (#2483).
   ///
-  /// #2483 chunk 1: this exists so the rest of `EnviousWisprASR` — which does
-  /// not import FluidAudio — can name today's value while the model directory
-  /// becomes an INJECTED parameter rather than something each load site
-  /// resolves on its own. This chunk is a semantic no-op: every caller passes
-  /// exactly this, so behaviour is byte-identical.
-  ///
-  /// It is FluidAudio's SHARED per-repo cache, which EnviousWispr does not own
-  /// (#2483). Chunk 2 changes what the host SELECTS, not this accessor, and
-  /// this accessor must not become the answer anywhere the host can supply one.
-  public static var defaultModelDirectory: URL {
+  /// **Named for what it is, not as a default.** It was `defaultModelDirectory`,
+  /// and that name is how it ended up as the fallback in three separate places;
+  /// each of those was a route back into the shared tree. Nothing may use this as
+  /// a fallback. It survives for exactly one purpose: it is the ORACLE for
+  /// `ParakeetInstallLocation.repoFolderName`, because its last path component is
+  /// the vendor's own `Repo.folderName`, and a test reads it at runtime so our
+  /// constant cannot drift from the directory the loader reconstructs.
+  public static var vendorSharedDirectory: URL {
     AsrModels.defaultCacheDirectory(for: .v3)
   }
 
   public func prepare() async throws {
     try await prepare(
-      cacheOnly: false, modelDirectory: Self.defaultModelDirectory, progressCallback: nil)
+      cacheOnly: false, modelDirectory: ParakeetInstallLocation.live, progressCallback: nil)
   }
 
   public func prepare(progressCallback: ProgressCallback?) async throws {
     try await prepare(
-      cacheOnly: false, modelDirectory: Self.defaultModelDirectory,
+      cacheOnly: false, modelDirectory: ParakeetInstallLocation.live,
       progressCallback: progressCallback)
   }
 
@@ -97,7 +96,7 @@ public actor ParakeetBackend: ASRBackend {
   ///   download into. Both vendor entry points below normalise a repo-shaped
   ///   path identically (`AsrModels.load(from:)` re-derives it through
   ///   `repoPath`, and `download(to:)` derives its own parent), so passing
-  ///   `Self.defaultModelDirectory` here is exactly the pre-#2483 behaviour.
+  ///   a repo-shaped path here behaves identically either way.
   public func prepare(
     cacheOnly: Bool, modelDirectory: URL, progressCallback: ProgressCallback?
   ) async throws {

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -33,12 +33,30 @@ public actor ParakeetBackend: ASRBackend {
 
   public init() {}
 
+  /// The directory FluidAudio would pick for itself.
+  ///
+  /// #2483 chunk 1: this exists so the rest of `EnviousWisprASR` — which does
+  /// not import FluidAudio — can name today's value while the model directory
+  /// becomes an INJECTED parameter rather than something each load site
+  /// resolves on its own. This chunk is a semantic no-op: every caller passes
+  /// exactly this, so behaviour is byte-identical.
+  ///
+  /// It is FluidAudio's SHARED per-repo cache, which EnviousWispr does not own
+  /// (#2483). Chunk 2 changes what the host SELECTS, not this accessor, and
+  /// this accessor must not become the answer anywhere the host can supply one.
+  public static var defaultModelDirectory: URL {
+    AsrModels.defaultCacheDirectory(for: .v3)
+  }
+
   public func prepare() async throws {
-    try await prepare(cacheOnly: false, progressCallback: nil)
+    try await prepare(
+      cacheOnly: false, modelDirectory: Self.defaultModelDirectory, progressCallback: nil)
   }
 
   public func prepare(progressCallback: ProgressCallback?) async throws {
-    try await prepare(cacheOnly: false, progressCallback: progressCallback)
+    try await prepare(
+      cacheOnly: false, modelDirectory: Self.defaultModelDirectory,
+      progressCallback: progressCallback)
   }
 
   /// #1348 Phase 2: whether this process may let FluidAudio touch the
@@ -75,7 +93,14 @@ public actor ParakeetBackend: ASRBackend {
   /// FluidAudio's own offline switch armed — zero network in this process.
   /// The legacy path (`cacheOnly: false`) stays byte-identical for the
   /// staged-rollout window (D5 §5), minus the deleted inert checksum no-op.
-  public func prepare(cacheOnly: Bool, progressCallback: ProgressCallback?) async throws {
+  /// - Parameter modelDirectory: the repo-shaped directory to load from or
+  ///   download into. Both vendor entry points below normalise a repo-shaped
+  ///   path identically (`AsrModels.load(from:)` re-derives it through
+  ///   `repoPath`, and `download(to:)` derives its own parent), so passing
+  ///   `Self.defaultModelDirectory` here is exactly the pre-#2483 behaviour.
+  public func prepare(
+    cacheOnly: Bool, modelDirectory: URL, progressCallback: ProgressCallback?
+  ) async throws {
     let handler = Self.makeLoadProgressHandler(progressCallback)
 
     Self.configureOfflineMode(cacheOnly: cacheOnly)
@@ -85,9 +110,11 @@ public actor ParakeetBackend: ASRBackend {
         // Delivery-managed: the default cache was admitted by the host's hash
         // gate before this call; offlineMode (armed above) turns any gap
         // into a typed throw the host maps to its repair path.
-        loadedModels = try await AsrModels.loadFromCache(version: .v3, progressHandler: handler)
+        loadedModels = try await AsrModels.load(
+          from: modelDirectory, version: .v3, progressHandler: handler)
       } else {
-        loadedModels = try await AsrModels.downloadAndLoad(version: .v3, progressHandler: handler)
+        loadedModels = try await AsrModels.downloadAndLoad(
+          to: modelDirectory, version: .v3, progressHandler: handler)
       }
       self.fluidModels = loadedModels
 

--- a/Sources/EnviousWisprASRService/ASRServiceHandler.swift
+++ b/Sources/EnviousWisprASRService/ASRServiceHandler.swift
@@ -38,10 +38,22 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
 
   // MARK: - Model Lifecycle
 
-  func loadModel(backendType: String, cacheOnly: Bool, reply: @escaping (NSError?) -> Void) {
+  func loadModel(
+    backendType: String, cacheOnly: Bool, modelDirectoryPath: String,
+    reply: @escaping (NSError?) -> Void
+  ) {
     nonisolated(unsafe) let safeReply = reply
     Task { @MainActor in
       do {
+        // #2483: fail closed. An empty path is the only value that could send
+        // this process back to a vendor default, and that default is the shared
+        // FluidAudio tree. Throwing costs one typed load failure the host
+        // already handles; guessing costs somebody else's model files.
+        guard !modelDirectoryPath.isEmpty else {
+          throw XPCASRTransportError.requestDecodingFailed(
+            "loadModel: empty modelDirectoryPath")
+        }
+        let modelDirectory = URL(fileURLWithPath: modelDirectoryPath, isDirectory: true)
         // Unload previous backend before loading new one
         self.parakeetBackend = nil
 
@@ -66,7 +78,8 @@ final class ASRServiceHandler: NSObject, ASRServiceProtocol, @unchecked Sendable
           // armed inside prepare so this process can never download. The
           // progress callback still feeds the shared file for the COMPILE/
           // LOAD phase (the download phase is host-fed under delivery mode).
-          try await backend.prepare(cacheOnly: cacheOnly) { fraction, phase, detail in
+          try await backend.prepare(cacheOnly: cacheOnly, modelDirectory: modelDirectory) {
+            fraction, phase, detail in
             // Hot path — runs on URLSession delegate thread. File write is fast.
             progressFile.write(fraction: fraction, phase: phase, detail: detail)
           }

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -177,7 +177,13 @@ public final class ModelDeliveryHome {
         installDirectory: ParakeetInstallLocation.directory(appSupport: appSupportRoot),
         metadataDirectory:
           appSupportRoot
-          .appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true))
+          .appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true),
+        // #2483: where this model USED to live, offered read-only so an existing
+        // copy — ours from before the move, or another FluidAudio app's — is
+        // reproduced instead of re-downloaded. Rooted at `appSupportRoot` so a
+        // suite passing an override never reads the real shared directory.
+        legacyDonorDirectory: ParakeetInstallLocation.legacySharedDonor(
+          appSupport: appSupportRoot))
       parakeetIdentity = identity
       parakeetRegistration = registration
       // #2119: reclaim staging abandoned by a superseded revision of THIS model.

--- a/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
+++ b/Sources/EnviousWisprAppKit/App/ModelDeliveryHome.swift
@@ -134,14 +134,20 @@ public final class ModelDeliveryHome {
   /// so tests pass a bundle pointed at the SAME committed manifest files
   /// instead of a divergent fixture. Internal, not public — no other
   /// consumer needs it.
-  /// - Parameter appSupportOverride: roots the metadata and WhisperKit install
-  ///   directories somewhere other than the user's real Application Support.
+  /// - Parameter appSupportOverride: roots the metadata and EVERY model install
+  ///   directory somewhere other than the user's real Application Support.
   ///   Production never passes it. Tests do, because construction now runs a
   ///   no-fetch launch probe against those directories, and a suite that reads
   ///   the real ones has a fixture that changes depending on whether the machine
-  ///   running it has ever used the feature. Parakeet's ASR cache is deliberately
-  ///   NOT rerouted: it comes from `AsrModels.defaultCacheDirectory` and is not
-  ///   part of what the probe touches.
+  ///   running it has ever used the feature.
+  ///
+  ///   **#2483 changed this parameter's reach.** It previously said Parakeet's
+  ///   cache was "deliberately NOT rerouted", which was true only because that
+  ///   cache was `AsrModels.defaultCacheDirectory` — FluidAudio's shared tree,
+  ///   which no override of ours could or should move. Parakeet now installs
+  ///   beneath this root like the other two families, so the override reroutes
+  ///   it as well and a suite passing one no longer reads or writes the real
+  ///   FluidAudio directory at all.
   /// - Parameter deliveryFlagDefaults: where the delivery kill switches are read
   ///   from. Production never passes it, so both handles fall back to the shared
   ///   suite exactly as before. Tests pass an in-memory suite, because the guard
@@ -162,7 +168,13 @@ public final class ModelDeliveryHome {
       let identity = manifest.identity
       let registration = DeliveryRegistration(
         manifest: manifest,
-        installDirectory: AsrModels.defaultCacheDirectory(for: .v3),
+        // #2483: our own directory, a sibling of `Models/whisper` below. This
+        // was `AsrModels.defaultCacheDirectory(for: .v3)` — FluidAudio's SHARED
+        // per-repo cache — from #1348 Phase 2 until now, which is what deleted
+        // other apps' files (#2483) and blocked installs we could not sweep
+        // (#2690). `ParakeetInstallLocation` owns the name, including why the
+        // last path component must stay `parakeet-tdt-0.6b-v3-coreml`.
+        installDirectory: ParakeetInstallLocation.directory(appSupport: appSupportRoot),
         metadataDirectory:
           appSupportRoot
           .appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true))

--- a/Sources/EnviousWisprCore/ASRServiceProtocol.swift
+++ b/Sources/EnviousWisprCore/ASRServiceProtocol.swift
@@ -23,8 +23,18 @@ import Foundation
   ///     the service loads the host-admitted cache with FluidAudio's offline
   ///     switch armed and can NEVER download; a cache miss throws typed.
   ///     False preserves the legacy in-service download path bit-for-bit.
+  ///   - modelDirectoryPath: #2483 — the install directory the HOST selected,
+  ///     as a filesystem path. The helper never resolves a directory of its
+  ///     own: every default it could reach is FluidAudio's shared cache, which
+  ///     EnviousWispr does not own. There is deliberately NO empty-string or
+  ///     nil fallback — an unusable value throws, because a fallback here is
+  ///     indistinguishable from correctness downstream and would silently
+  ///     select the one tree we are trying to stop touching. Host and helper
+  ///     ship in one signed bundle, so there is no version skew to absorb.
   ///   - reply: nil on success, NSError on failure.
-  func loadModel(backendType: String, cacheOnly: Bool, reply: @escaping (NSError?) -> Void)
+  func loadModel(
+    backendType: String, cacheOnly: Bool, modelDirectoryPath: String,
+    reply: @escaping (NSError?) -> Void)
 
   /// Unload the current model and free memory.
   func unloadModel(reply: @escaping () -> Void)

--- a/Sources/EnviousWisprCore/ParakeetInstallLocation.swift
+++ b/Sources/EnviousWisprCore/ParakeetInstallLocation.swift
@@ -21,6 +21,16 @@ import Foundation
 /// download of the same pinned revision either. Same reasoning the founder
 /// ratified for the other shared cache on 2026-07-16
 /// (`whisperkit-research.md` FACT: documents-huggingface-is-a-shared-cache-not-ours).
+///
+/// **Lives in Core on purpose (#2483 cloud round).** It started in the delivery
+/// module, which meant `EnviousWisprASR` could not name it and had to default to
+/// `ParakeetBackend`'s vendor directory instead. Three separate holes came out of
+/// that one fact — the XPC path, the in-process legacy branch, and
+/// `ActiveEngineOperation.load`, which reaches `loadModel()` without ever passing
+/// through the adapter that injects. Patching entry points was losing to a
+/// reviewer who could always find another; making the DEFAULT ours closes the set,
+/// because a site that forgets to inject now fails safe instead of falling into
+/// somebody else's directory.
 public enum ParakeetInstallLocation {
   /// The directory's last path component, and it is load-bearing rather than
   /// cosmetic. FluidAudio reconstructs a repo directory from whatever parent it

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -50,11 +50,28 @@ public enum LegacyDonorImport {
   /// simply yields fewer files.
   ///
   /// - Parameter donor: a directory this process may only read.
+  /// - Parameter trustedRoot: an app-owned directory that `staging` must resolve
+  ///   inside. Without it, containment is circular: proving the destination sits
+  ///   under `staging` says nothing when `staging` is itself a symlink into the
+  ///   donor's tree, and every copy would then land exactly where this type
+  ///   promises never to write.
   public static func reproduce(
-    manifest: DeliveryManifest, components: Set<String>, donor: URL, staging: URL
+    manifest: DeliveryManifest, components: Set<String>, donor: URL, staging: URL,
+    trustedRoot: URL
   ) -> Outcome {
     let fm = FileManager.default
     guard fm.fileExists(atPath: donor.path) else { return .none }
+
+    // Establish the write boundary ONCE, before anything is created. Resolving
+    // the staging root against a trusted app-owned root is what makes the
+    // containment check below non-circular; refusing a staging root that lands
+    // inside the donor is the same statement said the other way round, kept
+    // because it is the failure that matters and it should be impossible to
+    // read this code and miss it.
+    guard let stagingRoot = resolved(staging), let trusted = resolved(trustedRoot),
+      contained(stagingRoot, in: trusted)
+    else { return .none }
+    if let donorRoot = resolved(donor), contained(stagingRoot, in: donorRoot) { return .none }
 
     var files = 0
     var bytes: Int64 = 0
@@ -75,18 +92,22 @@ public enum LegacyDonorImport {
       // into a failed one. The fetcher already owns "is this staged file good"
       // and will resume or discard it, so this path must not pre-empt that.
       guard !fm.fileExists(atPath: destination.path) else { continue }
+      // Cloud round P2: check containment BEFORE creating anything. Creating the
+      // parents first and validating afterwards is too late — if an existing
+      // staging component is a symlink into the shared tree,
+      // `createIntermediateDirectories` follows it and has already made
+      // directories under FluidAudio by the time a later guard declines the
+      // copy. So walk up to the nearest ancestor that EXISTS, resolve THAT, and
+      // require it inside the staging root; only then create the rest.
+      guard let anchor = Self.nearestExistingAncestor(of: destination),
+        let anchorPath = Self.resolved(anchor), Self.contained(anchorPath, in: stagingRoot)
+      else { continue }
       try? fm.createDirectory(
         at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-      // Second-pass finding 7: prove the destination's PARENT really is inside
-      // staging before writing through it. A symlinked component directory in
-      // staging would otherwise let `copyItem` resolve out of the staging tree
-      // and write into the donor — which would make this type's read-only
-      // promise false by exactly the route the promise is about. `realpath`
-      // resolves every link in the chain; a parent that will not resolve, or
-      // resolves outside staging, means skip the file and let it download.
-      guard let stagingRoot = Self.resolved(staging),
-        let parent = Self.resolved(destination.deletingLastPathComponent()),
-        parent == stagingRoot || parent.hasPrefix(stagingRoot + "/")
+      // And again after creating, because the step above can itself traverse a
+      // link that appeared between the two.
+      guard let parent = Self.resolved(destination.deletingLastPathComponent()),
+        Self.contained(parent, in: stagingRoot)
       else { continue }
 
       if cloneItem(at: source, to: destination) {
@@ -113,6 +134,27 @@ public enum LegacyDonorImport {
     return Outcome(
       filesReproduced: files, bytesReproduced: bytes,
       clonedThroughout: everyCopyCloned && files > 0)
+  }
+
+  /// Whether `path` is the root itself or sits beneath it. Both arguments must
+  /// already be `realpath`-resolved; comparing unresolved paths here would be the
+  /// same mistake one level down.
+  private static func contained(_ path: String, in root: String) -> Bool {
+    path == root || path.hasPrefix(root + "/")
+  }
+
+  /// The closest ancestor of `url` that exists on disk, so containment can be
+  /// judged without creating anything first.
+  private static func nearestExistingAncestor(of url: URL) -> URL? {
+    var candidate = url.deletingLastPathComponent()
+    let fm = FileManager.default
+    while candidate.path != "/" {
+      if fm.fileExists(atPath: candidate.path) { return candidate }
+      let parent = candidate.deletingLastPathComponent()
+      guard parent.path != candidate.path else { break }
+      candidate = parent
+    }
+    return fm.fileExists(atPath: candidate.path) ? candidate : nil
   }
 
   /// The fully link-resolved path, or nil when it does not resolve.

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -129,12 +129,28 @@ public enum LegacyDonorImport {
       guard CacheAdmission.sizeMatches(url: source, expected: file.sizeBytes) else { continue }
 
       let destination = staging.appendingPathComponent(file.resolvedInstallPath)
-      // Second-pass finding 9: an existing staged file is LEFT ALONE. An earlier
-      // attempt can have staged a complete, correct file; replacing it with a
-      // same-size donor copy that is corrupt turns a resumable offline attempt
-      // into a failed one. The fetcher already owns "is this staged file good"
-      // and will resume or discard it, so this path must not pre-empt that.
-      guard !fm.fileExists(atPath: destination.path) else { continue }
+      // A staged SYMLINK is removed, not skipped (cloud round 6). `fileExists`
+      // FOLLOWS links, so a staged leaf pointing into the donor read as an
+      // ordinary resumable file: the fetcher then hashed THROUGH the link,
+      // passed, and promotion moved the link — not independent bytes — into the
+      // owned install directory. The admitted cache would have been a pointer at
+      // the donor, so another FluidAudio app replacing its own copy would break
+      // ours, and the vendor would still be handed a path reaching the shared
+      // tree. That defeats the entire change. `.isSymbolicLinkKey` reports the
+      // URL itself rather than its target, which is the no-follow read this
+      // needs. Removing it touches STAGING, which is ours, and the fetcher never
+      // creates symlinks — so a link here is never something we staged.
+      let leafIsSymlink =
+        (try? destination.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) ?? false
+      if leafIsSymlink {
+        try? fm.removeItem(at: destination)
+      } else if fm.fileExists(atPath: destination.path) {
+        // Round 2 finding 9: an existing REAL staged file is left alone. An
+        // earlier attempt can have staged a complete, correct file; replacing it
+        // with a same-size donor copy that is corrupt turns a resumable offline
+        // attempt into a failed one. The fetcher owns "is this staged file good".
+        continue
+      }
       // Cloud round P2: check containment BEFORE creating anything. Creating the
       // parents first and validating afterwards is too late — if an existing
       // staging component is a symlink into the shared tree,

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -80,22 +80,28 @@ public enum LegacyDonorImport {
 
     // Establish the write boundary ONCE, before anything is created.
     //
-    // Cloud round 2 P2: staging normally does NOT exist yet on a first delivery
-    // attempt — the fetcher creates it later — so requiring it to pre-exist made
-    // this return empty for exactly the users the import is for, and every one of
-    // them would have re-downloaded 483 MB. So: judge the nearest EXISTING
-    // ancestor, create staging only once that ancestor is proven inside the
-    // trusted root, and resolve afterwards.
-    guard let trusted = resolved(trustedRoot) else {
-      return .unsafeStagingRoot(detail: "trusted_root_unresolvable")
+    // **NOTHING HERE MAY REQUIRE A DIRECTORY TO ALREADY EXIST.** That mistake has
+    // now been made twice on this branch, in the same shape, and each time it
+    // broke the case the code exists to serve: round 2 required `staging`, which
+    // the fetcher creates later, so no existing user could import; round 3
+    // required `trustedRoot`, which `promoteAndAdmit` creates only after a
+    // successful fetch, so no NEW user could download at all. On a first install
+    // none of these paths exist yet — that is the normal state, not the edge
+    // case. `realpath` needs a real path, so every check below resolves the
+    // nearest EXISTING ancestor, proves containment there, and only then creates.
+    guard let trusted = ensureResolvedDirectory(trustedRoot) else {
+      return .unsafeStagingRoot(detail: "trusted_root_uncreatable")
+    }
+    // The boundary itself must not live inside the donor, or everything below is
+    // contained in the wrong tree.
+    if let donorRoot = resolved(donor), contained(trusted, in: donorRoot) {
+      return .unsafeStagingRoot(detail: "trusted_root_inside_donor")
     }
     guard let anchor = nearestExistingAncestor(of: staging), let anchorPath = resolved(anchor),
       contained(anchorPath, in: trusted)
     else { return .unsafeStagingRoot(detail: "staging_ancestor_outside_trusted_root") }
-    try? fm.createDirectory(at: staging, withIntermediateDirectories: true)
-    guard let stagingRoot = resolved(staging), contained(stagingRoot, in: trusted) else {
-      return .unsafeStagingRoot(detail: "staging_outside_trusted_root")
-    }
+    guard let stagingRoot = ensureResolvedDirectory(staging), contained(stagingRoot, in: trusted)
+    else { return .unsafeStagingRoot(detail: "staging_outside_trusted_root") }
     // Said the other way round as well, because this is the failure that matters
     // and it must be impossible to read this code and miss it.
     if let donorRoot = resolved(donor), contained(stagingRoot, in: donorRoot) {
@@ -155,8 +161,14 @@ public enum LegacyDonorImport {
       everyCopyCloned = false
       // Fall back to a real copy, which allocates. The caller has already
       // reserved headroom for exactly this case.
+      //
+      // CHUNKED, not `FileManager.copyItem`. Cancelling a Swift task does not
+      // interrupt a synchronous `copyItem`, and the shipped manifest's encoder
+      // weight is 445,187,200 bytes — about 92% of the import — so a check
+      // between files would let a cancel wait for almost the entire copy while
+      // `cancel(_:)` blocks on the drain.
       do {
-        try fm.copyItem(at: source, to: destination)
+        try copyInterruptibly(from: source, to: destination)
         files += 1
         bytes += file.sizeBytes
       } catch {
@@ -172,6 +184,20 @@ public enum LegacyDonorImport {
       Outcome(
         filesReproduced: files, bytesReproduced: bytes,
         clonedThroughout: everyCopyCloned && files > 0))
+  }
+
+  /// Creates `url` if it is not there, then returns its fully resolved path.
+  ///
+  /// The whole point is that a directory which does not exist yet is ORDINARY on
+  /// a first install, and `realpath` cannot resolve one. Returning nil means the
+  /// directory could not be created at all — a real failure worth refusing on,
+  /// such as an unwritable parent — not merely that it was absent a moment ago.
+  private static func ensureResolvedDirectory(_ url: URL) -> String? {
+    let fm = FileManager.default
+    if !fm.fileExists(atPath: url.path) {
+      try? fm.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+    return resolved(url)
   }
 
   /// Whether `path` is the root itself or sits beneath it. Both arguments must
@@ -204,6 +230,31 @@ public enum LegacyDonorImport {
     var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
     guard realpath(url.path, &buffer) != nil else { return nil }
     return String(cString: buffer)
+  }
+
+  /// Copies in chunks, aborting between chunks when the task is cancelled.
+  ///
+  /// Throws `CancellationError` on abort so the caller's existing catch removes
+  /// the partial file — a half-written file whose size happened to match would
+  /// otherwise be skipped by the fetcher as "already staged" and then fail its
+  /// hash.
+  private static func copyInterruptibly(from source: URL, to destination: URL) throws {
+    let reader = try FileHandle(forReadingFrom: source)
+    defer { try? reader.close() }
+    guard FileManager.default.createFile(atPath: destination.path, contents: nil) else {
+      throw CocoaError(.fileWriteUnknown)
+    }
+    let writer = try FileHandle(forWritingTo: destination)
+    defer { try? writer.close() }
+    // 4 MiB: large enough that the syscall overhead is irrelevant against a
+    // 445 MB file, small enough that a cancel is felt immediately.
+    let chunkBytes = 4 * 1024 * 1024
+    while true {
+      if Task.isCancelled { throw CancellationError() }
+      let chunk = try reader.read(upToCount: chunkBytes) ?? Data()
+      if chunk.isEmpty { break }
+      try writer.write(contentsOf: chunk)
+    }
   }
 
   /// APFS copy-on-write. Both paths end up independent — writing to one never

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -42,6 +42,23 @@ public enum LegacyDonorImport {
       filesReproduced: 0, bytesReproduced: 0, clonedThroughout: true)
   }
 
+  /// The result of one attempt, with REFUSAL kept distinct from "imported
+  /// nothing" (cloud round 2 P1).
+  ///
+  /// Collapsing the two was a real hole: an unsafe staging root returned an
+  /// empty `Outcome`, the caller read that as an ordinary miss, and then handed
+  /// the SAME unsafe staging URL to the fetcher, which writes through it — and
+  /// promotion then moves component roots out of whatever it resolves to. A
+  /// refusal here is a statement about the destination, not about the donor, so
+  /// the caller must abandon the attempt rather than continue without us.
+  public enum Result: Sendable, Equatable {
+    case imported(Outcome)
+    /// Staging does not resolve inside the trusted root, or resolves inside the
+    /// donor. Nothing was written. The caller MUST NOT proceed to fetch with
+    /// this staging directory.
+    case unsafeStagingRoot(detail: String)
+  }
+
   /// Copy every manifest file of `components` from `donor` into `staging`.
   ///
   /// Best-effort per file by design: a partial result is useful, because each
@@ -58,26 +75,45 @@ public enum LegacyDonorImport {
   public static func reproduce(
     manifest: DeliveryManifest, components: Set<String>, donor: URL, staging: URL,
     trustedRoot: URL
-  ) -> Outcome {
+  ) -> Result {
     let fm = FileManager.default
-    guard fm.fileExists(atPath: donor.path) else { return .none }
 
-    // Establish the write boundary ONCE, before anything is created. Resolving
-    // the staging root against a trusted app-owned root is what makes the
-    // containment check below non-circular; refusing a staging root that lands
-    // inside the donor is the same statement said the other way round, kept
-    // because it is the failure that matters and it should be impossible to
-    // read this code and miss it.
-    guard let stagingRoot = resolved(staging), let trusted = resolved(trustedRoot),
-      contained(stagingRoot, in: trusted)
-    else { return .none }
-    if let donorRoot = resolved(donor), contained(stagingRoot, in: donorRoot) { return .none }
+    // Establish the write boundary ONCE, before anything is created.
+    //
+    // Cloud round 2 P2: staging normally does NOT exist yet on a first delivery
+    // attempt — the fetcher creates it later — so requiring it to pre-exist made
+    // this return empty for exactly the users the import is for, and every one of
+    // them would have re-downloaded 483 MB. So: judge the nearest EXISTING
+    // ancestor, create staging only once that ancestor is proven inside the
+    // trusted root, and resolve afterwards.
+    guard let trusted = resolved(trustedRoot) else {
+      return .unsafeStagingRoot(detail: "trusted_root_unresolvable")
+    }
+    guard let anchor = nearestExistingAncestor(of: staging), let anchorPath = resolved(anchor),
+      contained(anchorPath, in: trusted)
+    else { return .unsafeStagingRoot(detail: "staging_ancestor_outside_trusted_root") }
+    try? fm.createDirectory(at: staging, withIntermediateDirectories: true)
+    guard let stagingRoot = resolved(staging), contained(stagingRoot, in: trusted) else {
+      return .unsafeStagingRoot(detail: "staging_outside_trusted_root")
+    }
+    // Said the other way round as well, because this is the failure that matters
+    // and it must be impossible to read this code and miss it.
+    if let donorRoot = resolved(donor), contained(stagingRoot, in: donorRoot) {
+      return .unsafeStagingRoot(detail: "staging_inside_donor")
+    }
+
+    // Only now is the donor's absence an ordinary, safe miss.
+    guard fm.fileExists(atPath: donor.path) else { return .imported(.none) }
 
     var files = 0
     var bytes: Int64 = 0
     var everyCopyCloned = true
 
     for file in manifest.files where components.contains(file.component) {
+      // Cloud round 2 P2: cooperative cancellation. A fallback copy moves
+      // hundreds of megabytes, and `cancel(_:)` waits for the attempt to drain —
+      // without this the user's cancel sits pending until the whole copy ends.
+      if Task.isCancelled { break }
       let source = donor.appendingPathComponent(file.resolvedInstallPath)
       // Size is the cheap gate that keeps us from copying a whole tree of the
       // wrong revision. It is NOT the correctness check — that is the staged
@@ -99,8 +135,9 @@ public enum LegacyDonorImport {
       // directories under FluidAudio by the time a later guard declines the
       // copy. So walk up to the nearest ancestor that EXISTS, resolve THAT, and
       // require it inside the staging root; only then create the rest.
-      guard let anchor = Self.nearestExistingAncestor(of: destination),
-        let anchorPath = Self.resolved(anchor), Self.contained(anchorPath, in: stagingRoot)
+      guard let fileAnchor = Self.nearestExistingAncestor(of: destination),
+        let fileAnchorPath = Self.resolved(fileAnchor),
+        Self.contained(fileAnchorPath, in: stagingRoot)
       else { continue }
       try? fm.createDirectory(
         at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -131,9 +168,10 @@ public enum LegacyDonorImport {
       }
     }
 
-    return Outcome(
-      filesReproduced: files, bytesReproduced: bytes,
-      clonedThroughout: everyCopyCloned && files > 0)
+    return .imported(
+      Outcome(
+        filesReproduced: files, bytesReproduced: bytes,
+        clonedThroughout: everyCopyCloned && files > 0))
   }
 
   /// Whether `path` is the root itself or sits beneath it. Both arguments must

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -69,13 +69,25 @@ public enum LegacyDonorImport {
       guard CacheAdmission.sizeMatches(url: source, expected: file.sizeBytes) else { continue }
 
       let destination = staging.appendingPathComponent(file.resolvedInstallPath)
+      // Second-pass finding 9: an existing staged file is LEFT ALONE. An earlier
+      // attempt can have staged a complete, correct file; replacing it with a
+      // same-size donor copy that is corrupt turns a resumable offline attempt
+      // into a failed one. The fetcher already owns "is this staged file good"
+      // and will resume or discard it, so this path must not pre-empt that.
+      guard !fm.fileExists(atPath: destination.path) else { continue }
       try? fm.createDirectory(
         at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-      // A leftover from an earlier attempt would make both copy paths fail with
-      // EEXIST. Removing it touches STAGING, never the donor.
-      if fm.fileExists(atPath: destination.path) {
-        try? fm.removeItem(at: destination)
-      }
+      // Second-pass finding 7: prove the destination's PARENT really is inside
+      // staging before writing through it. A symlinked component directory in
+      // staging would otherwise let `copyItem` resolve out of the staging tree
+      // and write into the donor — which would make this type's read-only
+      // promise false by exactly the route the promise is about. `realpath`
+      // resolves every link in the chain; a parent that will not resolve, or
+      // resolves outside staging, means skip the file and let it download.
+      guard let stagingRoot = Self.resolved(staging),
+        let parent = Self.resolved(destination.deletingLastPathComponent()),
+        parent == stagingRoot || parent.hasPrefix(stagingRoot + "/")
+      else { continue }
 
       if cloneItem(at: source, to: destination) {
         files += 1
@@ -101,6 +113,17 @@ public enum LegacyDonorImport {
     return Outcome(
       filesReproduced: files, bytesReproduced: bytes,
       clonedThroughout: everyCopyCloned && files > 0)
+  }
+
+  /// The fully link-resolved path, or nil when it does not resolve.
+  ///
+  /// `realpath(3)` rather than `URL.resolvingSymlinksInPath()`, which this
+  /// repo documents as insufficient for the `/private/tmp` case that every
+  /// temporary-directory test runs in.
+  private static func resolved(_ url: URL) -> String? {
+    var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(url.path, &buffer) != nil else { return nil }
+    return String(cString: buffer)
   }
 
   /// APFS copy-on-write. Both paths end up independent — writing to one never

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -15,6 +15,17 @@ import Foundation
 /// rather than a check that could be wrong: there is no write API on this path
 /// to reach.
 ///
+/// **KNOWN LIMIT, deliberately not closed: path checks are not atomic.** A hostile
+/// process running as the same user can replace a checked directory with a symlink
+/// between the check and the copy, and only descriptor-relative no-follow
+/// operations would close that. It is not closed here because the attacker it
+/// requires already has the capability the attack would gain: anything that can
+/// write inside our staging directory can write into the donor directly, without
+/// involving us. The promise this type makes is that OUR code does not write in
+/// the donor, not that a same-user attacker cannot. Cloud review round 5,
+/// classified HYPOTHETICAL per `validation-discipline.md`
+/// RULE: validate-automated-review-findings.
+///
 /// **It also does not verify.** Files land in the caller's staging directory,
 /// and `ManifestFetchTask` already refuses to skip a staged file unless its size
 /// AND streaming SHA-256 match the manifest (`ManifestFetchTask.swift:144-148`),
@@ -133,7 +144,13 @@ public enum LegacyDonorImport {
       // require it inside the staging root; only then create the rest.
       guard let fileAnchor = Self.nearestExistingAncestor(of: destination),
         let fileAnchorPath = Self.resolved(fileAnchor),
-        !Self.contained(fileAnchorPath, in: donorRoot)
+        // Both halves, and the staging half is the one round 5 caught: rejecting
+        // only the donor let a staging component symlinked to some UNRELATED
+        // directory pass, and `createDirectory` then made manifest subdirectories
+        // there before the post-creation check noticed. Checking the anchor needs
+        // nothing created first, so there is no reason to learn it late.
+        !Self.contained(fileAnchorPath, in: donorRoot),
+        Self.contained(fileAnchorPath, in: stagingRoot)
       else { continue }
       try? fm.createDirectory(
         at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -53,9 +53,9 @@ public enum LegacyDonorImport {
   /// the caller must abandon the attempt rather than continue without us.
   public enum Result: Sendable, Equatable {
     case imported(Outcome)
-    /// Staging does not resolve inside the trusted root, or resolves inside the
-    /// donor. Nothing was written. The caller MUST NOT proceed to fetch with
-    /// this staging directory.
+    /// Staging, or an ancestor of it, resolves inside the donor. Nothing was
+    /// written. The caller MUST NOT proceed to fetch with this staging
+    /// directory, because the fetcher would write through it.
     case unsafeStagingRoot(detail: String)
   }
 
@@ -67,49 +67,39 @@ public enum LegacyDonorImport {
   /// simply yields fewer files.
   ///
   /// - Parameter donor: a directory this process may only read.
-  /// - Parameter trustedRoot: an app-owned directory that `staging` must resolve
-  ///   inside. Without it, containment is circular: proving the destination sits
-  ///   under `staging` says nothing when `staging` is itself a symlink into the
-  ///   donor's tree, and every copy would then land exactly where this type
-  ///   promises never to write.
   public static func reproduce(
-    manifest: DeliveryManifest, components: Set<String>, donor: URL, staging: URL,
-    trustedRoot: URL
+    manifest: DeliveryManifest, components: Set<String>, donor: URL, staging: URL
   ) -> Result {
     let fm = FileManager.default
 
-    // Establish the write boundary ONCE, before anything is created.
+    // THE WHOLE GUARD, and it is deliberately this small.
     //
-    // **NOTHING HERE MAY REQUIRE A DIRECTORY TO ALREADY EXIST.** That mistake has
-    // now been made twice on this branch, in the same shape, and each time it
-    // broke the case the code exists to serve: round 2 required `staging`, which
-    // the fetcher creates later, so no existing user could import; round 3
-    // required `trustedRoot`, which `promoteAndAdmit` creates only after a
-    // successful fetch, so no NEW user could download at all. On a first install
-    // none of these paths exist yet — that is the normal state, not the edge
-    // case. `realpath` needs a real path, so every check below resolves the
-    // nearest EXISTING ancestor, proves containment there, and only then creates.
-    guard let trusted = ensureResolvedDirectory(trustedRoot) else {
-      return .unsafeStagingRoot(detail: "trusted_root_uncreatable")
-    }
-    // The boundary itself must not live inside the donor, or everything below is
-    // contained in the wrong tree.
-    if let donorRoot = resolved(donor), contained(trusted, in: donorRoot) {
-      return .unsafeStagingRoot(detail: "trusted_root_inside_donor")
-    }
+    // An earlier version proved staging sat inside a "trusted root" as well.
+    // That apparatus produced four defects across three review rounds — two of
+    // which would have broken the product for every user — and the fourth was
+    // that it CREATED the trusted root before checking it, so an ancestor
+    // symlinked into the donor got directories made inside the donor by the very
+    // code meant to prevent writes there. It was also never load-bearing:
+    // `ManifestFetchTask` writes into this same staging directory with no such
+    // check and always has, so guarding one writer among several was a door in a
+    // wall with other doors open.
+    //
+    // The hazard is exactly one sentence — "could a copy of mine land inside the
+    // donor" — and that is now exactly one question, asked against the nearest
+    // EXISTING ancestor first, so nothing is created before it is answered.
+    guard let donorRoot = resolved(donor) else { return .imported(.none) }
     guard let anchor = nearestExistingAncestor(of: staging), let anchorPath = resolved(anchor),
-      contained(anchorPath, in: trusted)
-    else { return .unsafeStagingRoot(detail: "staging_ancestor_outside_trusted_root") }
-    guard let stagingRoot = ensureResolvedDirectory(staging), contained(stagingRoot, in: trusted)
-    else { return .unsafeStagingRoot(detail: "staging_outside_trusted_root") }
-    // Said the other way round as well, because this is the failure that matters
-    // and it must be impossible to read this code and miss it.
-    if let donorRoot = resolved(donor), contained(stagingRoot, in: donorRoot) {
+      !contained(anchorPath, in: donorRoot)
+    else { return .unsafeStagingRoot(detail: "staging_ancestor_inside_donor") }
+    if !fm.fileExists(atPath: staging.path) {
+      try? fm.createDirectory(at: staging, withIntermediateDirectories: true)
+    }
+    guard let stagingRoot = resolved(staging) else {
+      return .unsafeStagingRoot(detail: "staging_uncreatable")
+    }
+    guard !contained(stagingRoot, in: donorRoot) else {
       return .unsafeStagingRoot(detail: "staging_inside_donor")
     }
-
-    // Only now is the donor's absence an ordinary, safe miss.
-    guard fm.fileExists(atPath: donor.path) else { return .imported(.none) }
 
     var files = 0
     var bytes: Int64 = 0
@@ -143,14 +133,14 @@ public enum LegacyDonorImport {
       // require it inside the staging root; only then create the rest.
       guard let fileAnchor = Self.nearestExistingAncestor(of: destination),
         let fileAnchorPath = Self.resolved(fileAnchor),
-        Self.contained(fileAnchorPath, in: stagingRoot)
+        !Self.contained(fileAnchorPath, in: donorRoot)
       else { continue }
       try? fm.createDirectory(
         at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
       // And again after creating, because the step above can itself traverse a
       // link that appeared between the two.
       guard let parent = Self.resolved(destination.deletingLastPathComponent()),
-        Self.contained(parent, in: stagingRoot)
+        !Self.contained(parent, in: donorRoot), Self.contained(parent, in: stagingRoot)
       else { continue }
 
       if cloneItem(at: source, to: destination) {
@@ -184,20 +174,6 @@ public enum LegacyDonorImport {
       Outcome(
         filesReproduced: files, bytesReproduced: bytes,
         clonedThroughout: everyCopyCloned && files > 0))
-  }
-
-  /// Creates `url` if it is not there, then returns its fully resolved path.
-  ///
-  /// The whole point is that a directory which does not exist yet is ORDINARY on
-  /// a first install, and `realpath` cannot resolve one. Returning nil means the
-  /// directory could not be created at all — a real failure worth refusing on,
-  /// such as an unwritable parent — not merely that it was absent a moment ago.
-  private static func ensureResolvedDirectory(_ url: URL) -> String? {
-    let fm = FileManager.default
-    if !fm.fileExists(atPath: url.path) {
-      try? fm.createDirectory(at: url, withIntermediateDirectories: true)
-    }
-    return resolved(url)
   }
 
   /// Whether `path` is the root itself or sits beneath it. Both arguments must

--- a/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
+++ b/Sources/EnviousWisprModelDelivery/LegacyDonorImport.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Reproduces model bytes a user already has, from a directory we may only READ
+/// (#2483).
+///
+/// The point of #2483 is that EnviousWispr installs into its own directory and
+/// never mutates FluidAudio's shared tree. Moving there naively would make every
+/// existing user re-download the pinned set — 483,256,769 bytes — and would also
+/// throw away a copy a *different* FluidAudio app already downloaded. This type
+/// is the answer to both: copy out, leave the original exactly as it was.
+///
+/// **Nothing here opens the donor for writing, and nothing here deletes.** The
+/// donor is addressed only through `FileManager.copyItem` and `clonefile`, both
+/// of which read it. That is the whole safety argument, and it is structural
+/// rather than a check that could be wrong: there is no write API on this path
+/// to reach.
+///
+/// **It also does not verify.** Files land in the caller's staging directory,
+/// and `ManifestFetchTask` already refuses to skip a staged file unless its size
+/// AND streaming SHA-256 match the manifest (`ManifestFetchTask.swift:144-148`),
+/// then `CacheAdmission.promoteAndAdmit` stamps only what verified. Re-checking
+/// here would be a second answer to a question that already has one, and the
+/// existing answer is the one that gates admission. A donor file that is
+/// truncated, stale, from another revision, or actively being rewritten by its
+/// owner therefore costs one wasted copy and falls through to a normal download.
+public enum LegacyDonorImport {
+
+  /// What one attempt did, for telemetry and for the caller's log line.
+  public struct Outcome: Sendable, Equatable {
+    /// Files copied into staging. Not "files admitted" — verification is
+    /// downstream and may still reject them.
+    public let filesReproduced: Int
+    /// Bytes read from the donor, by the manifest's reckoning.
+    public let bytesReproduced: Int64
+    /// True when every copy went through APFS copy-on-write rather than a full
+    /// byte copy. Reported rather than assumed: cloning needs one filesystem
+    /// that supports it, and a user whose home is on a volume that does not
+    /// gets a real copy and real allocation.
+    public let clonedThroughout: Bool
+
+    public static let none = Outcome(
+      filesReproduced: 0, bytesReproduced: 0, clonedThroughout: true)
+  }
+
+  /// Copy every manifest file of `components` from `donor` into `staging`.
+  ///
+  /// Best-effort per file by design: a partial result is useful, because each
+  /// file the fetch path finds already staged and verified is one it does not
+  /// download. A donor that is absent, unreadable, or holds a different revision
+  /// simply yields fewer files.
+  ///
+  /// - Parameter donor: a directory this process may only read.
+  public static func reproduce(
+    manifest: DeliveryManifest, components: Set<String>, donor: URL, staging: URL
+  ) -> Outcome {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: donor.path) else { return .none }
+
+    var files = 0
+    var bytes: Int64 = 0
+    var everyCopyCloned = true
+
+    for file in manifest.files where components.contains(file.component) {
+      let source = donor.appendingPathComponent(file.resolvedInstallPath)
+      // Size is the cheap gate that keeps us from copying a whole tree of the
+      // wrong revision. It is NOT the correctness check — that is the staged
+      // SHA-256 downstream — so a size match here still proves nothing and is
+      // not reported as if it did.
+      guard CacheAdmission.sizeMatches(url: source, expected: file.sizeBytes) else { continue }
+
+      let destination = staging.appendingPathComponent(file.resolvedInstallPath)
+      try? fm.createDirectory(
+        at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+      // A leftover from an earlier attempt would make both copy paths fail with
+      // EEXIST. Removing it touches STAGING, never the donor.
+      if fm.fileExists(atPath: destination.path) {
+        try? fm.removeItem(at: destination)
+      }
+
+      if cloneItem(at: source, to: destination) {
+        files += 1
+        bytes += file.sizeBytes
+        continue
+      }
+      everyCopyCloned = false
+      // Fall back to a real copy, which allocates. The caller has already
+      // reserved headroom for exactly this case.
+      do {
+        try fm.copyItem(at: source, to: destination)
+        files += 1
+        bytes += file.sizeBytes
+      } catch {
+        // Leave nothing half-written for the fetch path to resume onto: a
+        // partial file whose SIZE happened to match would be skipped as
+        // "already staged" and then fail its hash, which is a slower and more
+        // confusing route to the same download.
+        try? fm.removeItem(at: destination)
+      }
+    }
+
+    return Outcome(
+      filesReproduced: files, bytesReproduced: bytes,
+      clonedThroughout: everyCopyCloned && files > 0)
+  }
+
+  /// APFS copy-on-write. Both paths end up independent — writing to one never
+  /// affects the other — while sharing their blocks until something writes.
+  ///
+  /// Apple documents the independence, not zero allocation, so this is
+  /// "usually little extra space", never a guarantee of none. It fails when the
+  /// two paths are on different filesystems, when the filesystem does not
+  /// support cloning, or when the destination exists; every one of those falls
+  /// back to a real copy above rather than being treated as an error.
+  private static func cloneItem(at source: URL, to destination: URL) -> Bool {
+    source.withUnsafeFileSystemRepresentation { sourcePath in
+      destination.withUnsafeFileSystemRepresentation { destinationPath in
+        guard let sourcePath, let destinationPath else { return false }
+        return clonefile(sourcePath, destinationPath, 0) == 0
+      }
+    }
+  }
+}

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -7,11 +7,21 @@ public struct DeliveryRegistration: Sendable {
   public let manifest: DeliveryManifest
   public let installDirectory: URL
   public let metadataDirectory: URL
+  /// #2483: a directory that may already hold this model, which this process may
+  /// only READ. Set for Parakeet, whose install directory moved out of
+  /// FluidAudio's shared tree and whose users' bytes are still sitting in it.
+  /// `nil` for every other family, none of which ever installed anywhere but its
+  /// own directory. Never a write or delete target — see `LegacyDonorImport`.
+  public let legacyDonorDirectory: URL?
 
-  public init(manifest: DeliveryManifest, installDirectory: URL, metadataDirectory: URL) {
+  public init(
+    manifest: DeliveryManifest, installDirectory: URL, metadataDirectory: URL,
+    legacyDonorDirectory: URL? = nil
+  ) {
     self.manifest = manifest
     self.installDirectory = installDirectory
     self.metadataDirectory = metadataDirectory
+    self.legacyDonorDirectory = legacyDonorDirectory
   }
 }
 
@@ -628,9 +638,33 @@ public actor ModelDeliveryController {
       entries[identity] = entry
     }
 
+    // #2483: reproduce what the user already has, before any network.
+    //
+    // Deliberately AFTER the preflight above, which has just reserved headroom
+    // for exactly these bytes — a clone usually needs almost none, a fallback
+    // copy needs all of them, and neither is known in advance. Files land in
+    // staging; `ManifestFetchTask` then verifies each one's size and SHA-256 and
+    // skips the ones that pass, so a successful import turns this attempt into a
+    // zero-byte download and a rejected one costs only the copy.
+    //
+    // The donor is read-only (`LegacyDonorImport`), so nothing here can damage
+    // the directory the user's other apps share.
+    var donorOutcome = LegacyDonorImport.Outcome.none
+    if let donor = registration.legacyDonorDirectory, !componentsToFetch.isEmpty {
+      donorOutcome = LegacyDonorImport.reproduce(
+        manifest: manifest, components: componentsToFetch, donor: donor, staging: staging)
+      if donorOutcome.filesReproduced > 0 {
+        await AppLogger.shared.log(
+          "Model delivery reproduced \(donorOutcome.filesReproduced) file(s), "
+            + "\(donorOutcome.bytesReproduced) bytes, from the legacy shared directory "
+            + "(cloned: \(donorOutcome.clonedThroughout)) — no download needed for those files",
+          level: .info, category: "Delivery")
+      }
+    }
+
     // Accepted: this is the attempt_started line (accept-gated, EG-1
     // discipline; resumed truth from disk).
-    let resumed = stagedBytes > 0
+    let resumed = stagedBytes > 0 || donorOutcome.filesReproduced > 0
     emit(identity, .attemptStarted(resumed: resumed))
     let startedAt = ContinuousClock.now
     setState(

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -676,10 +676,7 @@ public actor ModelDeliveryController {
       // runs to completion.
       let copyTask = Task.detached(priority: .utility) {
         LegacyDonorImport.reproduce(
-          manifest: manifest, components: componentsToFetch, donor: donor, staging: staging,
-          // Staging lives at `metadataDirectory/staging/<cacheKey>`, so the
-          // metadata directory is the app-owned root staging must resolve inside.
-          trustedRoot: registration.metadataDirectory)
+          manifest: manifest, components: componentsToFetch, donor: donor, staging: staging)
       }
       let importResult = await withTaskCancellationHandler {
         await copyTask.value

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -670,15 +670,38 @@ public actor ModelDeliveryController {
     // way back, because the wait is exactly long enough for one to land.
     var donorOutcome = LegacyDonorImport.Outcome.none
     if let donor = registration.legacyDonorDirectory, !componentsToFetch.isEmpty {
-      donorOutcome = await Task.detached(priority: .utility) {
+      // Cloud round 2 P2: a detached task does NOT inherit cancellation, so the
+      // handle is held and cancelled explicitly. Without this, cancelling during
+      // a fallback copy leaves `cancel(_:)` waiting for the drain while the copy
+      // runs to completion.
+      let copyTask = Task.detached(priority: .utility) {
         LegacyDonorImport.reproduce(
           manifest: manifest, components: componentsToFetch, donor: donor, staging: staging,
           // Staging lives at `metadataDirectory/staging/<cacheKey>`, so the
           // metadata directory is the app-owned root staging must resolve inside.
           trustedRoot: registration.metadataDirectory)
-      }.value
+      }
+      let importResult = await withTaskCancellationHandler {
+        await copyTask.value
+      } onCancel: {
+        copyTask.cancel()
+      }
       guard entries[identity]?.generation == generation, !Task.isCancelled else {
         return finishCancelled(identity, generation: generation)
+      }
+      switch importResult {
+      case .imported(let outcome):
+        donorOutcome = outcome
+      case .unsafeStagingRoot(let detail):
+        // Cloud round 2 P1: a containment refusal is about the DESTINATION, so it
+        // must abandon the attempt. Treating it as an ordinary empty import would
+        // hand the same unsafe staging URL to the fetcher, which writes through
+        // it, and promotion would then move component roots out of whatever it
+        // resolves to — the exact write this type exists to prevent, reached by
+        // the code that just declined to perform it.
+        let failure = DeliveryFailure(
+          reason: .cacheRepairFailed, detail: "unsafe_staging:\(detail)")
+        return await finishFailed(identity, failure, generation: generation)
       }
       if donorOutcome.filesReproduced > 0 {
         await AppLogger.shared.log(

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -672,7 +672,10 @@ public actor ModelDeliveryController {
     if let donor = registration.legacyDonorDirectory, !componentsToFetch.isEmpty {
       donorOutcome = await Task.detached(priority: .utility) {
         LegacyDonorImport.reproduce(
-          manifest: manifest, components: componentsToFetch, donor: donor, staging: staging)
+          manifest: manifest, components: componentsToFetch, donor: donor, staging: staging,
+          // Staging lives at `metadataDirectory/staging/<cacheKey>`, so the
+          // metadata directory is the app-owned root staging must resolve inside.
+          trustedRoot: registration.metadataDirectory)
       }.value
       guard entries[identity]?.generation == generation, !Task.isCancelled else {
         return finishCancelled(identity, generation: generation)

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -662,15 +662,26 @@ public actor ModelDeliveryController {
     //
     // The donor is read-only (`LegacyDonorImport`), so nothing here can damage
     // the directory the user's other apps share.
+    //
+    // Second-pass finding 8: DETACHED. Without a cloning filesystem this copies
+    // hundreds of megabytes synchronously, and running that on the controller
+    // actor would lock out every other delivery call — including the cancel the
+    // user just pressed — for the whole copy. Cancellation is re-checked on the
+    // way back, because the wait is exactly long enough for one to land.
     var donorOutcome = LegacyDonorImport.Outcome.none
     if let donor = registration.legacyDonorDirectory, !componentsToFetch.isEmpty {
-      donorOutcome = LegacyDonorImport.reproduce(
-        manifest: manifest, components: componentsToFetch, donor: donor, staging: staging)
+      donorOutcome = await Task.detached(priority: .utility) {
+        LegacyDonorImport.reproduce(
+          manifest: manifest, components: componentsToFetch, donor: donor, staging: staging)
+      }.value
+      guard entries[identity]?.generation == generation, !Task.isCancelled else {
+        return finishCancelled(identity, generation: generation)
+      }
       if donorOutcome.filesReproduced > 0 {
         await AppLogger.shared.log(
           "Model delivery reproduced \(donorOutcome.filesReproduced) file(s), "
             + "\(donorOutcome.bytesReproduced) bytes, from the legacy shared directory "
-            + "(cloned: \(donorOutcome.clonedThroughout)) — no download needed for those files",
+            + "(cloned: \(donorOutcome.clonedThroughout)) — awaiting hash verification",
           level: .info, category: "Delivery")
       }
     }

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -577,7 +577,20 @@ public actor ModelDeliveryController {
         try admission.promoteAndAdmit(
           stagedComponents: [], stagingDirectory: stagingDirectory(for: registration),
           untouchedComponents: validation.verifiedComponents)
+      } catch let failure as DeliveryFailure {
+        // #2691: pass CacheAdmission's own failure through, exactly as the
+        // post-fetch promote below already does. This arm used to replace every
+        // throw with the fixed detail "admit_in_place", discarding the two
+        // details that say WHICH half failed — `orphan_cleanup` and
+        // `post_promote_stamp:<component>`. #2690's reporter could therefore
+        // only ever see one generic word for a failure that had a specific
+        // cause, and neither he nor the telemetry could tell an unremovable
+        // entry from a bad post-promote stamp.
+        return await finishFailed(identity, failure, generation: generation)
       } catch {
+        // Anything that is not a DeliveryFailure keeps the old site-named
+        // detail: there is no better name for it, and the site is still the
+        // most useful thing we know.
         let failure = DeliveryFailure(reason: .cacheRepairFailed, detail: "admit_in_place")
         return await finishFailed(identity, failure, generation: generation)
       }

--- a/Sources/EnviousWisprModelDelivery/ParakeetInstallLocation.swift
+++ b/Sources/EnviousWisprModelDelivery/ParakeetInstallLocation.swift
@@ -28,7 +28,17 @@ public enum ParakeetInstallLocation {
   /// re-appends `repo.folderName` — so a directory named anything else would
   /// make our install location and the runtime's lookup location disagree while
   /// both looked correct in isolation.
-  public static let repoFolderName = "parakeet-tdt-0.6b-v3-coreml"
+  ///
+  /// **It is NOT the Hugging Face repo slug**, and the two differ by exactly the
+  /// suffix that makes them look interchangeable. `Repo.name` is
+  /// `parakeet-tdt-0.6b-v3-coreml`; `Repo.folderName` falls through to
+  /// `name.replacingOccurrences(of: "-coreml", with: "")`
+  /// (`ModelNames.swift:265-266`), so the directory FluidAudio actually uses is
+  /// this one. Taking the value from our own delivery manifest — which carries
+  /// the slug — produced a directory the loader would never look in. The test
+  /// `lastComponentSurvivesVendorReconstruction` reads the vendor's value at
+  /// runtime rather than restating it here, which is what caught that.
+  public static let repoFolderName = "parakeet-tdt-0.6b-v3"
 
   /// Our owned install directory beneath a given Application Support root.
   ///

--- a/Sources/EnviousWisprModelDelivery/ParakeetInstallLocation.swift
+++ b/Sources/EnviousWisprModelDelivery/ParakeetInstallLocation.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Where EnviousWispr keeps its Parakeet model bytes (#2483).
+///
+/// The single authority. Before #2483 three places answered this question
+/// independently and all three answered `AsrModels.defaultCacheDirectory`,
+/// which is FluidAudio's SHARED per-repo cache under
+/// `~/Library/Application Support/FluidAudio/Models/`. That directory belongs
+/// to the FluidAudio package and to every other app built on it, and treating
+/// it as ours produced both halves of the same defect: we deleted files another
+/// app had put there (#2483), and we refused to install when we could not
+/// delete them (#2690).
+///
+/// **The rule this type exists to make structural: EnviousWispr creates,
+/// modifies, moves and deletes nothing under `FluidAudio/`.** It is categorical
+/// rather than filtered on purpose. A filter would need to answer "did we write
+/// this file", and nothing on disk answers it — the admission marker records
+/// what we VALIDATED, not what we WROTE, and we stamp one over pre-existing
+/// files we never downloaded (`ModelDeliveryController.adoptedInPlace`). Byte
+/// equality with our own manifest cannot separate our copy from a user's own
+/// download of the same pinned revision either. Same reasoning the founder
+/// ratified for the other shared cache on 2026-07-16
+/// (`whisperkit-research.md` FACT: documents-huggingface-is-a-shared-cache-not-ours).
+public enum ParakeetInstallLocation {
+  /// The directory's last path component, and it is load-bearing rather than
+  /// cosmetic. FluidAudio reconstructs a repo directory from whatever parent it
+  /// is handed — `AsrModels.repoPath(from:)` drops the last component and
+  /// re-appends `repo.folderName` — so a directory named anything else would
+  /// make our install location and the runtime's lookup location disagree while
+  /// both looked correct in isolation.
+  public static let repoFolderName = "parakeet-tdt-0.6b-v3-coreml"
+
+  /// Our owned install directory beneath a given Application Support root.
+  ///
+  /// A sibling of `EnviousWispr/Models/whisper`, which the multilingual family
+  /// has used since #1386 PR-2. Parakeet was the last family still installing
+  /// into somebody else's directory.
+  public static func directory(appSupport: URL) -> URL {
+    appSupport
+      .appendingPathComponent("EnviousWispr/Models", isDirectory: true)
+      .appendingPathComponent(repoFolderName, isDirectory: true)
+  }
+
+  /// The live location, for the one caller that has no injected root: the
+  /// engine adapter's legacy branch, which runs when delivery is switched off
+  /// or its manifest failed to load and therefore has no registration to read a
+  /// directory from.
+  ///
+  /// It resolves the REAL Application Support root even under a test that
+  /// redirected the delivery layer's root. That divergence is deliberate and
+  /// narrow: any caller holding a `ParakeetDeliveryHandle` must read the
+  /// handle's own `installDirectory` instead, so the only path reaching this
+  /// property is the one with nothing better to read. What it must never do is
+  /// resolve FluidAudio's shared directory, and it cannot.
+  public static var live: URL {
+    let appSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    return directory(appSupport: appSupport)
+  }
+}

--- a/Sources/EnviousWisprModelDelivery/ParakeetInstallLocation.swift
+++ b/Sources/EnviousWisprModelDelivery/ParakeetInstallLocation.swift
@@ -41,6 +41,22 @@ public enum ParakeetInstallLocation {
       .appendingPathComponent(repoFolderName, isDirectory: true)
   }
 
+  /// The directory Parakeet used to install into, kept ONLY as a read-only
+  /// donor so an existing copy can be reproduced rather than re-downloaded
+  /// (`LegacyDonorImport`).
+  ///
+  /// This is FluidAudio's shared per-repo cache. It is spelled out here rather
+  /// than taken from `AsrModels.defaultCacheDirectory` so that this module does
+  /// not depend on FluidAudio, and so the one remaining mention of the shared
+  /// tree in our code sits next to the rule about it. **Nothing may pass this
+  /// value as an install directory, a staging directory, or anything else a
+  /// write or delete can reach.**
+  public static func legacySharedDonor(appSupport: URL) -> URL {
+    appSupport
+      .appendingPathComponent("FluidAudio/Models", isDirectory: true)
+      .appendingPathComponent(repoFolderName, isDirectory: true)
+  }
+
   /// The live location, for the one caller that has no injected root: the
   /// engine adapter's legacy branch, which runs when delivery is switched off
   /// or its manifest failed to load and therefore has no registration to read a

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -334,6 +334,10 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     if let delivery, delivery.isEnabled() {
       deliveryActive = true
       asrManager.parakeetCacheOnly = true
+      // #2483: the load layer is TOLD where to look, from the registration the
+      // controller actually admitted into. Set before `ensureAvailable()` so a
+      // throw below cannot leave the manager pointing at a stale location.
+      asrManager.parakeetModelDirectory = delivery.installDirectory
       switch await delivery.ensureAvailable() {
       case .admitted:
         break
@@ -345,6 +349,16 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     } else {
       deliveryActive = false
       asrManager.parakeetCacheOnly = false
+      // #2483: the legacy branch gets our directory TOO, and this is the half
+      // that closes the vendor's own deletion. With `cacheOnly` false,
+      // FluidAudio's offline switch is off, so `ModelHub.loadModels` may purge
+      // the whole repo directory after a failed load and may write a vocabulary
+      // file into it. Both are acceptable inside a directory we own and were
+      // never acceptable inside FluidAudio's shared one. A handle that exists
+      // but is switched off still knows the admitted location; only a missing
+      // or unregistered handle falls back, and its fallback is still ours.
+      asrManager.parakeetModelDirectory =
+        delivery?.installDirectory ?? ParakeetInstallLocation.live
       delivery?.noteLegacyPathActive()
     }
 

--- a/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetModelDelivery.swift
@@ -41,6 +41,13 @@ public final class ParakeetDeliveryHandle {
   private let registration: DeliveryRegistration
   private let defaults: UserDefaults
 
+  /// #2483: where this handle admits bytes, so the adapter can tell the load
+  /// layer the same location rather than resolving one of its own. Reading it
+  /// from the registration is what keeps a test-redirected root honest — a
+  /// second derivation would silently disagree with the directory the
+  /// controller actually wrote to.
+  public var installDirectory: URL { registration.installDirectory }
+
   public init(
     controller: ModelDeliveryController, registration: DeliveryRegistration,
     defaults: UserDefaults? = nil

--- a/Tests/EnviousWisprASRTests/ParakeetRealBoundaryTests.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetRealBoundaryTests.swift
@@ -49,7 +49,9 @@ struct ParakeetRealBoundaryTests {
     let result: EnviousWisprCore.ASRResult = try await withParakeetOfflineModeExclusion {
       let backend = ParakeetBackend()
       do {
-        try await backend.prepare(cacheOnly: true, progressCallback: nil)
+        try await backend.prepare(
+          cacheOnly: true, modelDirectory: ParakeetBackend.defaultModelDirectory,
+          progressCallback: nil)
         let result = try await backend.transcribe(audioSamples: samples, options: .default)
         await backend.unload()
         return result

--- a/Tests/EnviousWisprASRTests/ParakeetRealBoundaryTests.swift
+++ b/Tests/EnviousWisprASRTests/ParakeetRealBoundaryTests.swift
@@ -50,7 +50,7 @@ struct ParakeetRealBoundaryTests {
       let backend = ParakeetBackend()
       do {
         try await backend.prepare(
-          cacheOnly: true, modelDirectory: ParakeetBackend.defaultModelDirectory,
+          cacheOnly: true, modelDirectory: ParakeetBackend.vendorSharedDirectory,
           progressCallback: nil)
         let result = try await backend.transcribe(audioSamples: samples, options: .default)
         await backend.unload()

--- a/Tests/EnviousWisprTests/ASR/ShippedBackendLatencyTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ShippedBackendLatencyTests.swift
@@ -118,7 +118,7 @@ struct ShippedBackendLatencyTests {
     let backend = ParakeetBackend()
     do {
       try await backend.prepare(
-        cacheOnly: true, modelDirectory: ParakeetBackend.defaultModelDirectory,
+        cacheOnly: true, modelDirectory: ParakeetBackend.vendorSharedDirectory,
         progressCallback: nil)
       let warmup = try await backend.transcribe(audioSamples: samples, options: .default)
       ShippedBackendLatencyFixture.requireExpectedTranscript(warmup, backend: "Parakeet warm-up")

--- a/Tests/EnviousWisprTests/ASR/ShippedBackendLatencyTests.swift
+++ b/Tests/EnviousWisprTests/ASR/ShippedBackendLatencyTests.swift
@@ -117,7 +117,9 @@ struct ShippedBackendLatencyTests {
       path: ShippedBackendLatencyFixture.audioURL.path)
     let backend = ParakeetBackend()
     do {
-      try await backend.prepare(cacheOnly: true, progressCallback: nil)
+      try await backend.prepare(
+        cacheOnly: true, modelDirectory: ParakeetBackend.defaultModelDirectory,
+        progressCallback: nil)
       let warmup = try await backend.transcribe(audioSamples: samples, options: .default)
       ShippedBackendLatencyFixture.requireExpectedTranscript(warmup, backend: "Parakeet warm-up")
 

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -490,7 +490,7 @@ import Testing
     // `retryDecode`/row-22 warmUp) callers alike.
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "prepare",
-      text: "try await parakeet.prepare(cacheOnly: true, progressCallback: progress)",
+      text: "try await parakeet.prepare(",
       classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "prepare",
@@ -528,7 +528,7 @@ import Testing
     // MARK: ASRManagerProxy — the XPC-fronted mirror of ASRManager.
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "loadModel",
-      text: "proxy.loadModel(backendType: self.activeBackendType.rawValue, cacheOnly: cacheOnly) {",
+      text: "proxy.loadModel(",
       classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManagerProxy.swift", matcher: "startStreaming",
@@ -585,11 +585,11 @@ import Testing
     // progressCallback:)`, both already counted, `transitivelyCoveredByCaller`.
     CallSite(
       file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "prepare",
-      text: "try await prepare(cacheOnly: false, progressCallback: nil)",
+      text: "try await prepare(",
       classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "prepare",
-      text: "try await prepare(cacheOnly: false, progressCallback: progressCallback)",
+      text: "try await prepare(",
       classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASR/ParakeetBackend.swift", matcher: "loadModels",
@@ -634,7 +634,7 @@ import Testing
       classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASRService/ASRServiceHandler.swift", matcher: "prepare",
-      text: "try await backend.prepare(cacheOnly: cacheOnly) { fraction, phase, detail in",
+      text: "try await backend.prepare(cacheOnly: cacheOnly, modelDirectory: modelDirectory) {",
       classification: .transitivelyCoveredByCaller),
 
     // MARK: CaptureVADSignalSource — a different subsystem (voice-activity

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -511,7 +511,7 @@ import Testing
         MemberSignature(
           condition: nil,
           signature:
-            "public var parakeetModelDirectory: URL {\n    get { ParakeetBackend.defaultModelDirectory }\n    set {}\n  }"
+            "public var parakeetModelDirectory: URL {\n    get { ParakeetInstallLocation.live }\n    set {}\n  }"
         ),
       ]),
     "ASREngineAdapter": Surface(

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -466,6 +466,8 @@ import Testing
         MemberSignature(condition: nil, signature: "var downloadPhase: String { get }"),
         MemberSignature(condition: nil, signature: "var downloadDetail: String { get }"),
         MemberSignature(condition: nil, signature: "var parakeetCacheOnly: Bool { get set }"),
+        MemberSignature(
+          condition: nil, signature: "var parakeetModelDirectory: URL { get set }"),
         MemberSignature(condition: nil, signature: "func loadModel() async throws"),
         MemberSignature(condition: nil, signature: "func unloadModel() async"),
         MemberSignature(
@@ -506,6 +508,11 @@ import Testing
         MemberSignature(
           condition: nil,
           signature: "public var parakeetCacheOnly: Bool {\n    get { false }\n    set {}\n  }"),
+        MemberSignature(
+          condition: nil,
+          signature:
+            "public var parakeetModelDirectory: URL {\n    get { ParakeetBackend.defaultModelDirectory }\n    set {}\n  }"
+        ),
       ]),
     "ASREngineAdapter": Surface(
       name: "ASREngineAdapter", file: "Sources/EnviousWisprPipeline/ASREngineAdapter.swift",
@@ -652,7 +659,7 @@ import Testing
         MemberSignature(
           condition: nil,
           signature:
-            "func loadModel(backendType: String, cacheOnly: Bool, reply: @escaping (NSError?) -> Void)"
+            "func loadModel(\n    backendType: String, cacheOnly: Bool, modelDirectoryPath: String,\n    reply: @escaping (NSError?) -> Void)"
         ),
         MemberSignature(condition: nil, signature: "func unloadModel(reply: @escaping () -> Void)"),
         MemberSignature(
@@ -714,7 +721,7 @@ import Testing
         MemberSignature(
           condition: nil,
           signature:
-            "public func prepare(cacheOnly: Bool, progressCallback: ProgressCallback?) async throws"
+            "public func prepare(\n    cacheOnly: Bool, modelDirectory: URL, progressCallback: ProgressCallback?\n  ) async throws"
         ),
       ]),
   ]

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
@@ -83,7 +83,7 @@ struct LegacyDonorImportTests {
     let outcome = try imported(
       LegacyDonorImport.reproduce(
         manifest: manifest, components: Set(files.map(\.component)), donor: donor,
-        staging: staging, trustedRoot: root))
+        staging: staging))
 
     #expect(outcome.filesReproduced == files.count)
     let after = try fingerprint(of: donor)
@@ -105,7 +105,7 @@ struct LegacyDonorImportTests {
     let outcome = try imported(
       LegacyDonorImport.reproduce(
         manifest: manifest, components: Set(files.map(\.component)), donor: donor,
-        staging: staging, trustedRoot: root))
+        staging: staging))
 
     #expect(outcome.filesReproduced == files.count)
     #expect(outcome.bytesReproduced == files.reduce(Int64(0)) { $0 + Int64($1.content.count) })
@@ -129,7 +129,7 @@ struct LegacyDonorImportTests {
     let outcome = try imported(
       LegacyDonorImport.reproduce(
         manifest: manifest, components: Set(files.map(\.component)), donor: donor,
-        staging: staging, trustedRoot: root))
+        staging: staging))
 
     #expect(outcome.filesReproduced == files.count - 1)
     #expect(
@@ -164,7 +164,7 @@ struct LegacyDonorImportTests {
     let outcome = try imported(
       LegacyDonorImport.reproduce(
         manifest: manifest, components: Set(files.map(\.component)), donor: donor,
-        staging: staging, trustedRoot: trustedRoot))
+        staging: staging))
 
     #expect(outcome.filesReproduced == files.count)
     for f in files {
@@ -188,7 +188,7 @@ struct LegacyDonorImportTests {
     let outcome = try imported(
       LegacyDonorImport.reproduce(
         manifest: manifest, components: Set(files.map(\.component)), donor: donor,
-        staging: unborn, trustedRoot: root))
+        staging: unborn))
 
     #expect(outcome.filesReproduced == files.count)
     for f in files {
@@ -212,7 +212,7 @@ struct LegacyDonorImportTests {
 
     let result = LegacyDonorImport.reproduce(
       manifest: manifest, components: Set(files.map(\.component)), donor: donor,
-      staging: aliased, trustedRoot: donor)
+      staging: aliased)
 
     // A REFUSAL, not an empty import. The caller aborts the whole attempt on
     // this, because continuing would hand the same unsafe staging URL to the
@@ -244,7 +244,7 @@ struct LegacyDonorImportTests {
     let outcome = try imported(
       LegacyDonorImport.reproduce(
         manifest: manifest, components: Set(files.map(\.component)), donor: missing,
-        staging: staging, trustedRoot: root))
+        staging: staging))
 
     #expect(outcome == .none)
     #expect(try fingerprint(of: staging).isEmpty)

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
@@ -115,6 +115,41 @@ struct LegacyDonorImportTests {
     }
   }
 
+  @Test("a staged file that is a symlink into the donor is replaced with real bytes")
+  func stagedSymlinkLeafIsNotTreatedAsResumable() throws {
+    // Cloud round 6. `fileExists` FOLLOWS links, so a staged leaf pointing at the
+    // donor read as an ordinary resumable file and was skipped; the fetcher then
+    // hashed through the link, passed, and promotion moved the LINK into the
+    // owned install directory. The admitted cache would have been a pointer at
+    // somebody else's file — another FluidAudio app replacing its copy would
+    // break ours — which is the opposite of what this whole change is for.
+    let (donor, staging, _) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: donor, path: f.path) }
+    let manifest = try ManifestFixture.manifest(files: files)
+
+    let leaf = staging.appendingPathComponent(files[0].path)
+    try FileManager.default.createDirectory(
+      at: leaf.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try FileManager.default.createSymbolicLink(
+      at: leaf, withDestinationURL: donor.appendingPathComponent(files[0].path))
+
+    let outcome = try imported(
+      LegacyDonorImport.reproduce(
+        manifest: manifest, components: Set(files.map(\.component)), donor: donor,
+        staging: staging))
+
+    #expect(outcome.filesReproduced == files.count)
+    // The staged leaf is now REAL BYTES, not a link, and its content is right.
+    let isLink =
+      (try? leaf.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) ?? false
+    #expect(!isLink, "staged leaf is still a symlink into the donor")
+    #expect(try Data(contentsOf: leaf) == files[0].content)
+    // And the donor's own file is untouched.
+    #expect(
+      try Data(contentsOf: donor.appendingPathComponent(files[0].path)) == files[0].content)
+  }
+
   @Test("a donor file of the wrong size is left behind, not copied")
   func wrongSizeIsSkipped() throws {
     let (donor, staging, root) = try makeDirs()

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprASR
+import EnviousWisprCore
 import Foundation
 import Testing
 
@@ -14,7 +15,9 @@ import Testing
 @Suite("Legacy donor import (#2483)", .tags(.productOutcome))
 struct LegacyDonorImportTests {
 
-  private func makeDirs() throws -> (donor: URL, staging: URL) {
+  /// `root` doubles as the app-owned trusted root the import requires staging to
+  /// resolve inside. In production that is the delivery metadata directory.
+  private func makeDirs() throws -> (donor: URL, staging: URL, root: URL) {
     let root = FileManager.default.temporaryDirectory
       .appendingPathComponent("donor-\(UUID().uuidString)", isDirectory: true)
     let donor = root.appendingPathComponent("donor", isDirectory: true)
@@ -22,7 +25,7 @@ struct LegacyDonorImportTests {
     for dir in [donor, staging] {
       try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
     }
-    return (donor, staging)
+    return (donor, staging, root)
   }
 
   private func write(_ content: Data, under root: URL, path: String) throws {
@@ -55,7 +58,7 @@ struct LegacyDonorImportTests {
 
   @Test("the donor keeps every file, its bytes and its inode")
   func donorIsUntouched() throws {
-    let (donor, staging) = try makeDirs()
+    let (donor, staging, root) = try makeDirs()
     let files = ManifestFixture.smallFiles
     for f in files { try write(f.content, under: donor, path: f.path) }
     // A file no manifest of ours names. Under the pre-#2483 behaviour this is
@@ -67,7 +70,7 @@ struct LegacyDonorImportTests {
     #expect(before.count == files.count + 1)
 
     let outcome = LegacyDonorImport.reproduce(
-      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging)
+      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging, trustedRoot: root)
 
     #expect(outcome.filesReproduced == files.count)
     let after = try fingerprint(of: donor)
@@ -81,13 +84,13 @@ struct LegacyDonorImportTests {
 
   @Test("every manifest file lands in staging with the donor's bytes")
   func filesReachStaging() throws {
-    let (donor, staging) = try makeDirs()
+    let (donor, staging, root) = try makeDirs()
     let files = ManifestFixture.smallFiles
     for f in files { try write(f.content, under: donor, path: f.path) }
     let manifest = try ManifestFixture.manifest(files: files)
 
     let outcome = LegacyDonorImport.reproduce(
-      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging)
+      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging, trustedRoot: root)
 
     #expect(outcome.filesReproduced == files.count)
     #expect(outcome.bytesReproduced == files.reduce(Int64(0)) { $0 + Int64($1.content.count) })
@@ -99,7 +102,7 @@ struct LegacyDonorImportTests {
 
   @Test("a donor file of the wrong size is left behind, not copied")
   func wrongSizeIsSkipped() throws {
-    let (donor, staging) = try makeDirs()
+    let (donor, staging, root) = try makeDirs()
     let files = ManifestFixture.smallFiles
     for f in files { try write(f.content, under: donor, path: f.path) }
     // A truncated or different-revision copy. It must not reach staging, where
@@ -109,7 +112,7 @@ struct LegacyDonorImportTests {
     let manifest = try ManifestFixture.manifest(files: files)
 
     let outcome = LegacyDonorImport.reproduce(
-      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging)
+      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging, trustedRoot: root)
 
     #expect(outcome.filesReproduced == files.count - 1)
     #expect(
@@ -117,16 +120,42 @@ struct LegacyDonorImportTests {
         atPath: staging.appendingPathComponent(files[0].path).path))
   }
 
+  @Test("a staging directory outside the trusted root is refused outright")
+  func stagingMustResolveInsideTheTrustedRoot() throws {
+    // Cloud round P2: proving the destination sits under `staging` says nothing
+    // if `staging` itself resolves into the donor's tree. Here staging IS a
+    // symlink into the donor, which is the shape that would have turned every
+    // copy into a write inside the directory this type promises never to touch.
+    let (donor, _, root) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: donor, path: f.path) }
+    let manifest = try ManifestFixture.manifest(files: files)
+    let aliased = root.appendingPathComponent("aliased-staging", isDirectory: true)
+    try FileManager.default.createSymbolicLink(at: aliased, withDestinationURL: donor)
+    let before = try fingerprint(of: donor)
+
+    let outcome = LegacyDonorImport.reproduce(
+      manifest: manifest, components: Set(files.map(\.component)), donor: donor,
+      staging: aliased, trustedRoot: donor)
+
+    #expect(outcome == .none)
+    let after = try fingerprint(of: donor)
+    #expect(after.count == before.count)
+    for (path, expected) in before {
+      #expect(after[path]?.1 == expected.1, "donor inode changed at \(path)")
+    }
+  }
+
   @Test("a donor that is not there costs nothing and reports nothing")
   func absentDonorIsNotAFailure() throws {
-    let (donor, staging) = try makeDirs()
+    let (donor, staging, root) = try makeDirs()
     let files = ManifestFixture.smallFiles
     let manifest = try ManifestFixture.manifest(files: files)
     let missing = donor.appendingPathComponent("never-existed", isDirectory: true)
 
     let outcome = LegacyDonorImport.reproduce(
       manifest: manifest, components: Set(files.map(\.component)), donor: missing,
-      staging: staging)
+      staging: staging, trustedRoot: root)
 
     #expect(outcome == .none)
     #expect(try fingerprint(of: staging).isEmpty)
@@ -159,9 +188,9 @@ struct ParakeetInstallLocationTests {
     // Reconstructing the expected value from `repoFolderName` compared that
     // constant with itself, so the one drift worth catching — the vendor
     // renaming its repo folder while our constant stands still — passed.
-    // `ParakeetBackend.defaultModelDirectory` is `AsrModels.defaultCacheDirectory`,
+    // `ParakeetBackend.vendorSharedDirectory` is `AsrModels.defaultCacheDirectory`,
     // whose last component IS the vendor's own `repo.folderName`.
-    let vendorFolderName = ParakeetBackend.defaultModelDirectory.lastPathComponent
+    let vendorFolderName = ParakeetBackend.vendorSharedDirectory.lastPathComponent
     // One literal, not a concatenation: `#expect`'s second argument is a
     // `Comment`, which a `+` expression cannot convert to.
     #expect(

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
@@ -137,6 +137,41 @@ struct LegacyDonorImportTests {
         atPath: staging.appendingPathComponent(files[0].path).path))
   }
 
+  @Test("a first install, where neither our metadata root nor staging exists yet")
+  func firstInstallCreatesEveryDirectoryItNeeds() throws {
+    // The regression this branch shipped TWICE, in the same shape. Round 2
+    // required `staging` to pre-exist; round 3 required `trustedRoot` to
+    // pre-exist, and `trustedRoot` is only created by `promoteAndAdmit` AFTER a
+    // successful fetch — so on a genuinely fresh install neither is there and the
+    // import refused, which the controller turns into a failed attempt. Every new
+    // user would have failed to download the model at all.
+    //
+    // The earlier tests could not see it because the fixture pre-created both.
+    // This one creates NOTHING except the donor.
+    let base = FileManager.default.temporaryDirectory
+      .appendingPathComponent("fresh-\(UUID().uuidString)", isDirectory: true)
+    let donor = base.appendingPathComponent("donor", isDirectory: true)
+    try FileManager.default.createDirectory(at: donor, withIntermediateDirectories: true)
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: donor, path: f.path) }
+    let manifest = try ManifestFixture.manifest(files: files)
+
+    let trustedRoot = base.appendingPathComponent("EnviousWispr/ModelDelivery", isDirectory: true)
+    let staging = trustedRoot.appendingPathComponent("staging/cache-key", isDirectory: true)
+    #expect(!FileManager.default.fileExists(atPath: trustedRoot.path))
+    #expect(!FileManager.default.fileExists(atPath: staging.path))
+
+    let outcome = try imported(
+      LegacyDonorImport.reproduce(
+        manifest: manifest, components: Set(files.map(\.component)), donor: donor,
+        staging: staging, trustedRoot: trustedRoot))
+
+    #expect(outcome.filesReproduced == files.count)
+    for f in files {
+      #expect(try Data(contentsOf: staging.appendingPathComponent(f.path)) == f.content)
+    }
+  }
+
   @Test("staging that does not exist yet is created, not treated as a refusal")
   func firstInstallStagingIsCreated() throws {
     // Cloud round 2 P2: on a first delivery attempt `metadataDirectory/staging/

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
@@ -56,6 +56,17 @@ struct LegacyDonorImportTests {
     return result
   }
 
+  /// Unwraps the imported case, failing the test on a refusal. A refusal is a
+  /// different claim from an empty import and the suite must never silently read
+  /// one as the other.
+  private func imported(_ result: LegacyDonorImport.Result) throws -> LegacyDonorImport.Outcome {
+    guard case .imported(let outcome) = result else {
+      Issue.record("expected an import, got \(result)")
+      throw CancellationError()
+    }
+    return outcome
+  }
+
   @Test("the donor keeps every file, its bytes and its inode")
   func donorIsUntouched() throws {
     let (donor, staging, root) = try makeDirs()
@@ -69,8 +80,10 @@ struct LegacyDonorImportTests {
     let before = try fingerprint(of: donor)
     #expect(before.count == files.count + 1)
 
-    let outcome = LegacyDonorImport.reproduce(
-      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging, trustedRoot: root)
+    let outcome = try imported(
+      LegacyDonorImport.reproduce(
+        manifest: manifest, components: Set(files.map(\.component)), donor: donor,
+        staging: staging, trustedRoot: root))
 
     #expect(outcome.filesReproduced == files.count)
     let after = try fingerprint(of: donor)
@@ -89,8 +102,10 @@ struct LegacyDonorImportTests {
     for f in files { try write(f.content, under: donor, path: f.path) }
     let manifest = try ManifestFixture.manifest(files: files)
 
-    let outcome = LegacyDonorImport.reproduce(
-      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging, trustedRoot: root)
+    let outcome = try imported(
+      LegacyDonorImport.reproduce(
+        manifest: manifest, components: Set(files.map(\.component)), donor: donor,
+        staging: staging, trustedRoot: root))
 
     #expect(outcome.filesReproduced == files.count)
     #expect(outcome.bytesReproduced == files.reduce(Int64(0)) { $0 + Int64($1.content.count) })
@@ -111,13 +126,39 @@ struct LegacyDonorImportTests {
     try write(Data("{".utf8), under: donor, path: files[0].path)
     let manifest = try ManifestFixture.manifest(files: files)
 
-    let outcome = LegacyDonorImport.reproduce(
-      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging, trustedRoot: root)
+    let outcome = try imported(
+      LegacyDonorImport.reproduce(
+        manifest: manifest, components: Set(files.map(\.component)), donor: donor,
+        staging: staging, trustedRoot: root))
 
     #expect(outcome.filesReproduced == files.count - 1)
     #expect(
       !FileManager.default.fileExists(
         atPath: staging.appendingPathComponent(files[0].path).path))
+  }
+
+  @Test("staging that does not exist yet is created, not treated as a refusal")
+  func firstInstallStagingIsCreated() throws {
+    // Cloud round 2 P2: on a first delivery attempt `metadataDirectory/staging/
+    // <cacheKey>` does not exist — the fetcher creates it later. Requiring it to
+    // pre-exist made the import return empty for exactly the users it is for, and
+    // every one of them would have re-downloaded the whole model.
+    let (donor, _, root) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: donor, path: f.path) }
+    let manifest = try ManifestFixture.manifest(files: files)
+    let unborn = root.appendingPathComponent("staging/cache-key", isDirectory: true)
+    #expect(!FileManager.default.fileExists(atPath: unborn.path))
+
+    let outcome = try imported(
+      LegacyDonorImport.reproduce(
+        manifest: manifest, components: Set(files.map(\.component)), donor: donor,
+        staging: unborn, trustedRoot: root))
+
+    #expect(outcome.filesReproduced == files.count)
+    for f in files {
+      #expect(try Data(contentsOf: unborn.appendingPathComponent(f.path)) == f.content)
+    }
   }
 
   @Test("a staging directory outside the trusted root is refused outright")
@@ -134,11 +175,23 @@ struct LegacyDonorImportTests {
     try FileManager.default.createSymbolicLink(at: aliased, withDestinationURL: donor)
     let before = try fingerprint(of: donor)
 
-    let outcome = LegacyDonorImport.reproduce(
+    let result = LegacyDonorImport.reproduce(
       manifest: manifest, components: Set(files.map(\.component)), donor: donor,
       staging: aliased, trustedRoot: donor)
 
-    #expect(outcome == .none)
+    // A REFUSAL, not an empty import. The caller aborts the whole attempt on
+    // this, because continuing would hand the same unsafe staging URL to the
+    // fetcher.
+    //
+    // The CASE is asserted, not the detail string. Several guards can catch this
+    // shape — the ancestor check fires before the inside-donor check here — and
+    // pinning which one would test the order of the implementation rather than
+    // the property that matters, which is that nothing was written and the
+    // caller is told to stop.
+    guard case .unsafeStagingRoot = result else {
+      Issue.record("expected a refusal, got \(result)")
+      return
+    }
     let after = try fingerprint(of: donor)
     #expect(after.count == before.count)
     for (path, expected) in before {
@@ -153,9 +206,10 @@ struct LegacyDonorImportTests {
     let manifest = try ManifestFixture.manifest(files: files)
     let missing = donor.appendingPathComponent("never-existed", isDirectory: true)
 
-    let outcome = LegacyDonorImport.reproduce(
-      manifest: manifest, components: Set(files.map(\.component)), donor: missing,
-      staging: staging, trustedRoot: root)
+    let outcome = try imported(
+      LegacyDonorImport.reproduce(
+        manifest: manifest, components: Set(files.map(\.component)), donor: missing,
+        staging: staging, trustedRoot: root))
 
     #expect(outcome == .none)
     #expect(try fingerprint(of: staging).isEmpty)

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprModelDelivery
+
+/// #2483. The promise a user feels: the model files another app put on their Mac
+/// are still there afterwards, byte for byte, and they do not pay for a download
+/// they have already done.
+///
+/// The donor directory here stands in for
+/// `~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml`,
+/// which EnviousWispr shared with every other FluidAudio app until this change.
+@Suite("Legacy donor import (#2483)", .tags(.productOutcome))
+struct LegacyDonorImportTests {
+
+  private func makeDirs() throws -> (donor: URL, staging: URL) {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("donor-\(UUID().uuidString)", isDirectory: true)
+    let donor = root.appendingPathComponent("donor", isDirectory: true)
+    let staging = root.appendingPathComponent("staging", isDirectory: true)
+    for dir in [donor, staging] {
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+    return (donor, staging)
+  }
+
+  private func write(_ content: Data, under root: URL, path: String) throws {
+    let url = root.appendingPathComponent(path)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try content.write(to: url)
+  }
+
+  /// Path → (bytes, inode). Inode as well as bytes, because a move or a
+  /// replace-with-identical-content would leave the bytes equal and is exactly
+  /// the outcome this change exists to prevent.
+  private func fingerprint(of root: URL) throws -> [String: (Data, UInt64)] {
+    let fm = FileManager.default
+    var result: [String: (Data, UInt64)] = [:]
+    guard
+      let walker = fm.enumerator(
+        at: root, includingPropertiesForKeys: [.isDirectoryKey],
+        errorHandler: { _, _ in false })
+    else { return result }
+    for case let url as URL in walker {
+      guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory != true
+      else { continue }
+      let attrs = try fm.attributesOfItem(atPath: url.path)
+      let inode = (attrs[.systemFileNumber] as? NSNumber)?.uint64Value ?? 0
+      result[url.path] = (try Data(contentsOf: url), inode)
+    }
+    return result
+  }
+
+  @Test("the donor keeps every file, its bytes and its inode")
+  func donorIsUntouched() throws {
+    let (donor, staging) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: donor, path: f.path) }
+    // A file no manifest of ours names. Under the pre-#2483 behaviour this is
+    // precisely what promotion's orphan cleanup deleted, and what #2690's
+    // reporter could not get past.
+    try write(Data("another app put this here".utf8), under: donor, path: "CtcHead.mlmodelc/x.bin")
+    let manifest = try ManifestFixture.manifest(files: files)
+    let before = try fingerprint(of: donor)
+    #expect(before.count == files.count + 1)
+
+    let outcome = LegacyDonorImport.reproduce(
+      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging)
+
+    #expect(outcome.filesReproduced == files.count)
+    let after = try fingerprint(of: donor)
+    #expect(after.count == before.count)
+    for (path, expected) in before {
+      let actual = after[path]
+      #expect(actual?.0 == expected.0, "donor bytes changed at \(path)")
+      #expect(actual?.1 == expected.1, "donor inode changed at \(path)")
+    }
+  }
+
+  @Test("every manifest file lands in staging with the donor's bytes")
+  func filesReachStaging() throws {
+    let (donor, staging) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: donor, path: f.path) }
+    let manifest = try ManifestFixture.manifest(files: files)
+
+    let outcome = LegacyDonorImport.reproduce(
+      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging)
+
+    #expect(outcome.filesReproduced == files.count)
+    #expect(outcome.bytesReproduced == files.reduce(Int64(0)) { $0 + Int64($1.content.count) })
+    for f in files {
+      let staged = staging.appendingPathComponent(f.path)
+      #expect(try Data(contentsOf: staged) == f.content, "staged bytes differ at \(f.path)")
+    }
+  }
+
+  @Test("a donor file of the wrong size is left behind, not copied")
+  func wrongSizeIsSkipped() throws {
+    let (donor, staging) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    for f in files { try write(f.content, under: donor, path: f.path) }
+    // A truncated or different-revision copy. It must not reach staging, where
+    // a size match would let the fetch path skip it and then fail its hash —
+    // a slower, more confusing route to the same download.
+    try write(Data("{".utf8), under: donor, path: files[0].path)
+    let manifest = try ManifestFixture.manifest(files: files)
+
+    let outcome = LegacyDonorImport.reproduce(
+      manifest: manifest, components: Set(files.map(\.component)), donor: donor, staging: staging)
+
+    #expect(outcome.filesReproduced == files.count - 1)
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: staging.appendingPathComponent(files[0].path).path))
+  }
+
+  @Test("a donor that is not there costs nothing and reports nothing")
+  func absentDonorIsNotAFailure() throws {
+    let (donor, staging) = try makeDirs()
+    let files = ManifestFixture.smallFiles
+    let manifest = try ManifestFixture.manifest(files: files)
+    let missing = donor.appendingPathComponent("never-existed", isDirectory: true)
+
+    let outcome = LegacyDonorImport.reproduce(
+      manifest: manifest, components: Set(files.map(\.component)), donor: missing,
+      staging: staging)
+
+    #expect(outcome == .none)
+    #expect(try fingerprint(of: staging).isEmpty)
+  }
+}
+
+/// The naming rule is load-bearing, not cosmetic, so it gets a test rather than
+/// a comment: FluidAudio rebuilds a repo directory from whatever parent it is
+/// handed, dropping the last component and re-appending its own folder name. A
+/// directory named anything else would make our install location and the
+/// runtime's lookup location disagree while each looked right on its own.
+@Suite("Parakeet install location (#2483)", .tags(.driftGuard))
+struct ParakeetInstallLocationTests {
+
+  @Test("we install under our own directory, never under FluidAudio")
+  func installDirectoryIsOurs() {
+    let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
+    let install = ParakeetInstallLocation.directory(appSupport: root)
+    #expect(install.path == "/tmp/appsupport/EnviousWispr/Models/parakeet-tdt-0.6b-v3-coreml")
+    #expect(!install.path.contains("FluidAudio"))
+  }
+
+  @Test("the last path component is the repo folder name FluidAudio reconstructs")
+  func lastComponentSurvivesVendorReconstruction() {
+    let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
+    let install = ParakeetInstallLocation.directory(appSupport: root)
+    #expect(install.lastPathComponent == ParakeetInstallLocation.repoFolderName)
+    // What AsrModels.repoPath(from:) does: drop the last component, re-append
+    // the repo folder name. A location that does not survive that round trip is
+    // one the runtime would look for somewhere else.
+    let reconstructed = install.deletingLastPathComponent()
+      .appendingPathComponent(ParakeetInstallLocation.repoFolderName, isDirectory: true)
+    #expect(reconstructed.standardizedFileURL == install.standardizedFileURL)
+  }
+
+  @Test("the donor points at the shared FluidAudio directory and is a different place")
+  func donorIsTheOldSharedDirectory() {
+    let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
+    let donor = ParakeetInstallLocation.legacySharedDonor(appSupport: root)
+    #expect(donor.path == "/tmp/appsupport/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml")
+    #expect(donor != ParakeetInstallLocation.directory(appSupport: root))
+  }
+}

--- a/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/LegacyDonorImportTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprASR
 import Foundation
 import Testing
 
@@ -144,20 +145,36 @@ struct ParakeetInstallLocationTests {
   func installDirectoryIsOurs() {
     let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
     let install = ParakeetInstallLocation.directory(appSupport: root)
-    #expect(install.path == "/tmp/appsupport/EnviousWispr/Models/parakeet-tdt-0.6b-v3-coreml")
+    // Literal on purpose, not derived from `repoFolderName`: this pins the
+    // SHAPE of the path independently, so a change to that constant has to be
+    // deliberate here too. The constant's agreement with FluidAudio is the
+    // separate test below.
+    #expect(install.path == "/tmp/appsupport/EnviousWispr/Models/parakeet-tdt-0.6b-v3")
     #expect(!install.path.contains("FluidAudio"))
   }
 
-  @Test("the last path component is the repo folder name FluidAudio reconstructs")
+  @Test("our folder name is the one FluidAudio itself reconstructs")
   func lastComponentSurvivesVendorReconstruction() {
+    // Second-pass finding 10: the ORACLE is FluidAudio, not our own constant.
+    // Reconstructing the expected value from `repoFolderName` compared that
+    // constant with itself, so the one drift worth catching — the vendor
+    // renaming its repo folder while our constant stands still — passed.
+    // `ParakeetBackend.defaultModelDirectory` is `AsrModels.defaultCacheDirectory`,
+    // whose last component IS the vendor's own `repo.folderName`.
+    let vendorFolderName = ParakeetBackend.defaultModelDirectory.lastPathComponent
+    // One literal, not a concatenation: `#expect`'s second argument is a
+    // `Comment`, which a `+` expression cannot convert to.
+    #expect(
+      ParakeetInstallLocation.repoFolderName == vendorFolderName,
+      "FluidAudio's repo folder is now \(vendorFolderName); our install directory is no longer the one its loader reconstructs")
+
     let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
     let install = ParakeetInstallLocation.directory(appSupport: root)
-    #expect(install.lastPathComponent == ParakeetInstallLocation.repoFolderName)
     // What AsrModels.repoPath(from:) does: drop the last component, re-append
-    // the repo folder name. A location that does not survive that round trip is
-    // one the runtime would look for somewhere else.
+    // the vendor's folder name. A location that does not survive that round
+    // trip is one the runtime would look for somewhere else.
     let reconstructed = install.deletingLastPathComponent()
-      .appendingPathComponent(ParakeetInstallLocation.repoFolderName, isDirectory: true)
+      .appendingPathComponent(vendorFolderName, isDirectory: true)
     #expect(reconstructed.standardizedFileURL == install.standardizedFileURL)
   }
 
@@ -165,7 +182,7 @@ struct ParakeetInstallLocationTests {
   func donorIsTheOldSharedDirectory() {
     let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
     let donor = ParakeetInstallLocation.legacySharedDonor(appSupport: root)
-    #expect(donor.path == "/tmp/appsupport/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml")
+    #expect(donor.path == "/tmp/appsupport/FluidAudio/Models/parakeet-tdt-0.6b-v3")
     #expect(donor != ParakeetInstallLocation.directory(appSupport: root))
   }
 }


### PR DESCRIPTION
## What this fixes

EnviousWispr installed the fast-English (Parakeet) model into
`~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3`, which is the FluidAudio
package's shared per-repo cache and belongs equally to every other app built on it.
Treating it as ours produced two halves of one defect:

- **We deleted files other apps put there.** Promotion's orphan cleanup removes every top-level
  entry our manifest does not name (`CacheAdmission.swift:259-266`), inside
  `~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3`. Reported as #2483. No
  live example is offered: an earlier draft cited `JointDecision.mlmodelc` on the dev machine, which
  turned out to be in the neighbouring `-coreml` directory our sweep never entered. Withdrawn.
- **We refuse to install when we cannot delete them.** A failed delete throws `cacheRepairFailed`
  and blocks admission, and the app does not work at all. This is a code path, not a field report —
  see the retraction below.

**RETRACTED: #2690 is not evidence for either harm.** An earlier revision of this description cited
it as a confirmed co-tenancy failure. Its root cause is unrelated: on that machine (macOS 14.8.9,
arm64, EnviousWispr 2.4.7) `~/Library/Application Support` is owned by `root:wheel` at mode 755 with
`writable: NO`, taken over on 28 August, so `EnviousWispr/` and `EnviousWispr/ModelDelivery/` do not
exist and cannot be created; `promoteAndAdmit` fails at its metadata step. **This change would not
have helped him.** Source: a directory listing the user sent by email, relayed by the #2690 session.
Not reproduced here, and not quoted in full anywhere public — its paths carry his account name, which
he had already chosen to blur.

**What that listing DOES establish, and each item is checkable rather than attributed:**

1. **The install directory is `parakeet-tdt-0.6b-v3`, and `-coreml` does not exist on that machine at
   all.** That is external confirmation of this branch's folder-name correction, from a Mac where only
   one of the two candidate directories exists — unlike the dev machine, where both do and either
   could be read as evidence.
2. **A third-party app filled our install directory before we arrived.** Its seven entries are exactly
   our manifest's seven components, dated 3 June; he installed 2.4.7 on 7 September. Co-tenancy,
   observed in the field. **Still not evidence that any destructive path fired.**
3. **`config.json` is 2 bytes, matching our manifest's declared size.** A second, independent route to
   the same conclusion as the marker argument below: byte-identity with our manifest cannot establish
   who wrote a file.

**A measurement caveat this exposes, worth stating because it bounds any future sizing of the
problem:** `posthog-ios` keeps its queue under `Library/Application Support/`
(`PostHogStorage.swift:19-54`), so a user whose Application Support is unwritable is invisible in our
telemetry by construction. Any field estimate of how common co-tenancy is will systematically miss
exactly the machines where it goes wrong.

A third path is the vendor's own: `ModelHub.loadModels` purges the WHOLE repo directory after a load
failure that is neither cancellation nor retryable (`ModelHub.swift:133-139`), guarded only by
`offlineMode`, which our legacy prepare explicitly sets false.

**No producer is ranked.** Nothing in either report establishes which path ran, and a differing
revision does not by itself fail to load. The delivery stream cannot rank them either: these paths
emit nothing on success, and `attempt_failed reason=cache_repair_failed` has zero rows across all
time and all environments.

## Why the rule is categorical

There is no ownership filter to build. The admission marker records what we **validated**, not what
we **wrote** — `ModelDeliveryController.swift:565-569` promotes with zero staged components and
`CacheAdmission.swift:269-287` then stamps pre-existing files we never downloaded. Byte equality
with our own manifest cannot separate our copy from a user's own download of the same pinned
revision either. So: **EnviousWispr, including its XPC helper and the vendor code it invokes,
creates, modifies, moves and deletes nothing under `FluidAudio/`.**

This is stricter than contract §5b, which authorises retiring a byte-identical copy owned by another
app for the multilingual family. That authorisation is untouched and does not extend here. Founder
approved the stricter rule for Parakeet at Gate 2 (2026-09-06).

## The six commits

1. **The host selects the model directory, not each load site.** Semantic no-op; every caller passes
   the value the load sites resolved for themselves. Before this, three places independently resolved
   `AsrModels.defaultCacheDirectory`, and the XPC helper received no directory at all, so no fix that
   moves the directory was possible.
2. **Parakeet installs in a directory we own** —
   `<appSupport>/EnviousWispr/Models/parakeet-tdt-0.6b-v3`, a sibling of the `Models/whisper`
   the multilingual family has used since #1386 PR-2. The legacy branch gets it too, which is what
   closes the vendor's purge: FluidAudio may wipe and write inside a directory we own.
3. **An existing copy is reproduced, not re-downloaded.** Manifest files are cloned (APFS
   copy-on-write, falling back to a real copy) out of the old shared directory into staging. The
   donor is read-only by construction — `clonefile` and `copyItem` are the only APIs on the path.
   No new verification: `ManifestFetchTask` already refuses to skip a staged file unless its size and
   SHA-256 match (`ManifestFetchTask.swift:144-148`).
4. **A failed in-place admission reports which half failed** (#2691). The catch replaced every throw
   with the fixed detail `admit_in_place`, discarding `orphan_cleanup` and
   `post_promote_stamp:<component>`. #2690 is what this costs: a plain permissions error arrived as
   one generic word, and it took a directory listing from the user to recover what the code already
   knew.
5. **Tests.**
6. **Second-pass behavioural review fixes**, including one that would have shipped: the folder name
   was taken from our manifest's Hugging Face slug (`…-v3-coreml`) rather than FluidAudio's
   `Repo.folderName` (`…-v3`, the `-coreml` suffix stripped at `ModelNames.swift:265-266`), so the
   loader would have looked in a directory we never wrote to. Also closed: with delivery switched
   OFF, `ASRManager` reached `prepare(progressCallback:)` and went straight back to the shared
   directory with downloading enabled — the kill switch would have restored the defect.

## Behaviour for existing users

Nothing re-downloads, provided the pinned files are readable and the local copy verifies. Their old
copy stays where it is — 483,256,769 bytes — because we cannot attribute it and therefore may not
remove it. On a cloning filesystem the new copy adds little on top; on one without, it is a real
second copy. The outcome reports which happened rather than assuming.

A reproduced copy is visible without new telemetry: it emits `attemptCompleted` with an empty bytes
bucket, while a genuinely already-present cache takes the `adoptedInPlace` path and emits no attempt
at all.

## Rollback

**Not the kill switch.** Flag-off restores the legacy backend path, which before this change reached
the vendor default directory with `offlineMode` false and re-armed the purge. Any rollback build must
carry the directory routing.

## Testing

`scripts/xcode-test.sh` green: 7389 tests / 659 suites, 3 pre-existing known issues, TEST SUCCEEDED.

The install-location test reads FluidAudio's folder name at RUNTIME rather than restating it. That is
what caught the wrong constant above; the previous version built its expected value from the same
constant it was testing and could not have.

Seven new tests. The load-bearing one asserts the donor's files keep their bytes **and their inode** —
bytes alone would pass against a move-and-replace, which is the exact outcome this change exists to
prevent. It was mutation-checked: with a `removeItem` on the donor planted in the import, the suite
fails; with it removed, it passes.

The install location has its own test rather than a comment, because the last path component is
load-bearing: `AsrModels.repoPath(from:)` drops the last component and re-appends the repo folder
name, so any other name would make our install location and the runtime's lookup location disagree
while each looked correct alone.

## Still open

- Live UAT on real hardware, including the preservation drill against a staged foreign copy.
- `ModelHub`'s full write surface is not exhaustively cleared: `loadModelsOnce` creates the supplied
  parent before any offline check (`ModelHub.swift:322`), `ModelCache.createDirectoryRobustly` can
  remove a file along an ancestor path (`ModelCache.swift:38-55`), and two explicit cache-clearing
  APIs have no offline guard (`ModelHub.swift:52-54`, `:61-67`, no caller found in the inspected
  files). None of these can reach the shared tree once nothing hands it to the vendor, which is the
  property this change establishes and the reason the inventory is deliberately left open rather
  than chased.

Plan: `docs/feature-requests/issue-2483-2026-09-06-parakeet-shared-cache-ownership.md` (revision 5,
one coverage round, two grounded rounds and one behavioural second pass, all on Codex Astra).

Closes #2483
Closes #2691
