### PR TITLE
test(llm): bind the warm window itself, which coldWindow could not (#2632)

### DIFF
--- a/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
@@ -87,6 +87,21 @@ struct LLMWarmupGateTests {
     let session = freshSession()
     let now = Date()
 
+    // The FLOOR, and it is the only thing here that can see the constant change.
+    // Both boundaries below are derived FROM `warmWindowSeconds`, deliberately, so
+    // that changing the window length is a product decision rather than a test
+    // edit — but that also means they move with it: at a window of ZERO,
+    // `justInside` is one second BEFORE the success and `justOutside` one second
+    // after, and both assertions still hold. The 2026-09-07 battery measured
+    // exactly that (#2632 row 2): `warmWindowSeconds = 0` left this case green and
+    // was caught only incidentally by `acceptedPolishMarksWarm`, which asks at
+    // `now` itself. So the derived arithmetic proves the ORDERING and this line
+    // proves there is a window at all. A minute is the floor because a window
+    // shorter than one dictation cannot suppress the second warm-up it exists for.
+    #expect(
+      LLMNetworkSession.warmWindowSeconds >= 60,
+      "a warm window shorter than a minute is not a window")
+
     #expect(session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: now))
     session.releaseWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", succeededAt: now)
 


### PR DESCRIPTION
Part of #2632, which stays open until this lands.

`Tier: SMALL | Test: required (LLM) | Modules: EnviousWisprTests`
`Lane: Code`

## What the battery found

The 2026-09-07 mutation battery set `LLMNetworkSession.warmWindowSeconds` from 300 to 0. `coldWindow` stayed **green**. `acceptedPolishMarksWarm` failed instead — a real catch that says nothing about the case which names the window.

The reason is in the test, not the guard. `coldWindow` derives both of its boundaries FROM the constant:

```swift
let justInside  = now.addingTimeInterval(LLMNetworkSession.warmWindowSeconds - 1)
let justOutside = now.addingTimeInterval(LLMNetworkSession.warmWindowSeconds + 1)
```

At a window of zero those become `now - 1` and `now + 1`, and both assertions still hold: a claim one second before a success is refused, one second after is allowed. **The expectations move with the value they exist to pin, so no value of the constant can make this case red.** `validation-discipline.md` RULE: verify-the-feature-not-the-crash, nominal-constant form.

## What changes

One assertion, and the derived arithmetic stays exactly as it was — changing the window length should remain a product decision rather than a test edit. What that arithmetic cannot do is notice the window disappearing, so a floor is added beside it:

```swift
#expect(
  LLMNetworkSession.warmWindowSeconds >= 60,
  "a warm window shorter than a minute is not a window")
```

Strictly more is asserted than before and nothing is relaxed. `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night: a survivor is resolved by observing the subject more tightly and NEVER by loosening an assertion.

Sixty seconds is the floor because a window shorter than one dictation cannot suppress the second warm-up it exists for.

## Proof

The same mutant that left this case green on `origin/main` must now turn it red. Battery receipt below.

## Evidence

| check | result |
|---|---|
| `check-cited-symbols.py` | PASSED, 4 symbols |
| the mutant, re-run against THIS branch | `coldWindow()` **Passed → Failed** at `LLMWarmupGateTests.swift:101`: `(LLMNetworkSession.warmWindowSeconds → 0.0) >= (60 → 60.0)` |
| the same mutant on `origin/main` | `coldWindow()` stayed **green**; `acceptedPolishMarksWarm()` failed instead |
| baseline | green before and after, both runs; worktree restored byte-identical |

The two rows above are the whole point: same mutant, same suite, opposite verdict for the case that names the window.
| local `codex review --base origin/main` | "adds a minimum warm-window assertion that the existing 300-second setting satisfies. It leaves production behavior unchanged, and no actionable defects were found" |
