### PR TITLE
fix(recovery): the real crash-recovery key safety net (#1807)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -299,7 +299,7 @@ final class RecoveryCoordinator {
   /// #1755 chunk 4: one failure-only breadcrumb per failed component per
   /// destruction call. Never includes the recovery ID, path, or raw error —
   /// deletion stays best-effort and swallowed; this is diagnosis only.
-  private func emitDeletionFailed(component: String, source: DestructionSource) {
+  private func emitDeletionFailed(component: String, source: DestructionSource, error: any Error) {
     // #1762 r5: reports the ACTION and its result, nothing further. Five review
     // rounds went to disposition clauses here — "stays on disk", "already
     // deleted", "a future launch will retry" — and each was wrong in some real
@@ -316,6 +316,26 @@ final class RecoveryCoordinator {
     } else {
       SentryBreadcrumb.add(stage: "recovery", message: "deletion_failed", data: data)
     }
+    TelemetryService.shared.recoveryDeletionFailed(
+      component: component, source: source.rawValue,
+      errorDomain: Self.errorDomainBucket(for: error), errorCode: Self.errorCode(for: error))
+  }
+
+  private static func errorDomainBucket(for error: any Error) -> String {
+    switch error {
+    case let nsError as NSError where nsError.domain == NSCocoaErrorDomain: return "cocoa"
+    case let nsError as NSError where nsError.domain == NSPOSIXErrorDomain: return "posix"
+    default: return "other"
+    }
+  }
+
+  /// `RecoveryKeyStoreError.deleteFailed(OSStatus)` bridges to `NSError` without surfacing its
+  /// associated OSStatus as `.code`. Unwrap explicitly; every other error keeps its bridged NSError code.
+  private static func errorCode(for error: any Error) -> Int {
+    if let keyError = error as? RecoveryKeyStoreError, case .deleteFailed(let status) = keyError {
+      return Int(status)
+    }
+    return (error as NSError).code
   }
 
   /// #1740 (founder Gate 2): did a SPENT attempt's cleanup actually happen?
@@ -362,7 +382,7 @@ final class RecoveryCoordinator {
       }
       emitCleanupOutcome(component: "spool", source: source, succeeded: true)
     } catch {
-      emitDeletionFailed(component: "spool", source: source)
+      emitDeletionFailed(component: "spool", source: source, error: error)
       emitCleanupOutcome(component: "spool", source: source, succeeded: false)
     }
     // Key deletion ALWAYS runs, detached, even after a spool failure.
@@ -394,7 +414,7 @@ final class RecoveryCoordinator {
         }
       } catch {
         await MainActor.run {
-          self.emitDeletionFailed(component: "key", source: source)
+          self.emitDeletionFailed(component: "key", source: source, error: error)
           self.emitCleanupOutcome(component: "key", source: source, succeeded: false)
         }
       }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -410,6 +410,25 @@ final class RecoveryCoordinator {
       errorDomain: Self.errorDomainBucket(for: error), errorCode: Self.errorCode(for: error))
   }
 
+  /// #1807 (cloud review, PR #2717): SEPARATE from `emitDeletionFailed` on purpose. Failing to
+  /// ESTABLISH the discard marker (this) and failing to DELETE an already-established one
+  /// (`emitDeletionFailed(component: "marker", ...)`) are different severities — this one means the
+  /// crash-safety evidence never existed at all — and `recoveryDeletionFailed`'s own contract is
+  /// scoped to delete failures only. Reusing it here would make production telemetry unable to tell
+  /// the two apart.
+  private func emitMarkerPersistenceFailed(source: DestructionSource, error: any Error) {
+    RecoveryLog.line("marker WRITE FAILED (\(source.rawValue))")
+    let data = ["component": "marker", "source": source.rawValue]
+    if let sink = deletionFailureBreadcrumbForTesting {
+      sink("recovery", "marker_persistence_failed", data)
+    } else {
+      SentryBreadcrumb.add(stage: "recovery", message: "marker_persistence_failed", data: data)
+    }
+    TelemetryService.shared.recoveryMarkerPersistenceFailed(
+      source: source.rawValue,
+      errorDomain: Self.errorDomainBucket(for: error), errorCode: Self.errorCode(for: error))
+  }
+
   /// `RecoverySpoolStoreError`'s four cases all carry a real POSIX `errno` as their
   /// associated `Int32` (cloud review, PR #2717). Bridging the enum to `NSError`
   /// does not surface that value as `.domain`/`.code` — it yields Swift's own
