### PR TITLE
fix(delivery): carry the underlying error's identity out of admit-in-place (#2691)

### DIFF
--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -588,10 +588,24 @@ public actor ModelDeliveryController {
         // entry from a bad post-promote stamp.
         return await finishFailed(identity, failure, generation: generation)
       } catch {
-        // Anything that is not a DeliveryFailure keeps the old site-named
-        // detail: there is no better name for it, and the site is still the
-        // most useful thing we know.
-        let failure = DeliveryFailure(reason: .cacheRepairFailed, detail: "admit_in_place")
+        // Everything else is a Cocoa error from one of `promoteAndAdmit`'s SEVEN
+        // untyped `try` sites, and until #2691's follow-up they all arrived as the
+        // bare word `admit_in_place`. That is most of the function: removing the
+        // marker, creating the install directory, replacing and moving components,
+        // reading attributes, creating the METADATA directory, and writing the
+        // marker. #2690's reporter throws at the metadata directory — his
+        // `Application Support` is root-owned, so it cannot be created — and the
+        // typed pass-through above does not reach him, because `FileManager` does
+        // not mint `DeliveryFailure`.
+        //
+        // So carry the underlying error's identity. Domain and code ONLY: they
+        // name EACCES in one word without putting a path, a home directory or a
+        // user name into telemetry or a log line, and they are a closed set, so
+        // this cannot become unbounded cardinality.
+        let underlying = error as NSError
+        let failure = DeliveryFailure(
+          reason: .cacheRepairFailed,
+          detail: "admit_in_place:\(underlying.domain):\(underlying.code)")
         return await finishFailed(identity, failure, generation: generation)
       }
       // No fetch happened (existing file adopted in place — the #1363 EG-1

--- a/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
+++ b/Sources/EnviousWisprModelDelivery/ModelDeliveryController.swift
@@ -588,12 +588,18 @@ public actor ModelDeliveryController {
         // entry from a bad post-promote stamp.
         return await finishFailed(identity, failure, generation: generation)
       } catch {
-        // Everything else is a Cocoa error from one of `promoteAndAdmit`'s SEVEN
-        // untyped `try` sites, and until #2691's follow-up they all arrived as the
-        // bare word `admit_in_place`. That is most of the function: removing the
-        // marker, creating the install directory, replacing and moving components,
-        // reading attributes, creating the METADATA directory, and writing the
-        // marker. #2690's reporter throws at the metadata directory — his
+        // Everything else is a Cocoa error from one of the FIVE untyped `try`
+        // sites this call can actually reach, and until #2691's follow-up they all
+        // arrived as the bare word `admit_in_place`: removing the marker, creating
+        // the install directory, reading attributes for the stamp, creating the
+        // METADATA directory, and writing the marker.
+        //
+        // Five, not seven: this arm passes `stagedComponents: []`, so the
+        // component loop at `CacheAdmission.swift:245-252` never iterates and its
+        // remove/move throws belong to the post-fetch call alone. Counted by
+        // reading what THIS call site reaches rather than what the function
+        // contains, which is the distinction a first draft of this comment got
+        // wrong. #2690's reporter throws at the metadata directory — his
         // `Application Support` is root-owned, so it cannot be created — and the
         // typed pass-through above does not reach him, because `FileManager` does
         // not mint `DeliveryFailure`.


### PR DESCRIPTION
## What this fixes

#2691 shipped in #2694 as a typed `DeliveryFailure` pass-through on the adopt-in-place catch. That recovered the two details `CacheAdmission` mints itself — `orphan_cleanup` and `post_promote_stamp:<component>` — and it was the right change.

**It reaches two of the seven throw sites this call can produce, and the other five still reported the bare word `admit_in_place`.** They are `FileManager` and `JSONEncoder` calls raising Cocoa errors, which fell to the generic arm:

| Site | `CacheAdmission.swift` |
|---|---|
| remove the marker | `:238` |
| create the install directory | `:241` |
| read attributes for the stamp | `:273` |
| **create the metadata directory** | **`:284`** |
| write the marker | `:287` |

**#2690's reporter throws at `:284`.** His `~/Library/Application Support` is owned by `root:wheel` at mode 755, so `EnviousWispr/ModelDelivery` cannot be created. `FileManager` does not mint `DeliveryFailure`, so the typed pass-through never reaches him.

I claimed in #2694 that the fix made his class of failure diagnosable. **It did not.** This is that claim made true rather than withdrawn.

## The change

The generic arm carries the underlying `NSError`'s domain and code:

```swift
let underlying = error as NSError
let failure = DeliveryFailure(
  reason: .cacheRepairFailed,
  detail: "admit_in_place:\(underlying.domain):\(underlying.code)")
```

Domain and code **only**, and both halves of that are deliberate:

- They name EACCES in one word. That is the whole of #2690's diagnosis, which currently costs a directory listing from the user.
- They are a closed set, so telemetry cardinality stays bounded.
- They carry no path, home directory or user name, so nothing private reaches a log line or an event. The failing path would have been the obvious thing to include and is exactly what must not be.

## Provenance

Found by the #2690 session reading the merged diff of #2694, and verified here against `promoteAndAdmit` in main before acting on it.

**Count corrected after review (`d82c6220`).** A first draft said seven untyped sites. That counted what the FUNCTION contains rather than what THIS call site reaches: the adopt-in-place arm passes `stagedComponents: []`, so the component loop at `CacheAdmission.swift:245-252` never iterates and its `removeItem`/`moveItem` throws belong to the post-fetch call alone. Five reachable untyped sites, listed above. The distinction — reachable versus present — is now in the code comment, because the number alone is what a future reader would otherwise inherit.

## Testing

`scripts/xcode-test.sh` green: 7393 tests / 659 suites, 3 pre-existing known issues, TEST SUCCEEDED.

No new test. The behaviour is a string in a failure detail on paths that require an unwritable or otherwise broken filesystem to reach, and a test that constructs one would assert the format of a diagnostic rather than a property a user feels. Stated rather than silently skipped, per `testing-philosophy.md` — if a reviewer disagrees, the honest test is a real permission-denied fixture, not a mock that returns a chosen `NSError`.

Part of #2691
