### PR TITLE
ci(uat): gate the single-instance guard by moving it out of the PyObjC import path (#2426)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -602,7 +602,7 @@ jobs:
           scripts/ci/check-download-link-utms.sh --self-test
           scripts/ci/check-download-link-utms.sh
 
-      - name: RuntimeUAT PTT binding policy + Swift/Python key parity
+      - name: RuntimeUAT PTT binding policy + Swift/Python key parity + instance guard
         run: |
           set -euo pipefail
           # #1997. The UAT harness resolves which key to hold for push-to-talk.
@@ -613,9 +613,24 @@ jobs:
           # MODIFIER_KEYS drift apart in EITHER direction: an app-only key makes
           # the harness refuse (safe), but a Python-only key makes it post a
           # modifier event at a Carbon-registered hotkey and produce exactly that
-          # false product FAIL. Neither module imports Quartz, so both run here.
+          # false product FAIL.
+          #
+          # #2426 adds the third. The membership rule for this step is that a
+          # module here imports nothing heavy: no Quartz, no PyObjC, so it can be
+          # imported on the hosted runner without an untested assumption about
+          # what that runner has. `ptt_binding` and `faultInjection` already met
+          # it. `wispr_eyes` does not — it reaches ApplicationServices through
+          # `ui_helpers` — so its single-instance guard was MOVED to
+          # `instance_guard.py`, which imports only `os`, `subprocess` and `sys`.
+          # That is what makes the third line safe to add: the rule was satisfied
+          # rather than waived. The guard refuses a UAT verdict when a second
+          # EnviousWispr is running, because every instance answers the same
+          # global hotkey and writes the same `app.log`, so a marker count drawn
+          # from that log is unattributable — measured 2026-08-25 as two real
+          # recordings from one gesture, reading as the app double-counting.
           python3 Tests/RuntimeUAT/ptt_binding.py --self-test
           python3 Tests/RuntimeUAT/faultInjection.py --self-test
+          python3 Tests/RuntimeUAT/instance_guard.py --self-test
 
       - name: Judge receipt + billing contracts (#2007/#2008)
         run: |

--- a/Tests/RuntimeUAT/instance_guard.py
+++ b/Tests/RuntimeUAT/instance_guard.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""The single-instance guard for the RuntimeUAT harness, and its control.
+
+SPLIT OUT OF `wispr_eyes.py` SO A CI JOB CAN RUN IT (#2426). `wispr_eyes`
+imports `ui_helpers`, which imports `ApplicationServices` — so importing it at
+all requires PyObjC on the runner, and the pull-request workflow's RuntimeUAT step was
+deliberately limited to modules that need nothing heavy. This module imports
+`os`, `subprocess` and `sys` and nothing else, so the guard — the part actually
+worth gating — runs on the hosted runner while the UI-driving harness around it
+stays out of CI, where it could not run headless anyway.
+
+`wispr_eyes.py` re-exports both functions, so every existing caller and every
+`wispr_eyes.running_enviouswispr_instances(...)` reference keeps working.
+
+Run the control:
+
+    python3 Tests/RuntimeUAT/instance_guard.py --self-test
+"""
+
+import os
+import subprocess
+import sys
+
+
+def running_enviouswispr_instances():
+    """Every running EnviousWispr app bundle, as {pid: executable path}.
+
+    Reads `comm`, NOT `command`. `command` is the executable PLUS its arguments
+    with no delimiter between them, so recovering the executable means guessing
+    where the arguments begin - and every guess is wrong for some legal path. An
+    earlier version split on the first `" -"`, which silently truncates
+    `/Users/x/EW - issue/build/EnviousWispr Local.app/...` to `/Users/x/EW` and
+    drops that instance from the count. `comm` is the executable alone, so there
+    is nothing to parse. (Verified here: on macOS it is the full path, unlike
+    Linux where `comm` is the basename.)
+
+    Still excludes our own pid. A caller's argv routinely carries both
+    `EnviousWispr` (a worktree path) and `.app/Contents/MacOS/` (a script running
+    under `Python.app`), and excluding `python3` does not help - the interpreter's
+    binary is named `Python`. The basename test already rejects `.../Python`, so
+    the pid check is the second of two mechanisms rather than the only one; the
+    self-test carries a row that binds it, because a mutant proved the obvious row
+    did not.
+
+    Deliberately NOT scoped to `EnviousWispr Local.app`. A Release-configuration
+    test host is named `EnviousWispr.app`, carries the PRODUCTION bundle id, and
+    answers the same global hotkey; a `Local.app` pattern cannot see it, which is
+    exactly the instance you most want counted.
+    """
+    # `-ww` asks for unlimited width. macOS `ps(1)` documents that output can be
+    # truncated to the terminal width and that a second `-w` lifts the bound. It
+    # did NOT reproduce here - piped output stayed intact at 88,841 characters
+    # even with COLUMNS=60 - so this is insurance, not a fix for an observed
+    # truncation. It earns its place because the failure would be SILENT and in
+    # the dangerous direction: a truncated suffix drops a real instance, and the
+    # verdict becomes unattributable with nothing to indicate it.
+    out = subprocess.run(["ps", "-eww", "-o", "pid=,comm="],
+                         capture_output=True, text=True).stdout
+    me = str(os.getpid())
+    found = {}
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        pid, exe = line.strip().split(None, 1)
+        if pid == me:
+            continue
+        # An EXACT suffix, so the app's own XPC service and `llama-server` - both
+        # inside the same bundle and both in this listing - are excluded.
+        if exe.endswith(".app/Contents/MacOS/EnviousWispr"):
+            found[pid] = exe
+    return found
+
+
+def _require_single_instance(what):
+    """REFUSE rather than choose when more than one EnviousWispr is running.
+
+    Every instance answers the same global hotkey and writes the same shared
+    `app.log`, so a marker count drawn from that log is unattributable the moment
+    there are two. Measured 2026-08-25: a second instance inside the window
+    returned 2 of every marker with DISTINCT session ids - two real recordings
+    from one gesture - which reads as the app double-counting a synthetic press.
+    A confident wrong subject, pointing at production code.
+
+    Returns the instance map so the caller can re-check it afterwards. A wrong
+    refusal costs a rerun; a wrong verdict costs somebody a debugging session in
+    correct code.
+    """
+    found = running_enviouswispr_instances()
+    if len(found) != 1:
+        rows = "\n".join(f"    {p}  {c}" for p, c in sorted(found.items()))
+        print(f"BLOCKED: {what} needs exactly ONE running EnviousWispr; "
+              f"found {len(found)}.\n{rows}")
+        return None
+    return found
+
+
+def run_guard_cases():
+    """Control for the single-instance guard - a HARNESS CONTRACT test.
+
+    It protects the INSTRUMENT and says nothing about whether hands-free works
+    (testing-philosophy.md RULE: every-test-declares-which-of-four-things-it-protects).
+
+    CI RUNS THIS, as of #2426. It did not before, and the reason it did not is
+    the reason this module exists: these rows lived in `wispr_eyes.py`, which
+    imports `ui_helpers` and so needs PyObjC to import at all, and wiring that to
+    the required check would have rested on an untested assumption about the
+    hosted runner. Moving the guard to a module importing `os` and `subprocess`
+    removes the assumption rather than testing it. It runs beside the siblings
+    that were already wired in on the same grounds, `ptt_binding.py` and
+    `faultInjection.py`. By hand, either entry point drives these same rows:
+
+        python3 Tests/RuntimeUAT/instance_guard.py --self-test
+        python3 Tests/RuntimeUAT/wispr_eyes.py --self-test
+
+    Every row drives the real function with an injected `ps` table, and the set is
+    two-way: three rows must REFUSE and two must PASS, so a guard that stopped
+    classifying anything fails here rather than looking clean.
+    """
+    import types
+    real_run = subprocess.run
+    me = str(os.getpid())
+
+    def fake(rows):
+        def _run(cmd, *a, **k):
+            if list(cmd[:1]) == ["ps"]:
+                return types.SimpleNamespace(stdout="\n".join(rows), returncode=0)
+            return real_run(cmd, *a, **k)
+        return _run
+
+    ONE = ["  111 /Users/x/EW/build/EnviousWispr Local.app/Contents/MacOS/EnviousWispr"]
+    cases = [
+        ("one dev instance", ONE, 1, True),
+        ("two dev instances", ONE + [
+            "  222 /Users/x/wt/.derivedData/Dev/Build/Products/Dev/EnviousWispr Local.app"
+            "/Contents/MacOS/EnviousWispr"], 2, False),
+        # The Release test host carries the PRODUCTION bundle id and answers the same
+        # global hotkey, and a pattern scoped to `EnviousWispr Local.app` cannot see
+        # it - which is the instance you most want counted.
+        ("dev + Release test host", ONE + [
+            "  333 /Users/x/wt/.derivedData/Release/Build/Products/Release/EnviousWispr.app"
+            "/Contents/MacOS/EnviousWispr"], 2, False),
+        # The probe's own argv carries `EnviousWispr` (a worktree path) AND
+        # `.app/Contents/MacOS/` (it runs under Python.app). A command-line
+        # substring test finds itself; excluding `python3` does not help, because
+        # the interpreter's binary is named `Python`.
+        ("one instance + this probe's own argv", ONE + [
+            f"  {me} /opt/homebrew/Frameworks/Python.framework/Versions/3.13/Resources"
+            f"/Python.app/Contents/MacOS/Python -u /tmp/EnviousWispr/probe.py"], 1, True),
+        # The row above does NOT bind the pid exclusion, and a mutant proved it: a
+        # Python probe's executable is `.../Python`, which the basename test
+        # already rejects, so removing `if pid == me` left the self-test green.
+        # This row is the one that binds it - our own pid wearing an executable
+        # the basename test WOULD accept. Contrived as a process, exact as a
+        # requirement: the two mechanisms answer different questions ("is this an
+        # EnviousWispr app" and "is this me"), and only this row can tell whether
+        # the second one is still there.
+        ("our own pid wearing a matching executable", ONE + [
+            f"  {me} /Users/x/EW/build/EnviousWispr Local.app"
+            f"/Contents/MacOS/EnviousWispr"], 1, True),
+        ("no instance at all", ["  999 /usr/bin/vim"], 0, False),
+        # A worktree or parent directory may legally contain " - ". An earlier
+        # version recovered the executable by splitting `command` on the first
+        # `" -"`, which truncates this to `/Users/x/EW` and drops the instance -
+        # a real second app going uncounted, which is the one failure this guard
+        # exists to prevent. Reading `comm` removes the parse entirely; this row
+        # is what stops anyone reintroducing one.
+        ("a path containing a space-hyphen is still counted", ONE + [
+            "  444 /Users/x/EW - issue/build/EnviousWispr Local.app"
+            "/Contents/MacOS/EnviousWispr"], 2, False),
+        # Same bundle, sibling executables. `comm` lists them, and an EXACT
+        # suffix is what keeps them out of the count; a substring test would
+        # treble every instance.
+        ("the app's own XPC service and llama-server are not instances", ONE + [
+            "  555 /Users/x/EW/build/EnviousWispr Local.app/Contents/XPCServices"
+            "/EnviousWisprASRService.xpc/Contents/MacOS/EnviousWisprASRService",
+            "  556 /Users/x/EW/build/EnviousWispr Local.app/Contents/Resources"
+            "/llama-server"], 1, True),
+    ]
+
+    failures = []
+    for name, rows, want_n, want_pass in cases:
+        subprocess.run = fake(rows)
+        try:
+            n = len(running_enviouswispr_instances())
+            got_pass = _require_single_instance("self-test") is not None
+        finally:
+            subprocess.run = real_run
+        if n != want_n or got_pass != want_pass:
+            failures.append(f"{name}: count={n} (want {want_n}), "
+                            f"guard={'PASS' if got_pass else 'REFUSED'} "
+                            f"(want {'PASS' if want_pass else 'REFUSED'})")
+        else:
+            print(f"  ok      {name}")
+    return failures, len(cases)
+
+
+def _self_test():
+    """The guard control, as CI runs it.
+
+    Two-way by construction: three rows must REFUSE and the rest must PASS, so a
+    guard that stopped classifying anything fails here rather than looking clean.
+    """
+    failures, total = run_guard_cases()
+    if failures:
+        for f in failures:
+            print(f"  FAIL    {f}")
+        print(f"\ninstance_guard self-test: {len(failures)} of {total} FAILED")
+        return 1
+    print(f"\ninstance_guard self-test: {total}/{total} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        sys.exit(_self_test())
+    print("instance_guard is a library. Run `--self-test` for the harness control.")
+    sys.exit(2)

--- a/Tests/RuntimeUAT/wispr_eyes.py
+++ b/Tests/RuntimeUAT/wispr_eyes.py
@@ -11,6 +11,11 @@ from ui_helpers import (find_app_pid, get_ax_app, get_attr, set_attr, perform_ac
     get_process_memory_mb, get_clipboard_text, validate_app_ready, element_frame,
     _iter_children_with_menubars)
 from ptt_binding import PTTBindingError, require_push_to_talk, resolve
+# #2426: the single-instance guard lives in its own module so CI can run its
+# control without importing PyObjC. Re-exported here because every caller and
+# every `wispr_eyes.running_enviouswispr_instances(...)` reference predates it.
+from instance_guard import (running_enviouswispr_instances,  # noqa: F401
+                            _require_single_instance, run_guard_cases)
 
 _pid = None
 _app = None
@@ -1697,78 +1702,6 @@ def press_record_key():
     _si.modifier_up(binding.keycode)
 
 
-def running_enviouswispr_instances():
-    """Every running EnviousWispr app bundle, as {pid: executable path}.
-
-    Reads `comm`, NOT `command`. `command` is the executable PLUS its arguments
-    with no delimiter between them, so recovering the executable means guessing
-    where the arguments begin - and every guess is wrong for some legal path. An
-    earlier version split on the first `" -"`, which silently truncates
-    `/Users/x/EW - issue/build/EnviousWispr Local.app/...` to `/Users/x/EW` and
-    drops that instance from the count. `comm` is the executable alone, so there
-    is nothing to parse. (Verified here: on macOS it is the full path, unlike
-    Linux where `comm` is the basename.)
-
-    Still excludes our own pid. A caller's argv routinely carries both
-    `EnviousWispr` (a worktree path) and `.app/Contents/MacOS/` (a script running
-    under `Python.app`), and excluding `python3` does not help - the interpreter's
-    binary is named `Python`. The basename test already rejects `.../Python`, so
-    the pid check is the second of two mechanisms rather than the only one; the
-    self-test carries a row that binds it, because a mutant proved the obvious row
-    did not.
-
-    Deliberately NOT scoped to `EnviousWispr Local.app`. A Release-configuration
-    test host is named `EnviousWispr.app`, carries the PRODUCTION bundle id, and
-    answers the same global hotkey; a `Local.app` pattern cannot see it, which is
-    exactly the instance you most want counted.
-    """
-    # `-ww` asks for unlimited width. macOS `ps(1)` documents that output can be
-    # truncated to the terminal width and that a second `-w` lifts the bound. It
-    # did NOT reproduce here - piped output stayed intact at 88,841 characters
-    # even with COLUMNS=60 - so this is insurance, not a fix for an observed
-    # truncation. It earns its place because the failure would be SILENT and in
-    # the dangerous direction: a truncated suffix drops a real instance, and the
-    # verdict becomes unattributable with nothing to indicate it.
-    out = subprocess.run(["ps", "-eww", "-o", "pid=,comm="],
-                         capture_output=True, text=True).stdout
-    me = str(os.getpid())
-    found = {}
-    for line in out.splitlines():
-        if not line.strip():
-            continue
-        pid, exe = line.strip().split(None, 1)
-        if pid == me:
-            continue
-        # An EXACT suffix, so the app's own XPC service and `llama-server` - both
-        # inside the same bundle and both in this listing - are excluded.
-        if exe.endswith(".app/Contents/MacOS/EnviousWispr"):
-            found[pid] = exe
-    return found
-
-
-def _require_single_instance(what):
-    """REFUSE rather than choose when more than one EnviousWispr is running.
-
-    Every instance answers the same global hotkey and writes the same shared
-    `app.log`, so a marker count drawn from that log is unattributable the moment
-    there are two. Measured 2026-08-25: a second instance inside the window
-    returned 2 of every marker with DISTINCT session ids - two real recordings
-    from one gesture - which reads as the app double-counting a synthetic press.
-    A confident wrong subject, pointing at production code.
-
-    Returns the instance map so the caller can re-check it afterwards. A wrong
-    refusal costs a rerun; a wrong verdict costs somebody a debugging session in
-    correct code.
-    """
-    found = running_enviouswispr_instances()
-    if len(found) != 1:
-        rows = "\n".join(f"    {p}  {c}" for p, c in sorted(found.items()))
-        print(f"BLOCKED: {what} needs exactly ONE running EnviousWispr; "
-              f"found {len(found)}.\n{rows}")
-        return None
-    return found
-
-
 # One per launch of a debug build. Chosen over `[Recovery] #1 scan pass 1 started
 # (launch)` by measurement rather than taste: 437 occurrences against 112 in the
 # same log, because the recovery line is conditional and this one is not. It also
@@ -2848,100 +2781,21 @@ def record_with_fault(scenario_name, **kwargs):
 
 
 def _self_test():
-    """Control for the single-instance guard - a HARNESS CONTRACT test.
+    """Control for the harness contract - it protects the INSTRUMENT and says
+    nothing about whether hands-free works (testing-philosophy.md
+    RULE: every-test-declares-which-of-four-things-it-protects).
 
-    It protects the INSTRUMENT and says nothing about whether hands-free works
-    (testing-philosophy.md RULE: every-test-declares-which-of-four-things-it-protects).
-
-    NOTHING RUNS THIS AUTOMATICALLY, stated rather than implied because a suite no
-    gate invokes reports nothing. The sibling `--self-test` modules that CI does
-    run (`ptt_binding.py`, `faultInjection.py`) are wired in on the stated grounds
-    that "neither module imports Quartz". This one does, transitively through
-    `ui_helpers`, so wiring it to the required check would rest on an untested
-    assumption about the hosted runner's PyObjC - and a CI addition that fails
-    reddens the required check for everybody. Run it by hand:
+    Two halves. The single-instance guard's rows live in `instance_guard.py` and
+    are called in here, so running this by hand still covers them and CI covers
+    them too (#2426); the log-side rows below are this module's own and stay
+    here, because they read `app.log` through code that needs the rest of the
+    harness. Run either entry point:
 
         python3 Tests/RuntimeUAT/wispr_eyes.py --self-test
-
-    Every row drives the real function with an injected `ps` table, and the set is
-    two-way: three rows must REFUSE and two must PASS, so a guard that stopped
-    classifying anything fails here rather than looking clean.
+        python3 Tests/RuntimeUAT/instance_guard.py --self-test
     """
-    import types, pathlib, shutil
-    real_run = subprocess.run
-    me = str(os.getpid())
-
-    def fake(rows):
-        def _run(cmd, *a, **k):
-            if list(cmd[:1]) == ["ps"]:
-                return types.SimpleNamespace(stdout="\n".join(rows), returncode=0)
-            return real_run(cmd, *a, **k)
-        return _run
-
-    ONE = ["  111 /Users/x/EW/build/EnviousWispr Local.app/Contents/MacOS/EnviousWispr"]
-    cases = [
-        ("one dev instance", ONE, 1, True),
-        ("two dev instances", ONE + [
-            "  222 /Users/x/wt/.derivedData/Dev/Build/Products/Dev/EnviousWispr Local.app"
-            "/Contents/MacOS/EnviousWispr"], 2, False),
-        # The Release test host carries the PRODUCTION bundle id and answers the same
-        # global hotkey, and a pattern scoped to `EnviousWispr Local.app` cannot see
-        # it - which is the instance you most want counted.
-        ("dev + Release test host", ONE + [
-            "  333 /Users/x/wt/.derivedData/Release/Build/Products/Release/EnviousWispr.app"
-            "/Contents/MacOS/EnviousWispr"], 2, False),
-        # The probe's own argv carries `EnviousWispr` (a worktree path) AND
-        # `.app/Contents/MacOS/` (it runs under Python.app). A command-line
-        # substring test finds itself; excluding `python3` does not help, because
-        # the interpreter's binary is named `Python`.
-        ("one instance + this probe's own argv", ONE + [
-            f"  {me} /opt/homebrew/Frameworks/Python.framework/Versions/3.13/Resources"
-            f"/Python.app/Contents/MacOS/Python -u /tmp/EnviousWispr/probe.py"], 1, True),
-        # The row above does NOT bind the pid exclusion, and a mutant proved it: a
-        # Python probe's executable is `.../Python`, which the basename test
-        # already rejects, so removing `if pid == me` left the self-test green.
-        # This row is the one that binds it - our own pid wearing an executable
-        # the basename test WOULD accept. Contrived as a process, exact as a
-        # requirement: the two mechanisms answer different questions ("is this an
-        # EnviousWispr app" and "is this me"), and only this row can tell whether
-        # the second one is still there.
-        ("our own pid wearing a matching executable", ONE + [
-            f"  {me} /Users/x/EW/build/EnviousWispr Local.app"
-            f"/Contents/MacOS/EnviousWispr"], 1, True),
-        ("no instance at all", ["  999 /usr/bin/vim"], 0, False),
-        # A worktree or parent directory may legally contain " - ". An earlier
-        # version recovered the executable by splitting `command` on the first
-        # `" -"`, which truncates this to `/Users/x/EW` and drops the instance -
-        # a real second app going uncounted, which is the one failure this guard
-        # exists to prevent. Reading `comm` removes the parse entirely; this row
-        # is what stops anyone reintroducing one.
-        ("a path containing a space-hyphen is still counted", ONE + [
-            "  444 /Users/x/EW - issue/build/EnviousWispr Local.app"
-            "/Contents/MacOS/EnviousWispr"], 2, False),
-        # Same bundle, sibling executables. `comm` lists them, and an EXACT
-        # suffix is what keeps them out of the count; a substring test would
-        # treble every instance.
-        ("the app's own XPC service and llama-server are not instances", ONE + [
-            "  555 /Users/x/EW/build/EnviousWispr Local.app/Contents/XPCServices"
-            "/EnviousWisprASRService.xpc/Contents/MacOS/EnviousWisprASRService",
-            "  556 /Users/x/EW/build/EnviousWispr Local.app/Contents/Resources"
-            "/llama-server"], 1, True),
-    ]
-
-    failures = []
-    for name, rows, want_n, want_pass in cases:
-        subprocess.run = fake(rows)
-        try:
-            n = len(running_enviouswispr_instances())
-            got_pass = _require_single_instance("self-test") is not None
-        finally:
-            subprocess.run = real_run
-        if n != want_n or got_pass != want_pass:
-            failures.append(f"{name}: count={n} (want {want_n}), "
-                            f"guard={'PASS' if got_pass else 'REFUSED'} "
-                            f"(want {'PASS' if want_pass else 'REFUSED'})")
-        else:
-            print(f"  ok      {name}")
+    import pathlib, shutil
+    failures, guard_rows = run_guard_cases()
 
     # The banner counter's PURE half, driven with synthetic text. This is where
     # the two review findings on the log side live: a banner written before
@@ -3157,7 +3011,7 @@ def _self_test():
         else:
             print(f"  ok      {name}")
 
-    total = (len(cases) + len(banner_cases) + banner_rows_extra + file_rows
+    total = (guard_rows + len(banner_cases) + banner_rows_extra + file_rows
              + len(window_cases))
     if failures:
         for f in failures:


### PR DESCRIPTION
Closes #2426.

`Tier: SMALL | Test: required (RuntimeUAT self-test) | Modules: Tests/RuntimeUAT, CI`
`Lane: CI/workflow | mixed_pr: true`

## What a person gets

Nothing user-facing. The UAT harness has a guard that refuses to return a verdict when two copies of EnviousWispr are running, because both answer the same global hotkey and write the same `app.log`, so a marker count drawn from that log is unattributable. Measured 2026-08-25: a second instance inside the window returned 2 of every marker with distinct session ids, which reads as the app double-counting. Nothing checked that guard automatically. Now the required check does.

## Why route 3 rather than the measurement

The issue offers a throwaway CI step to learn whether `import wispr_eyes` succeeds on the hosted runner, and calls route 3 the better outcome either way. Route 3 removes the question instead of answering it. `running_enviouswispr_instances` and `_require_single_instance` moved verbatim into `Tests/RuntimeUAT/instance_guard.py`, which imports `os`, `subprocess` and `sys`; `wispr_eyes.py` re-exports both, so `measure_overlay_first_render.py`'s `_we.running_enviouswispr_instances()` call is untouched.

## Evidence

| check | result |
|---|---|
| `python3 Tests/RuntimeUAT/instance_guard.py --self-test` | 8/8 passed |
| `python3 Tests/RuntimeUAT/wispr_eyes.py --self-test` | 28/28 passed, same total as `origin/main` before the change |
| import isolation: the file copied alone into an empty directory, no sibling on the path | 8/8 passed |
| static import audit | `os`, `subprocess`, `sys`, `types` — all stdlib |
| `.claude/scripts/check-cited-symbols.py` | PASSED, 12 symbols, 4 files |

Mutation control, 3/3 CAUGHT, restore byte-identical and green after:

| mutant | result |
|---|---|
| drop the own-pid exclusion | 1 of 8 FAILED |
| substring instead of the exact `.app/Contents/MacOS/EnviousWispr` suffix | 1 of 8 FAILED |
| `len(found) != 1` weakened to `< 1` | 3 of 8 FAILED |

## The comment that had to change

The step's comment asserted "Neither module imports Quartz, so both run here", which stops being true of the SET the moment a third line joins it. It is replaced by the membership rule it stood for — a module in this step imports nothing heavy — plus why the new module satisfies it.

## Review

`codex review --base origin/main`: "The extracted guard preserves the existing behavior and callers, and CI now runs its standalone tests. All four relevant self-test commands passed; no actionable regressions were found."