### PR TITLE
chore(release): bump version to 2.4.8

### DIFF
--- a/Sources/EnviousWispr/Resources/Info.plist
+++ b/Sources/EnviousWispr/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.7</string>
+	<string>2.4.8</string>
 	<key>CFBundleVersion</key>
-	<string>2.4.7</string>
+	<string>2.4.8</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -55,6 +55,44 @@ enum WhatsNewContent {
   }
 
   static let entries: [Entry] = [
+    // MARK: - v2.4.8
+
+    // #2483, #2691 and #2697, merged fe044f6e / 85ddc26e / d49494f3. ONE user
+    // story across three PRs, told once: the speech model moved into a folder of
+    // our own, and everything else in those PRs is repair to a move no user has
+    // run yet. Per whats-new-protocol RULE: whats-new-content-rules, a change
+    // reaching users for the FIRST time carries no repair copy — nobody ran the
+    // version being repaired, so #2697's fixes to #2483 are invisible by
+    // construction and are not narrated.
+    //
+    // The measurements stay HERE rather than in the copy, where the claim sweep
+    // still needs them. Measured on the founder's machine, 2026-09-07: 23 files,
+    // 483,256,769 bytes, reused in 0.8-1.0 seconds by copy-on-write clone; the
+    // shared FluidAudio directory byte- and inode-identical after every one of
+    // eleven force-killed runs; a damaged file repaired from that directory
+    // fetching under 50 MB where the same test before the fix fetched 200-600 MB.
+    //
+    // "reused in seconds" is the only near-numeric claim in the copy and it is
+    // deliberately vague against a measured 0.8-1.0s, because the number is this
+    // machine's and a slower Mac is not being promised anything.
+    Entry(
+      id: "model-lives-in-our-own-folder",
+      icon: "folder.badge.gearshape",
+      title: "The speech model now lives in its own folder",
+      description:
+        "EnviousWispr keeps its speech model somewhere that belongs to it, and leaves every other app's files alone. If the model is already on your Mac it gets reused in seconds instead of downloaded again, even if you are offline.",
+      version: "2.4.8"
+    ),
+
+    Entry(
+      id: "model-repairs-itself",
+      icon: "arrow.triangle.2.circlepath",
+      title: "A damaged speech model fixes itself",
+      description:
+        "If part of the speech model goes missing or gets corrupted, EnviousWispr puts it back using what is already on your Mac. You do not have to do anything, and it does not download the whole model again to fix one file.",
+      version: "2.4.8"
+    ),
+
     // MARK: - v2.4.7
 
     // **THIS GROUP IS OPEN AND 2.4.6 HAS SHIPPED** (tag v2.4.6, 2026-08-28), so

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -75,6 +75,26 @@ enum WhatsNewContent {
     // "reused in seconds" is the only near-numeric claim in the copy and it is
     // deliberately vague against a measured 0.8-1.0s, because the number is this
     // machine's and a slower Mac is not being promised anything.
+    //
+    // THE REPAIR ENTRY WAS SCOPED after cloud review (#2701). It said the repair
+    // uses "what is already on your Mac", which is only true when a valid donor
+    // copy exists: on a FRESH install, or once the legacy FluidAudio directory
+    // has been removed, or when that directory holds the same damaged file,
+    // there is no second copy and the fetch supplies the component. Both halves
+    // are now stated, so the sentence is true in every case rather than in the
+    // one I was picturing. The surviving claim — that only the missing piece is
+    // fetched, not the whole model — holds either way and is measured.
+    //
+    // NOT WRITTEN, and the reasoning belongs here rather than in a review thread:
+    // review asked for an entry covering the user whose Application Support is
+    // unwritable, because #2697 routes the model and its metadata through
+    // `StorageRoot` and that user can now get a model where 2.4.7 could not
+    // create one. That is real and it is proven at the unit level. It is NOT
+    // written up, because their dictation history and custom words still resolve
+    // to the unwritable path and still fail (#2695 PR 2 closes that), and no end
+    // to end run on such a machine exists. An entry would promise a working app
+    // to someone who will still hit failures. It belongs in the release that
+    // finishes the job.
     Entry(
       id: "model-lives-in-our-own-folder",
       icon: "folder.badge.gearshape",
@@ -89,7 +109,7 @@ enum WhatsNewContent {
       icon: "arrow.triangle.2.circlepath",
       title: "A damaged speech model fixes itself",
       description:
-        "If part of the speech model goes missing or gets corrupted, EnviousWispr puts it back using what is already on your Mac. You do not have to do anything, and it does not download the whole model again to fix one file.",
+        "If part of the speech model goes missing or gets corrupted, EnviousWispr repairs it on its own. Where a copy is already on your Mac it uses that one. Otherwise it fetches just the missing piece instead of the whole model.",
       version: "2.4.8"
     ),
 

--- a/Sources/EnviousWisprCore/WhatsNewConstants.swift
+++ b/Sources/EnviousWisprCore/WhatsNewConstants.swift
@@ -4,7 +4,7 @@ import Foundation
 /// EnviousWisprServices (SettingsManager) and the app shell can reference it.
 public enum WhatsNewConstants {
   /// Bump when bundled What's New content changes in a user-visible way.
-  public static let currentContentVersion = "2.4.7"
+  public static let currentContentVersion = "2.4.8"
 
   /// UserDefaults key for the last content version the user has viewed.
   public static let lastSeenVersionDefaultsKey = "lastSeenWhatsNewVersion"

--- a/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
+++ b/Tests/EnviousWisprTests/Settings/WhatsNewContentTests.swift
@@ -125,7 +125,7 @@ struct WhatsNewContentTests {
     // untouched by #1493; asserting the real sequence is the falsifiable version.
     #expect(
       WhatsNewContent.versions == [
-        "2.4.7", "2.4.6", "2.4.5", "2.4.4", "2.4.3", "2.4.1", "2.4.0",
+        "2.4.8", "2.4.7", "2.4.6", "2.4.5", "2.4.4", "2.4.3", "2.4.1", "2.4.0",
         "2.3.2", "2.3.1", "2.3.0",
         "2.2.1", "2.2.0",
         "2.1.4", "2.1.3", "2.1.2", "2.1.1", "2.1.0",


### PR DESCRIPTION
## v2.4.8 — hot fix for the speech model's folder

Five commits since `v2.4.7`; two are user-visible and they are ONE story, so there are two entries rather than five.

### What a person gets

**The speech model now lives in its own folder.** EnviousWispr keeps it somewhere that belongs to it and leaves every other app's files alone. If the model is already on the Mac it is reused in seconds instead of downloaded again, even offline.

**A damaged speech model fixes itself.** A missing or corrupted piece is put back from what is already on disk, with no user action and without re-downloading the whole model to repair one file.

### Why three PRs get two entries

#2483, #2691 and #2697 are the same story. v2.4.7 shipped BEFORE #2483 merged, so everything after it is repair to a move no user has run — and `whats-new-protocol.md` RULE: whats-new-content-rules says a change reaching users for the first time carries no repair copy. Narrating #2697's fixes would describe bugs in something nobody has seen.

The other three commits were classified rather than skipped: #2695 (`StorageRoot`) has no production consumer a user reaches except through #2697's call sites; #2691 changes a failure DETAIL string, which is diagnostics; #2689 is website help content.

### Every claim verified before the commit

| Claim | Evidence |
|---|---|
| "leaves every other app's files alone" | the shared FluidAudio directory byte- AND inode-identical after **eleven** force-killed migration runs on real hardware |
| "reused in seconds" | measured 0.8-1.0s for 23 files / 483,256,769 bytes, and deliberately left vaguer than the number because it is one machine's |
| "even if you are offline" | copy-on-write clone from a directory already on disk; the kill-switch case ran with delivery disabled and produced all 23 files |
| "does not download the whole model again to fix one file" | a repair after one corrupted file fetched `bytes=under_50mb`, where the same test before the fix fetched `bytes=200mb_600mb` |

**Checked and left alone:** no entry names a count, a percentage, a duration or a file size. The measurements live in the group comment, where the claim sweep needs them.

### Step 3.5 — reachability in a Release build

A patch note is a promise and a dev build cannot verify it. `#if DEBUG` over the delivery path returns five blocks, every one classified by reading its body: two are the Live UAT stall seam, three are the local delivery log (#2135). **No feature gate.**

Release binary probed with controls in both directions:

- both new entry titles **PRESENT**
- a shipped v2.4.7 title **PRESENT** (so the probe works)
- `stallHook` **ABSENT** (the test seam does not ship)

### Validation

`scripts/xcode-test.sh` green: 7636 tests, TEST SUCCEEDED. Release lane run separately during #2699: 6970 tests, PASS.

No `release-action` issues are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWg83EcTGNX2zDd8q1Qv1t
