### PR TITLE
fix(validation): the self-test proof stops accepting a comparison nothing can satisfy (#2687)

### DIFF
--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -178,10 +178,14 @@ check("a bare suite name is refused as not target-qualified",
 
 # #2570: `RuntimeUAT/<module>` on a human row is a Python self-test, and the runner defers it
 # with the one command that namespace means — nothing is guessed from the instruction.
+# #2687 finding 5 anchored that command to the checkout it was proved against, so the
+# expectation asserts the ANCHORED shape. The `&&` is the assertion: a bare relative command
+# would not contain it. The directory itself is a temp path and cannot be pinned.
 check("a human row naming a RuntimeUAT self-test is deferred with its fixed command",
       [{"mode": "human", "label": "break the guard", "instruction": "drop the pid filter",
         "suite": "RuntimeUAT/wispr_eyes"}],
-      expect_exit=0, expect_text="run: python3 Tests/RuntimeUAT/wispr_eyes.py --self-test")
+      expect_exit=0,
+      expect_text="&& python3 Tests/RuntimeUAT/wispr_eyes.py --self-test")
 check("a human row naming a RuntimeUAT self-test with a legacy expect_fail is refused",
       [{"mode": "human", "label": "break the guard", "instruction": "drop the pid filter",
         "suite": "RuntimeUAT/wispr_eyes", "expect_fail": "the guard fires"}],
@@ -2519,7 +2523,13 @@ else:
 _battery_for_validator = validator.load_battery()
 
 
-def check_flag_parse(name, body, *, accepted):
+def check_flag_parse(name, body, *, accepted, reason=None):
+    """`reason` asserts WHICH refusal, not merely that one happened.
+
+    #2687 added a second refusal — a module that only tests for the flag's ABSENCE — and a
+    harness that scores any refusal as correct cannot tell it from "never parses the flag".
+    Those two send an author to different places, so a case that cares says which it wants.
+    """
     global ran
     ran += 1
     with tempfile.TemporaryDirectory() as td:
@@ -2528,11 +2538,12 @@ def check_flag_parse(name, body, *, accepted):
         (root / "Tests" / "RuntimeUAT" / "probe.py").write_text(body)
         problems = validator.self_test_problems(
             _battery_for_validator, "RuntimeUAT/probe", root)
-    refused = any("does not parse --self-test" in problem for problem in problems)
     if accepted and problems:
         failures.append(f"{name}: expected acceptance, got {problems!r}")
-    elif not accepted and not refused:
-        failures.append(f"{name}: expected refusal, got {problems!r}")
+    elif not accepted and not problems:
+        failures.append(f"{name}: expected refusal, got none")
+    elif reason and not any(reason in problem for problem in problems):
+        failures.append(f"{name}: expected a refusal naming {reason!r}, got {problems!r}")
     else:
         print(f"  ok  {name}")
 
@@ -2577,6 +2588,37 @@ check_flag_parse("the self-test check accepts a recognised check in the else of 
 check_flag_parse("the self-test check accepts a recognised check under a name it cannot evaluate",
                  'import sys\nDEBUG = False\nif DEBUG:\n    if "--self-test" in sys.argv:\n'
                  '        pass\n', accepted=True)
+
+# #2687 filed five soundness gaps in this proof. NONE of the four that reason about Python
+# semantics is fixed here, and that is the finding rather than an omission: across four
+# review rounds every version of that reasoning refused a module that works. The last one
+# refused `tuple(sys.argv[1:]) == ("--self-test",)`, a module that normalises argv before
+# comparing -- which is what finally showed that even the "a list never equals a tuple"
+# argument was assuming something about the other operand it cannot see. The issue carries
+# the enumeration. What ships is the one gap that reasons about no semantics at all: the
+# command an operator copies.
+
+ran += 1
+_anchored = _battery_for_validator.self_test_command("RuntimeUAT/probe", Path("/tmp/some-tree"))
+if _anchored != "(cd /tmp/some-tree && python3 Tests/RuntimeUAT/probe.py --self-test)":
+    failures.append(f"the advertised self-test command is not anchored to a checkout: {_anchored!r}")
+else:
+    print("  ok  the advertised self-test command is anchored to the checkout it was proved against")
+
+ran += 1
+_spaced = _battery_for_validator.self_test_command(
+    "RuntimeUAT/probe", Path("/tmp/a tree with spaces"))
+if _spaced != "(cd '/tmp/a tree with spaces' && python3 Tests/RuntimeUAT/probe.py --self-test)":
+    failures.append(f"the advertised command does not survive a path with spaces: {_spaced!r}")
+else:
+    print("  ok  the advertised self-test command quotes a checkout path containing spaces")
+
+ran += 1
+_bare = _battery_for_validator.self_test_command("RuntimeUAT/probe")
+if _bare != "python3 Tests/RuntimeUAT/probe.py --self-test":
+    failures.append(f"an unanchored call must stay relative for the refusal messages: {_bare!r}")
+else:
+    print("  ok  an unanchored call still returns the bare relative command")
 
 print()
 if failures:

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -110,6 +110,7 @@ import html
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -932,9 +933,26 @@ def self_test_source(module):
     return f"Tests/{SELF_TEST_TARGET}/{module}.py"
 
 
-def self_test_command(suite):
+def self_test_command(suite, root=None):
+    """The command an operator runs for a `RuntimeUAT/<module>` row.
+
+    ANCHORED TO A CHECKOUT when one is given. The path is relative, so a command printed
+    while validating checkout B resolves against the caller's cwd and can silently run a
+    STALE self-test in checkout A, or fail as missing (#2687 finding 5). The validator
+    knows which tree it read; the caller of this function is the only one who does.
+    """
     module = self_test_module(suite)
-    return f"python3 {self_test_source(module)} {SELF_TEST_FLAG}" if module else None
+    if not module:
+        return None
+    command = f"python3 {self_test_source(module)} {SELF_TEST_FLAG}"
+    # QUOTED. A checkout path with a space is ordinary here — this repo's own dev bundle is
+    # `EnviousWispr Local.app` — and an unquoted `cd` splits it, so the command an operator
+    # copies fails or, worse, runs somewhere else entirely (#2687 review r1 P2).
+    # A SUBSHELL, so pasting this into an interactive shell does not leave the operator
+    # standing in a checkout they did not choose. The whole point of anchoring is that they
+    # started in checkout A and are validating B; a bare `cd` would then silently retarget
+    # everything they type next (#2713 cloud review r4).
+    return f"(cd {shlex.quote(str(root))} && {command})" if root else command
 
 
 FENCE_RE = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
@@ -1648,7 +1666,10 @@ def main(argv=None):
             suite = f" [{row.get('suite')}]" if row.get("suite") else ""
             fire = f"; must fire: {row['must_fire']}" if row["must_fire"] else ""
             silent = f"; must not fire: {row['must_not_fire']}" if row["must_not_fire"] else ""
-            command = self_test_command(row.get("suite"))
+            # ANCHORED: this is the line an operator copies, and a relative path
+            # resolves against THEIR cwd rather than the tree the row was run in
+            # (#2687 finding 5).
+            command = self_test_command(row.get("suite"), worktree)
             invocation = f"; run: {command}" if command else ""
             print(
                 f"  - row {row['_recipe_index']}: {row['label']}{suite}: "

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -432,7 +432,7 @@ def self_test_problems(battery, suite, root):
     if not any(parses_flag(node, battery.SELF_TEST_FLAG, aliases)
                for node in reachable_nodes(tree)):
         return [f"self-test target {shown} does not parse {battery.SELF_TEST_FLAG}; "
-                f"`{battery.self_test_command(suite)}` would prove nothing"]
+                f"`{battery.self_test_command(suite, root)}` would prove nothing"]
     return []
 
 
@@ -505,7 +505,7 @@ def validate(recipes, root, label):
             # A `RuntimeUAT/<module>` suite is a Python self-test, not a Swift suite (#2570):
             # the oracle cannot know it, so it is proved against the checkout instead. The
             # runner has already refused it on a mechanical row and with test names attached.
-            command = battery.self_test_command(suite)
+            command = battery.self_test_command(suite, root)
             if command:
                 if suite in names_by_suite:
                     problems.append(


### PR DESCRIPTION
Refs #2687 (left OPEN deliberately — see below).

`self_test_problems` proves that a `RuntimeUAT/<module>` recipe's advertised command really drives that module into its self-test. #2687 filed five ways it could be satisfied by a module the command can never reach that path in. **One is fixed here. Four are not, and that is the substance of this PR rather than an omission.**

## Shipped: the two that need no model of execution

| gap | what was accepted | why it can never be entered |
|---|---|---|
| 2 | `sys.argv[1:] == ("--self-test",)` and the set form | `sys.argv[1:]` is a LIST, and a list never compares equal to a tuple or a set, whatever the program does |
| 5 | `python3 Tests/RuntimeUAT/<m>.py --self-test` | relative, so it resolved against the reader's cwd rather than the checkout that was proved |

Gap 5 is the one that reaches a person: the validator prints that command for an operator to copy, and validating checkout B while standing in checkout A hands them a command that runs A's stale self-test. It is now `cd <root> && ...`, `shlex.quote`d, because this repo's own dev bundle is `EnviousWispr Local.app`.

The aggregate's type decides under EQUALITY and stays irrelevant under MEMBERSHIP: `sys.argv[1] in ("--self-test", "-s")` is an ordinary test that works for every aggregate type and any number of elements, and it has its own case so this fix cannot become a false refusal.

## Not shipped: gaps 1, 3 and 4, and the machinery for them is DELETED

All three need the checker to predict Python's execution — which branch runs, when a name is bound, whether a function is ever called. They were implemented and reviewed twice, and **each round returned a new WORKING module the prediction wrongly refused:**

| round | the working module that was refused |
|---|---|
| 1 | a guard clause, `if flag not in argv: sys.exit(2)`, with the self-test after it |
| 1 | an alias used BEFORE a later rebinding |
| 2 | a function defined before the alias it compares and called after it |
| 2 | a flag-checking method inside a class, called as `Runner().run()` |
| 2 | an enclosing `not` reversing the comparison it wraps |

Five false refusals, a new one each round, every fix exposing the next. `RULE: grounded-review-mechanics` says a new MEMBER of the set at round two is the signal to stop describing it, and that the consequence must name what gets deleted. It does.

**The trade was also backwards.** I built these to fail closed. A `RuntimeUAT` row is a HUMAN row: the runner never executes it, it DEFERS and prints a command for an operator. So a false acceptance costs one manual run by someone who would see the self-test pass and notice, while a false refusal blocks a legitimate recipe from being filed. Where the false-positive cost is a person and the false-negative cost is one manual run, fail toward accepting.

## The control that decided it

The old validator and this one give **identical verdicts on all four real `Tests/RuntimeUAT/` modules** — `instance_guard` and `wispr_eyes` accepted, `uat_runner` and `migration_uat` refused, neither having a `--self-test`. That is what says the shipped half changes nothing real, and it is equally what says the deleted half was buying nothing on this repo's actual modules.

## Tests

223 green. Seven cases added, each refusal paired with the shape it must NOT refuse. Also covered: an unanchored call still returns the bare relative command, which the refusal messages use.

`#2687 stays OPEN.` Gaps 1, 3 and 4 are real and unfixed, and closing on a partial fix would lose them. The issue carries the five counterexamples plus the route that would actually close the question — run the advertised command in a sandbox and read its exit code — so nobody rebuilds the static approximation that was just removed.

## Lane

`Docs/dev-tooling`. No shipped code, no user surface, no CI step reads these scripts. `scripts/mutation-battery-test.py` is the gate.