@@ -685,7 +704,7 @@ final class RecoveryCoordinator {
         return true
       } catch {
         await MainActor.run {
-          self.emitDeletionFailed(component: "marker", source: source, error: error)
+          self.emitMarkerPersistenceFailed(source: source, error: error)
         }
         return false
       }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -47,17 +47,55 @@ final class RecoveryCoordinator {
   private let existingRecoveryIDs: @MainActor () async -> Set<String>
   /// Whether a live dictation is in flight — the recovery-independent contention
   /// guard (a recording can arm in the launch window even with recovery OFF, so
-  /// `armedSessionID` alone wouldn't catch it). Recovery never runs the shared
-  /// engine while this is true; it defers to a future launch.
+  /// `pendingSessions` protection alone wouldn't catch it — recovery is OFF
+  /// means no directive, no protection entry, at all). Recovery never runs the
+  /// shared engine while this is true; it defers to a future launch.
   private let isDictationActive: @MainActor () -> Bool
 
-  /// The recovery session armed for the CURRENT recording, or nil. Set BEFORE
-  /// the directive's key is durably stored (so the launch scan can never delete a
-  /// key it snapshots mid-arm); cleared if that store fails, on durable save, or
-  /// when the recording ends without a durable save. Its remaining job in PR2 is
-  /// to let the launch scan PROTECT a live in-progress recording from a
-  /// concurrent-arm race. MainActor-confined.
-  private var armedSessionID: String?
+  /// #1807 (§C) — per-session protection, replacing the single-slot
+  /// `armedSessionID: String?` this used to be. Keyed by recovery session id.
+  /// ONLY covers LIVE-ARMED sessions from THIS launch (`makeDirective`
+  /// inserts, the four live `handle*` entry points retire) — a scan-discovered
+  /// orphan from a PRIOR process's crash never has an entry here, because no
+  /// writer in this process will ever touch it (§3c: `historyDedup`,
+  /// `replayOutcome`, and `userDiscard` call `destroySpoolAndKey` directly,
+  /// unchanged, exactly as before this chunk).
+  ///
+  /// A session stays protected (excluded from the scan's `recoverable` list
+  /// and the key-only sweep) not just until its final disposition is known,
+  /// but until its writer ALSO confirms it can never write to the spool again
+  /// AND the resulting cleanup operation (a destroy, or a plain retain) has
+  /// actually SETTLED — not merely been dispatched. A genuinely unfinished
+  /// writer stays protected; that is an intentional pending state, not a leak.
+  /// MainActor-confined, exactly like the slot it replaces.
+  ///
+  /// `internal`, not `private`: `Disposition.retain` must be nameable from
+  /// `requestDisposal`'s test-facing call site (see that function's doc).
+  struct PendingSession {
+    enum Disposition {
+      case destroy(DestructionSource)
+      case retain
+    }
+    /// nil until a `handle*` call installs it via `requestDisposal`. Refines
+    /// the plan's `finalDispositionKnown` boolean into an enum carrying the
+    /// actual action, per Codex plan-review round 2: "a Boolean and an
+    /// arbitrary callback are not the complete contract."
+    var disposition: Disposition?
+    /// Set by `acknowledgeWriterQuiescent`. Proof only that the writer (if one
+    /// ever existed) will never touch this spool again — NEVER proof it wrote
+    /// successfully (§2.5-4; the completion closure fires on error paths too).
+    var writerCanNeverWriteAgain = false
+    /// True once this coordinator has claimed the session's one cleanup
+    /// operation — guards a duplicate disposition call or a duplicate writer
+    /// ack from starting a second marker write or deletion.
+    var cleanupClaimed = false
+    /// Every caller awaiting this session's cleanup SETTLING, not merely being
+    /// claimed. Production discards the `Task` it gets back; tests await it
+    /// instead of a fixed delay (§11's test contract). Resolved exactly once,
+    /// inside `retireSettledSession`.
+    var settlementContinuations: [CheckedContinuation<Void, Never>] = []
+  }
+  private var pendingSessions: [String: PendingSession] = [:]
 
   /// True while an orphan is being actively replayed on the shared engine.
   /// DRIVES the recording gate: a record-press while true mints no session (shows
@@ -230,14 +268,17 @@ final class RecoveryCoordinator {
     guard let payload = try? JSONEncoder().encode(directive) else { return nil }
 
     // Protect this id from the launch scan BEFORE the key can land on disk.
-    // Ordering invariant: `armedSessionID` is set (synchronously, on the
-    // MainActor) no later than the key hits disk. The scan reads `armed` AFTER
-    // snapshotting the on-disk spools, so any spool it could have snapshotted was
-    // armed before this assignment and is therefore already protected — closing
-    // the mid-arm gap (Codex code-diff r4 P2). Cleared below if the durable store
-    // fails. (A concurrent double-arm overwrites this; the loser's key is an
-    // orphan a future launch scan recovers or sweeps — harmless.)
-    armedSessionID = recoverySessionID
+    // Ordering invariant: the `pendingSessions` entry is inserted
+    // (synchronously, on the MainActor) no later than the key hits disk. The
+    // scan reads pending membership AFTER snapshotting the on-disk spools, so
+    // any spool it could have snapshotted was armed before this assignment and
+    // is therefore already protected — closing the mid-arm gap (Codex
+    // code-diff r4 P2). Removed below if the durable store fails — no writer
+    // will ever exist for this id, so there is nothing left to protect or
+    // join against; this is NOT routed through `requestDisposal`/
+    // `acknowledgeWriterQuiescent` (#1807 §C), since a directive that never
+    // left the coordinator needs no Audio round-trip.
+    pendingSessions[recoverySessionID] = PendingSession()
 
     // Durably store the key off the MainActor BEFORE returning an enabled
     // payload. Fail-open: a store failure disables recovery for this take.
@@ -246,11 +287,12 @@ final class RecoveryCoordinator {
       (try? keyStore.store(keyData: keyData, for: recoverySessionID)) != nil
     }.value
     guard stored else {
-      // No durable key landed — un-protect so the scan isn't guarding a phantom
-      // and a later non-saved cleanup is a no-op. Guard the id in case a
-      // concurrent arm overwrote the slot (won't happen with sequential
-      // recordings, but keeps the clear precise).
-      if armedSessionID == recoverySessionID { armedSessionID = nil }
+      // No durable key landed — un-protect so the scan isn't guarding a
+      // phantom and a later non-saved cleanup is a no-op. Keyed by this exact
+      // fresh UUID, so a concurrent double-arm (a different id) is unaffected
+      // — unlike the single-slot `armedSessionID` this replaces, no id
+      // collision is possible here.
+      pendingSessions.removeValue(forKey: recoverySessionID)
       SentryBreadcrumb.captureError(
         RecoveryArmError.keyStoreFailed, category: .recoveryKeyStoreFailed, stage: "recording",
         extra: ["backend": backendType.rawValue])
@@ -262,7 +304,12 @@ final class RecoveryCoordinator {
 
   /// #1755 chunk 4 — fixed, low-cardinality labels for WHY a destruction ran.
   /// Closed enum: no caller-supplied strings, no configurability.
-  private enum DestructionSource: String {
+  ///
+  /// #1807: widened from `private` to `internal` — `PendingSession
+  /// .Disposition.destroy(DestructionSource)` is itself internal, and an
+  /// associated value cannot be more restrictive than the case that carries
+  /// it. Still constructible only within `EnviousWisprAppKit`.
+  enum DestructionSource: String {
     case durableSave = "durable_save"
     case liveEnding = "live_ending"
     case preStartAbort = "pre_start_abort"
@@ -421,6 +468,132 @@ final class RecoveryCoordinator {
     }
   }
 
+  // MARK: - #1807 (§C) — session-keyed protection + writer-completion join
+
+  /// A `handle*` call installs this LIVE-ARMED session's final disposition (a
+  /// specific `DestructionSource`, or `.retain` for "keep it"). Joins with
+  /// `acknowledgeWriterQuiescent` — cleanup runs only once BOTH facts are
+  /// known, whichever arrives second. Idempotent: a duplicate call for a
+  /// session whose disposition is already installed joins the existing
+  /// operation rather than starting another one. Returns a `Task` that
+  /// completes once this session's cleanup has SETTLED — claimed, and for a
+  /// destroy, its detached key-deletion work has finished — never merely
+  /// dispatched. Production callers discard it; tests await it instead of a
+  /// fixed delay (§11's test contract).
+  ///
+  /// `internal`, not `private`: the RETAIN branch of `PendingSession
+  /// .Disposition` is currently unreachable through any real
+  /// `RecordingRecoveryEnding` (every cell of `shouldDeleteOnLiveEnding`
+  /// returns true today) — exposed for direct testing of that branch, the
+  /// same reasoning `shouldDeleteOnLiveEnding`/`shouldDeleteAfterReplay`
+  /// already use for their own static, directly-tested predicates.
+  @discardableResult
+  func requestDisposal(
+    recoverySessionID id: String, disposition: PendingSession.Disposition
+  ) -> Task<Void, Never> {
+    // #1807 round-2 correction (Codex chunk-2 review, finding 2): a missing
+    // entry means either this id was never admitted, or it was already
+    // retired — NEVER manufacture a fresh one here. Doing so could strand a
+    // waiter (nothing will ever complete the phantom entry's other half) or
+    // let an already-cleaned-up session be re-processed.
+    guard var entry = pendingSessions[id] else { return Task {} }
+    if entry.disposition == nil, !entry.cleanupClaimed {
+      entry.disposition = disposition
+    }
+    return awaitSettlement(recoverySessionID: id, entry: entry)
+  }
+
+  /// The writer confirms it can never write to `id`'s spool again — fires for
+  /// a real writer's finalize AND for every explicit "no writer, ever"
+  /// acknowledgment (decode failure, disabled directive, low-disk refusal,
+  /// and a pre-start abort's own direct ack). Idempotent — a late/duplicate
+  /// ack for an already-claimed session joins silently. `internal`, not
+  /// `private`: `WisprBootstrapper` (same module, different file) wires
+  /// Audio's completion closure directly to this.
+  func acknowledgeWriterQuiescent(recoverySessionID id: String) {
+    // #1807 round-2 correction: same reasoning as `requestDisposal` above —
+    // a missing entry means never-admitted or already-retired, either way
+    // nothing to acknowledge.
+    guard var entry = pendingSessions[id] else { return }
+    guard !entry.cleanupClaimed else { return }
+    entry.writerCanNeverWriteAgain = true
+    pendingSessions[id] = entry
+    tryClaimAndRunCleanup(recoverySessionID: id)
+  }
+
+  /// Writes `entry` back, attempts the join, and returns a `Task` resolved on
+  /// settlement — now, if the join completes synchronously as part of this
+  /// very call; later, when the missing half arrives via the other entry
+  /// point above.
+  private func awaitSettlement(
+    recoverySessionID id: String, entry: PendingSession
+  ) -> Task<Void, Never> {
+    pendingSessions[id] = entry
+    if let settling = tryClaimAndRunCleanup(recoverySessionID: id) {
+      return settling
+    }
+    // #1807 round-2 correction (Codex chunk-2 review, finding 4): STRONG
+    // self capture, matching `destroySpoolAndKey`'s own established pattern
+    // ("the failure breadcrumb must survive coordinator deallocation racing
+    // the detached delete"). A `[weak self]` here can silently strand a
+    // waiter forever if the coordinator is released while this task is
+    // in flight — the continuation lives INSIDE `pendingSessions`, so a
+    // dropped `self` before the continuation registers means no path this
+    // task's own reference chain can rely on. The task is short-lived; the
+    // temporary strong retention ends when it completes.
+    return Task { @MainActor [self] in
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        guard var waiting = self.pendingSessions[id] else {
+          // Already retired — a same-launch race resolved it between the
+          // write above and this continuation being registered.
+          continuation.resume()
+          return
+        }
+        waiting.settlementContinuations.append(continuation)
+        self.pendingSessions[id] = waiting
+      }
+    }
+  }
+
+  /// The ONE place a session's cleanup operation is claimed and run, whichever
+  /// of `requestDisposal`/`acknowledgeWriterQuiescent` completes the join.
+  /// Returns the settling `Task` when it claimed and started cleanup just now;
+  /// nil when the join is still incomplete (leaves the entry protected) or was
+  /// already claimed by an earlier call.
+  @discardableResult
+  private func tryClaimAndRunCleanup(recoverySessionID id: String) -> Task<Void, Never>? {
+    guard var entry = pendingSessions[id],
+      let disposition = entry.disposition,
+      entry.writerCanNeverWriteAgain,
+      !entry.cleanupClaimed
+    else { return nil }
+    entry.cleanupClaimed = true
+    pendingSessions[id] = entry
+    // #1807 round-2 correction (finding 4): STRONG self capture in both
+    // branches below — see `awaitSettlement`'s identical note.
+    switch disposition {
+    case .retain:
+      return Task { @MainActor [self] in
+        self.retireSettledSession(recoverySessionID: id)
+      }
+    case .destroy(let source):
+      let inner = destroySpoolAndKey(id: id, source: source)
+      return Task { @MainActor [self] in
+        _ = await inner.value
+        self.retireSettledSession(recoverySessionID: id)
+      }
+    }
+  }
+
+  /// Remove a session's entry once its cleanup has genuinely settled, and
+  /// resume every caller awaiting settlement.
+  private func retireSettledSession(recoverySessionID id: String) {
+    guard let entry = pendingSessions.removeValue(forKey: id) else { return }
+    for continuation in entry.settlementContinuations {
+      continuation.resume()
+    }
+  }
+
   /// Delete-versus-retain for a live recording that ended without a durable
   /// save (#1464; policy cutover #1755, founder Gate 2 2026-07-23). An ending
   /// fired ⇒ the app was ALIVE ⇒ the user witnessed the outcome, got the one
@@ -506,12 +679,13 @@ final class RecoveryCoordinator {
   }
 
   /// A recording's transcript was durably saved — delete that session's spool +
-  /// key. Best-effort, off the user's path, idempotent. Returns the detached
-  /// work so tests can await it; callers discard it.
+  /// key. Best-effort, off the user's path, idempotent. Returns a `Task` that
+  /// completes once cleanup has SETTLED (#1807 §C: waits for the writer's own
+  /// confirmation it can never write again, not merely for disposition to be
+  /// known) so tests can await it; production callers discard it.
   @discardableResult
   func handleDurableSave(recoverySessionID id: String) -> Task<Void, Never> {
-    if armedSessionID == id { armedSessionID = nil }
-    return destroySpoolAndKey(id: id, source: .durableSave)
+    requestDisposal(recoverySessionID: id, disposition: .destroy(.durableSave))
   }
 
   /// A `.complete` dictation whose History save FAILED (#1740). The live path
@@ -532,9 +706,8 @@ final class RecoveryCoordinator {
   @discardableResult
   func handleHistorySaveFailed(recoverySessionID id: String?) -> Task<Void, Never>? {
     guard let id else { return nil }
-    if armedSessionID == id { armedSessionID = nil }
     nextLaunchOnlyRecoveryIDs.insert(id)
-    return destroySpoolAndKey(id: id, source: .historySaveFailed)
+    return requestDisposal(recoverySessionID: id, disposition: .destroy(.historySaveFailed))
   }
 
   /// A recording ended at a terminal state WITHOUT a durable transcript save
@@ -556,7 +729,6 @@ final class RecoveryCoordinator {
     recoverySessionID id: String?, ending: RecordingRecoveryEnding
   ) -> Task<Void, Never>? {
     guard let id else { return nil }
-    if armedSessionID == id { armedSessionID = nil }
     guard Self.shouldDeleteOnLiveEnding(ending) else {
       // #1762: the RETAIN branch. A live ending that keeps its spool is the one
       // that produces an orphan for a later launch to find, so it must not be
@@ -567,7 +739,11 @@ final class RecoveryCoordinator {
         RecoveryLog.line("live ending (\(ending)) — keeping the spool for a future launch")
       }
       nextLaunchOnlyRecoveryIDs.insert(id)
-      return nil
+      // #1807 (§C): retain still joins the writer-quiescence contract — the
+      // entry stays protected until the writer confirms it will never touch
+      // this spool again, exactly like the delete branch below. Only then is
+      // protection actually safe to drop.
+      return requestDisposal(recoverySessionID: id, disposition: .retain)
     }
     // #1762: the DELETE branch. Logged on REQUEST, before the destructor runs —
     // `emitDeletionFailed` only fires on failure, so a successful live-ending
@@ -583,7 +759,7 @@ final class RecoveryCoordinator {
     // failed one leaves the survivor as a next-launch item, consistent with
     // the best-effort crash-atomicity contract (§3.5).
     nextLaunchOnlyRecoveryIDs.insert(id)
-    return destroySpoolAndKey(id: id, source: .liveEnding)
+    return requestDisposal(recoverySessionID: id, disposition: .destroy(.liveEnding))
   }
 
   /// A record-press aborted BEFORE a kernel session was minted (a PTT release or
@@ -595,8 +771,13 @@ final class RecoveryCoordinator {
   @discardableResult
   func handlePreStartAbort(recoverySessionID id: String?) -> Task<Void, Never>? {
     guard let id else { return nil }
-    if armedSessionID == id { armedSessionID = nil }
-    return destroySpoolAndKey(id: id, source: .preStartAbort)
+    // #1807 (§C): a pre-start abort means no kernel session was ever minted,
+    // so Audio never saw this id and no writer could ever exist for it —
+    // acknowledge that directly rather than waiting on a round-trip that will
+    // never arrive. Order versus `requestDisposal` below does not matter: the
+    // join completes once both halves are installed, whichever runs first.
+    acknowledgeWriterQuiescent(recoverySessionID: id)
+    return requestDisposal(recoverySessionID: id, disposition: .destroy(.preStartAbort))
   }
 
   /// On launch, scan for orphan spools and recover them (#1063 PR2 — replaces
@@ -693,7 +874,6 @@ final class RecoveryCoordinator {
     // and finished must not read like a pass that stalled — that ambiguity is
     // the whole reason this issue exists.
     RecoveryLog.line("\(spoolIDs.count) spool(s) on disk")
-    let armed = armedSessionID
 
     // Sweep KEY-ONLY orphans first: a key whose spool was never written — a
     // recording that armed then crashed before the helper wrote the first frame.
@@ -704,11 +884,11 @@ final class RecoveryCoordinator {
     // its key to decrypt). Runs even when there are zero spools.
     //
     // Race-safe ordering (Codex code-diff r2 + r4 P2): inside the detached task,
-    // snapshot the keys FIRST, then read the live armed id AND re-list the spools
-    // FRESH (not the scan-start `spoolIDs` snapshot). Three protections, each read
-    // as late as possible so it sees the most recent state:
+    // snapshot the keys FIRST, then read the live-armed set AND re-list the
+    // spools FRESH (not the scan-start `spoolIDs` snapshot). Three protections,
+    // each read as late as possible so it sees the most recent state:
     //   - a key armed AFTER the key snapshot can't be in `keyIDs` (stored later);
-    //   - a currently-arming take is caught by the freshly-read `liveArmed`;
+    //   - a currently-arming take is caught by the freshly-read protection set;
     //   - a take that armed AND ENDED at a FAILURE terminal after the scan snapshot
     //     RETAINS its spool — re-listing spools fresh sees that spool, so its key is
     //     NOT swept (the stale scan-start snapshot would have missed it and deleted
@@ -718,13 +898,19 @@ final class RecoveryCoordinator {
     let makeSpoolStore = self.makeSpoolStore
     Task.detached(priority: .utility) { [weak self] in
       let keyIDs = keyStore.listAccountIDs()
-      let liveArmed = await MainActor.run { self?.armedSessionID }
+      // #1807 (§C): a vanished coordinator must ABORT the sweep — it is not
+      // evidence the protection set is empty. `self?.pendingSessions.keys`
+      // reads nil only when `self` is nil, never when the set is genuinely
+      // empty (an empty dictionary's `.keys` is a real, non-nil, empty value).
+      guard let liveArmedKeys = await MainActor.run(body: { self?.pendingSessions.keys })
+      else { return }
+      let liveArmed = Set(liveArmedKeys)
       // Fail CLOSED if the fresh re-list errors (Codex code-diff r5 P2): treating
       // an IO/permission error as "no spools" would delete keys for real `.ewrec`
       // files. Abort the sweep instead — same discipline as the scan-start list.
       guard let currentSpoolList = try? makeSpoolStore().listSpoolSessionIDs() else { return }
       let currentSpools = Set(currentSpoolList)
-      for id in keyIDs where id != liveArmed && !currentSpools.contains(id) {
+      for id in keyIDs where !liveArmed.contains(id) && !currentSpools.contains(id) {
         try? keyStore.delete(for: id)
       }
     }
@@ -736,8 +922,18 @@ final class RecoveryCoordinator {
     // excluded; the contention guard below is the backstop.
     let alreadySaved = await existingRecoveryIDs()
 
+    // #1807 (§C): read the live-armed protection set FRESH, after the dedup
+    // await above, not the value that would have been captured before it — a
+    // take that armed DURING that suspension must be excluded too, matching
+    // the recheck-after-every-suspension requirement (§C, independent of §D).
+    let armedIDs = Set(pendingSessions.keys)
     var recoverable: [String] = []
-    for id in spoolIDs where id != armed {
+    // #1807 round-2 correction (Codex chunk-2 review, finding 3): also skip
+    // ids already held for a future launch — a spool this launch already
+    // failed to delete once (a live-ending or history-save-failure retry
+    // candidate) should not be retried through a SECOND, independent
+    // destroySpoolAndKey call from the dedup path this same pass.
+    for id in spoolIDs where !armedIDs.contains(id) && !nextLaunchOnlyRecoveryIDs.contains(id) {
       if alreadySaved.contains(id) {
         // Saved in a prior run's save→delete crash window: delete WITHOUT
         // re-transcribing (the dedup MUST precede any append — History forbids a
@@ -787,6 +983,16 @@ final class RecoveryCoordinator {
       // atomic handshake below, not inside it — the handshake itself still
       // has no `await` between its own check and claim.
       await Task.yield()
+      // #1807 round-2 correction (Codex chunk-2 review, finding 3): recheck
+      // pending membership and same-launch suppression immediately after
+      // this suspension, before replay admission — a take that armed, or a
+      // spool that got held for a future launch, DURING the yield above must
+      // not be replayed. Matches the recheck-after-every-suspension
+      // requirement (§C) and the identical recheck already applied to the
+      // dedup loop above, after its own `await`.
+      guard !pendingSessions.keys.contains(id), !nextLaunchOnlyRecoveryIDs.contains(id) else {
+        continue
+      }
       // Atomic per-item handshake (§3.1/§3.2) — ONE non-suspending MainActor
       // turn: checked and claimed here with no `await` between any step, so
       // there is no window between "checked" and "acted." Preserves the
@@ -873,7 +1079,13 @@ final class RecoveryCoordinator {
       default: disposition = willDelete ? "requesting deletion" : "keeping"
       }
       RecoveryLog.line("replay \(Self.logLabel(outcome)) — \(disposition)")
-      if willDelete {
+      // #1807 (§C): recheck the live-armed protection set fresh, after the
+      // `await replayer.replay(...)` suspension above — an orphan's id
+      // reusing a freshly-armed live session's id is not a real occurrence
+      // (fresh UUIDs per arm), but a direct destroy here must still defer to
+      // that session's own join rather than racing it, on the same recheck
+      // discipline the scan's dedup loop above follows.
+      if willDelete, !pendingSessions.keys.contains(id) {
         destroySpoolAndKey(id: id, source: .replayOutcome)
       }
       // Post the standalone success notice for a recording that landed in History.

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -89,6 +89,7 @@ final class RecoveryCoordinator {
     /// operation — guards a duplicate disposition call or a duplicate writer
     /// ack from starting a second marker write or deletion.
     var cleanupClaimed = false
+    var markerPersistence: Task<Void, Never>?
     /// Every caller awaiting this session's cleanup SETTLING, not merely being
     /// claimed. Production discards the `Task` it gets back; tests await it
     /// instead of a fixed delay (§11's test contract). Resolved exactly once,
@@ -96,6 +97,26 @@ final class RecoveryCoordinator {
     var settlementContinuations: [CheckedContinuation<Void, Never>] = []
   }
   private var pendingSessions: [String: PendingSession] = [:]
+  private var discardOperations: [String: Task<Void, Never>] = [:]
+  // Instance-scoped completion seam; production never awaits the sweep.
+  // periphery:ignore - test seam
+  var markerSweepForTesting: Task<Void, Never>?
+
+  private var protectedSessionIDs: Set<String> {
+    Set(pendingSessions.keys).union(discardOperations.keys)
+  }
+
+  private func claimDiscardOperation(
+    id: String, work: @escaping @MainActor () async -> Void
+  ) -> Task<Void, Never> {
+    if let existing = discardOperations[id] { return existing }
+    let task = Task { @MainActor [self] in
+      await work()
+      discardOperations.removeValue(forKey: id)
+    }
+    discardOperations[id] = task
+    return task
+  }
 
   /// True while an orphan is being actively replayed on the shared engine.
   /// DRIVES the recording gate: a record-press while true mints no session (shows
@@ -318,6 +339,12 @@ final class RecoveryCoordinator {
     case userDiscard = "user_discard"
     /// #1740: a live `.complete` dictation whose History write failed.
     case historySaveFailed = "history_save_failed"
+    /// #1807 §D1: the scan found a spool that ALREADY carries a committed
+    /// discard marker (`.final`/`.interruptedTemp`) — a prior pass or launch
+    /// already decided to discard it, but the destructive delete never
+    /// completed (crash, or the delete itself failed). No replay is ever
+    /// attempted for this case; this is a cleanup retry, not a fresh decision.
+    case markedForDiscard = "marked_for_discard"
   }
 
   /// #1755 chunk 4 test seams (internal; nil in production — the real spool
@@ -394,7 +421,11 @@ final class RecoveryCoordinator {
     component: String, source: DestructionSource, succeeded: Bool
   ) {
     switch source {
-    case .replayOutcome, .historySaveFailed:
+    case .replayOutcome, .historySaveFailed, .markedForDiscard:
+      // #1807 §D1: `.markedForDiscard` is a retry of a previously-failed
+      // cleanup (a spent decision, same spirit as the two existing spent-
+      // attempt sources) — whether the retry actually succeeded is exactly
+      // the signal this event exists to answer.
       if let sink = cleanupTelemetryForTesting {
         sink(source.rawValue, component, succeeded)
       } else {
@@ -415,7 +446,36 @@ final class RecoveryCoordinator {
   /// double-delete or a concurrently-removed spool is a harmless no-op. Returns the
   /// detached key-delete work so tests can await completion; callers may discard it.
   @discardableResult
-  private func destroySpoolAndKey(id: String, source: DestructionSource) -> Task<Void, Never> {
+  private func destroySpoolAndKey(
+    id: String, source: DestructionSource,
+    markerPersistence: Task<Void, Never>? = nil
+  ) -> Task<Void, Never> {
+    if let existing = discardOperations[id] { return existing }
+    // #1807 round-2 correction (Codex chunk-3 review round 2, finding 1):
+    // `discardOperations[id]` protects only WHILE this operation is running —
+    // it clears once the work settles, success or failure. `nextLaunchOnlyRecoveryIDs`
+    // is a SEPARATE concern this does not replace: if BOTH the marker write
+    // and the delete fail, an id with no marker and a surviving spool must
+    // still not be reclassified as a fresh REPLAY candidate this launch (the
+    // exact resurrection bug this suppression exists to prevent). CLEANUP
+    // eligibility (can `.markedForDiscard` retry) and REPLAY eligibility
+    // (can this id enter `recoverable`) are different questions — the scan's
+    // marker check now runs BEFORE this suppression is consulted (see
+    // `runOneScanPass`), so a genuinely marked survivor still retries
+    // cleanup regardless of this insert.
+    nextLaunchOnlyRecoveryIDs.insert(id)
+    let marker =
+      markerPersistence
+      ?? beginDiscardMarkerPersistence(recoverySessionID: id, source: source)
+    return claimDiscardOperation(id: id) { [self] in
+      await marker.value
+      await performSpoolAndKeyDestruction(id: id, source: source).value
+    }
+  }
+
+  private func performSpoolAndKeyDestruction(
+    id: String, source: DestructionSource
+  ) -> Task<Void, Never> {
     #if DEBUG
       // #1755 chunk 6: crash-boundary hold — immediately before the spool
       // attempt (seam or real store). Unarmed: no-op.
@@ -499,8 +559,33 @@ final class RecoveryCoordinator {
     guard var entry = pendingSessions[id] else { return Task {} }
     if entry.disposition == nil, !entry.cleanupClaimed {
       entry.disposition = disposition
+      if case .destroy(let source) = disposition {
+        // #1807 (§D1): marker persistence begins as soon as final disposition
+        // arrives — NOT gated on the writer-quiescence join below, which can
+        // still be pending. Off-MainActor, per §D2's ordering item 2
+        // (inherited by §D1). A `.retain` disposition writes no marker — a
+        // marker means "never replay," which is the opposite of retaining.
+        entry.markerPersistence = beginDiscardMarkerPersistence(
+          recoverySessionID: id, source: source)
+      }
     }
     return awaitSettlement(recoverySessionID: id, entry: entry)
+  }
+
+  /// Begins immediately at disposition, and settles before destructive cleanup.
+  private func beginDiscardMarkerPersistence(
+    recoverySessionID id: String, source: DestructionSource
+  ) -> Task<Void, Never> {
+    let store = makeSpoolStore()
+    return Task.detached(priority: .utility) { [self] in
+      do {
+        try store.writeDiscardMarker(for: id)
+      } catch {
+        await MainActor.run {
+          self.emitDeletionFailed(component: "marker", source: source, error: error)
+        }
+      }
+    }
   }
 
   /// The writer confirms it can never write to `id`'s spool again — fires for
@@ -577,7 +662,8 @@ final class RecoveryCoordinator {
         self.retireSettledSession(recoverySessionID: id)
       }
     case .destroy(let source):
-      let inner = destroySpoolAndKey(id: id, source: source)
+      let inner = destroySpoolAndKey(
+        id: id, source: source, markerPersistence: entry.markerPersistence)
       return Task { @MainActor [self] in
         _ = await inner.value
         self.retireSettledSession(recoverySessionID: id)
@@ -899,10 +985,10 @@ final class RecoveryCoordinator {
     Task.detached(priority: .utility) { [weak self] in
       let keyIDs = keyStore.listAccountIDs()
       // #1807 (§C): a vanished coordinator must ABORT the sweep — it is not
-      // evidence the protection set is empty. `self?.pendingSessions.keys`
+      // evidence the protection set is empty. `self?.protectedSessionIDs`
       // reads nil only when `self` is nil, never when the set is genuinely
       // empty (an empty dictionary's `.keys` is a real, non-nil, empty value).
-      guard let liveArmedKeys = await MainActor.run(body: { self?.pendingSessions.keys })
+      guard let liveArmedKeys = await MainActor.run(body: { self?.protectedSessionIDs })
       else { return }
       let liveArmed = Set(liveArmedKeys)
       // Fail CLOSED if the fresh re-list errors (Codex code-diff r5 P2): treating
@@ -915,6 +1001,34 @@ final class RecoveryCoordinator {
       }
     }
 
+    // Every sweep candidate claims the same per-session operation as disposal.
+    let markerSweep = Task.detached(priority: .utility) { [weak self] in
+      guard let markerIDs = try? store.listDiscardMarkerSessionIDs(),
+        let listedSpools = try? store.listSpoolSessionIDs()
+      else { return }
+      for id in Set(markerIDs).subtracting(listedSpools) {
+        let cleanup: Task<Void, Never>? = await MainActor.run {
+          guard let self, !self.protectedSessionIDs.contains(id) else { return nil }
+          return self.claimDiscardOperation(id: id) {
+            await Task.detached(priority: .utility) {
+              do {
+                let spoolIDs = try store.listSpoolSessionIDs()
+                guard !spoolIDs.contains(id) else { return }
+                // Persist audio absence BEFORE removing either form of evidence.
+                try store.syncSpoolDirectory()
+                try store.deleteDiscardMarker(for: id)
+                try store.syncSpoolDirectory()
+              } catch {
+                // Failure before evidence removal leaves the marker for another pass.
+              }
+            }.value
+          }
+        }
+        if let cleanup { await cleanup.value }
+      }
+    }
+    markerSweepForTesting = markerSweep
+
     guard !spoolIDs.isEmpty else { return false }
 
     // Snapshot the History dedup set. A recording that arms during the dedup
@@ -926,14 +1040,45 @@ final class RecoveryCoordinator {
     // await above, not the value that would have been captured before it — a
     // take that armed DURING that suspension must be excluded too, matching
     // the recheck-after-every-suspension requirement (§C, independent of §D).
-    let armedIDs = Set(pendingSessions.keys)
+    let armedIDs = protectedSessionIDs
     var recoverable: [String] = []
-    // #1807 round-2 correction (Codex chunk-2 review, finding 3): also skip
-    // ids already held for a future launch — a spool this launch already
-    // failed to delete once (a live-ending or history-save-failure retry
-    // candidate) should not be retried through a SECOND, independent
-    // destroySpoolAndKey call from the dedup path this same pass.
-    for id in spoolIDs where !armedIDs.contains(id) && !nextLaunchOnlyRecoveryIDs.contains(id) {
+    // #1807 round-2 correction (Codex chunk-3 review round 2, finding 1):
+    // `nextLaunchOnlyRecoveryIDs` is no longer part of THIS loop condition —
+    // an id held for a future launch must still have its MARKER checked
+    // (below), so a `.markedForDiscard` retry is never blocked by the same
+    // suppression that protects REPLAY eligibility. Only after the marker
+    // check clears as `.absent` does the suppression apply, right before
+    // `recoverable`/History-dedup classification.
+    for id in spoolIDs where !armedIDs.contains(id) {
+      // #1807 (§D1): the discard marker is checked BEFORE History-dedup
+      // classification, in this SAME sequence — not a separate pass. A
+      // committed discard decision vetoes replay ahead of every other check,
+      // and (round 2) ahead of the same-launch suppression below too —
+      // CLEANUP eligibility and REPLAY eligibility are different questions.
+      switch store.hasDiscardMarker(for: id) {
+      case .final, .interruptedTemp:
+        // Never replay; a prior pass or launch already decided to discard
+        // this spool but the destructive delete never completed. Retry
+        // cleanup without ever appending to `recoverable`.
+        RecoveryLog.line("already marked for discard — retrying cleanup, no replay")
+        destroySpoolAndKey(id: id, source: .markedForDiscard)
+        continue
+      case .unreadable:
+        // Cannot tell — defer this spool THIS PASS rather than guess either
+        // way (never collapse into `.absent`, the exact `fileExists` mistake
+        // §A already fixed once in this file).
+        RecoveryLog.line("discard marker unreadable — deferring this spool this pass")
+        continue
+      case .absent:
+        break  // ordinary eligibility checks apply below
+      }
+      // #1807 round-2 correction (finding 1): an UNMARKED id already held for
+      // a future launch (a live-ending/history-save-failure whose cleanup
+      // failed, with no marker ever committed) must not be reclassified as a
+      // fresh replay candidate this launch — the resurrection bug this
+      // suppression exists to prevent. A marked id already retried above and
+      // never reaches this line.
+      guard !nextLaunchOnlyRecoveryIDs.contains(id) else { continue }
       if alreadySaved.contains(id) {
         // Saved in a prior run's save→delete crash window: delete WITHOUT
         // re-transcribing (the dedup MUST precede any append — History forbids a
@@ -984,15 +1129,26 @@ final class RecoveryCoordinator {
       // has no `await` between its own check and claim.
       await Task.yield()
       // #1807 round-2 correction (Codex chunk-2 review, finding 3): recheck
-      // pending membership and same-launch suppression immediately after
-      // this suspension, before replay admission — a take that armed, or a
-      // spool that got held for a future launch, DURING the yield above must
-      // not be replayed. Matches the recheck-after-every-suspension
-      // requirement (§C) and the identical recheck already applied to the
-      // dedup loop above, after its own `await`.
-      guard !pendingSessions.keys.contains(id), !nextLaunchOnlyRecoveryIDs.contains(id) else {
+      // pending membership immediately after this suspension, before replay
+      // admission — a take that armed DURING the yield above must not be
+      // replayed. Matches the recheck-after-every-suspension requirement
+      // (§C) and the identical recheck already applied to the dedup loop
+      // above, after its own `await`.
+      guard !protectedSessionIDs.contains(id) else { continue }
+      // #1807 round-2 correction (chunk-3 review round 2, finding 1): the
+      // marker check runs BEFORE the same-launch suppression check, exactly
+      // like the dedup loop above — a marked survivor still retries cleanup
+      // even if it's also in `nextLaunchOnlyRecoveryIDs`.
+      switch store.hasDiscardMarker(for: id) {
+      case .final, .interruptedTemp:
+        destroySpoolAndKey(id: id, source: .markedForDiscard)
         continue
+      case .unreadable:
+        continue
+      case .absent:
+        break
       }
+      guard !nextLaunchOnlyRecoveryIDs.contains(id) else { continue }
       // Atomic per-item handshake (§3.1/§3.2) — ONE non-suspending MainActor
       // turn: checked and claimed here with no `await` between any step, so
       // there is no window between "checked" and "acted." Preserves the
@@ -1085,7 +1241,7 @@ final class RecoveryCoordinator {
       // (fresh UUIDs per arm), but a direct destroy here must still defer to
       // that session's own join rather than racing it, on the same recheck
       // discipline the scan's dedup loop above follows.
-      if willDelete, !pendingSessions.keys.contains(id) {
+      if willDelete, !protectedSessionIDs.contains(id) {
         destroySpoolAndKey(id: id, source: .replayOutcome)
       }
       // Post the standalone success notice for a recording that landed in History.

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -89,8 +89,8 @@ final class RecoveryCoordinator {
     /// operation — guards a duplicate disposition call or a duplicate writer
     /// ack from starting a second marker write or deletion.
     var cleanupClaimed = false
-    /// #1807 (§D2): `Bool` (not `Void`) — carries whether the write actually
-    /// succeeded, the first axis of `destroySpoolAndKey`'s decision table.
+    /// Reports proven durable discard evidence, including an earlier commit
+    /// reused by a later cleanup attempt.
     var markerPersistence: Task<Bool, Never>?
     /// Every caller awaiting this session's cleanup SETTLING, not merely being
     /// claimed. Production discards the `Task` it gets back; tests await it
@@ -100,6 +100,14 @@ final class RecoveryCoordinator {
   }
   private var pendingSessions: [String: PendingSession] = [:]
   private var discardOperations: [String: Task<Void, Never>] = [:]
+  // Proven commits remain authoritative across retries until evidence removal begins.
+  private var durableDiscardEvidenceIDs: Set<String> = []
+
+  // Instance-scoped completion seam for disposal integration tests.
+  func awaitDiscardOperationsForTesting() async {
+    let operations = Array(discardOperations.values)
+    for operation in operations { await operation.value }
+  }
   // Instance-scoped completion seam; production never awaits the sweep.
   // periphery:ignore - test seam
   var markerSweepForTesting: Task<Void, Never>?
@@ -573,6 +581,7 @@ final class RecoveryCoordinator {
 
       // Evidence is last; failed key/sidecar cleanup cannot prevent this attempt.
       if audioRemovalConfirmed {
+        durableDiscardEvidenceIDs.remove(id)
         let result: Result<Void, any Error> = await Task.detached(priority: .utility) {
           var firstFailure: (any Error)?
           do { try store.deleteDiscardMarker(for: id) } catch { firstFailure = error }
@@ -633,12 +642,12 @@ final class RecoveryCoordinator {
 
   /// Begins immediately at disposition, and settles before destructive cleanup.
   ///
-  /// #1807 (§D2): returns whether the write actually SUCCEEDED — "durable
-  /// discard evidence: yes/no" is the first axis of the decision table
-  /// `destroySpoolAndKey` applies once this settles.
+  /// Returns whether durable discard evidence is established. A retained
+  /// session keeps its proven commit across later cleanup attempts.
   private func beginDiscardMarkerPersistence(
     recoverySessionID id: String, source: DestructionSource
   ) -> Task<Bool, Never> {
+    if durableDiscardEvidenceIDs.contains(id) { return Task { true } }
     let store = makeSpoolStore()
     let override = destructionMarkerWriteForTesting
     return Task.detached(priority: .utility) { [self] in
@@ -646,8 +655,10 @@ final class RecoveryCoordinator {
         if let override {
           try override(id)
         } else {
-          try store.writeDiscardMarker(for: id)
+          let existingEvidence = try store.synchronizeExistingDiscardEvidence(for: id)
+          if !existingEvidence { try store.writeDiscardMarker(for: id) }
         }
+        await MainActor.run { _ = self.durableDiscardEvidenceIDs.insert(id) }
         return true
       } catch {
         await MainActor.run {
@@ -1099,20 +1110,10 @@ final class RecoveryCoordinator {
       for id in Set(markerIDs).subtracting(listedSpools) {
         let cleanup: Task<Void, Never>? = await MainActor.run {
           guard let self, !self.protectedSessionIDs.contains(id) else { return nil }
-          return self.claimDiscardOperation(id: id) {
-            await Task.detached(priority: .utility) {
-              do {
-                let spoolIDs = try store.listSpoolSessionIDs()
-                guard !spoolIDs.contains(id) else { return }
-                // Persist audio absence BEFORE removing either form of evidence.
-                try store.syncSpoolDirectory()
-                try store.deleteDiscardMarker(for: id)
-                try store.syncSpoolDirectory()
-              } catch {
-                // Failure before evidence removal leaves the marker for another pass.
-              }
-            }.value
-          }
+          // Audio absence still needs a durable confirmation. The common
+          // operation also cleans the sidecars/key preserved by an earlier
+          // failed sync, before removing the discard evidence last.
+          return self.destroySpoolAndKey(id: id, source: .markedForDiscard)
         }
         if let cleanup { await cleanup.value }
       }

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -89,7 +89,9 @@ final class RecoveryCoordinator {
     /// operation — guards a duplicate disposition call or a duplicate writer
     /// ack from starting a second marker write or deletion.
     var cleanupClaimed = false
-    var markerPersistence: Task<Void, Never>?
+    /// #1807 (§D2): `Bool` (not `Void`) — carries whether the write actually
+    /// succeeded, the first axis of `destroySpoolAndKey`'s decision table.
+    var markerPersistence: Task<Bool, Never>?
     /// Every caller awaiting this session's cleanup SETTLING, not merely being
     /// claimed. Production discards the `Task` it gets back; tests await it
     /// instead of a fixed delay (§11's test contract). Resolved exactly once,
@@ -359,6 +361,11 @@ final class RecoveryCoordinator {
   var destructionSpoolDeleteForTesting: ((String) throws -> Void)?
   // periphery:ignore - test seam
   var destructionKeyDeleteForTesting: (@Sendable (String) throws -> Void)?
+  /// #1807 §D2 test seam: force the discard-marker write to fail without a
+  /// real filesystem fault, so the decision table's "no durable evidence at
+  /// all" fallback cell is directly reachable from a test.
+  // periphery:ignore - test seam
+  var destructionMarkerWriteForTesting: (@Sendable (String) throws -> Void)?
   // periphery:ignore - test seam
   var deletionFailureBreadcrumbForTesting:
     (@MainActor @Sendable (_ stage: String, _ message: String, _ data: [String: String]) -> Void)?
@@ -448,7 +455,7 @@ final class RecoveryCoordinator {
   @discardableResult
   private func destroySpoolAndKey(
     id: String, source: DestructionSource,
-    markerPersistence: Task<Void, Never>? = nil
+    markerPersistence: Task<Bool, Never>? = nil
   ) -> Task<Void, Never> {
     if let existing = discardOperations[id] { return existing }
     // #1807 round-2 correction (Codex chunk-3 review round 2, finding 1):
@@ -468,61 +475,113 @@ final class RecoveryCoordinator {
       markerPersistence
       ?? beginDiscardMarkerPersistence(recoverySessionID: id, source: source)
     return claimDiscardOperation(id: id) { [self] in
-      await marker.value
-      await performSpoolAndKeyDestruction(id: id, source: source).value
+      let markerCommitted = await marker.value
+      await performSpoolAndKeyDestruction(
+        id: id, source: source, markerCommitted: markerCommitted
+      ).value
     }
   }
 
+  /// #1807 (§D2) — the decision table's own home. `markerCommitted` is
+  /// "durable discard evidence: yes/no"; audio removal is tracked
+  /// SEPARATELY from sidecar cleanup (never inferred from a combined
+  /// result — `RecoverySpoolStore.delete()`'s old conflated shape is why
+  /// this method no longer calls it). Sidecars remain intact until audio
+  /// removal is durable. Then sidecar and key attempts fail independently.
+  ///
+  /// | durable discard evidence | audio removal confirmed | key action |
+  /// |---|---|---|
+  /// | yes | yes | delete |
+  /// | yes | no  | **retain key, retain discard evidence** |
+  /// | no  | yes | delete |
+  /// | no  | no  | best-effort erasure (today's existing fallback) |
+  ///
+  /// Discard evidence is removed LAST, only after CONFIRMED synced audio
+  /// removal — never before, and never when audio removal failed (the
+  /// interrupted-write / final marker is exactly what must survive that
+  /// case, so a future launch never resurrects it as a fresh orphan).
   private func performSpoolAndKeyDestruction(
-    id: String, source: DestructionSource
+    id: String, source: DestructionSource, markerCommitted: Bool
   ) -> Task<Void, Never> {
-    #if DEBUG
-      // #1755 chunk 6: crash-boundary hold — immediately before the spool
-      // attempt (seam or real store). Unarmed: no-op.
-      crashBoundaryController.boundaryReached(.beforeSpoolDelete)
-    #endif
-    do {
-      if let override = destructionSpoolDeleteForTesting {
-        try override(id)
-      } else {
-        try makeSpoolStore().delete(recoverySessionID: id)
-      }
-      emitCleanupOutcome(component: "spool", source: source, succeeded: true)
-    } catch {
-      emitDeletionFailed(component: "spool", source: source, error: error)
-      emitCleanupOutcome(component: "spool", source: source, succeeded: false)
-    }
-    // Key deletion ALWAYS runs, detached, even after a spool failure.
+    let store = makeSpoolStore()
+    let audioOverride = destructionSpoolDeleteForTesting
     let keyStore = self.keyStore
     let keyOverride = destructionKeyDeleteForTesting
-    // Capture self STRONGLY: the failure breadcrumb must survive coordinator
-    // deallocation racing the detached delete (a weak capture silently
-    // dropped it). The task is short-lived; the temporary strong retention
-    // ends when the task completes.
     #if DEBUG
       let crashBoundaryController = self.crashBoundaryController
     #endif
-    return Task.detached(priority: .utility) {
+    return Task { @MainActor [self] in
       #if DEBUG
-        // #1755 chunk 6: crash-boundary hold — immediately before the key
-        // attempt. While destruction_api_return is armed this call GATES
-        // (parks without publishing) so the caller-side hook can prove the
-        // live-ending API returned first.
-        crashBoundaryController.boundaryReached(.beforeKeyDelete)
+        crashBoundaryController.boundaryReached(.beforeSpoolDelete)
       #endif
-      do {
-        if let keyOverride {
-          try keyOverride(id)
-        } else {
-          try keyStore.delete(for: id)
+      let audioResult: Result<Void, any Error>
+      if let audioOverride {
+        // Existing actor-confined test seam; production disk work is detached.
+        audioResult = Result { try audioOverride(id) }
+      } else {
+        audioResult = await Task.detached(priority: .utility) {
+          Result { try store.removeSpoolAudioDurably(recoverySessionID: id) }
+        }.value
+      }
+      let audioRemovalConfirmed: Bool
+      switch audioResult {
+      case .success:
+        audioRemovalConfirmed = true
+      case .failure(let error):
+        audioRemovalConfirmed = false
+        emitDeletionFailed(component: "spool", source: source, error: error)
+      }
+
+      var sidecarCleanupSucceeded = true
+      if audioRemovalConfirmed {
+        let result = await Task.detached(priority: .utility) {
+          Result { try store.cleanupSpoolSidecars(recoverySessionID: id) }
+        }.value
+        if case .failure(let error) = result {
+          sidecarCleanupSucceeded = false
+          emitDeletionFailed(component: "spool", source: source, error: error)
         }
-        await MainActor.run {
-          self.emitCleanupOutcome(component: "key", source: source, succeeded: true)
+      }
+      emitCleanupOutcome(
+        component: "spool", source: source,
+        succeeded: audioRemovalConfirmed && sidecarCleanupSucceeded)
+
+      if markerCommitted && !audioRemovalConfirmed {
+        RecoveryLog.line("retaining key: durable discard evidence, unconfirmed audio removal")
+        return
+      }
+
+      let keyResult: Result<Void, any Error> = await Task.detached(priority: .utility) {
+        #if DEBUG
+          crashBoundaryController.boundaryReached(.beforeKeyDelete)
+        #endif
+        return Result {
+          if let keyOverride {
+            try keyOverride(id)
+          } else {
+            try keyStore.delete(for: id)
+          }
         }
-      } catch {
-        await MainActor.run {
-          self.emitDeletionFailed(component: "key", source: source, error: error)
-          self.emitCleanupOutcome(component: "key", source: source, succeeded: false)
+      }.value
+      switch keyResult {
+      case .success:
+        emitCleanupOutcome(component: "key", source: source, succeeded: true)
+      case .failure(let error):
+        emitDeletionFailed(component: "key", source: source, error: error)
+        emitCleanupOutcome(component: "key", source: source, succeeded: false)
+      }
+
+      // Evidence is last; failed key/sidecar cleanup cannot prevent this attempt.
+      if audioRemovalConfirmed {
+        let result: Result<Void, any Error> = await Task.detached(priority: .utility) {
+          var firstFailure: (any Error)?
+          do { try store.deleteDiscardMarker(for: id) } catch { firstFailure = error }
+          do { try store.syncSpoolDirectory() } catch { firstFailure = firstFailure ?? error }
+          if let firstFailure { return .failure(firstFailure) }
+          return .success(())
+        }.value
+        if case .failure(let error) = result {
+          emitDeletionFailed(component: "marker", source: source, error: error)
         }
       }
     }
@@ -573,17 +632,28 @@ final class RecoveryCoordinator {
   }
 
   /// Begins immediately at disposition, and settles before destructive cleanup.
+  ///
+  /// #1807 (§D2): returns whether the write actually SUCCEEDED — "durable
+  /// discard evidence: yes/no" is the first axis of the decision table
+  /// `destroySpoolAndKey` applies once this settles.
   private func beginDiscardMarkerPersistence(
     recoverySessionID id: String, source: DestructionSource
-  ) -> Task<Void, Never> {
+  ) -> Task<Bool, Never> {
     let store = makeSpoolStore()
+    let override = destructionMarkerWriteForTesting
     return Task.detached(priority: .utility) { [self] in
       do {
-        try store.writeDiscardMarker(for: id)
+        if let override {
+          try override(id)
+        } else {
+          try store.writeDiscardMarker(for: id)
+        }
+        return true
       } catch {
         await MainActor.run {
           self.emitDeletionFailed(component: "marker", source: source, error: error)
         }
+        return false
       }
     }
   }
@@ -785,10 +855,19 @@ final class RecoveryCoordinator {
   /// `fireStateChangeIfNeeded()` call, and that same-launch wake must not
   /// rediscover a spool whose deletion failed.
   ///
-  /// NOTE: unlike launch replay, this spool carries NO attempt marker — no
-  /// replay ever ran for it. If deletion fails, a later launch gives it its
-  /// FIRST crash-recovery attempt, which is consistent with the one-attempt
-  /// rule. No-op when `id` is nil (armed only when recovery was on).
+  /// #1807 (founder decision, superseding the note this replaces): unlike
+  /// launch replay, this spool carries no ATTEMPT marker — no replay ever
+  /// ran for it. The original note here said that meant a later launch
+  /// would give a delete-failure survivor its FIRST crash-recovery attempt,
+  /// "consistent with the one-attempt rule." Codex's design review (Q3)
+  /// found this made `.historySaveFailed` the one destruction source that
+  /// could not honestly promise "never replay a concluded take" without an
+  /// explicit decision — the founder chose uniformity: this source now
+  /// writes the SAME durable no-replay marker (§D1) every other source
+  /// does, before its delete is even attempted, so a survivor is a
+  /// `.markedForDiscard` cleanup retry on the next scan, never a fresh
+  /// first-ever attempt. No special case remains. No-op when `id` is nil
+  /// (armed only when recovery was on).
   @discardableResult
   func handleHistorySaveFailed(recoverySessionID id: String?) -> Task<Void, Never>? {
     guard let id else { return nil }
@@ -936,6 +1015,36 @@ final class RecoveryCoordinator {
     RecoveryLog.line("scan finished")
   }
 
+  /// The production orphan-key sweep, returned so tests can await this operation
+  /// independently of the marker sweep that may legitimately retire its evidence.
+  @discardableResult
+  func startKeyOnlySweep() -> Task<Void, Never> {
+    let keyStore = self.keyStore
+    let makeSpoolStore = self.makeSpoolStore
+    return Task.detached(priority: .utility) { [weak self] in
+      let keyIDs = keyStore.listAccountIDs()
+      // #1807 (§C): a vanished coordinator must ABORT the sweep — it is not
+      // evidence the protection set is empty. `self?.protectedSessionIDs`
+      // reads nil only when `self` is nil, never when the set is genuinely
+      // empty (an empty dictionary's `.keys` is a real, non-nil, empty value).
+      guard let liveArmedKeys = await MainActor.run(body: { self?.protectedSessionIDs })
+      else { return }
+      let liveArmed = Set(liveArmedKeys)
+      // Fail CLOSED if the fresh re-list errors (Codex code-diff r5 P2): treating
+      // an IO/permission error as "no spools" would delete keys for real `.ewrec`
+      // files. Abort the sweep instead — same discipline as the scan-start list.
+      guard let currentSpoolList = try? makeSpoolStore().listSpoolSessionIDs() else { return }
+      let currentSpools = Set(currentSpoolList)
+      for id in keyIDs where !liveArmed.contains(id) && !currentSpools.contains(id) {
+        // A failed audio-directory sync leaves a marker and a retained key.
+        // The marker-only sweep must establish durable absence before this
+        // orphan-key path can erase that key. Unreadability also defers.
+        guard makeSpoolStore().hasDiscardMarker(for: id) == .absent else { continue }
+        try? keyStore.delete(for: id)
+      }
+    }
+  }
+
   /// One full discovery + per-item-replay pass. Returns `true` exactly when
   /// the pass stopped because a live record-press was refused mid-scan (§3.1)
   /// — the signal `drainPendingRescan()` uses to stop draining outright rather
@@ -980,26 +1089,7 @@ final class RecoveryCoordinator {
     //     NOT swept (the stale scan-start snapshot would have missed it and deleted
     //     the key, making that recording undecryptable — r4 P2).
     // Only a key with NO spool now (and not live-armed) is a true key-only orphan.
-    let keyStore = self.keyStore
-    let makeSpoolStore = self.makeSpoolStore
-    Task.detached(priority: .utility) { [weak self] in
-      let keyIDs = keyStore.listAccountIDs()
-      // #1807 (§C): a vanished coordinator must ABORT the sweep — it is not
-      // evidence the protection set is empty. `self?.protectedSessionIDs`
-      // reads nil only when `self` is nil, never when the set is genuinely
-      // empty (an empty dictionary's `.keys` is a real, non-nil, empty value).
-      guard let liveArmedKeys = await MainActor.run(body: { self?.protectedSessionIDs })
-      else { return }
-      let liveArmed = Set(liveArmedKeys)
-      // Fail CLOSED if the fresh re-list errors (Codex code-diff r5 P2): treating
-      // an IO/permission error as "no spools" would delete keys for real `.ewrec`
-      // files. Abort the sweep instead — same discipline as the scan-start list.
-      guard let currentSpoolList = try? makeSpoolStore().listSpoolSessionIDs() else { return }
-      let currentSpools = Set(currentSpoolList)
-      for id in keyIDs where !liveArmed.contains(id) && !currentSpools.contains(id) {
-        try? keyStore.delete(for: id)
-      }
-    }
+    startKeyOnlySweep()
 
     // Every sweep candidate claims the same per-session operation as disposal.
     let markerSweep = Task.detached(priority: .utility) { [weak self] in

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -410,7 +410,29 @@ final class RecoveryCoordinator {
       errorDomain: Self.errorDomainBucket(for: error), errorCode: Self.errorCode(for: error))
   }
 
-  private static func errorDomainBucket(for error: any Error) -> String {
+  /// `RecoverySpoolStoreError`'s four cases all carry a real POSIX `errno` as their
+  /// associated `Int32` (cloud review, PR #2717). Bridging the enum to `NSError`
+  /// does not surface that value as `.domain`/`.code` — it yields Swift's own
+  /// synthesized domain/case-index instead, so every marker-write or
+  /// directory-sync failure was reported as `error_domain=other` with a
+  /// meaningless code, unable to distinguish disk-full from permission-denied
+  /// from a generic I/O fault. Unwrap explicitly, same as `RecoveryKeyStoreError`
+  /// below.
+  private static func spoolStoreErrno(for error: any Error) -> Int32? {
+    guard let spoolError = error as? RecoverySpoolStoreError else { return nil }
+    switch spoolError {
+    case .attemptMarkerWriteFailed(let code), .readinessRetryMarkerWriteFailed(let code),
+      .escapeMarkerWriteFailed(let code), .discardMarkerWriteFailed(let code):
+      return code
+    }
+  }
+
+  // `internal`, not `private`: direct unit-testing of the domain/code bucketing
+  // needs to reach these without a live telemetry sink — same reasoning
+  // `PendingSession`/`requestDisposal` already use for their own directly-tested
+  // static logic.
+  static func errorDomainBucket(for error: any Error) -> String {
+    if spoolStoreErrno(for: error) != nil { return "posix" }
     switch error {
     case let nsError as NSError where nsError.domain == NSCocoaErrorDomain: return "cocoa"
     case let nsError as NSError where nsError.domain == NSPOSIXErrorDomain: return "posix"
@@ -420,10 +442,11 @@ final class RecoveryCoordinator {
 
   /// `RecoveryKeyStoreError.deleteFailed(OSStatus)` bridges to `NSError` without surfacing its
   /// associated OSStatus as `.code`. Unwrap explicitly; every other error keeps its bridged NSError code.
-  private static func errorCode(for error: any Error) -> Int {
+  static func errorCode(for error: any Error) -> Int {
     if let keyError = error as? RecoveryKeyStoreError, case .deleteFailed(let status) = keyError {
       return Int(status)
     }
+    if let errno = spoolStoreErrno(for: error) { return Int(errno) }
     return (error as NSError).code
   }
 

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -208,8 +208,15 @@ package final class WisprBootstrapper {
 
     // Audio capture runs in-process (#1543, D-028 — the separate XPC audio
     // helper was collapsed away). The ASR helper below stays isolated.
+    //
+    // #1807 (§C): kept as a separate, concretely-typed reference so its
+    // `onRecoveryWriterQuiescent` closure can be wired to `recoveryCoordinator`
+    // once that exists below — the closure lives on the concrete type, not
+    // the `AudioCaptureInterface` protocol, so every other conformer (test
+    // fakes, simulator doubles) needs no change.
+    let audioCaptureManager = AudioCaptureManager()
     let audioCapture: any AudioCaptureInterface = InputResolutionTelemetryReporting.observing(
-      AudioCaptureManager())
+      audioCaptureManager)
 
     // #1707 Phase 3 (§3.2): the atomic mutual-exclusion primitive between
     // crash-recovery replay and every OTHER engine-mutating operation. One
@@ -974,6 +981,14 @@ package final class WisprBootstrapper {
     // `engineMutationScope`'s wake closure (constructed before `asrManager`,
     // above) can reach it.
     recoveryCoordinatorForEngineMutationScope = recoveryCoordinator
+    // #1807 (§C) — the one narrow Audio→Coordinator wire this chunk adds:
+    // Audio's writer-completion ack (fired for a real writer AND for every
+    // explicit no-writer case) tells the coordinator's per-session join that
+    // this session's writer will never touch its spool again. Direct wiring,
+    // no Pipeline involvement — matches the plan's proposed shape.
+    audioCaptureManager.onRecoveryWriterQuiescent = { [weak recoveryCoordinator] sessionID in
+      recoveryCoordinator?.acknowledgeWriterQuiescent(recoverySessionID: sessionID)
+    }
     // #1063 PR2: the "recovering" pill's Discard action.
 
     // #1464: after a leftover recording lands in History, post the standalone green

--- a/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureInterface.swift
@@ -180,6 +180,33 @@ public protocol AudioCaptureInterface: AnyObject {
   /// Every caller except the kernel uses the no-arg `beginCapturePhase()`
   /// convenience in the extension below.
   func beginCapturePhase(recoveryPayload: Data?) async throws -> AsyncStream<AVAudioPCMBuffer>
+  /// #1807 — like `beginCapturePhase(recoveryPayload:)`, but also carries the
+  /// SAME recording's plain recovery session id, supplied independently of the
+  /// opaque `recoveryPayload` — never derived from it, since decoding the
+  /// payload is exactly what can fail. The kernel mints both from the same arm
+  /// (`RecoveryCoordinator.makeDirective`) and already carries the plain id on
+  /// `DictationSessionConfig`, so this costs it nothing to forward. Lets a
+  /// coordinator-side writer-completion join still name the session on a
+  /// decode failure or a disabled/low-disk refusal, not only on success.
+  /// Defaulted below to forward to the payload-only overload — every other
+  /// conformer (test fakes, simulator doubles) needs no change.
+  /// `AudioCaptureManager` overrides it with the real, id-aware implementation.
+  func beginCapturePhase(
+    recoverySessionID: String?, recoveryPayload: Data?
+  ) async throws -> AsyncStream<AVAudioPCMBuffer>
+  /// #1807 round 2 — the kernel calls this when it decides NOT to call
+  /// `beginCapturePhase` at all for an armed `recoverySessionID` (a terminal
+  /// before capture start: permission denial, an engine-start failure, an
+  /// ASR-adapter-start failure, and any future early exit in
+  /// `RecordingSessionKernel.runForwardPath`). Also fires from inside
+  /// `beginCapturePhase` itself when IT exits before reaching
+  /// `startRecoverySpooling` (e.g. no active source). Without this, a session
+  /// that armed but never actually spooled leaves its `pendingSessions` entry
+  /// waiting on a writer ack that will never arrive — safe for one launch
+  /// (§7/§9's accepted "writer completion never arrives" fallback), but never
+  /// closed until the next relaunch resets the in-memory table. Defaulted to
+  /// a no-op — only `AudioCaptureManager` needs it.
+  func recoveryCaptureDidNotStart(recoverySessionID: String)
   func startCapture() async throws -> AsyncStream<AVAudioPCMBuffer>  // periphery:ignore - convenience method combining engine + capture phases
   /// Stop the capture session identified by `sessionID`, returning its samples.
   /// Fenced on the armed capture generation (#1579): a mismatched ID is a total
@@ -234,6 +261,20 @@ extension AudioCaptureInterface {
   public func beginCapturePhase() async throws -> AsyncStream<AVAudioPCMBuffer> {
     try await beginCapturePhase(recoveryPayload: nil)
   }
+
+  /// #1807: default for every conformer that has no reason to track the plain
+  /// session id separately from the payload (test fakes, simulator doubles) —
+  /// forwards to the payload-only overload, ignoring `recoverySessionID`.
+  /// `AudioCaptureManager` overrides this with the real implementation.
+  public func beginCapturePhase(
+    recoverySessionID: String?, recoveryPayload: Data?
+  ) async throws -> AsyncStream<AVAudioPCMBuffer> {
+    try await beginCapturePhase(recoveryPayload: recoveryPayload)
+  }
+
+  /// #1807 round 2: no-op default — test fakes and simulator doubles have no
+  /// writer-completion join to notify. `AudioCaptureManager` overrides it.
+  public func recoveryCaptureDidNotStart(recoverySessionID: String) {}
 
   /// #1317: fail-closed default so every existing conformer (test fakes,
   /// simulator doubles) that has no reason to track this stays

--- a/Sources/EnviousWisprAudio/AudioCaptureManager.swift
+++ b/Sources/EnviousWisprAudio/AudioCaptureManager.swift
@@ -510,6 +510,19 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   /// `beginCapturePhase` and fed the authoritative captured samples on a poll
   /// loop. nil when recovery is off / failed to arm. MainActor-confined.
   private var recoverySpoolWriter: RecoverySpoolWriter?
+  /// #1807 — the SAME session's plain id, captured at writer-creation time and
+  /// cleared alongside `recoverySpoolWriter`. Read at finalize time instead of
+  /// re-deriving "whichever session is current" — closes the stale-completion
+  /// hazard where a late ack must resolve against the writer it actually
+  /// belonged to, never the manager's current session.
+  private var recoverySpoolWriterSessionID: String?
+  /// #1807 — fired exactly once per take that ever reached
+  /// `startRecoverySpooling`, meaning "this session's writer (if any) can never
+  /// write to its spool again." Fires for the no-writer cases too (decode
+  /// failure, disabled directive, low-disk refusal), not only after a real
+  /// writer finalizes. Set by the composition root; nil in every existing
+  /// caller and test, so unwired behavior is unchanged.
+  public var onRecoveryWriterQuiescent: (@MainActor @Sendable (String) -> Void)?
   /// Poll task feeding new captured samples to the writer. Cancelled on stop.
   private var recoveryFeedTask: Task<Void, Never>?
   /// High-water mark of `capturedSamples` already handed to the writer, so the
@@ -583,7 +596,8 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   ///      value (`RULE: read-the-bind-prepare-returned-never-re-derive-it`), and
   ///      it is also the only source of truth on the warm path, which fires no
   ///      callback at all.
-  private func prepareAndAttribute(_ source: any AudioInputSource) async throws -> BoundInputDevice {
+  private func prepareAndAttribute(_ source: any AudioInputSource) async throws -> BoundInputDevice
+  {
     latestInputResolutionAttempt = nil
     currentInputResolutionSource = nil
     source.onInputResolutionAttemptFinalized = { [weak self] attempt in
@@ -618,6 +632,30 @@ public final class AudioCaptureManager: AudioCaptureInterface {
   public func beginCapturePhase(recoveryPayload: Data?) async throws
     -> AsyncStream<AVAudioPCMBuffer>
   {
+    try await beginCapturePhase(recoverySessionID: nil, recoveryPayload: recoveryPayload)
+  }
+
+  /// #1807 — real implementation, overriding the protocol's forwarding
+  /// default. `recoverySessionID` is the plain id the kernel mints alongside
+  /// `recoveryPayload` from the same arm; threading it in separately lets
+  /// `startRecoverySpooling` acknowledge "no writer will ever exist" even when
+  /// the payload fails to decode.
+  public func beginCapturePhase(
+    recoverySessionID: String?, recoveryPayload: Data?
+  ) async throws -> AsyncStream<AVAudioPCMBuffer> {
+    // #1807 round 2: this function has two exits before `startRecoverySpooling`
+    // below — the `activeSource` guard right here, and `source.startCapture()`
+    // throwing further down. A `defer` covers both (and any future one) without
+    // needing to touch each site: if we leave this function having never
+    // reached `startRecoverySpooling`, and the coordinator armed this id, tell
+    // it directly rather than leaving its join waiting on an ack that can now
+    // never arrive from inside `startRecoverySpooling` itself.
+    var reachedRecoverySpooling = false
+    defer {
+      if !reachedRecoverySpooling, let recoverySessionID {
+        recoveryCaptureDidNotStart(recoverySessionID: recoverySessionID)
+      }
+    }
     guard let source = activeSource else {
       throw AudioError.formatCreationFailed(
         source: "AudioCaptureManager.beginCapturePhase.no_active_source")
@@ -718,7 +756,8 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     // Crash-recovery limb: arm the spool from the directive AFTER capture is
     // live (the feed loop guards on `isCapturing`). Fail-open — never throws,
     // never gates the returned stream (heart path is byte-identical).
-    startRecoverySpooling(payload: recoveryPayload)
+    reachedRecoverySpooling = true
+    startRecoverySpooling(recoverySessionID: recoverySessionID, payload: recoveryPayload)
     #if DEBUG
       // Bake-off manager-side evidence companion (#1377 §3.5): pairs the app's
       // REQUEST (backend + requested device) with each source's own
@@ -1051,8 +1090,8 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     /// real device format a stub cannot provide — the same constraint that forced
     /// `installCapturedSourceForTesting`. Lets the predecessor-retirement tests
     /// assert against the REAL spool files rather than manager internals.
-    func armRecoverySpoolingForTesting(payload: Data?) {
-      startRecoverySpooling(payload: payload)
+    func armRecoverySpoolingForTesting(recoverySessionID: String? = nil, payload: Data?) {
+      startRecoverySpooling(recoverySessionID: recoverySessionID, payload: payload)
     }
 
     /// Test seam (#2594): pin the low-disk preflight's answer. `nil` restores the
@@ -1705,7 +1744,16 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     recoveryFeedTask = nil
   }
 
-  private func startRecoverySpooling(payload: Data?) {
+  /// #1807 round 2 — `AudioCaptureInterface` conformance. The kernel (or this
+  /// manager's own `beginCapturePhase`) calls this when it decides an armed
+  /// `recoverySessionID` will never reach a real writer at all. Same ack as a
+  /// real writer's finalize — "will never write again," never "wrote
+  /// successfully" — just fired without a writer ever having existed.
+  public func recoveryCaptureDidNotStart(recoverySessionID: String) {
+    onRecoveryWriterQuiescent?(recoverySessionID)
+  }
+
+  private func startRecoverySpooling(recoverySessionID: String?, payload: Data?) {
     // #1579 (defect 1b): RETIRE any predecessor before resetting, never drop it.
     // The old code nil'd `recoverySpoolWriter` and left `recoveryFeedTask` alive.
     // That task holds its writer strongly and guards only on `isCapturing` +
@@ -1721,13 +1769,37 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     recoveryFinalized = false
     recoveryFedSampleCount = 0
     recoverySpoolWriter = nil
+    recoverySpoolWriterSessionID = nil
+    // #1807: `recoverySessionID` must NEVER gate whether decoding/writer
+    // creation is attempted — only `payload` decides that, exactly as before
+    // this chunk. `recoverySessionID` is a SEPARATE channel used only to name
+    // the session for a no-writer ack when the payload itself can't (decode
+    // failure) — it is nil for every non-kernel caller (the no-arg
+    // convenience passes nil for both) and for every existing test that arms
+    // a payload directly without also naming a session id.
     guard let payload,
       let directive = try? JSONDecoder().decode(RecoverySpoolDirective.self, from: payload),
       directive.enabled
-    else { return }
+    else {
+      // #1807: decode failed, payload was nil, or recovery was explicitly
+      // disabled for this take — no writer will ever be created. Ack using
+      // the plain id supplied independently of this payload, when one was
+      // supplied; nil means the coordinator never protected anything here.
+      if let recoverySessionID {
+        onRecoveryWriterQuiescent?(recoverySessionID)
+      }
+      return
+    }
     // Low-disk preflight: don't start a spool when free space is already below
     // the watermark the heart path needs (History save / ASR temp / model cache).
-    guard hasSufficientDiskSpace(forSpoolAt: directive.spoolPath) else { return }
+    guard hasSufficientDiskSpace(forSpoolAt: directive.spoolPath) else {
+      // #1807: refused before a writer existed — same no-writer ack as above.
+      // Use the DECODED directive's own id here, not the separately-supplied
+      // parameter: decode already succeeded, so it is always available and
+      // guaranteed to be this take's real id.
+      onRecoveryWriterQuiescent?(directive.recoverySessionID)
+      return
+    }
 
     let writer = RecoverySpoolWriter(
       recoverySessionID: directive.recoverySessionID,
@@ -1736,6 +1808,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       settings: directive.settingsSnapshot)
     writer.start()
     recoverySpoolWriter = writer
+    recoverySpoolWriterSessionID = directive.recoverySessionID
     startRecoveryFeed(writer: writer, spoolPath: directive.spoolPath)
   }
 
@@ -1789,8 +1862,7 @@ public final class AudioCaptureManager: AudioCaptureInterface {
       writer.append(Array(tail[recoveryFedSampleCount...]))
     }
     writer.flush()
-    writer.finalize(reason: .cleanFinalized)
-    recoverySpoolWriter = nil
+    finalizeWriterAndAck(writer, reason: .cleanFinalized)
   }
 
   /// Finalize the spool for a non-clean reason (low disk). Guarded so clean-stop
@@ -1800,8 +1872,28 @@ public final class AudioCaptureManager: AudioCaptureInterface {
     recoveryFinalized = true
     recoveryFeedTask?.cancel()
     recoveryFeedTask = nil
-    writer.finalize(reason: reason)
+    finalizeWriterAndAck(writer, reason: reason)
+  }
+
+  /// #1807 — shared by `stopRecoverySpooling` and `finalizeRecovery`: finalize
+  /// the writer, then fire `onRecoveryWriterQuiescent` for the SAME session id
+  /// captured at writer-creation time (`recoverySpoolWriterSessionID`), never
+  /// re-read against "whatever session is current" — the exact stale-completion
+  /// hazard a late/superseded ack must not fall into. Fires on both healthy and
+  /// error paths, matching `finalize`'s own contract: "will never write again,"
+  /// not "wrote successfully."
+  private func finalizeWriterAndAck(
+    _ writer: RecoverySpoolWriter, reason: RecoverySpoolTerminationReason
+  ) {
+    let sessionID = recoverySpoolWriterSessionID
+    let ack = onRecoveryWriterQuiescent
     recoverySpoolWriter = nil
+    recoverySpoolWriterSessionID = nil
+    guard let sessionID, let ack else {
+      writer.finalize(reason: reason)
+      return
+    }
+    writer.finalize(reason: reason, notifying: { ack(sessionID) })
   }
 
   /// True when the spool volume has at least the low-disk watermark free. Reads

--- a/Sources/EnviousWisprAudio/RecoverySpoolWriter.swift
+++ b/Sources/EnviousWisprAudio/RecoverySpoolWriter.swift
@@ -214,6 +214,18 @@ public final class RecoverySpoolWriter: @unchecked Sendable {
     }
   }
 
+  /// #1807 — adapts `finalize(reason:completion:)` for a MainActor caller. Fires
+  /// on BOTH healthy and error paths, exactly like the base overload: it proves
+  /// "this writer will never touch the file again," never "wrote successfully."
+  /// Must not be read as marker-persistence confirmation — that is a separate,
+  /// later check (the discard marker's own durability, not this ack).
+  public func finalize(
+    reason: RecoverySpoolTerminationReason,
+    notifying completion: @escaping @MainActor @Sendable () -> Void
+  ) {
+    finalize(reason: reason, completion: { Task { @MainActor in completion() } })
+  }
+
   private func markFailed() {
     state.withLock { $0.healthy = false }
   }

--- a/Sources/EnviousWisprCore/Constants.swift
+++ b/Sources/EnviousWisprCore/Constants.swift
@@ -317,6 +317,12 @@ public enum RecoveryConstants {
   /// the end. Rewriting a sealed header mid-session to record a later fact would
   /// put the audio at risk to store metadata.
   public static let escapeMarkerFileExtension = "escape"
+  /// File extension for a per-spool DISCARD marker (#1807 §D1). Presence-only,
+  /// written durably (temp + fsync + atomic rename + directory sync) BEFORE any
+  /// destructive delete once a session's final disposition is "destroy" — a
+  /// committed, permanent "never replay this session" decision, independent of
+  /// whether the audio unlink itself later succeeds. Named `<recoverySessionID>.discard`.
+  public static let discardMarkerFileExtension = "discard"
   /// On-disk format version recorded in the header.
   public static let formatVersion = 1
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1433,6 +1433,19 @@ final class RecordingSessionKernel {
       finishTerminal(.failed(.prepareFailed), sid: sid)
       return
     }
+    // #1807 round 2: this function has many `finishTerminal(...); return`
+    // exits between here and `beginCapturePhase` below (permission denial,
+    // an engine-start failure, an ASR-adapter-start failure, and any future
+    // one) — a `defer` covers all of them without needing to touch each site.
+    // If this session armed crash recovery and we leave without ever handing
+    // the directive to Audio, tell Audio directly so its writer-completion
+    // join isn't left waiting on an ack that can now never arrive.
+    var handedRecoveryToAudio = false
+    defer {
+      if !handedRecoveryToAudio, let id = config.recoverySessionID {
+        audioCapture.recoveryCaptureDidNotStart(recoverySessionID: id)
+      }
+    }
     // Push the frozen device UIDs BEFORE the capture source is built (PR-4.5
     // #3 — parity with old Parakeet pipeline `:1434-1439`). The capture
     // layer reads UIDs at source construction (the source is rebuilt between
@@ -1694,9 +1707,16 @@ final class RecordingSessionKernel {
     // rescue.
     audioCapture.onBufferCaptured = makeBufferCallback(sid)
     do {
+      // #1807 round 2: set BEFORE the call, not after — once `beginCapturePhase`
+      // is actually invoked, Audio's own `defer` (inside that function) owns
+      // acknowledging any exit before it reaches `startRecoverySpooling`,
+      // including this call throwing. This flag only answers "did the kernel
+      // even attempt to hand the directive off."
+      handedRecoveryToAudio = true
       // Forward the opaque crash-recovery directive (nil unless armed) to the
       // helper. The kernel never interprets it — recovery is a limb (#1063 PR1).
-      _ = try await audioCapture.beginCapturePhase(recoveryPayload: config.recoveryPayload)
+      _ = try await audioCapture.beginCapturePhase(
+        recoverySessionID: config.recoverySessionID, recoveryPayload: config.recoveryPayload)
     } catch {
       guard isCurrent(sid) else { return }
       audioCapture.onBufferCaptured = nil

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1844,6 +1844,26 @@ public final class TelemetryService {
       ])
   }
 
+  /// #1807: fires ONLY when `RecoveryCoordinator.destroySpoolAndKey`'s spool or key delete throws.
+  /// Event absence does not establish that #1807 is fixed — a `component=spool` failure means the
+  /// spool-and-sidecar deletion operation threw; the audio may already have been removed before a
+  /// sidecar-only failure.
+  ///
+  /// Privacy: shape only — component/source labels, a bucketed error domain, and a numeric error
+  /// code. Never a path, description, `userInfo`, or recovery id.
+  public func recoveryDeletionFailed(
+    component: String, source: String, errorDomain: String, errorCode: Int
+  ) {
+    PostHogSDK.shared.capture(
+      "recovery.deletion_failed",
+      properties: [
+        "component": component,
+        "source": source,
+        "error_domain": errorDomain,
+        "error_code": errorCode,
+      ])
+  }
+
   public func recoveryPressBlocked(asrBackend: String) {
     PostHogSDK.shared.capture(
       "recovery.press_blocked", properties: ["asr_backend": asrBackend])

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1844,10 +1844,14 @@ public final class TelemetryService {
       ])
   }
 
-  /// #1807: fires ONLY when `RecoveryCoordinator.destroySpoolAndKey`'s spool or key delete throws.
-  /// Event absence does not establish that #1807 is fixed — a `component=spool` failure means the
-  /// spool-and-sidecar deletion operation threw; the audio may already have been removed before a
-  /// sidecar-only failure.
+  /// #1807: fires ONLY when `RecoveryCoordinator.destroySpoolAndKey`'s spool, key, or EXISTING
+  /// marker delete throws. Event absence does not establish that #1807 is fixed — a
+  /// `component=spool` failure means the spool-and-sidecar deletion operation threw; the audio may
+  /// already have been removed before a sidecar-only failure. `component=marker` here is
+  /// SPECIFICALLY the delete of an already-established marker (a low-severity cleanup miss, the
+  /// evidence itself already exists) — never a failure to WRITE one; see
+  /// `recoveryMarkerPersistenceFailed` for that (cloud review, PR #2717: the two failure modes
+  /// have very different severity and were previously indistinguishable in telemetry).
   ///
   /// Privacy: shape only — component/source labels, a bucketed error domain, and a numeric error
   /// code. Never a path, description, `userInfo`, or recovery id.
@@ -1858,6 +1862,27 @@ public final class TelemetryService {
       "recovery.deletion_failed",
       properties: [
         "component": component,
+        "source": source,
+        "error_domain": errorDomain,
+        "error_code": errorCode,
+      ])
+  }
+
+  /// #1807 (cloud review, PR #2717): fires when `RecoveryCoordinator.beginDiscardMarkerPersistence`
+  /// fails to ESTABLISH durable no-replay evidence for a session — the discard marker was never
+  /// written (or an existing one could not be confirmed durable), not that an already-established
+  /// one failed to be cleaned up (that is `recoveryDeletionFailed` with `component=marker`). This is
+  /// the higher-severity case: without this evidence, a crash before the coordinator's own destroy
+  /// path runs can leave the session's spool unmarked and eligible for replay on the next launch.
+  ///
+  /// Privacy: shape only — source label, a bucketed error domain, and a numeric error code. Never a
+  /// path, description, `userInfo`, or recovery id.
+  public func recoveryMarkerPersistenceFailed(
+    source: String, errorDomain: String, errorCode: Int
+  ) {
+    PostHogSDK.shared.capture(
+      "recovery.marker_persistence_failed",
+      properties: [
         "source": source,
         "error_domain": errorDomain,
         "error_code": errorCode,

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -49,7 +49,6 @@ public struct RecoverySpoolStore: Sendable {
   /// The `recoverySessionID`s of every spool file currently on disk.
   public func listSpoolSessionIDs() throws -> [String] {
     let fm = FileManager.default
-    guard fm.fileExists(atPath: directory.path) else { return [] }
     let entries = try fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
     return
       entries

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -1,3 +1,4 @@
+import Darwin
 import EnviousWisprCore
 import Foundation
 
@@ -508,6 +509,176 @@ public struct RecoverySpoolStore: Sendable {
     }
   }
 
+  // MARK: - Discard marker (#1807 §D1)
+
+  /// Sidecar path for a spool's discard marker (`<id>.discard`).
+  private func discardMarkerURL(for recoverySessionID: String) -> URL {
+    directory.appendingPathComponent(
+      "\(recoverySessionID).\(RecoveryConstants.discardMarkerFileExtension)")
+  }
+
+  private func discardMarkerTempURL(for recoverySessionID: String) -> URL {
+    directory.appendingPathComponent(
+      ".\(recoverySessionID).\(RecoveryConstants.discardMarkerFileExtension).tmp")
+  }
+
+  /// Commit the no-replay decision before attempting destructive cleanup.
+  /// Success means the marker bytes AND the final directory entry are durable
+  /// — this is the readiness-retry marker's full durable-write shape
+  /// (temp → `F_FULLFSYNC` → atomic rename → `syncDirectory`), directory sync
+  /// included, because the marker's whole purpose (surviving a crash) depends
+  /// on the rename itself being durable, not merely the bytes.
+  ///
+  /// Retain this marker until the session cannot create another spool, the
+  /// audio has been removed, and that removal is durably synchronized. Only
+  /// then may cleanup remove the marker.
+  ///
+  /// A failed marker write is not permission to retain replayable discarded
+  /// audio — the caller falls back to today's unconditional key-erasure path.
+  public func writeDiscardMarker(for recoverySessionID: String) throws {
+    let url = discardMarkerURL(for: recoverySessionID)
+    let tmpURL = discardMarkerTempURL(for: recoverySessionID)
+    let fd = Foundation.open(tmpURL.path, O_CREAT | O_WRONLY | O_TRUNC, 0o600)
+    guard fd >= 0 else { throw RecoverySpoolStoreError.discardMarkerWriteFailed(errno) }
+    let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+    // #1807 round-2 correction (Codex chunk-3 review, finding 3): NEVER remove
+    // `tmpURL` on any failure below — an interrupted write is evidence a
+    // committed decision was underway, and `.interruptedTemp` reads must find
+    // it. Every `errno` read is captured IMMEDIATELY at its own failure site,
+    // not after an intervening Foundation call, which can silently clobber it.
+    do {
+      // Presence is the signal; a single byte gives fsync something to flush.
+      try handle.write(contentsOf: Data([0x31]))
+      guard fcntl(fd, F_FULLFSYNC) != -1 else {
+        let code = errno
+        try? handle.close()
+        throw RecoverySpoolStoreError.discardMarkerWriteFailed(code)
+      }
+      try handle.close()
+    } catch let error as RecoverySpoolStoreError {
+      throw error
+    } catch {
+      // #1807 round-2 correction (Codex chunk-3 review round 2, finding 2):
+      // `try? handle.close()` below is ITSELF a syscall that can overwrite
+      // `errno` before it's read — the exact staleness bug this whole
+      // correction pass exists to close. Read the code from the THROWN
+      // error instead (Foundation's write failure already carries the real
+      // POSIX code, captured at throw time), never from a fresh `errno` read
+      // after `close()`.
+      let nsError = error as NSError
+      let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
+      let posix = nsError.domain == NSPOSIXErrorDomain ? nsError : underlying
+      let code: Int32
+      if let posix, posix.domain == NSPOSIXErrorDomain {
+        code = Int32(exactly: posix.code) ?? EIO
+      } else {
+        code = EIO
+      }
+      try? handle.close()
+      throw RecoverySpoolStoreError.discardMarkerWriteFailed(code)
+    }
+    // Atomic rename via raw POSIX `rename(2)`, not `FileManager.replaceItemAt`/
+    // `moveItem` (unlike the sibling markers) — POSIX guarantees `rename(2)`
+    // atomically replaces an existing destination, which matters more here:
+    // never removing the temp on failure means the caller must be able to
+    // trust THIS call's all-or-nothing semantics exactly, not a higher-level
+    // API's.
+    guard Darwin.rename(tmpURL.path, url.path) == 0 else {
+      throw RecoverySpoolStoreError.discardMarkerWriteFailed(errno)
+    }
+    // The file's own bytes are already fsynced; the rename lives in the
+    // containing DIRECTORY, a separate durability question — see the
+    // readiness-retry marker's identical `syncDirectory` call for why this
+    // matters more here than for the attempt/Escape markers, which skip it.
+    try Self.syncDirectory(containing: url)
+  }
+
+  /// Read a spool's discard-marker state. FOUR-valued — `.unreadable` must
+  /// never collapse into `.absent` (the exact `fileExists`-boolean mistake §A
+  /// already fixed once in this file): a probe attempts to actually OPEN each
+  /// path and distinguishes `ENOENT` (genuinely absent) from any other errno
+  /// (permission denied, I/O error — cannot tell, so defer rather than assume
+  /// safety either way).
+  public func hasDiscardMarker(for recoverySessionID: String) -> DiscardMarkerState {
+    switch Self.probeMarkerFile(discardMarkerURL(for: recoverySessionID)) {
+    case .present: return .final
+    case .unreadable: return .unreadable
+    case .absent:
+      switch Self.probeMarkerFile(discardMarkerTempURL(for: recoverySessionID)) {
+      case .present: return .interruptedTemp
+      case .absent: return .absent
+      case .unreadable: return .unreadable
+      }
+    }
+  }
+
+  private enum MarkerFileProbe { case present, absent, unreadable }
+
+  private static func probeMarkerFile(_ url: URL) -> MarkerFileProbe {
+    let fd = Foundation.open(url.path, O_RDONLY)
+    if fd >= 0 {
+      Foundation.close(fd)
+      return .present
+    }
+    return errno == ENOENT ? .absent : .unreadable
+  }
+
+  /// Delete a spool's discard marker (both the final marker and any
+  /// interrupted-write temp — the temp goes FIRST, matching
+  /// `deleteReadinessRetryMarker`/`deleteEscapeMarker`). Idempotent — a
+  /// missing marker is success. Callers must only call this once durable
+  /// audio removal is confirmed; this method itself enforces no ordering.
+  public func deleteDiscardMarker(for recoverySessionID: String) throws {
+    // #1807 round-2 correction (Codex chunk-3 review, finding 3 follow-up):
+    // attempt BOTH removals independently, matching `delete(recoverySessionID:)`'s
+    // own established idiom in this file — a `for`-loop chained through `try`
+    // would let a temp-removal failure prevent even ATTEMPTING the final
+    // marker's removal, orphaning it permanently.
+    var firstFailure: (any Error)?
+    do {
+      try FileManager.default.removeItem(at: discardMarkerTempURL(for: recoverySessionID))
+    } catch let error as CocoaError where error.code == .fileNoSuchFile {
+      // Absence is success.
+    } catch {
+      firstFailure = error
+    }
+    do {
+      try FileManager.default.removeItem(at: discardMarkerURL(for: recoverySessionID))
+    } catch let error as CocoaError where error.code == .fileNoSuchFile {
+      // Absence is success.
+    } catch {
+      if firstFailure == nil { firstFailure = error }
+    }
+    if let firstFailure { throw firstFailure }
+  }
+
+  /// Every session id currently carrying a discard marker (final OR
+  /// interrupted-temp) — the population the marker-only-survivor sweep (#1807
+  /// §D1) scans, alongside the ordinary `.ewrec` listing `listSpoolSessionIDs`
+  /// already provides. Fails closed exactly like `listSpoolSessionIDs`: a
+  /// directory-listing error must not be read as "no markers," since that
+  /// would let the sweep retire evidence it never actually inspected.
+  public func listDiscardMarkerSessionIDs() throws -> [String] {
+    let entries = try FileManager.default.contentsOfDirectory(
+      at: directory, includingPropertiesForKeys: nil)
+    let markerExtension = RecoveryConstants.discardMarkerFileExtension
+    return
+      entries
+      .compactMap { url -> String? in
+        // Matches both `<id>.discard` and the interrupted-write `.<id>.discard.tmp`
+        // — a marker-only survivor's evidence can be either, and the sweep must
+        // see both to retire them (§D1: "interrupted-temp also never replays").
+        if url.pathExtension == markerExtension {
+          return url.deletingPathExtension().lastPathComponent
+        }
+        let name = url.lastPathComponent
+        guard name.hasPrefix("."), name.hasSuffix(".\(markerExtension).tmp") else { return nil }
+        let withoutLeadingDot = name.dropFirst()
+        return String(withoutLeadingDot.dropLast(".\(markerExtension).tmp".count))
+      }
+      .sorted()
+  }
+
   /// Create the directory at 0700, drop the Spotlight marker, and exclude it
   /// from backups. Re-enforced on every init. Soft-fails on any filesystem
   /// operation — better to lose a privacy guarantee than crash a limb.
@@ -582,6 +753,10 @@ public enum RecoverySpoolStoreError: Error, Equatable {
   /// dictation the user cancelled, which is worse than the discard they asked
   /// for and were expecting (#2087).
   case escapeMarkerWriteFailed(Int32)
+  /// The discard marker could not be written durably (carries `errno`, #1807
+  /// §D1). NOT permission to retain replayable discarded audio — the caller
+  /// falls back to today's unconditional key-erasure path.
+  case discardMarkerWriteFailed(Int32)
 }
 
 /// The three outcomes of reading a spool's Escape Recovery marker (#2087).
@@ -594,4 +769,20 @@ public enum EscapeMarkerRead: Equatable, Sendable {
   case absent
   case valid(EscapeRecoveryMarker)
   case malformed
+}
+
+/// The four outcomes of reading a spool's discard marker (#1807 §D1).
+/// `.unreadable` must never collapse into `.absent` — see `hasDiscardMarker`'s
+/// doc for why a probe, not a boolean `fileExists`, distinguishes them.
+public enum DiscardMarkerState: Equatable, Sendable {
+  /// Never replay; safe to request cleanup.
+  case final
+  /// Also never replay — mirrors `readEscapeMarker`'s `.malformed`-from-temp
+  /// precedent: an interrupted write is evidence of a committed decision, not
+  /// absence of one.
+  case interruptedTemp
+  /// Ordinary recovery eligibility checks apply.
+  case absent
+  /// DEFER this spool this pass — never treat as absent.
+  case unreadable
 }

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -542,6 +542,27 @@ public struct RecoverySpoolStore: Sendable {
       ".\(recoverySessionID).\(RecoveryConstants.discardMarkerFileExtension).tmp")
   }
 
+  /// Establish durability for evidence left by a prior process without
+  /// allocating or replacing its marker. Presence alone is not a sync receipt.
+  public func synchronizeExistingDiscardEvidence(for recoverySessionID: String) throws -> Bool {
+    for url in [discardMarkerURL(for: recoverySessionID),
+                discardMarkerTempURL(for: recoverySessionID)] {
+      let fd = Foundation.open(url.path, O_RDONLY)
+      guard fd >= 0 else {
+        let code = errno
+        if code == ENOENT { continue }
+        throw RecoverySpoolStoreError.discardMarkerWriteFailed(code)
+      }
+      defer { Foundation.close(fd) }
+      guard fcntl(fd, F_FULLFSYNC) != -1 else {
+        throw RecoverySpoolStoreError.discardMarkerWriteFailed(errno)
+      }
+      try Self.syncDirectory(containing: url)
+      return true
+    }
+    return false
+  }
+
   /// Commit the no-replay decision before attempting destructive cleanup.
   /// Success means the marker bytes AND the final directory entry are durable
   /// — this is the readiness-retry marker's full durable-write shape

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -507,6 +507,19 @@ public struct RecoverySpoolStore: Sendable {
           recoverySessionID: recoverySessionID, triggeredAt: triggeredAt, takeID: takeID))
       return true
     } catch {
+      // Cloud review (PR #2717): the caller's own fallback to the coordinator's
+      // marker-aware destructor is NOT synchronous — `finishTerminal(.cancelled)`
+      // only sets state the lifecycle observer reacts to on a LATER MainActor
+      // turn (a queued Task). A process exit inside that gap would leave this
+      // spool with no Escape marker and no discard marker at all, so the next
+      // launch replays a take the user cancelled — the exact resurrection this
+      // whole mechanism exists to prevent. Best-effort, synchronous, right here:
+      // this does NOT decide destruction (still exclusively the coordinator's
+      // job, whenever it gets to it) — it only makes sure the "never replay"
+      // evidence survives a crash between now and then. A later, real write
+      // for the same id (the coordinator's own normal disposal flow) simply
+      // reconfirms the same marker; harmless.
+      try? writeDiscardMarker(for: recoverySessionID)
       return false
     }
   }
@@ -545,8 +558,10 @@ public struct RecoverySpoolStore: Sendable {
   /// Establish durability for evidence left by a prior process without
   /// allocating or replacing its marker. Presence alone is not a sync receipt.
   public func synchronizeExistingDiscardEvidence(for recoverySessionID: String) throws -> Bool {
-    for url in [discardMarkerURL(for: recoverySessionID),
-                discardMarkerTempURL(for: recoverySessionID)] {
+    for url in [
+      discardMarkerURL(for: recoverySessionID),
+      discardMarkerTempURL(for: recoverySessionID),
+    ] {
       let fd = Foundation.open(url.path, O_RDONLY)
       guard fd >= 0 else {
         let code = errno

--- a/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
+++ b/Sources/EnviousWisprStorage/RecoverySpoolStore.swift
@@ -143,28 +143,36 @@ public struct RecoverySpoolStore: Sendable {
       truncated: !sawCleanFinalize)
   }
 
-  /// Delete a spool file AND its recovery-attempt marker (#1063 PR2). Idempotent
-  /// — a missing file is success. Deleting the spool always clears its marker so
-  /// no stale marker outlives the spool it guarded (success and abandon paths
-  /// both route here).
-  public func delete(recoverySessionID: String) throws {
+  /// Remove ONLY the spool audio file, and durably sync that removal to the
+  /// containing directory (#1807 §D2). Kept separate from sidecar cleanup
+  /// below — the decision table needs to know specifically whether the AUDIO
+  /// is durably gone, independent of any sidecar's own fate. Idempotent — an
+  /// already-absent spool still counts as durable absence.
+  public func removeSpoolAudioDurably(recoverySessionID: String) throws {
     let url = spoolURL(for: recoverySessionID)
     do {
       try FileManager.default.removeItem(at: url)
     } catch let error as CocoaError where error.code == .fileNoSuchFile {
-      // Spool already gone — still clear any marker below.
+      // Already gone — durable absence either way.
     }
-    // #2087: BOTH sidecars are attempted even if the first throws, then the
-    // first failure is surfaced. Chaining them with `try` looks equivalent and
-    // is not: the spool is already gone by this point, so nothing will ever scan
-    // this id again, and a sidecar skipped because its predecessor threw is
-    // orphaned permanently. An Escape marker left behind that way outlives the
-    // audio it describes with no path back to it.
-    //
-    // The spool still goes FIRST. It is the only file that carries recoverable
-    // audio, so if a partial failure must leave something behind, it should
-    // leave metadata a later delete is idempotent about — never audio whose
-    // provenance sidecar has already been destroyed.
+    try Self.syncDirectory(containing: url)
+  }
+
+  /// Clean up a spool's non-discard sidecars: the recovery-attempt, Escape,
+  /// and readiness-retry markers (#1063 PR2, #2087). Never the spool file
+  /// itself (#1807 §D2 tracks that separately via `removeSpoolAudioDurably`)
+  /// and never the discard marker — its own lifetime (retained until
+  /// confirmed, synced audio removal) is the coordinator's explicit
+  /// responsibility, not a sidecar's.
+  ///
+  /// #2087: BOTH sidecars are attempted even if the first throws, then the
+  /// first failure is surfaced. Chaining them with `try` looks equivalent and
+  /// is not: by the time this runs the spool is already gone (or is about to
+  /// be — callers run this alongside `removeSpoolAudioDurably`), so nothing
+  /// will ever scan this id again, and a sidecar skipped because its
+  /// predecessor threw is orphaned permanently. An Escape marker left behind
+  /// that way outlives the audio it describes with no path back to it.
+  public func cleanupSpoolSidecars(recoverySessionID: String) throws {
     var firstFailure: (any Error)?
     do { try deleteAttemptMarker(for: recoverySessionID) } catch { firstFailure = error }
     do { try deleteEscapeMarker(for: recoverySessionID) } catch {
@@ -467,16 +475,29 @@ public struct RecoverySpoolStore: Sendable {
   /// half-perform. Either the marker is durably on disk and this returns `true`,
   /// or nothing survives and it returns `false`.
   ///
-  /// **On failure it destroys the spool and its sidecars.** That looks harsh and
-  /// is the only honest option: a spool left behind with no readable marker is
-  /// replayed at the next launch as an ordinary crash rescue, producing a
-  /// PERMANENT History row for a dictation the user cancelled. Given the choice
-  /// between losing a take the user asked to discard and keeping one they never
-  /// agreed to keep, this loses the take — which is also exactly what today's
-  /// destructive cancel does, so the caller's fallback is unchanged behaviour.
+  /// #1807 (§D2) — superseding the original note this replaces: on failure this
+  /// used to destroy the spool and its sidecars DIRECTLY, bypassing every
+  /// coordinator-owned contract (the writer-quiescence join, the discard
+  /// marker, `pendingSessions`/`nextLaunchOnlyRecoveryIDs`) — a second,
+  /// independent decider of final disposal that Storage does not own and
+  /// should not make. **Storage does not import or call the coordinator**, so
+  /// the fix is NOT a new upward dependency here — it is simply not acting: on
+  /// failure this now ONLY returns `false`, and the CALLER's own existing
+  /// fallback (`RecordingSessionKernel`'s `prepareEscapeRecoveryIfNeeded`
+  /// already falls back to an ordinary destructive cancel, which reaches
+  /// `RecoveryCoordinator.handleRecordingEndedWithoutDurableSave` with a
+  /// `.cancelled` ending — `shouldDeleteOnLiveEnding` already returns `true`
+  /// for it) does the SAME thing this used to do directly, but through the
+  /// coordinator's now marker-aware destructor instead of around it. The
+  /// original reasoning for why failure discards the take, not why it used to
+  /// delete directly, still holds and is preserved below.
   ///
-  /// Best-effort cleanup: if the destroy also fails there is nothing further to
-  /// try, and the caller has already been told to treat this as a plain cancel.
+  /// A spool left behind with no readable marker would be replayed at the next
+  /// launch as an ordinary crash rescue, producing a PERMANENT History row for
+  /// a dictation the user cancelled. Given the choice between losing a take
+  /// the user asked to discard and keeping one they never agreed to keep, the
+  /// caller's fallback loses the take — exactly what today's destructive
+  /// cancel already does.
   public func prepareEscapeRecovery(
     recoverySessionID: String, triggeredAt: Date, takeID: String?
   ) -> Bool {
@@ -486,7 +507,6 @@ public struct RecoverySpoolStore: Sendable {
           recoverySessionID: recoverySessionID, triggeredAt: triggeredAt, takeID: takeID))
       return true
     } catch {
-      try? delete(recoverySessionID: recoverySessionID)
       return false
     }
   }

--- a/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
+++ b/Tests/EnviousWisprTests/Audio/AudioCaptureManagerSpoolPredecessorTests.swift
@@ -302,6 +302,126 @@ import Testing
           == false,
         "nothing was written for the starved take")
     }
+
+    // MARK: - 6. #1807 (§C) — `onRecoveryWriterQuiescent` ack firing
+
+    @Test(
+      "beginCapturePhase throwing before it ever reaches startRecoverySpooling still acks (round 2)"
+    )
+    func beginCapturePhaseThrowBeforeSpoolingStillAcks() async throws {
+      // No `startEnginePhase()` call, so `activeSource` is nil and
+      // `beginCapturePhase` throws before EVER reaching `startRecoverySpooling`
+      // — the exact gap Codex chunk-2 review round 2 found: a session that
+      // armed via `makeDirective` but whose capture-start failed before Audio
+      // ever spooled anything left its `pendingSessions` entry waiting on a
+      // writer ack that could never arrive from inside `startRecoverySpooling`
+      // itself (nothing in there ever runs).
+      let manager = AudioCaptureManager()
+      var acked: [String] = []
+      manager.onRecoveryWriterQuiescent = { acked.append($0) }
+
+      await #expect(throws: (any Error).self) {
+        _ = try await manager.beginCapturePhase(
+          recoverySessionID: "no-source-take", recoveryPayload: nil)
+      }
+
+      #expect(
+        acked == ["no-source-take"],
+        "beginCapturePhase's own defer must ack when it exits before startRecoverySpooling")
+    }
+
+    @Test("a decode failure fires the no-writer ack, using the separately-supplied id")
+    func decodeFailureFiresNoWriterAck() async throws {
+      let manager = AudioCaptureManager()
+      manager.installDiskSpaceCheckForTesting { _ in true }
+      var acked: [String] = []
+      manager.onRecoveryWriterQuiescent = { acked.append($0) }
+
+      manager.armRecoverySpoolingForTesting(
+        recoverySessionID: "undecodable-take", payload: Data([0xFF, 0x00, 0x01]))
+
+      #expect(manager.debugRecoverySpoolWriter == nil, "no writer is created on decode failure")
+      #expect(
+        acked == ["undecodable-take"],
+        "the ack must fire using the id supplied independently of the payload, since decoding it is what failed"
+      )
+    }
+
+    @Test("a disabled directive fires the no-writer ack")
+    func disabledDirectiveFiresNoWriterAck() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      manager.installDiskSpaceCheckForTesting { _ in true }
+      var acked: [String] = []
+      manager.onRecoveryWriterQuiescent = { acked.append($0) }
+      let directive = RecoverySpoolDirective(
+        enabled: false, recoverySessionID: "disabled-take",
+        spoolPath: dir.appendingPathComponent("disabled-take.\(RecoveryConstants.fileExtension)")
+          .path,
+        keyData: nil, settingsSnapshot: Self.snapshot())
+      let payload = try JSONEncoder().encode(directive)
+
+      manager.armRecoverySpoolingForTesting(recoverySessionID: "disabled-take", payload: payload)
+
+      #expect(manager.debugRecoverySpoolWriter == nil)
+      #expect(acked == ["disabled-take"])
+    }
+
+    @Test("a low-disk refusal fires the no-writer ack, using the decoded directive's own id")
+    func lowDiskRefusalFiresNoWriterAck() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      manager.installDiskSpaceCheckForTesting { _ in false }
+      var acked: [String] = []
+      manager.onRecoveryWriterQuiescent = { acked.append($0) }
+
+      manager.armRecoverySpoolingForTesting(
+        recoverySessionID: "starved-take",
+        payload: try Self.payload(sessionID: "starved-take", dir: dir))
+
+      #expect(manager.debugRecoverySpoolWriter == nil)
+      #expect(acked == ["starved-take"])
+    }
+
+    @Test(
+      "predecessor retirement acks the PREDECESSOR's id, never the successor's — closes the stale-completion hazard"
+    )
+    func predecessorRetirementAcksThePredecessorID() async throws {
+      let dir = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: dir) }
+      let manager = AudioCaptureManager()
+      manager.installDiskSpaceCheckForTesting { _ in true }
+      manager.isCapturing = true
+      var acked: [String] = []
+
+      manager.armRecoverySpoolingForTesting(
+        recoverySessionID: "predecessor",
+        payload: try Self.payload(sessionID: "predecessor", dir: dir))
+      #expect(acked.isEmpty, "the first arm alone must not ack anything yet")
+
+      let successorPayload = try Self.payload(sessionID: "successor", dir: dir)
+      // #1807 round-2 correction (Codex chunk-2 review, finding 5): the
+      // writer's own `finalize` completion (what `Self.drain` awaits) fires
+      // on the writer's write queue; the ACK fires from a SEPARATE MainActor
+      // task hop the `notifying:` adapter schedules on top of it (see
+      // `RecoverySpoolWriter.finalize(reason:notifying:)`). Draining the
+      // writer queue alone races that second hop. Wait on the ack ITSELF.
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        manager.onRecoveryWriterQuiescent = {
+          acked.append($0)
+          continuation.resume()
+        }
+        manager.armRecoverySpoolingForTesting(
+          recoverySessionID: "successor", payload: successorPayload)
+      }
+
+      #expect(
+        acked == ["predecessor"],
+        "retirement must ack the PREDECESSOR's captured id — never the successor's, and never twice"
+      )
+    }
   }
 
   /// Local stub for the teardown ingress above. Mirrors the stop-fence suite's

--- a/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/RecordingSessionKernelTests.swift
@@ -264,6 +264,28 @@ import Testing
       #expect(capturedIdentity == "asr.unrecognized_model_load_failure")
     }
 
+    // MARK: #1807 round 2 — a pre-Audio terminal still acknowledges recovery
+
+    /// `runForwardPath`'s `defer` (added for the recovery-key-safety-net fix,
+    /// issue #1807) must fire `recoveryCaptureDidNotStart` when the session
+    /// concludes BEFORE ever calling `beginCapturePhase` — a model-load
+    /// failure is exactly that shape. Without this, a session that armed
+    /// crash recovery but never reached Audio at all leaves its
+    /// `RecoveryCoordinator` protection entry waiting on a writer ack that
+    /// can now never arrive.
+    @Test("model-load failure acknowledges recovery without attempting capture")
+    func preAudioFailureAcknowledgesRecovery() async {
+      let (context, wrapper) = makeWrapper(
+        behavior: .failLoad(NSError(domain: "test", code: 1)))
+      wrapper.sessionConfigForTesting = .testDefault(recoverySessionID: "pre-audio-failure")
+
+      await apply(.start, to: wrapper, concluding: true)
+
+      #expect(wrapper.testKernel.recordingOutcome == .failed(.modelLoadFailed))
+      #expect(context.capture.beginCapturePhaseCallCount == 0)
+      #expect(context.capture.recoveryNotStartedIDs == ["pre-audio-failure"])
+    }
+
     // MARK: #959 — seam routing: ordinary terminal uses cheap cancel(), wedge uses recoverFromWedge()
 
     @Test("#959 an ordinary terminal routes through cheap cancel(), never recoverFromWedge()")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeAudioCapture.swift
@@ -53,6 +53,11 @@ final class FakeAudioCapture: AudioCaptureInterface {
   /// scheduling the cleanup would look identical to one that gated it.
   private(set) var stopCaptureRefusedCallCount = 0
   private(set) var beginCapturePhaseCallCount = 0
+  /// #1807 round 2 — every id `recoveryCaptureDidNotStart` was called with, in
+  /// order. Proves the kernel's own `runForwardPath` defer fires on a
+  /// pre-Audio terminal (a session that armed recovery but never reached
+  /// `beginCapturePhase` at all).
+  private(set) var recoveryNotStartedIDs: [String] = []
   private(set) var preWarmCallCount = 0
   private(set) var abortPreWarmCallCount = 0
   private(set) var deliveredBufferCount = 0
@@ -224,6 +229,11 @@ final class FakeAudioCapture: AudioCaptureInterface {
     if failEngineStartOnAttempt == startEnginePhaseCallCount {
       throw FakeCaptureError.engineStartFailed
     }
+  }
+
+  /// #1807 round 2 — `AudioCaptureInterface` conformance.
+  func recoveryCaptureDidNotStart(recoverySessionID: String) {
+    recoveryNotStartedIDs.append(recoverySessionID)
   }
 
   func beginCapturePhase(recoveryPayload: Data?) async throws -> AsyncStream<AVAudioPCMBuffer> {

--- a/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/ReadinessRetryTests.swift
@@ -495,7 +495,7 @@ struct ReadinessRetryTelemetryContractTests {
       let temp = h.spoolDir.appendingPathComponent(".\(h.id).readiness-retry.tmp")
       try Data([0x31]).write(to: temp)
 
-      try h.store.delete(recoverySessionID: h.id)
+      try h.store.cleanupSpoolSidecars(recoverySessionID: h.id)
 
       #expect(!h.store.hasReadinessRetryMarker(for: h.id), "no stale marker outlives its spool")
       #expect(

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -317,9 +317,101 @@ struct RecoveryCoordinatorTests {
     #expect(
       emitted.first(where: { $0.component == "spool" })?.succeeded == false,
       "a thrown spool delete reports failure")
+    // #1807 §D2: a real armed session writes its discard marker durably, so
+    // this is the decision table's RETAIN cell (marker committed, audio
+    // removal failed) — the key delete is never attempted, so no "key"
+    // event exists at all.
+    #expect(
+      emitted.first(where: { $0.component == "key" }) == nil,
+      "marker committed + audio removal failed retains the key: no key attempt, no key telemetry")
+  }
+
+  @Test(
+    "cleanup telemetry: key deletion is still attempted when the marker itself failed to persist (§D2 best-effort fallback)"
+  )
+  func cleanupTelemetryStillAttemptsKeyWhenMarkerFails() async throws {
+    struct InjectedDeleteFailure: Error {}
+    let h = Self.makeHarness()
+    let sink = CleanupSink()
+    h.coordinator.cleanupTelemetryForTesting = { source, component, ok in
+      sink.add(source, component, ok)
+    }
+    let id = try await Self.armRealSession(h)
+    try Self.writeSpool(h.spoolStore, id)
+    // Both audio removal AND the marker fail: with no durable discard
+    // evidence at all, §D2 falls back to today's existing behavior — still
+    // attempt the key delete best-effort, rather than leaving it retained
+    // with nothing on disk to explain why.
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
+    h.coordinator.destructionKeyDeleteForTesting = { _ in }
+    h.coordinator.destructionMarkerWriteForTesting = { _ in throw InjectedDeleteFailure() }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+
+    let emitted = sink.all
     #expect(
       emitted.first(where: { $0.component == "key" })?.succeeded == true,
-      "the key delete still ran and succeeded")
+      "no durable discard evidence exists: key delete still attempted and succeeds")
+  }
+
+  @Test(
+    "§D2 regression: the key-only sweep must not erase a retained key when the audio unlink succeeded but the directory sync did not"
+  )
+  func keyOnlySweepRespectsRetainedKey() async throws {
+    struct InjectedSyncFailure: Error {}
+    let h = Self.makeHarness()
+    let id = try await Self.armRealSession(h)
+    try Self.writeSpool(h.spoolStore, id)
+    // Simulate "unlink succeeded, directory sync did not": the file is
+    // genuinely gone from disk (so a fresh `listSpoolSessionIDs()` will not
+    // see it) but the operation as a whole still reports failure, exactly
+    // like a real `removeSpoolAudioDurably` whose `syncDirectory` throws
+    // after the file is already removed.
+    h.coordinator.destructionSpoolDeleteForTesting = { sessionID in
+      try FileManager.default.removeItem(at: h.spoolStore.spoolURL(for: sessionID))
+      throw InjectedSyncFailure()
+    }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+
+    // §D2 RETAIN cell: marker committed (real armed session), audio removal
+    // failed — key and marker both survive the destructor itself.
+    #expect((try? h.keyStore.retrieve(for: id)) != nil, "destructor retained the key")
+    #expect(h.spoolStore.hasDiscardMarker(for: id) != .absent, "destructor retained the marker")
+
+    // Now run the independent key-only sweep. The spool file is truly gone
+    // from disk, so without the marker check this sweep would read the key
+    // as an ordinary orphan and erase it out from under the retention the
+    // destructor just chose.
+    // Run the production key sweep alone: a simultaneous marker sweep could
+    // legitimately sync absence and retire the evidence before the key check.
+    await h.coordinator.startKeyOnlySweep().value
+
+    #expect(
+      (try? h.keyStore.retrieve(for: id)) != nil,
+      "the key-only sweep must defer to the marker, not treat a synced-away spool as a plain orphan"
+    )
+  }
+
+  @Test(
+    "§D2 regression: sidecar cleanup is skipped (not attempted) when audio removal itself failed, preserving the replay-once evidence"
+  )
+  func sidecarsSurviveAFailedAudioRemoval() async throws {
+    struct InjectedDeleteFailure: Error {}
+    let h = Self.makeHarness()
+    let id = try await Self.armRealSession(h)
+    try Self.writeSpool(h.spoolStore, id)
+    try h.spoolStore.writeAttemptMarker(for: id)
+    #expect(h.spoolStore.hasAttemptMarker(for: id))
+
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+
+    #expect(
+      h.spoolStore.hasAttemptMarker(for: id),
+      "audio removal failed: sidecar cleanup must not even attempt to run, or the last evidence a replay was already tried is lost"
+    )
   }
 
   // MARK: - #1740 launch-replay save failure deletes
@@ -1448,11 +1540,13 @@ struct RecoveryCoordinatorTests {
     var value: Int { lock.withLock { count } }
   }
 
-  // Best-effort deletion stays best-effort (no retries, no escapes); the ONLY
-  // new behavior is one failure breadcrumb per failed component per
-  // destruction call, with exact shape and a fixed source label.
+  // Best-effort deletion stays best-effort (no retries, no escapes). §D2
+  // changes what "best-effort" means for the key: a real armed session's
+  // discard marker commits durably, so a spool (audio) failure now lands on
+  // the RETAIN cell — the key delete is never even attempted — rather than
+  // running unconditionally as it did before chunk 4.
   @Test(
-    "live-ending destruction: 2×2 spool/key failure matrix emits exactly one breadcrumb per failed component",
+    "live-ending destruction: 2×2 spool/key failure matrix — key retained (not attempted) exactly when audio removal fails with a committed marker",
     arguments: [false, true], [false, true])
   func deletionFailureMatrix(spoolFails: Bool, keyFails: Bool) async throws {
     let harness = Self.makeHarness()
@@ -1485,29 +1579,34 @@ struct RecoveryCoordinatorTests {
     await unwrapped.value
 
     #expect(spoolAttempts.value == 1, "spool attempt exactly once")
-    #expect(keyAttempts.value == 1, "key attempt exactly once, even after spool failure")
-    let expectedCount = (spoolFails ? 1 : 0) + (keyFails ? 1 : 0)
-    #expect(log.crumbs.count == expectedCount, "exactly one breadcrumb per failed component")
+
     if spoolFails {
+      // §D2 RETAIN cell: a real armed session's marker commits durably, so a
+      // failed audio removal keeps the key rather than attempting its delete.
+      #expect(
+        keyAttempts.value == 0, "audio removal failed with a committed marker: key never attempted")
+      #expect(
+        log.crumbs.count == 1,
+        "only the spool failure breadcrumb — keyFails is moot, no attempt was made")
       #expect(
         log.crumbs.contains(
           Crumb(
             stage: "recovery", message: "deletion_failed",
             data: ["component": "spool", "source": "live_ending"])),
         "exact spool failure breadcrumb")
-    }
-    if keyFails {
+    } else {
+      #expect(keyAttempts.value == 1, "audio removal succeeded: key delete attempted normally")
+      let expectedCount = keyFails ? 1 : 0
       #expect(
-        log.crumbs.contains(
-          Crumb(
-            stage: "recovery", message: "deletion_failed",
-            data: ["component": "key", "source": "live_ending"])),
-        "exact key failure breadcrumb")
-    }
-    if spoolFails && keyFails {
-      #expect(
-        Set(log.crumbs.map { $0.data["component"] ?? "" }) == ["spool", "key"],
-        "both-fail cell: one spool + one key, no duplicate")
+        log.crumbs.count == expectedCount, "a breadcrumb only if the key delete itself failed")
+      if keyFails {
+        #expect(
+          log.crumbs.contains(
+            Crumb(
+              stage: "recovery", message: "deletion_failed",
+              data: ["component": "key", "source": "live_ending"])),
+          "exact key failure breadcrumb")
+      }
     }
   }
 

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -414,6 +414,30 @@ struct RecoveryCoordinatorTests {
     )
   }
 
+  @Test(
+    "cloud review PR #2717: RecoverySpoolStoreError's real errno survives telemetry bucketing, for all four cases"
+  )
+  func spoolStoreErrorsUnwrapToRealPosixCode() {
+    let cases: [(RecoverySpoolStoreError, Int32)] = [
+      (.attemptMarkerWriteFailed(EACCES), EACCES),
+      (.readinessRetryMarkerWriteFailed(ENOSPC), ENOSPC),
+      (.escapeMarkerWriteFailed(EISDIR), EISDIR),
+      (.discardMarkerWriteFailed(EIO), EIO),
+    ]
+    for (error, expectedErrno) in cases {
+      #expect(
+        RecoveryCoordinator.errorDomainBucket(for: error) == "posix",
+        "\(error) must bucket as posix, not fall through to 'other'")
+      #expect(
+        RecoveryCoordinator.errorCode(for: error) == Int(expectedErrno),
+        "\(error) must report the real errno \(expectedErrno), not a synthesized enum case code")
+    }
+    // Two-way control: an error with no special-cased unwrap still falls
+    // through to the ordinary bridged NSError reading, unchanged.
+    struct PlainError: Error {}
+    #expect(RecoveryCoordinator.errorDomainBucket(for: PlainError()) == "other")
+  }
+
   // MARK: - #1740 launch-replay save failure deletes
 
   @Test("launch-replay .failed(.save) destroys the spool AND the key")
@@ -938,7 +962,8 @@ struct RecoveryCoordinatorTests {
     await h.coordinator.scanAndRecover()
     await h.coordinator.awaitDiscardOperationsForTesting()
     #expect(h.replayer.replayedIDs.isEmpty)
-    #expect((try? h.keyStore.retrieve(for: id)) != nil,
+    #expect(
+      (try? h.keyStore.retrieve(for: id)) != nil,
       "a failed refresh cannot erase the proof from the prior successful commit")
     #expect(h.spoolStore.hasDiscardMarker(for: id) == .final)
   }

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -438,6 +438,37 @@ struct RecoveryCoordinatorTests {
     #expect(RecoveryCoordinator.errorDomainBucket(for: PlainError()) == "other")
   }
 
+  @Test(
+    "cloud review PR #2717: failing to WRITE the discard marker reports marker_persistence_failed, never deletion_failed"
+  )
+  func markerWriteFailureUsesItsOwnTelemetryEvent() async throws {
+    struct InjectedMarkerWriteFailure: Error {}
+    let h = Self.makeHarness()
+    let log = CrumbLog()
+    let id = try await Self.armRealSession(h)
+    try Self.writeSpool(h.spoolStore, id)
+    h.coordinator.destructionMarkerWriteForTesting = { _ in throw InjectedMarkerWriteFailure() }
+    h.coordinator.deletionFailureBreadcrumbForTesting = { stage, message, data in
+      log.crumbs.append(Crumb(stage: stage, message: message, data: data))
+    }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+
+    let crumbs = log.crumbs
+    #expect(
+      crumbs.contains(
+        Crumb(
+          stage: "recovery", message: "marker_persistence_failed",
+          data: ["component": "marker", "source": "history_save_failed"])),
+      "establishing evidence failed — the higher-severity event")
+    #expect(
+      !crumbs.contains(where: {
+        $0.message == "deletion_failed" && $0.data["component"] == "marker"
+      }),
+      "a write failure must never be reported as a delete failure — they mean very different things"
+    )
+  }
+
   // MARK: - #1740 launch-replay save failure deletes
 
   @Test("launch-replay .failed(.save) destroys the spool AND the key")

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -125,6 +125,21 @@ struct RecoveryCoordinatorTests {
     try Data([1, 2, 3]).write(to: store.spoolURL(for: id))
   }
 
+  /// #1807 (§C): real admission for destructor tests that predate the join.
+  /// `requestDisposal`/`acknowledgeWriterQuiescent` refuse to manufacture a
+  /// `pendingSessions` entry for an id they don't already recognize (round-2
+  /// correction, Codex chunk-2 review finding 2) — so every test that reaches
+  /// the join now needs a REAL admitted id, not an arbitrary unarmed one
+  /// (§11's test contract). Writes no spool/key itself; callers still do that
+  /// with the returned id, matching each test's own existing shape.
+  private static func armRealSession(_ h: Harness) async throws -> String {
+    try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false)
+    ).recoverySessionID
+  }
+
   // MARK: - Arm + durable save (PR1 behavior, unchanged)
 
   @Test("recovery off ⇒ no directive")
@@ -174,9 +189,11 @@ struct RecoveryCoordinatorTests {
   @Test("durable save deletes that session's spool + key")
   func durableSaveDeletes() async throws {
     let h = Self.makeHarness()
-    let id = "session-\(UUID().uuidString)"
+    // #1807 (§C): real admission — see `armRealSession`'s doc.
+    let id = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, id)
     try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
     await h.coordinator.handleDurableSave(recoverySessionID: id).value
     #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
@@ -187,9 +204,10 @@ struct RecoveryCoordinatorTests {
   @Test("live History-save failure destroys the spool AND the key")
   func historySaveFailureDestroysSpoolAndKey() async throws {
     let h = Self.makeHarness()
-    let id = "histsavefail-\(UUID().uuidString)"
+    let id = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, id)
     try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
     let task = h.coordinator.handleHistorySaveFailed(recoverySessionID: id)
     await task?.value
     #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
@@ -218,11 +236,12 @@ struct RecoveryCoordinatorTests {
   @Test("live History-save failure suppresses same-launch rediscovery even when delete throws")
   func historySaveFailureSuppressesBeforeDestroying() async throws {
     let h = Self.makeHarness()
-    let id = "suppress-\(UUID().uuidString)"
+    let id = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, id)
     struct InjectedDeleteFailure: Error {}
     h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
     h.coordinator.destructionKeyDeleteForTesting = { _ in }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
     await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
     // The spool survived the failed delete...
     #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
@@ -260,15 +279,15 @@ struct RecoveryCoordinatorTests {
     }
 
     // Spent attempt: the live History-save-failure path.
-    let spent = "tele-spent-\(UUID().uuidString)"
+    let spent = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, spent)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: spent)
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: spent)
     await h.coordinator.handleHistorySaveFailed(recoverySessionID: spent)?.value
 
     // NOT a spent attempt: an ordinary successful dictation.
-    let healthy = "tele-healthy-\(UUID().uuidString)"
+    let healthy = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, healthy)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: healthy)
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: healthy)
     await h.coordinator.handleDurableSave(recoverySessionID: healthy).value
 
     let emitted = sink.all
@@ -287,10 +306,11 @@ struct RecoveryCoordinatorTests {
     h.coordinator.cleanupTelemetryForTesting = { source, component, ok in
       sink.add(source, component, ok)
     }
-    let id = "tele-fail-\(UUID().uuidString)"
+    let id = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, id)
     h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
     h.coordinator.destructionKeyDeleteForTesting = { _ in }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
     await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
 
     let emitted = sink.all
@@ -332,9 +352,9 @@ struct RecoveryCoordinatorTests {
       .cancelled(.user(.cancelButton)), .cancelled(.systemOrFault),
     ]
     for ending in allEndings {
-      let id = "del-\(UUID().uuidString)"
+      let id = try await Self.armRealSession(h)
       try Self.writeSpool(h.spoolStore, id)
-      try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+      h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
       let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
         recoverySessionID: id, ending: ending)
       let unwrapped = try #require(task, "\(ending) must return the destruction work")
@@ -476,9 +496,9 @@ struct RecoveryCoordinatorTests {
   @Test("pre-start abort deletes the just-armed spool + key")
   func preStartAbortDeletes() async throws {
     let h = Self.makeHarness()
-    let id = "abort-\(UUID().uuidString)"
+    // #1807 (§C): real admission — see `armRealSession`'s doc.
+    let id = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, id)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
     await h.coordinator.handlePreStartAbort(recoverySessionID: id)?.value
     #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
@@ -488,6 +508,155 @@ struct RecoveryCoordinatorTests {
   func preStartAbortNoopWhenNil() {
     let h = Self.makeHarness()
     #expect(h.coordinator.handlePreStartAbort(recoverySessionID: nil) == nil)
+  }
+
+  // MARK: - #1807 (§C) — session-keyed protection + writer-completion join
+
+  /// The join's whole reason to exist: disposition alone must NOT destroy
+  /// anything until the writer also confirms it can never write again. Uses
+  /// REAL arming (`makeDirective`), not an arbitrary unarmed id — the test
+  /// contract §11 requires this.
+  @Test("disposition alone does not destroy — the writer's own ack is required too")
+  func dispositionAloneDoesNotDestroy() async throws {
+    let h = Self.makeHarness()
+    let armed = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let id = armed.recoverySessionID
+    try Self.writeSpool(h.spoolStore, id)
+
+    // Disposition arrives, but the writer has not acked yet.
+    let task = h.coordinator.handleDurableSave(recoverySessionID: id)
+    // Give any accidental synchronous destruction a chance to run before
+    // asserting it did not — a flaky pass here would hide a real defect.
+    await Task.yield()
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "disposition alone must not destroy — the writer has not confirmed quiescence")
+
+    // The writer confirms — NOW the join completes and cleanup runs.
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await task.value
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
+  /// The symmetric order: the writer's ack arrives FIRST, disposition second.
+  /// Cleanup must still fire exactly once, only after both halves land.
+  @Test("writer ack before disposition still joins correctly (order-independent)")
+  func writerAckBeforeDispositionStillJoins() async throws {
+    let h = Self.makeHarness()
+    let armed = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let id = armed.recoverySessionID
+    try Self.writeSpool(h.spoolStore, id)
+
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await Task.yield()
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "an ack with no disposition yet must not destroy anything")
+
+    await h.coordinator.handleDurableSave(recoverySessionID: id).value
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+  }
+
+  /// Two sessions arming close together (the overlapping-arms race, Codex Q5)
+  /// must BOTH stay protected — a single-slot `armedSessionID` could only
+  /// guard one of them.
+  @Test("two sessions arming close together both stay protected through the scan")
+  func overlappingArmsBothProtected() async throws {
+    let h = Self.makeHarness()
+    let first = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let second = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    #expect(first.recoverySessionID != second.recoverySessionID)
+    try Self.writeSpool(h.spoolStore, first.recoverySessionID)
+    try Self.writeSpool(h.spoolStore, second.recoverySessionID)
+
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "neither pending session is a scan-eligible orphan")
+    #expect(
+      FileManager.default.fileExists(
+        atPath: h.spoolStore.spoolURL(for: first.recoverySessionID).path),
+      "first arm's spool survives the scan")
+    #expect(
+      FileManager.default.fileExists(
+        atPath: h.spoolStore.spoolURL(for: second.recoverySessionID).path),
+      "second arm's spool survives the scan")
+  }
+
+  /// Two sessions arming close together, one fully disposed while the other
+  /// stays pending — proves per-session state does not cross-contaminate (the
+  /// central case §C exists for: a completion must resolve against the
+  /// session it belongs to, never "whichever session is current").
+  @Test("one session's completed join does not affect the other's pending protection")
+  func independentSessionsDoNotCrossContaminate() async throws {
+    let h = Self.makeHarness()
+    let a = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let b = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    try Self.writeSpool(h.spoolStore, a.recoverySessionID)
+    try Self.writeSpool(h.spoolStore, b.recoverySessionID)
+
+    // A completes fully (both halves land).
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: a.recoverySessionID)
+    await h.coordinator.handleDurableSave(recoverySessionID: a.recoverySessionID).value
+    #expect(
+      !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: a.recoverySessionID).path))
+
+    // B never received either half — still fully protected.
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "B is still pending, not a scan-eligible orphan")
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: b.recoverySessionID).path),
+      "B's spool must survive — A's completion must not have touched it")
+  }
+
+  /// A retain disposition (the future-proof branch in
+  /// `handleRecordingEndedWithoutDurableSave`) also joins on the writer's ack
+  /// before releasing protection — not just the destroy branch.
+  @Test("a retain disposition also waits for the writer ack before releasing protection")
+  func retainDispositionAlsoJoins() async throws {
+    let h = Self.makeHarness()
+    let armed = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let id = armed.recoverySessionID
+    try Self.writeSpool(h.spoolStore, id)
+
+    // Retain via `requestDisposal` directly (mirrors the currently-unreachable
+    // retain branch in `handleRecordingEndedWithoutDurableSave` — see
+    // `liveEndingPredicate` for why every real ending currently deletes).
+    let task = h.coordinator.requestDisposal(recoverySessionID: id, disposition: .retain)
+    await Task.yield()
+    // Still protected — the scan must not touch it while the join is pending.
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "a still-pending retain must not be scan-eligible")
+
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await task.value
+    // Retained, not destroyed — the spool and key are both untouched.
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+    // And now genuinely retired — a fresh scan treats it as an ordinary orphan.
+    h.replayer.outcomeByDefault = .recovered
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [id], "once retired, ordinary scan eligibility applies")
   }
 
   // MARK: - Launch scan + recover
@@ -605,9 +774,9 @@ struct RecoveryCoordinatorTests {
     // the launch/wake scan has nothing left to replay, which removes the
     // same-launch race population at the source instead of suppressing it.
     let h = Self.makeHarness()
-    let id = "live-fail-\(UUID().uuidString)"
+    let id = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, id)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
     let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
       recoverySessionID: id, ending: .failed)
     let unwrapped = try #require(task, ".failed now returns destruction work")
@@ -868,9 +1037,13 @@ struct RecoveryCoordinatorTests {
 
     // **cleanupArm, observed by its EFFECT**, since the seam discards the Task
     // the coordinator returns. The spool for an aborted arm must be gone.
-    let aborted = "aborted-\(UUID().uuidString)"
+    // #1807 (§C): reuses `armed.recoverySessionID` — the join now requires a
+    // REAL admitted id (`requestDisposal`/`acknowledgeWriterQuiescent` refuse
+    // to manufacture an entry for one they don't recognize, round-2
+    // correction, Codex chunk-2 review finding 2) — see `armRealSession`'s
+    // doc for the general pattern this test inlines against `armed` instead.
+    let aborted = armed.recoverySessionID
     try Self.writeSpool(h.spoolStore, aborted)
-    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: aborted)
     await access.cleanupArm(aborted)
     for _ in 0..<100_000
     where FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: aborted).path) {
@@ -1125,8 +1298,10 @@ struct RecoveryCoordinatorTests {
     }
 
     // Drive the REAL live-ending destruction route with a delete-class ending.
+    let matrixID = try await Self.armRealSession(harness)
+    coordinator.acknowledgeWriterQuiescent(recoverySessionID: matrixID)
     let task = coordinator.handleRecordingEndedWithoutDurableSave(
-      recoverySessionID: "matrix-\(spoolFails)-\(keyFails)", ending: .discarded)
+      recoverySessionID: matrixID, ending: .discarded)
     let unwrapped = try #require(task, "a delete-class ending must return the detached work")
     // Awaiting the destruction task IS the completion proof: the key attempt
     // increments inline and the key-failure breadcrumb's MainActor emission is
@@ -1187,8 +1362,17 @@ struct RecoveryCoordinatorTests {
     coordinator?.deletionFailureBreadcrumbForTesting = { stage, message, data in
       log.crumbs.append(Crumb(stage: stage, message: message, data: data))
     }
+    // #1807 (§C): real admission — see `armRealSession`'s doc. Armed directly
+    // against `coordinator` (not via the helper) since this test tracks it as
+    // a separately-nilled optional.
+    let lifetimeID = try #require(
+      await coordinator?.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false)
+    ).recoverySessionID
+    coordinator?.acknowledgeWriterQuiescent(recoverySessionID: lifetimeID)
     let task = try #require(coordinator).handleRecordingEndedWithoutDurableSave(
-      recoverySessionID: "lifetime", ending: .discarded)
+      recoverySessionID: lifetimeID, ending: .discarded)
     let unwrapped = try #require(task)
     await entry.wait()  // entry — resumes immediately if it already fired
     harness = nil
@@ -1205,145 +1389,159 @@ struct RecoveryCoordinatorTests {
       "the strong capture must deliver the breadcrumb after ownership release")
   }
 
-#if DEBUG
-  // MARK: - #1755 chunk 6 — crash-boundary hook lockstep (coordinator side)
+  #if DEBUG
+    // MARK: - #1755 chunk 6 — crash-boundary hook lockstep (coordinator side)
 
-  private static func makeBoundaryController() -> CrashBoundaryFaultController {
-    let dir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("ew-cb-coord-\(UUID().uuidString)", isDirectory: true)
-    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    return CrashBoundaryFaultController(
-      armFilePath: dir.appendingPathComponent("arm").path,
-      reachedFilePath: dir.appendingPathComponent("reached").path)
-  }
-
-  @Test("before_spool_delete fires before the spool attempt; release lets deletion proceed")
-  func beforeSpoolDeleteHook() async throws {
-    let h = Self.makeHarness()
-    let controller = Self.makeBoundaryController()
-    h.coordinator.crashBoundaryController = controller
-    defer { controller.clear() }
-    let spoolAttempted = AtomicCounter()
-    let attemptsAtBoundary = AtomicCounter()
-    h.coordinator.destructionSpoolDeleteForTesting = { _ in spoolAttempted.increment() }
-    h.coordinator.destructionKeyDeleteForTesting = { _ in }
-    controller.onPublishForTesting = { _ in
-      // Publication callback fires synchronously at the hook, BEFORE the
-      // spool attempt; record and release immediately (no polling).
-      for _ in 0..<spoolAttempted.value { attemptsAtBoundary.increment() }
-      controller.releaseHeldForTesting()
+    private static func makeBoundaryController() -> CrashBoundaryFaultController {
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ew-cb-coord-\(UUID().uuidString)", isDirectory: true)
+      try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      return CrashBoundaryFaultController(
+        armFilePath: dir.appendingPathComponent("arm").path,
+        reachedFilePath: dir.appendingPathComponent("reached").path)
     }
-    #expect(controller.arm(trialID: "cb1", boundary: .beforeSpoolDelete))
 
-    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
-      recoverySessionID: "cb-spool", ending: .failed)
-    let unwrapped = try #require(task)
-    await unwrapped.value
-
-    #expect(controller.isReached(trialID: "cb1", boundary: .beforeSpoolDelete))
-    #expect(attemptsAtBoundary.value == 0, "the boundary sits BEFORE the spool attempt")
-    #expect(spoolAttempted.value == 1, "release lets the real attempt proceed")
-  }
-
-  @Test("before_key_delete fires inside the detached task before the key attempt")
-  func beforeKeyDeleteHook() async throws {
-    let h = Self.makeHarness()
-    let controller = Self.makeBoundaryController()
-    h.coordinator.crashBoundaryController = controller
-    defer { controller.clear() }
-    let keyAttempted = AtomicCounter()
-    let attemptsAtBoundary = AtomicCounter()
-    h.coordinator.destructionSpoolDeleteForTesting = { _ in }
-    h.coordinator.destructionKeyDeleteForTesting = { _ in keyAttempted.increment() }
-    controller.onPublishForTesting = { _ in
-      for _ in 0..<keyAttempted.value { attemptsAtBoundary.increment() }
-      controller.releaseHeldForTesting()
-    }
-    #expect(controller.arm(trialID: "cb2", boundary: .beforeKeyDelete))
-
-    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
-      recoverySessionID: "cb-key", ending: .failed)
-    let unwrapped = try #require(task)
-    await unwrapped.value
-
-    #expect(controller.isReached(trialID: "cb2", boundary: .beforeKeyDelete))
-    #expect(attemptsAtBoundary.value == 0, "the boundary sits BEFORE the key attempt")
-    #expect(keyAttempted.value == 1, "release lets the real attempt proceed")
-  }
-
-  @Test("destruction_api_return: key deletion gated across the API return; caller hook publishes after")
-  func destructionAPIReturnHookOrdering() async throws {
-    let h = Self.makeHarness()
-    let controller = Self.makeBoundaryController()
-    h.coordinator.crashBoundaryController = controller
-    defer { controller.clear() }
-    let keyAttempted = AtomicCounter()
-    h.coordinator.destructionSpoolDeleteForTesting = { _ in }
-    // The key-delete seam SIGNALS entry so the gated schedule is provable
-    // without any polling: the gate parks BEFORE the seam runs, so entry
-    // never fires while gated.
-    let keyEntered = OneShotSignal()
-    h.coordinator.destructionKeyDeleteForTesting = { _ in
-      keyAttempted.increment()
-      keyEntered.signal()
-    }
-    // Observe the real detached key path REACHING the gate — `keyAttempted ==
-    // 0` alone could mean the detached task simply has not started yet.
-    let gateDecision = OneShotSignal()
-    let gateDecisionLock = NSLock()
-    nonisolated(unsafe) var keyWasGated: Bool?
-    controller.onKeyDeleteGateDecisionForTesting = { decision in
-      gateDecisionLock.withLock {
-        if keyWasGated == nil { keyWasGated = decision }
+    @Test("before_spool_delete fires before the spool attempt; release lets deletion proceed")
+    func beforeSpoolDeleteHook() async throws {
+      let h = Self.makeHarness()
+      let controller = Self.makeBoundaryController()
+      h.coordinator.crashBoundaryController = controller
+      defer { controller.clear() }
+      let spoolAttempted = AtomicCounter()
+      let attemptsAtBoundary = AtomicCounter()
+      h.coordinator.destructionSpoolDeleteForTesting = { _ in spoolAttempted.increment() }
+      h.coordinator.destructionKeyDeleteForTesting = { _ in }
+      controller.onPublishForTesting = { _ in
+        // Publication callback fires synchronously at the hook, BEFORE the
+        // spool attempt; record and release immediately (no polling).
+        for _ in 0..<spoolAttempted.value { attemptsAtBoundary.increment() }
+        controller.releaseHeldForTesting()
       }
-      gateDecision.signal()
+      #expect(controller.arm(trialID: "cb1", boundary: .beforeSpoolDelete))
+
+      // #1807 (§C): real admission — see `armRealSession`'s doc.
+      let cbSpoolID = try await Self.armRealSession(h)
+      h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: cbSpoolID)
+      let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: cbSpoolID, ending: .failed)
+      let unwrapped = try #require(task)
+      await unwrapped.value
+
+      #expect(controller.isReached(trialID: "cb1", boundary: .beforeSpoolDelete))
+      #expect(attemptsAtBoundary.value == 0, "the boundary sits BEFORE the spool attempt")
+      #expect(spoolAttempted.value == 1, "release lets the real attempt proceed")
     }
-    #expect(controller.arm(trialID: "cb3", boundary: .destructionAPIReturn))
 
-    // The API must return while the key path is gated.
-    let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
-      recoverySessionID: "cb-api", ending: .failed)
-    let unwrapped = try #require(task, "the API returned while the key path is gated")
-    await gateDecision.wait()
-    #expect(
-      gateDecisionLock.withLock { keyWasGated } == true,
-      "the real detached key path reached the API-return gate")
-    #expect(keyAttempted.value == 0, "key deletion has not passed its pre-point")
-    #expect(
-      !controller.isReached(trialID: "cb3", boundary: .destructionAPIReturn),
-      "gating alone must not publish")
+    @Test("before_key_delete fires inside the detached task before the key attempt")
+    func beforeKeyDeleteHook() async throws {
+      let h = Self.makeHarness()
+      let controller = Self.makeBoundaryController()
+      h.coordinator.crashBoundaryController = controller
+      defer { controller.clear() }
+      let keyAttempted = AtomicCounter()
+      let attemptsAtBoundary = AtomicCounter()
+      h.coordinator.destructionSpoolDeleteForTesting = { _ in }
+      h.coordinator.destructionKeyDeleteForTesting = { _ in keyAttempted.increment() }
+      controller.onPublishForTesting = { _ in
+        for _ in 0..<keyAttempted.value { attemptsAtBoundary.increment() }
+        controller.releaseHeldForTesting()
+      }
+      #expect(controller.arm(trialID: "cb2", boundary: .beforeKeyDelete))
 
-    // The caller-side hook (what DictationRuntime's closure runs after the
-    // API returns) publishes and parks on a background thread; its
-    // publication callback releases every hold, freeing the gated key path.
-    let published = OneShotSignal()
-    controller.onPublishForTesting = { _ in
-      controller.releaseHeldForTesting()
-      published.signal()
+      // #1807 (§C): real admission — see `armRealSession`'s doc.
+      let cbKeyID = try await Self.armRealSession(h)
+      h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: cbKeyID)
+      let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: cbKeyID, ending: .failed)
+      let unwrapped = try #require(task)
+      await unwrapped.value
+
+      #expect(controller.isReached(trialID: "cb2", boundary: .beforeKeyDelete))
+      #expect(attemptsAtBoundary.value == 0, "the boundary sits BEFORE the key attempt")
+      #expect(keyAttempted.value == 1, "release lets the real attempt proceed")
     }
-    let callerDone = OneShotSignal()
-    Thread.detachNewThread {
-      controller.boundaryReached(.destructionAPIReturn)
-      callerDone.signal()
+
+    @Test(
+      "destruction_api_return: key deletion gated across the API return; caller hook publishes after"
+    )
+    func destructionAPIReturnHookOrdering() async throws {
+      let h = Self.makeHarness()
+      let controller = Self.makeBoundaryController()
+      h.coordinator.crashBoundaryController = controller
+      defer { controller.clear() }
+      let keyAttempted = AtomicCounter()
+      h.coordinator.destructionSpoolDeleteForTesting = { _ in }
+      // The key-delete seam SIGNALS entry so the gated schedule is provable
+      // without any polling: the gate parks BEFORE the seam runs, so entry
+      // never fires while gated.
+      let keyEntered = OneShotSignal()
+      h.coordinator.destructionKeyDeleteForTesting = { _ in
+        keyAttempted.increment()
+        keyEntered.signal()
+      }
+      // Observe the real detached key path REACHING the gate — `keyAttempted ==
+      // 0` alone could mean the detached task simply has not started yet.
+      let gateDecision = OneShotSignal()
+      let gateDecisionLock = NSLock()
+      nonisolated(unsafe) var keyWasGated: Bool?
+      controller.onKeyDeleteGateDecisionForTesting = { decision in
+        gateDecisionLock.withLock {
+          if keyWasGated == nil { keyWasGated = decision }
+        }
+        gateDecision.signal()
+      }
+      #expect(controller.arm(trialID: "cb3", boundary: .destructionAPIReturn))
+
+      // #1807 (§C): real admission — see `armRealSession`'s doc.
+      let cbAPIID = try await Self.armRealSession(h)
+      h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: cbAPIID)
+      // The API must return while the key path is gated.
+      let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
+        recoverySessionID: cbAPIID, ending: .failed)
+      let unwrapped = try #require(task, "the API returned while the key path is gated")
+      await gateDecision.wait()
+      #expect(
+        gateDecisionLock.withLock { keyWasGated } == true,
+        "the real detached key path reached the API-return gate")
+      #expect(keyAttempted.value == 0, "key deletion has not passed its pre-point")
+      #expect(
+        !controller.isReached(trialID: "cb3", boundary: .destructionAPIReturn),
+        "gating alone must not publish")
+
+      // The caller-side hook (what DictationRuntime's closure runs after the
+      // API returns) publishes and parks on a background thread; its
+      // publication callback releases every hold, freeing the gated key path.
+      let published = OneShotSignal()
+      controller.onPublishForTesting = { _ in
+        controller.releaseHeldForTesting()
+        published.signal()
+      }
+      let callerDone = OneShotSignal()
+      Thread.detachNewThread {
+        controller.boundaryReached(.destructionAPIReturn)
+        callerDone.signal()
+      }
+      await published.wait()
+      await callerDone.wait()
+      await keyEntered.wait()
+      await unwrapped.value
+      #expect(controller.isReached(trialID: "cb3", boundary: .destructionAPIReturn))
+      #expect(keyAttempted.value == 1, "the gated key deletion completed after release")
     }
-    await published.wait()
-    await callerDone.wait()
-    await keyEntered.wait()
-    await unwrapped.value
-    #expect(controller.isReached(trialID: "cb3", boundary: .destructionAPIReturn))
-    #expect(keyAttempted.value == 1, "the gated key deletion completed after release")
-  }
 
-#endif
+  #endif
 
-  @Test("a FAILED live-ending spool delete is suppressed from the same-launch rescan (PR #1761 cloud P2)")
+  @Test(
+    "a FAILED live-ending spool delete is suppressed from the same-launch rescan (PR #1761 cloud P2)"
+  )
   func failedLiveDeleteSuppressedSameLaunch() async throws {
     let h = Self.makeHarness()
     struct InjectedDeleteFailure: Error {}
     h.coordinator.destructionSpoolDeleteForTesting = { _ in throw InjectedDeleteFailure() }
     h.coordinator.destructionKeyDeleteForTesting = { _ in }
-    let id = "suppress-\(UUID().uuidString)"
+    let id = try await Self.armRealSession(h)
     try Self.writeSpool(h.spoolStore, id)
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
     let task = h.coordinator.handleRecordingEndedWithoutDurableSave(
       recoverySessionID: id, ending: .failed)
     let unwrapped = try #require(task)

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -921,6 +921,55 @@ struct RecoveryCoordinatorTests {
     await disposal.value
   }
 
+  @Test("a cleanup retry preserves a previously committed discard decision")
+  func retryKeepsPreviouslyCommittedEvidence() async throws {
+    struct UnlinkFailure: Error {}
+    struct MarkerRewriteFailure: Error {}
+    let h = Self.makeHarness()
+    let id = try await Self.armRealSession(h)
+    try Self.writeSpool(h.spoolStore, id)
+    h.coordinator.destructionSpoolDeleteForTesting = { _ in throw UnlinkFailure() }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+    #expect(h.spoolStore.hasDiscardMarker(for: id) == .final)
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+
+    h.coordinator.destructionMarkerWriteForTesting = { _ in throw MarkerRewriteFailure() }
+    await h.coordinator.scanAndRecover()
+    await h.coordinator.awaitDiscardOperationsForTesting()
+    #expect(h.replayer.replayedIDs.isEmpty)
+    #expect((try? h.keyStore.retrieve(for: id)) != nil,
+      "a failed refresh cannot erase the proof from the prior successful commit")
+    #expect(h.spoolStore.hasDiscardMarker(for: id) == .final)
+  }
+
+  @Test("marker-only retry completes cleanup of sidecars retained after failed audio sync")
+  func markerOnlyRetryFinishesRetainedSidecars() async throws {
+    struct SyncFailure: Error {}
+    let h = Self.makeHarness()
+    let id = try await Self.armRealSession(h)
+    try Self.writeSpool(h.spoolStore, id)
+    try h.spoolStore.writeAttemptMarker(for: id)
+    h.coordinator.destructionSpoolDeleteForTesting = { sessionID in
+      try FileManager.default.removeItem(at: h.spoolStore.spoolURL(for: sessionID))
+      throw SyncFailure()
+    }
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await h.coordinator.handleHistorySaveFailed(recoverySessionID: id)?.value
+    #expect(try h.spoolStore.listSpoolSessionIDs().isEmpty)
+    #expect(h.spoolStore.hasAttemptMarker(for: id))
+    #expect(h.spoolStore.hasDiscardMarker(for: id) == .final)
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+
+    h.coordinator.destructionSpoolDeleteForTesting = nil
+    await h.coordinator.scanAndRecover()
+    await (try #require(h.coordinator.markerSweepForTesting)).value
+    #expect(!h.spoolStore.hasAttemptMarker(for: id))
+    #expect(h.spoolStore.hasDiscardMarker(for: id) == .absent)
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+    #expect(h.replayer.replayedIDs.isEmpty)
+  }
+
   // MARK: - Launch scan + recover
 
   @Test("scan replays every recoverable orphan, gate ends cleared")

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -448,6 +448,17 @@ struct RecoveryCoordinatorTests {
     }
   }
 
+  /// #1807 round-2 (Codex chunk-3 review, finding 1): `destroySpoolAndKey`'s
+  /// spool delete is no longer synchronous with its caller — it now waits for
+  /// marker persistence to settle FIRST (crash-safety: the marker must be
+  /// durable before a destructive delete that might fail partway). Same poll
+  /// idiom as `awaitKeyDeleted`.
+  private static func awaitSpoolGone(_ store: RecoverySpoolStore, id: String) async {
+    for _ in 0..<200 where FileManager.default.fileExists(atPath: store.spoolURL(for: id).path) {
+      try? await Task.sleep(for: .milliseconds(5))  // settle: poll interval; loop cond is the signal
+    }
+  }
+
   @Test("the coordinator deletes the spool + key after a .recovered replay")
   func recoveredReplayDeletes() async throws {
     let h = Self.makeHarness()
@@ -659,6 +670,165 @@ struct RecoveryCoordinatorTests {
     #expect(h.replayer.replayedIDs == [id], "once retired, ordinary scan eligibility applies")
   }
 
+  // MARK: - #1807 (§D1) — durable discard marker: write, read, restart cleanup
+
+  private static func awaitMarker(
+    _ store: RecoverySpoolStore, id: String, expected: DiscardMarkerState
+  ) async {
+    for _ in 0..<200 where store.hasDiscardMarker(for: id) != expected {
+      try? await Task.sleep(for: .milliseconds(5))  // settle: poll interval; loop cond is the signal
+    }
+  }
+
+  @Test("a real disposal writes the discard marker, independently of the writer-quiescence join")
+  func disposalWritesDiscardMarker() async throws {
+    let h = Self.makeHarness()
+    let armed = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let id = armed.recoverySessionID
+    try Self.writeSpool(h.spoolStore, id)
+
+    // Disposition arrives, but the writer has NOT acked yet — marker
+    // persistence must still begin (§D2's ordering item 2, inherited by §D1:
+    // "marker persistence begins as soon as final disposition arrives").
+    let task = h.coordinator.requestDisposal(
+      recoverySessionID: id, disposition: .destroy(.durableSave))
+    await Self.awaitMarker(h.spoolStore, id: id, expected: .final)
+    #expect(h.spoolStore.hasDiscardMarker(for: id) == .final)
+
+    // Join still completes normally afterward.
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await task.value
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+  }
+
+  @Test("a .retain disposition never writes a discard marker")
+  func retainDispositionWritesNoMarker() async throws {
+    let h = Self.makeHarness()
+    let armed = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let id = armed.recoverySessionID
+    try Self.writeSpool(h.spoolStore, id)
+
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await h.coordinator.requestDisposal(recoverySessionID: id, disposition: .retain).value
+
+    #expect(
+      h.spoolStore.hasDiscardMarker(for: id) == .absent,
+      "a marker means \"never replay\" — the opposite of retaining for a future launch")
+  }
+
+  @Test("scan excludes a .final-marked spool from replay and retries cleanup, not a fresh decision")
+  func scanRetriesAMarkedForDiscardSurvivor() async throws {
+    let h = Self.makeHarness()
+    let id = "marked-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    try h.spoolStore.writeDiscardMarker(for: id)
+
+    await h.coordinator.scanAndRecover()
+
+    #expect(h.replayer.replayedIDs.isEmpty, "a committed discard decision vetoes replay")
+    await Self.awaitKeyDeleted(h.keyStore, id: id)
+    #expect(
+      !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "the retry actually deletes — this is cleanup, not a stall")
+  }
+
+  @Test("scan excludes an .interruptedTemp-marked spool from replay too")
+  func scanRetriesAnInterruptedMarkerSurvivor() async throws {
+    let h = Self.makeHarness()
+    let id = "interrupted-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    let tmp = h.spoolStore.directoryURL.appendingPathComponent(
+      ".\(id).\(RecoveryConstants.discardMarkerFileExtension).tmp")
+    try Data([0x31]).write(to: tmp)
+
+    await h.coordinator.scanAndRecover()
+
+    #expect(
+      h.replayer.replayedIDs.isEmpty,
+      "an interrupted marker write is evidence of a committed decision, not absence of one")
+    await Self.awaitKeyDeleted(h.keyStore, id: id)
+  }
+
+  @Test("an unreadable discard marker defers a listed spool without deleting it")
+  func unreadableDiscardMarkerDefersRealCandidate() async throws {
+    let h = Self.makeHarness()
+    let id = "unreadable-marker"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    let marker = h.spoolStore.directoryURL.appendingPathComponent("\(id).discard")
+    try FileManager.default.createSymbolicLink(
+      atPath: marker.path, withDestinationPath: marker.lastPathComponent)
+    #expect(try h.spoolStore.listSpoolSessionIDs().contains(id))
+    #expect(h.spoolStore.hasDiscardMarker(for: id) == .unreadable)
+    await h.coordinator.scanAndRecover()
+    await (try #require(h.coordinator.markerSweepForTesting)).value
+    #expect(h.replayer.replayedIDs.isEmpty)
+    #expect(try h.spoolStore.listSpoolSessionIDs().contains(id))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+  }
+
+  @Test("a genuine unmarked crash-orphan still reaches recovery (positive control)")
+  func unmarkedOrphanStillReplays() async throws {
+    let h = Self.makeHarness()
+    let id = "unmarked-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    h.replayer.outcomeByDefault = .recovered
+
+    await h.coordinator.scanAndRecover()
+
+    #expect(
+      h.replayer.replayedIDs == [id],
+      "the marker veto must not accidentally block ordinary recovery")
+  }
+
+  @Test("marker-only-survivor sweep retires an orphaned marker with no matching spool")
+  func markerOnlySurvivorSweepRetires() async throws {
+    let h = Self.makeHarness()
+    let id = "orphan-marker-\(UUID().uuidString)"
+    try h.spoolStore.writeDiscardMarker(for: id)
+    // No `.ewrec` file for this id at all — a marker-only survivor.
+
+    await h.coordinator.scanAndRecover()
+    await (try #require(h.coordinator.markerSweepForTesting)).value
+
+    #expect(h.spoolStore.hasDiscardMarker(for: id) == .absent)
+  }
+
+  @Test(
+    "marker-only-survivor sweep SKIPS a session still pending in this launch (lifetime gate)")
+  func markerOnlySurvivorSweepRespectsLifetimeGate() async throws {
+    let h = Self.makeHarness()
+    let armed = try #require(
+      await h.coordinator.makeDirective(
+        settings: Self.freshSettings(crashRecoveryEnabled: true),
+        backendType: .parakeet, supportsLanguageDetection: false))
+    let id = armed.recoverySessionID
+    // Disposition arrives (marker-write begins) but the writer never acks —
+    // this session stays in `pendingSessions` indefinitely, exactly the
+    // "pending writer, marker maybe written, no .ewrec yet" case the lifetime
+    // gate exists to distinguish from a genuine survivor.
+    let disposal = h.coordinator.requestDisposal(
+      recoverySessionID: id, disposition: .destroy(.durableSave))
+    await Self.awaitMarker(h.spoolStore, id: id, expected: .final)
+
+    await h.coordinator.scanAndRecover()
+    await (try #require(h.coordinator.markerSweepForTesting)).value
+
+    #expect(
+      h.spoolStore.hasDiscardMarker(for: id) == .final,
+      "still pending in this launch — the sweep must not touch it")
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await disposal.value
+  }
+
   // MARK: - Launch scan + recover
 
   @Test("scan replays every recoverable orphan, gate ends cleared")
@@ -690,6 +860,9 @@ struct RecoveryCoordinatorTests {
     try Self.writeSpool(h.spoolStore, fresh)
     await h.coordinator.scanAndRecover()
     #expect(h.replayer.replayedIDs == [fresh], "saved id deduped, not replayed")
+    // #1807 round-2: the delete now waits for marker persistence first (not
+    // synchronous with `scanAndRecover()` returning) — poll for it.
+    await Self.awaitSpoolGone(h.spoolStore, id: saved)
     #expect(
       !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: saved).path),
       "deduped orphan deleted")
@@ -1094,6 +1267,9 @@ struct RecoveryCoordinatorTests {
     #expect(h.replayer.abortedSeen == [true], "isAborted read true after Discard bumped generation")
     #expect(!h.coordinator.isRecovering, "gate cleared")
     #expect(h.resetEngineCount.value == 1, "Discard hard-reset the shared engine")
+    // #1807 round-2: the delete now waits for marker persistence first (not
+    // synchronous with `scanAndRecover()` returning) — poll for it.
+    await Self.awaitSpoolGone(h.spoolStore, id: id)
     #expect(
       !FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
       "Discard deleted the orphan the user was waiting on")

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -530,4 +530,96 @@ struct RecoverySpoolStoreTests {
       as? NSNumber
     #expect(mode?.int16Value == 0o600, "owner-only, matching the attempt marker and the spool")
   }
+
+  // MARK: - Discard marker (#1807 §D1)
+
+  @Test("discard marker: absent before any write")
+  func discardMarkerAbsentInitially() throws {
+    let store = makeStore()
+    #expect(store.hasDiscardMarker(for: "never-written") == .absent)
+  }
+
+  @Test("discard marker: write makes it .final, and 0600, and never listed as a spool")
+  func discardMarkerWriteReadsAsFinal() throws {
+    let store = makeStore()
+    try store.writeDiscardMarker(for: "committed")
+
+    #expect(store.hasDiscardMarker(for: "committed") == .final)
+    #expect(try store.listSpoolSessionIDs().isEmpty, "scan lists only .ewrec spools")
+
+    let url = store.directoryURL.appendingPathComponent(
+      "committed.\(RecoveryConstants.discardMarkerFileExtension)")
+    let mode =
+      try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+    #expect(mode?.int16Value == 0o600, "owner-only, matching the rest of the marker family")
+  }
+
+  /// The exact `fileExists`-boolean mistake §A already fixed once in this
+  /// file, checked again for the new marker: an interrupted write is
+  /// EVIDENCE of a committed decision, not absence of one.
+  @Test("discard marker: an interrupted write reads as .interruptedTemp, never .absent")
+  func interruptedDiscardMarkerWriteIsNotAbsence() throws {
+    let store = makeStore()
+    let tmp = store.directoryURL.appendingPathComponent(
+      ".interrupted.\(RecoveryConstants.discardMarkerFileExtension).tmp")
+    try Data([0x31]).write(to: tmp)
+
+    #expect(
+      store.hasDiscardMarker(for: "interrupted") == .interruptedTemp,
+      ".absent would let a committed discard decision replay")
+  }
+
+  /// The two-way control: an unreadable final path must defer, never collapse
+  /// into `.absent` (which would replay) NOR into `.final` (which would
+  /// silently discard a spool nobody actually decided to discard).
+  @Test("discard marker: a directory the read cannot access reads as .unreadable, not .absent")
+  func unreadableDiscardMarkerDefersRatherThanAssumingAbsence() throws {
+    let store = makeStore()
+    // A path pointing INTO a component that is not a directory makes any
+    // `open()` on it fail with something other than ENOENT (ENOTDIR) — a
+    // deterministic, real "cannot tell" case, not a permission-mocking seam.
+    let blocker = store.directoryURL.appendingPathComponent("blocker")
+    try Data([0]).write(to: blocker)
+    let blockedStore = RecoverySpoolStore(directory: blocker)
+
+    #expect(blockedStore.hasDiscardMarker(for: "anything") == .unreadable)
+  }
+
+  @Test("discard marker: delete is idempotent and clears an interrupted write too")
+  func discardMarkerDeleteIsIdempotentAndClearsTemp() throws {
+    let store = makeStore()
+    try store.writeDiscardMarker(for: "a")
+    try store.deleteDiscardMarker(for: "a")
+    #expect(store.hasDiscardMarker(for: "a") == .absent)
+    // Idempotent — deleting an already-absent marker does not throw.
+    try store.deleteDiscardMarker(for: "a")
+
+    let tmp = store.directoryURL.appendingPathComponent(
+      ".stale.\(RecoveryConstants.discardMarkerFileExtension).tmp")
+    try Data([0x31]).write(to: tmp)
+    try store.deleteDiscardMarker(for: "stale")
+    #expect(!FileManager.default.fileExists(atPath: tmp.path))
+    #expect(store.hasDiscardMarker(for: "stale") == .absent)
+  }
+
+  @Test("discard marker: listDiscardMarkerSessionIDs finds both final and interrupted-temp markers")
+  func listDiscardMarkerSessionIDsFindsBoth() throws {
+    let store = makeStore()
+    try store.writeDiscardMarker(for: "final-one")
+    let tmp = store.directoryURL.appendingPathComponent(
+      ".temp-one.\(RecoveryConstants.discardMarkerFileExtension).tmp")
+    try Data([0x31]).write(to: tmp)
+    // A real spool must never be mistaken for a discard marker by the list.
+    try Data([1, 2, 3]).write(to: store.spoolURL(for: "unrelated-spool"))
+
+    let ids = try store.listDiscardMarkerSessionIDs()
+
+    #expect(Set(ids) == ["final-one", "temp-one"])
+  }
+
+  @Test("discard marker: an empty directory lists no markers")
+  func listDiscardMarkerSessionIDsEmptyWhenNone() throws {
+    let store = makeStore()
+    #expect(try store.listDiscardMarkerSessionIDs().isEmpty)
+  }
 }

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -232,10 +232,12 @@ struct RecoverySpoolStoreTests {
       reason: .cleanFinalized)
 
     #expect(try store.listSpoolSessionIDs() == ["alpha", "beta"])
-    try store.delete(recoverySessionID: "alpha")
+    try store.removeSpoolAudioDurably(recoverySessionID: "alpha")
+    try store.cleanupSpoolSidecars(recoverySessionID: "alpha")
     #expect(try store.listSpoolSessionIDs() == ["beta"])
     // Idempotent: deleting a missing spool is success.
-    try store.delete(recoverySessionID: "alpha")
+    try store.removeSpoolAudioDurably(recoverySessionID: "alpha")
+    try store.cleanupSpoolSidecars(recoverySessionID: "alpha")
   }
 
   // MARK: - One-attempt marker (#1063 PR2; broader meaning since #1740)
@@ -261,7 +263,8 @@ struct RecoverySpoolStoreTests {
       store: store, sessionID: "gamma", cipher: cipher, chunks: [[0.3]], reason: .cleanFinalized)
     try store.writeAttemptMarker(for: "gamma")
     #expect(store.hasAttemptMarker(for: "gamma"))
-    try store.delete(recoverySessionID: "gamma")
+    try store.removeSpoolAudioDurably(recoverySessionID: "gamma")
+    try store.cleanupSpoolSidecars(recoverySessionID: "gamma")
     #expect(!store.hasAttemptMarker(for: "gamma"), "spool delete cleared the marker")
     #expect(try store.listSpoolSessionIDs() == [])
   }
@@ -361,7 +364,8 @@ struct RecoverySpoolStoreTests {
 
     // A marker outliving its spool would tell the next launch that audio which
     // no longer exists was an escape recovery.
-    try store.delete(recoverySessionID: "delta")
+    try store.removeSpoolAudioDurably(recoverySessionID: "delta")
+    try store.cleanupSpoolSidecars(recoverySessionID: "delta")
     #expect(store.readEscapeMarker(for: "delta") == .absent, "spool delete cleared the marker")
 
     // Idempotent — a missing marker is success, not an error.
@@ -398,7 +402,7 @@ struct RecoverySpoolStoreTests {
       EscapeRecoveryMarker(recoverySessionID: id, triggeredAt: Date()))
 
     var threw = false
-    do { try store.delete(recoverySessionID: id) } catch { threw = true }
+    do { try store.cleanupSpoolSidecars(recoverySessionID: id) } catch { threw = true }
 
     #expect(threw, "the failure must surface, not be swallowed")
     #expect(
@@ -434,8 +438,16 @@ struct RecoverySpoolStoreTests {
   /// producing a PERMANENT History row for a dictation the user cancelled. So the
   /// failure path must also DESTROY the spool — which costs the user exactly what
   /// pressing cancel already costs them, and is what the caller falls back to.
-  @Test("prepare fails: returns false AND destroys the spool, leaving nothing to replay")
+  @Test(
+    "prepare fails: returns false and leaves the spool for the CALLER's own destructive-cancel fallback"
+  )
   func prepareEscapeRecoveryFailsClosed() async throws {
+    // #1807 (§D2): this used to destroy the spool directly here — a second,
+    // Storage-owned decider of final disposal, bypassing the coordinator's
+    // writer-quiescence join and discard marker entirely. `false` now means
+    // exactly what it always documented: "the caller performs today's
+    // ordinary destructive cancel" — which is `RecoveryCoordinator`'s own
+    // marker-aware destructor, not a duplicate one living here.
     let store = makeStore()
     let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
     await writeSpool(
@@ -443,13 +455,6 @@ struct RecoverySpoolStoreTests {
 
     // Block the marker write at its FIRST step: the temp path is already a
     // directory, so `open(…, O_CREAT | O_WRONLY)` fails with EISDIR.
-    //
-    // An earlier version of this test blocked the DESTINATION instead and proved
-    // nothing — macOS `replaceItemAt` happily replaces a non-empty directory with
-    // a file, so the write succeeded and the assertion caught my wrong assumption
-    // about the filesystem rather than a defect. The spool directory itself stays
-    // writable on purpose: sealing it would break the cleanup too, and then the
-    // test could not observe the destruction it exists to check.
     let tmpBlocker = store.directoryURL.appendingPathComponent(
       ".doomed.\(RecoveryConstants.escapeMarkerFileExtension).tmp")
     try FileManager.default.createDirectory(at: tmpBlocker, withIntermediateDirectories: true)
@@ -459,8 +464,8 @@ struct RecoverySpoolStoreTests {
 
     #expect(ok == false, "the caller must be told to perform an ordinary cancel")
     #expect(
-      try store.listSpoolSessionIDs() == [],
-      "the spool is destroyed — a survivor with no marker replays as permanent History")
+      try store.listSpoolSessionIDs() == ["doomed"],
+      "Storage does not destroy it directly — that is the caller's job now")
   }
 
   /// An interrupted marker write is EVIDENCE, not absence.

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolStoreTests.swift
@@ -439,7 +439,7 @@ struct RecoverySpoolStoreTests {
   /// failure path must also DESTROY the spool — which costs the user exactly what
   /// pressing cancel already costs them, and is what the caller falls back to.
   @Test(
-    "prepare fails: returns false and leaves the spool for the CALLER's own destructive-cancel fallback"
+    "prepare fails: returns false, writes a discard marker as crash-window evidence, and leaves the spool for the CALLER's own destructive-cancel fallback"
   )
   func prepareEscapeRecoveryFailsClosed() async throws {
     // #1807 (§D2): this used to destroy the spool directly here — a second,
@@ -448,6 +448,14 @@ struct RecoverySpoolStoreTests {
     // exactly what it always documented: "the caller performs today's
     // ordinary destructive cancel" — which is `RecoveryCoordinator`'s own
     // marker-aware destructor, not a duplicate one living here.
+    //
+    // Cloud review (PR #2717): the caller's fallback is NOT synchronous —
+    // `finishTerminal(.cancelled)` only sets state a LATER MainActor turn
+    // reacts to, so a process exit between this call returning and that later
+    // turn running would leave no evidence at all. This method now writes the
+    // discard marker itself, synchronously, as a best-effort crash-window
+    // closer — never a destruction decision, just evidence a decision was
+    // already made.
     let store = makeStore()
     let cipher = RecoverySpoolCipher(mode: .aesGcm256, keyData: Self.key())
     await writeSpool(
@@ -466,6 +474,9 @@ struct RecoverySpoolStoreTests {
     #expect(
       try store.listSpoolSessionIDs() == ["doomed"],
       "Storage does not destroy it directly — that is the caller's job now")
+    #expect(
+      store.hasDiscardMarker(for: "doomed") == .final,
+      "a crash right after this call must not resurrect a take the user cancelled")
   }
 
   /// An interrupted marker write is EVIDENCE, not absence.


### PR DESCRIPTION
## Summary

Fixes #1807 — crash recovery could fail to unlock a saved recording (`recovery_decrypt_failed`).

Root cause: the per-session recovery key could be deleted at the wrong moment relative to the
recording's audio being durably confirmed gone or kept, because the coordinator had no durable,
crash-survivable record of a "discard" decision to check before destroying either the key or the
audio. This PR ships the real architectural fix (per founder direction: prioritize the long-term
solid refactor over a narrow patch) in four build chunks, all independently reviewed to clean by
Codex, plus a final whole-diff pass across all four together:

1. **Small fix + telemetry** — fail closed on a spool-listing error, add deletion-failure telemetry.
2. **Session-keyed protection + writer-completion join** — replaces a single optional "armed session"
   slot with a keyed table, so overlapping recordings can't step on each other's cleanup, and cleanup
   waits for the writer to genuinely finish before ever touching a session's audio or key.
3. **Durable discard marker** — a new on-disk marker (write-then-sync-then-atomic-rename, matching the
   existing readiness-retry marker's durability shape) records a "this take is decided-discard" decision
   BEFORE any destructive delete runs, so a crash between deciding and deleting never leaves an orphan
   that gets silently re-decided differently on the next launch.
4. **Conditional key retention** — the actual bug fix. The key is now deleted only when it's safe to:
   `marker committed AND audio removal failed` retains both the key and the marker (this is the exact
   scenario #1807 reports); every other combination matches today's existing best-effort behavior.

## Founder decision recorded in this PR

`.historySaveFailed`'s old "one more replay attempt" exception is removed — it's now uniform with the
other seven destruction sources, all sharing one discard-marker contract. Recorded per founder direction
during plan review (2026-09-07).

## Review

- All 4 chunks individually reached `CHUNK-CLEAN` against their own diffs (multiple rounds each; 8 real
  defects found and fixed across the build, listed in each chunk's own commit message).
- A final whole-diff review across all four chunks together (required separately — a per-chunk review
  can't see cross-chunk interactions) found 2 more real defects on the first pass, fixed, confirmed clean
  on the second pass.
- An additional local `codex review --base origin/main` pass (Phase 3 validation) found no further issues.

## Testing

- `scripts/xcode-test.sh`: 7667 tests, all passing (Debug lane).
- `scripts/xcode-test.sh --release`: 6993 tests, all passing (Release lane), run twice (once mid-work,
  once against the final commit).
- Phase 3 validation (`scripts/validate-pr.sh`): PASS. Live UAT heart-path sanity ran for real against the
  built dev app (silent — audio routed through a loopback device, nothing audible) and passed: exact
  transcript match, 0.516s total pipeline time, no crash, no stuck overlay.
- One known gap, documented rather than silently skipped: the plan's 3-point stop-to-terminal/stop-to-paste
  latency comparison (before/after the session-join chunk, and again after the final chunk) only has the
  final measurement from this session — no earlier checkpoint data was found on disk. The final number
  itself (0.516s total, well within normal range) shows no obvious regression.
- One ship-criteria item (confirming the new marker-write-failure telemetry event fires live) was verified
  by direct source trace plus existing real-filesystem-fault unit test coverage rather than a fresh live
  trigger — the discard path requires a cancel action, which can't be driven synthetically in this app
  (documented limitation, not something this PR could work around).

Full detail: `docs/feature-requests/issue-1807-2026-09-07-recovery-key-safety-net.md` (gitignored, not in
this diff).

## Test plan

- [x] `scripts/xcode-test.sh` (Debug + Release lanes)
- [x] Codex review — per-chunk (4x) + whole-diff (2 rounds) + Phase 3 cloud-style pass
- [x] Live UAT heart-path sanity, silent
- [ ] Founder's own before/after confirmation of the `.historySaveFailed` policy change (plan §11.2 —
      a real behavior change he made the call on, worth one explicit look once shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPCDNazD4YERRJekZ31pab
