### PR TITLE
fix(paste): bound activation and terminal-budget AX calls against a frozen target

### DIFF
--- a/Sources/EnviousWisprServices/PasteService.swift
+++ b/Sources/EnviousWisprServices/PasteService.swift
@@ -1191,7 +1191,7 @@ public enum PasteService {
     // Cloud review found it; the discipline already existed one function away.
     guard
       let fresh = budget.step(
-        applying: element, label: "focused",
+        applying: nil, label: "focused", onTimeoutFailure: nil,
         {
           freshFocusedElement(matching: element, messagingTimeout: max(0.005, budget.remaining))
         })
@@ -1208,7 +1208,9 @@ public enum PasteService {
       // that blew the budget and latched terminal insertion off (#1941).
       scanProcesses: { TerminalProcessScanner.liveTerminalSnapshot() },
       readScreenTail: {
-        budget.step(applying: fresh, label: "screen") { terminalScreenTail(of: fresh) }
+        budget.step(applying: fresh, label: "screen", onTimeoutFailure: nil) {
+          terminalScreenTail(of: fresh)
+        }
       })
 
     // The typed refusal is REPORTED, not discarded. §8 of the plan lists eight
@@ -1352,14 +1354,23 @@ public enum PasteService {
     budget: TerminalResolutionBudget? = nil
   ) -> CaretContext? {
     // One helper, so no read can be added later that forgets to be counted.
-    func bounded<T>(_ label: String, _ body: () -> T) -> T {
+    // #2705: `receiver` is the object `body` actually messages — `fresh` for
+    // everything after the initial lookup, `nil` for that lookup itself
+    // (which self-bounds via `freshFocusedElement`'s own `messagingTimeout`).
+    // NEVER the captured `element` — that stays the Tier 1 write target and
+    // must not pick up a timeout from a caret-context read that runs before
+    // it (see `TerminalResolutionBudget.step`'s doc comment).
+    func bounded<T>(
+      _ label: String, applying receiver: AXUIElement?, onTimeoutFailure: T, _ body: () -> T
+    ) -> T {
       guard let budget else { return body() }
-      return budget.step(applying: element, label: label, body)
+      return budget.step(
+        applying: receiver, label: label, onTimeoutFailure: onTimeoutFailure, body)
     }
 
     guard
       let fresh = bounded(
-        "focused",
+        "focused", applying: nil, onTimeoutFailure: nil,
         {
           freshFocusedElement(
             matching: element,
@@ -1371,7 +1382,8 @@ public enum PasteService {
     var roleRef: CFTypeRef?
     guard
       bounded(
-        "role", { AXUIElementCopyAttributeValue(fresh, kAXRoleAttribute as CFString, &roleRef) })
+        "role", applying: fresh, onTimeoutFailure: .cannotComplete,
+        { AXUIElementCopyAttributeValue(fresh, kAXRoleAttribute as CFString, &roleRef) })
         == .success,
       let role = roleRef as? String, textRoles.contains(role)
     else { return nil }
@@ -1379,7 +1391,7 @@ public enum PasteService {
     var countRef: CFTypeRef?
     guard
       bounded(
-        "count",
+        "count", applying: fresh, onTimeoutFailure: .cannotComplete,
         {
           AXUIElementCopyAttributeValue(
             fresh, kAXNumberOfCharactersAttribute as CFString, &countRef)
@@ -1387,7 +1399,10 @@ public enum PasteService {
       let characterCount = countRef as? Int
     else { return nil }
 
-    guard let range = bounded("range", { selectedRange(of: fresh) }) else { return nil }
+    guard
+      let range = bounded(
+        "range", applying: fresh, onTimeoutFailure: nil, { selectedRange(of: fresh) })
+    else { return nil }
 
     guard
       let assembled = assembleCaretContext(
@@ -1396,12 +1411,15 @@ public enum PasteService {
         selectionLength: range.length,
         window: window,
         readRange: { location, length in
-          bounded("range_read", { string(of: fresh, at: location, length: length) })
+          bounded(
+            "range_read", applying: fresh, onTimeoutFailure: nil,
+            { string(of: fresh, at: location, length: length) })
         })
     else { return nil }
 
     let isBrowserAddressBar = bounded(
-      "browser_address_bar", { addressBarFamily(of: fresh) != nil })
+      "browser_address_bar", applying: fresh, onTimeoutFailure: false,
+      { addressBarFamily(of: fresh) != nil })
     guard isBrowserAddressBar else { return assembled }
     return CaretContext(
       leftWindow: assembled.leftWindow, rightWindow: assembled.rightWindow,
@@ -2334,9 +2352,18 @@ public enum PasteService {
   /// Force-activate an app by PID using the Accessibility API.
   /// Bypasses macOS 14+ restrictions on background processes stealing focus.
   /// Requires Accessibility permission (AXIsProcessTrusted).
+  ///
+  /// #2633: `axApp` is bounded before the write so an unresponsive target
+  /// cannot block this call indefinitely. This handle is created fresh here
+  /// on every call and is never the captured Tier 1 focused element, so
+  /// bounding it cannot affect Tier 1's write/verify sequence (see
+  /// docs/feature-requests/issue-2705-2026-09-07-paste-delivery-refactor.md).
   public static func forceActivateApp(pid: pid_t) -> Bool {
     guard AXIsProcessTrusted() else { return false }
     let axApp = AXUIElementCreateApplication(pid)
+    guard
+      AXUIElementSetMessagingTimeout(axApp, Float(axMessagingTimeoutSeconds)) == .success
+    else { return false }
     let result = AXUIElementSetAttributeValue(
       axApp,
       "AXFrontmost" as CFString,

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -148,7 +148,8 @@ package final class TerminalResolutionBudget: Sendable {
   }
 
   /// Run one bounded step: apply the remaining budget as the accessibility
-  /// messaging timeout, run the call, then charge what it actually took.
+  /// messaging timeout on the object `body` actually messages, run the call,
+  /// then charge what it actually took.
   ///
   /// This is what makes the cap CUMULATIVE rather than per-call (founder,
   /// 2026-07-28: "it has to be a 100 ms cap for all the questions"). An earlier
@@ -165,12 +166,29 @@ package final class TerminalResolutionBudget: Sendable {
   /// 1.79 ms in iTerm2, with the only spikes (19-35 ms) on a cold first call.
   /// The cap is roughly fifty times the typical cost and three times the worst
   /// observed — it exists to bound a wedge, and never bites healthy work.
+  ///
+  /// #2705: `element` used to be discarded — this bounded a throwaway
+  /// `AXUIElementCreateApplication` handle nobody read, so the messaging
+  /// timeout it "set" protected nothing. Now `element` is the exact object
+  /// `body` messages, `nil` when `body` already bounds its own receiver
+  /// (`freshFocusedElement`'s own `messagingTimeout` parameter). `nil` never
+  /// touches the CAPTURED Tier 1 focused element's timeout — every real caller
+  /// passes either `nil` or a freshly-requeried element, never the original
+  /// capture, so this step cannot leak a bound onto Tier 1's write/verify
+  /// sequence (docs/feature-requests/issue-2705-2026-09-07-paste-delivery-refactor.md).
+  /// - Parameter element: the object `body` will message, or `nil` when `body`
+  ///   bounds itself. A non-`nil` element whose timeout fails to set returns
+  ///   `onTimeoutFailure` without running `body` at all.
   /// - Parameter label: names this step in the timing trace. Required rather
   ///   than defaulted, so a new bounded step cannot silently appear in the log
   ///   as an anonymous cost.
-  package func step<T>(applying element: AXUIElement, label: String, _ body: () -> T) -> T {
-    let application = AXUIElementCreateApplication(processIdentifier(of: element))
-    AXUIElementSetMessagingTimeout(application, Float(max(0.005, remaining)))
+  package func step<T>(
+    applying element: AXUIElement?, label: String, onTimeoutFailure: T, _ body: () -> T
+  ) -> T {
+    if let element {
+      guard AXUIElementSetMessagingTimeout(element, Float(max(0.005, remaining))) == .success
+      else { return onTimeoutFailure }
+    }
     let started = now()
     defer {
       // ONE call. `charge` both charges and records, so the separate
@@ -210,12 +228,6 @@ package final class TerminalResolutionBudget: Sendable {
     }
     let total = samples.reduce(0.0) { $0 + $1.seconds }
     return parts.joined(separator: " ") + " total=\(String(format: "%.1f", total * 1000))ms"
-  }
-
-  private func processIdentifier(of element: AXUIElement) -> pid_t {
-    var pid: pid_t = 0
-    AXUIElementGetPid(element, &pid)
-    return pid
   }
 }
 

--- a/Tests/EnviousWisprTests/Services/PasteServiceActivationTimeoutTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteServiceActivationTimeoutTests.swift
@@ -72,6 +72,14 @@ struct PasteServiceActivationTimeoutTests {
     // register with the Accessibility subsystem before it is a real target.
     // The loop exits on the real signal (the AX call itself succeeding); the
     // sleep is only the poll interval, bounded by the attempt cap below.
+    //
+    // Codex review found the gap this closes: without tracking whether the
+    // loop actually succeeded, an exhausted, never-registered fixture would
+    // still get frozen and the test would still pass — a never-registered
+    // target ALSO fails fast, with no help from the fix under test. That
+    // makes the pass meaningless rather than wrong, and indistinguishable
+    // from a real pass without this check.
+    var registered = false
     var attempts = 0
     while attempts < 20 {
       Thread.sleep(forTimeInterval: 0.1)  // deadline-fallback: poll interval; loop exits on the AX success check above it
@@ -80,8 +88,13 @@ struct PasteServiceActivationTimeoutTests {
       if AXUIElementSetAttributeValue(axApp, "AXFrontmost" as CFString, true as CFTypeRef)
         == .success
       {
+        registered = true
         break
       }
+    }
+    guard registered else {
+      process.terminate()
+      throw TestFixtureError.neverRegistered
     }
 
     guard kill(process.processIdentifier, SIGSTOP) == 0 else {
@@ -102,6 +115,7 @@ struct PasteServiceActivationTimeoutTests {
 
   private enum TestFixtureError: Error {
     case couldNotFreeze
+    case neverRegistered
   }
 
   @Test(

--- a/Tests/EnviousWisprTests/Services/PasteServiceActivationTimeoutTests.swift
+++ b/Tests/EnviousWisprTests/Services/PasteServiceActivationTimeoutTests.swift
@@ -1,0 +1,128 @@
+import ApplicationServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprServices
+
+/// #2705: `PasteService.forceActivateApp` used to call
+/// `AXUIElementSetAttributeValue(axApp, "AXFrontmost", ...)` with no messaging
+/// timeout at all. Against a target that stops responding — frozen, wedged,
+/// not merely gone — that call could block the calling actor for as long as
+/// the target stays unresponsive (#2633).
+///
+/// A dead PID does not reproduce this: a process that no longer exists fails
+/// FAST, because there is nothing to wait on. The real hazard needs a target
+/// that is genuinely alive but not servicing its run loop, which is what
+/// `FrozenAppHelper.swift` is for — a real, minimal `NSApplication` the test
+/// launches, confirms is a real AX target, then freezes at the OS level with
+/// `SIGSTOP` (founder direction 2026-09-07: build the real fixture, not a
+/// lighter proxy, since this only needs to run locally).
+///
+/// Measured manually against this exact fixture before writing this suite
+/// (2026-09-07): an unbounded `AXUIElementSetAttributeValue` against a
+/// SIGSTOP'd target returned after 1.509s (macOS's own undocumented default),
+/// not instantly and not indefinitely. With `AXUIElementSetMessagingTimeout`
+/// set to 0.5s first, the same call against the same frozen process returned
+/// in 0.511s. Both returned `.cannotComplete` — the call genuinely failed
+/// both times, at different speeds, not a silent success. This suite asserts
+/// the fast side stays fast, so a regression that removes the timeout call
+/// shows up as this test taking over a second instead of a changed assertion.
+///
+/// Not run in CI: no Accessibility session on a hosted runner, and freezing a
+/// real process is exactly the kind of test that must never share a runner
+/// with anything else. Gated on both `AXIsProcessTrusted()` and `CI` being
+/// unset, matching the convention in `RenderedPillFreezeTests.swift`.
+///
+/// On a dev machine this still SKIPS until Accessibility trust is granted to
+/// the unit-test host, not to Xcode or the app — confirmed by a one-time
+/// diagnostic print of the actual running process, 2026-09-07: the binary is
+/// `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Xcode/Agents/xctest`.
+/// Grant it via System Settings > Privacy & Security > Accessibility > "+",
+/// browsing to that exact path (Cmd+Shift+G in the file picker to paste it).
+@Suite(
+  "PasteService activation timeout against a genuinely frozen target (#2705)",
+  .tags(.productOutcome, .realBoundary))
+struct PasteServiceActivationTimeoutTests {
+
+  /// `xcodebuild test` forwards `TEST_RUNNER_CI` and Xcode's test runner
+  /// strips the prefix, so the value reaching this process is `CI` — same
+  /// mechanism, same reasoning as `RenderedPillFreezeTests.isDeveloperMachine`.
+  static var runsOnThisMachine: Bool {
+    AXIsProcessTrusted() && (ProcessInfo.processInfo.environment["CI"] ?? "").isEmpty
+  }
+
+  private static var fixtureURL: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // Services
+      .deletingLastPathComponent()  // EnviousWisprTests
+      .deletingLastPathComponent()  // Tests
+      .appendingPathComponent("Fixtures/frozen-app/FrozenAppHelper.swift")
+  }
+
+  /// Launch the real fixture app, wait for it to become a genuine AX target,
+  /// then freeze it at the OS level. Returns once frozen; the caller owns
+  /// killing `process` when done.
+  private static func launchAndFreezeFixture() throws -> Process {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["swift", fixtureURL.path]
+    try process.run()
+
+    // The interpreter needs a moment to parse, launch NSApplication, and
+    // register with the Accessibility subsystem before it is a real target.
+    // The loop exits on the real signal (the AX call itself succeeding); the
+    // sleep is only the poll interval, bounded by the attempt cap below.
+    var attempts = 0
+    while attempts < 20 {
+      Thread.sleep(forTimeInterval: 0.1)  // deadline-fallback: poll interval; loop exits on the AX success check above it
+      attempts += 1
+      let axApp = AXUIElementCreateApplication(process.processIdentifier)
+      if AXUIElementSetAttributeValue(axApp, "AXFrontmost" as CFString, true as CFTypeRef)
+        == .success
+      {
+        break
+      }
+    }
+
+    guard kill(process.processIdentifier, SIGSTOP) == 0 else {
+      process.terminate()
+      throw TestFixtureError.couldNotFreeze
+    }
+    return process
+  }
+
+  private static func killFixture(_ process: Process) {
+    // CONT before KILL: a stopped process is not guaranteed to process a
+    // signal cleanly, and this is cheap insurance against a leaked frozen
+    // process outliving the test run.
+    kill(process.processIdentifier, SIGCONT)
+    kill(process.processIdentifier, SIGKILL)
+    process.waitUntilExit()
+  }
+
+  private enum TestFixtureError: Error {
+    case couldNotFreeze
+  }
+
+  @Test(
+    "forceActivateApp bounds against a real frozen target instead of taking the OS default",
+    .enabled(if: runsOnThisMachine))
+  func forceActivateAppBoundsAgainstAFrozenTarget() throws {
+    let process = try Self.launchAndFreezeFixture()
+    defer { Self.killFixture(process) }
+
+    let started = Date()
+    let activated = PasteService.forceActivateApp(pid: process.processIdentifier)
+    let elapsed = Date().timeIntervalSince(started)
+
+    // The call must fail — the target is frozen and cannot actually come to
+    // the front — but it must fail FAST. 1.0s is the assertion line: well
+    // above the configured 0.5s bound (so ordinary scheduling jitter cannot
+    // flake this), well below the 1.509s measured default this fix replaces.
+    #expect(!activated, "a frozen target cannot actually activate")
+    #expect(
+      elapsed < 1.0,
+      "forceActivateApp took \(elapsed)s against a frozen target — expected under 1.0s; the pre-#2705 code measured 1.509s here"
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -268,7 +268,9 @@ struct TerminalContextResolverTests {
 
     let shared = TerminalResolutionBudget(total: 1.0, now: { clock.read() })
     var calls = 0
-    for _ in 0..<3 { _ = shared.step(applying: element, label: "probe") { calls += 1 } }
+    for _ in 0..<3 {
+      _ = shared.step(applying: element, label: "probe", onTimeoutFailure: ()) { calls += 1 }
+    }
 
     #expect(calls == 3)
     // THE POINT. Cumulative charges all three: 0.090. A per-call bound retains
@@ -279,7 +281,7 @@ struct TerminalContextResolverTests {
     // between them while neither does alone, so exhaustion is reachable only by
     // accumulating — a per-call bound would sit at 30 ms and stay open.
     let tight = TerminalResolutionBudget(total: 0.040, now: { clock.read() })
-    for _ in 0..<2 { _ = tight.step(applying: element, label: "probe") {} }
+    for _ in 0..<2 { _ = tight.step(applying: element, label: "probe", onTimeoutFailure: ()) {} }
 
     #expect(tight.isExhausted, "two 30 ms calls must exhaust a 40 ms cumulative cap")
     #expect(tight.remaining == 0)
@@ -301,7 +303,7 @@ struct TerminalContextResolverTests {
     let budget = TerminalResolutionBudget(total: 0.100, now: { clock.read() })
     let element = AXUIElementCreateSystemWide()
 
-    for _ in 0..<5 { _ = budget.step(applying: element, label: "probe") {} }
+    for _ in 0..<5 { _ = budget.step(applying: element, label: "probe", onTimeoutFailure: ()) {} }
 
     #expect(!budget.isExhausted, "five healthy calls must not exhaust the cap")
     #expect(
@@ -324,8 +326,8 @@ struct TerminalContextResolverTests {
       budget.timingDescription.isEmpty,
       "no step ran, so the line must carry nothing rather than an empty bracket")
 
-    _ = budget.step(applying: element, label: "focused") {}
-    _ = budget.step(applying: element, label: "screen") {}
+    _ = budget.step(applying: element, label: "focused", onTimeoutFailure: ()) {}
+    _ = budget.step(applying: element, label: "screen", onTimeoutFailure: ()) {}
 
     let description = budget.timingDescription
     #expect(description.contains("focused="), "each step is named, got \(description)")
@@ -347,7 +349,7 @@ struct TerminalContextResolverTests {
     // charged even a rounding error, the total the cap is judged against would
     // drift with the number of phases rather than with real work.
     budget.mark("recheck")
-    _ = budget.step(applying: element, label: "focused") {}
+    _ = budget.step(applying: element, label: "focused", onTimeoutFailure: ()) {}
 
     let withPhases = budget.timingDescription
     #expect(withPhases.contains("|recheck|"), "the phase boundary must be visible")
@@ -369,7 +371,7 @@ struct TerminalContextResolverTests {
     let element = AXUIElementCreateSystemWide()
 
     budget.charge(0.090, label: "scan")
-    _ = budget.step(applying: element, label: "screen") {}
+    _ = budget.step(applying: element, label: "screen", onTimeoutFailure: ()) {}
 
     let description = budget.timingDescription
     #expect(description.contains("scan=90.0ms"), "named and real, got \(description)")

--- a/Tests/Fixtures/frozen-app/FrozenAppHelper.swift
+++ b/Tests/Fixtures/frozen-app/FrozenAppHelper.swift
@@ -1,0 +1,16 @@
+// #2705 test fixture, NOT part of any compiled target (lives outside every
+// Tuist `sources` glob — see Project.swift). Invoked at test runtime with
+// `swift Tests/Fixtures/frozen-app/FrozenAppHelper.swift`, never compiled in.
+//
+// A minimal, real AppKit app: nothing more than what an ordinary macOS app
+// needs to register with the Accessibility subsystem and become a genuine
+// target for `AXUIElementCreateApplication(pid)`. It does NOT freeze itself —
+// the test freezes it from outside with SIGSTOP once it has confirmed the
+// process is a real, responsive AX target, which is the actual shape of a
+// third-party app that stops answering: the process is alive, just not
+// servicing its run loop, whatever the reason.
+import Cocoa
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+app.run()


### PR DESCRIPTION
## Summary

Phase 1 of #2705 (paste delivery refactor): bound the two Accessibility calls proven independent of #2652's write-outcome hazard, so a target app that stops responding can no longer block delivery indefinitely (#2633).

- `PasteService.forceActivateApp` now sets a real messaging timeout on the app-activation handle before writing `AXFrontmost`. This handle is freshly created inside the function and is never the captured Tier 1 focused element, so it cannot affect Tier 1's write/verify sequence.
- `TerminalResolutionBudget.step` now applies its timeout to the object its caller's `body` actually messages (a freshly-requeried element, or `nil` when the body self-bounds), instead of a throwaway `AXUIElementCreateApplication` handle nobody read — which meant the "bound" it set previously protected nothing.

Three other candidate fixes from the original draft plan (the capture-time timeout, the AppleScript fallback timeout, turning `boundMessagingTimeout` on) were found to share #2652's write-outcome hazard during review and are deferred to a data-gated Phase 3. A fourth (widening the web-content ancestor-walk depth) was dropped — its only live caller never reaches the apps it was meant to fix.

Full plan: `docs/feature-requests/issue-2705-2026-09-07-paste-delivery-refactor.md` (local file, `docs/` is gitignored in this repo).

## Test plan

- [x] `scripts/xcode-test.sh` — 7,637 tests across 3 bundles, all passing (3 pre-existing, unrelated known-issue self-tests, not failures)
- [x] New regression test (`PasteServiceActivationTimeoutTests`): launches a real minimal app, freezes it with `SIGSTOP`, confirms `forceActivateApp` fails fast instead of hanging. Measured manually before writing it: unbounded 1.509s, bounded 0.511s, against the identical frozen process. Local-only (gated on Accessibility trust + `CI` unset) — requires the Accessibility permission be granted to `.../Xcode.app/.../Agents/xctest` on the dev machine.
- [x] Local Codex review — one finding (unconfirmed fixture readiness before freezing), fixed in a follow-up commit and re-verified passing.
- [x] `swift build -c release` — passes (part of the debug/release lanes above)

Part of #2705
