### PR TITLE
fix(pipeline): the casing snapshot stops waiting for the main actor (#1946 chunk 1)

### DIFF
--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -281,15 +281,23 @@ struct KernelFinalizationWiring {
     // Takes the RESOLVED language, so it must be called after resolution, not
     // before it (grounded review r1: the snapshot used to be taken above the
     // deadline, where the language is not yet known).
-    // #1946: `async @Sendable`, not `@MainActor`. The production default below
-    // still hops to the main actor, so runtime behaviour is unchanged — the
-    // change exists so a test can inject a closure that stalls HERE without
-    // occupying the main actor. Blocking a synchronous `@MainActor` seam also
-    // blocks `withOrderedDeadline`'s timer, which is `Task { @MainActor }`
+    // #1946: `async @Sendable`, not `@MainActor`. The async seam exists so a
+    // test can inject a closure that stalls HERE without occupying the main
+    // actor. Blocking a synchronous `@MainActor` seam also blocks
+    // `withOrderedDeadline`'s timer, which is `Task { @MainActor }`
     // (`TaskTimeout.swift:127-132`), so the timeout could never fire and the
     // hop-stall case was untestable by construction (grounded r1).
+    // The production default no longer hops to the main actor (#1946). The hop
+    // was never needed: `SeamCasingOracleRuntime.snapshot(for:)` is nonisolated
+    // and does its whole job under that type's own lock, making no synchronous
+    // spell-checker call. It cost exactly as long as the main thread happened to
+    // be occupied, 1:1 (measured 2026-08-10,
+    // issue-1946-artifacts/2026-08-10-hop-vs-pool.out).
+    // The decision lease is unaffected. `snapshot(for:)` takes the lease and
+    // `drain` admits a preparation under the SAME lock, so that handshake is
+    // serialised by the lock and never by the main actor.
     seamCasingOracle: @escaping @Sendable (String?) async -> SeamCasingOracle = {
-      language in await MainActor.run { SeamCasingOracleRuntime.snapshot(for: language) }
+      language in SeamCasingOracleRuntime.snapshot(for: language)
     },
     // Paired with the seam above. A READY snapshot holds a lease that stops the
     // preparation drain entering the shared spell checker underneath a decision
@@ -790,10 +798,14 @@ struct KernelFinalizationWiring {
             // discarded-on-timeout one, since the deadline cannot preempt this
             // closure and it always runs to completion.
             let oracleSnapshot = await seamCasingOracle(resolution.language)
-            // Its OWN duration, because the phase cannot separate this hop from
+            // Its OWN duration, because the phase cannot separate the fetch from
             // repair's own work — both sit in `.repair(oracleTouched: false)`.
-            // Measured 2026-08-10: this hop costs exactly as long as the main
-            // thread is occupied, 1:1 (issue-1946-artifacts/2026-08-10-hop-vs-pool.out).
+            // This used to be a main-actor hop that cost exactly as long as the
+            // main thread happened to be occupied, 1:1 (measured 2026-08-10,
+            // issue-1946-artifacts/2026-08-10-hop-vs-pool.out). The production
+            // default stopped hopping in #1946, so the mark now measures the
+            // runtime's own lock-guarded fetch. It stays because an injected
+            // test closure can still stall here.
             gate.mark(.oracleFetched)
             // Release ONLY IF a lease was actually taken. `snapshot(for:)` leases
             // on a ready answer and not on a refusal, so an unconditional release

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -2283,7 +2283,133 @@ import os
     }
   }
 
+  @Test("#1946 The production casing snapshot reaches the oracle while the main actor is busy")
+  func productionCasingSnapshotDoesNotWaitForTheMainActor() async throws {
+    // The PRODUCTION default snapshot closure, which is why this case builds the
+    // wiring directly instead of using `makeWiring`. That helper's injected
+    // oracle seam is `@MainActor`, so it hops by construction and could never
+    // pose this question. It is driven through the real `deliver` rather than
+    // called on its own, because a default argument has no call site to grep:
+    // testing the closure in isolation would leave "and the wiring uses it"
+    // unproven.
+    //
+    // Shape. `resolveLanguage` runs inside the deadline's operation task, which
+    // is off the main actor. It queues a block that OCCUPIES the main actor,
+    // waits until that block is running, and only then returns. The oracle fetch
+    // is the very next thing the operation does. A fetch that first waits for
+    // the main actor can never reach the oracle here, so the consultation never
+    // happens, so the occupying block ends on its fail-safe instead of on the
+    // signal — which is what the shipped code did before #1946.
+    //
+    // Each precondition is its OWN expectation with its own message, because a
+    // fixture that did not establish its scenario must not be read as an answer
+    // about the code. Two review rounds landed on exactly that, one round apart.
+    //
+    // KNOWN LIMIT, stated rather than machined around. This is a scheduling
+    // test. It asserts that the occupying block held the main actor before the
+    // fetch and that the deadline had not already claimed, and both of those are
+    // checkable. It CANNOT establish that the operation task got CPU between
+    // `beginRepair` and the occupying block's bound, so a starved worker fails
+    // this case against correct code. Healthy cost measured at 35-44 ms, so that
+    // is rare; re-run once before reading a red here as the hop returning. An
+    // earlier revision retried unstaged attempts three times, which added a
+    // state machine without covering this case, and was deleted.
+    //
+    // It occupies the shared main actor, briefly when healthy and for the full
+    // bound when not, so prefer running it alone when investigating a failure.
+    try await withSeamCasingOracleExclusion {
+      let mainOccupied = DispatchSemaphore(value: 0)
+      let consulted = DispatchSemaphore(value: 0)
+      let mainReleased = DispatchSemaphore(value: 0)
+      // WHY each wait stopped, never merely that it stopped. A bare signal fires
+      // on the fail-safe too, so the broken path would report what the fixed one
+      // reports.
+      let sawConsultation = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+      let occupiedMain = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+
+      // Signals from `dictionaryVerdict` because the #1921 oracle-stall case
+      // above already establishes that this text reaches that closure.
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(
+        SeamCasingOracle(
+          unavailableReason: nil,
+          dictionaryVerdict: { _ in
+            consulted.signal()
+            return .ordinary
+          },
+          isLearnedWord: { _ in false },
+          isRecognizedName: { _, _ in false },
+          isNoun: { _ in false }))
+      #expect(
+        Self.oracleIsAvailable(),
+        "precondition: the installed oracle must come back available, or nothing can consult it")
+
+      let outcome = KernelFinalizationOutcome()
+      let context = KernelSessionContext()
+      context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+      context.targetElement = Self.stubCaretElement()
+
+      let wiring = KernelFinalizationWiring(
+        outcome: outcome,
+        context: context,
+        adapter: Self.transcribedEngine(),
+        steps: makeSteps(),
+        textProcessingRunner: TextProcessingRunner(
+          timeoutExecutor: FakeTimeoutExecutor(throwBelowSeconds: 0).run),
+        save: { _, _ in },
+        deliverPaste: { _ in Self.deliveredResult },
+        readCaretContext: { _, _, _ in Self.midSentenceCaret },
+        // `seamCasingOracle` is deliberately NOT passed. The production default
+        // is the subject of this case.
+        resolveLanguage: { _, _, _, _, _ in
+          DispatchQueue.main.async {
+            mainOccupied.signal()
+            // deadline-fallback: the consultation is the signal; this bound only
+            // stops a defect hanging the suite.
+            let waited = consulted.wait(timeout: .now() + 5)
+            sawConsultation.withLock { $0 = waited }
+            mainReleased.signal()
+          }
+          // deadline-fallback: the block reaching the main actor is the signal.
+          // Its RESULT is kept and asserted below, because a block that arrives
+          // AFTER the fetch would see `consulted` already signalled and report a
+          // pass the code never earned.
+          let occupied = mainOccupied.wait(timeout: .now() + 5)
+          occupiedMain.withLock { $0 = occupied }
+          return DictationLanguageResolver.Resolution(
+            language: "en", source: .dictation, confidenceBucket: .ge90)
+        },
+        pasteCompletionRegistry: nil,
+        copyToClipboard: { text in
+          Issue.record("unexpected clipboard copy: \(text)")
+        })
+
+      _ = await wiring.deliver("Review this before the meeting", .ordinary)
+
+      #expect(
+        await awaitSignal(mainReleased),
+        "precondition: the occupying block must have finished, or this run measured nothing")
+      #expect(
+        occupiedMain.withLock { $0 } == .success,
+        "precondition: the occupying block must hold the main actor BEFORE the fetch")
+      #expect(
+        outcome.languageResolutionSource == "dictation",
+        """
+        precondition: the 100 ms deadline must not have claimed before repair began. \
+        The gate freezes without a resolution only in that case, and no fetch is \
+        attempted, so the run says nothing about where the fetch would have run
+        """)
+      #expect(
+        sawConsultation.withLock { $0 } == .success,
+        """
+        the production snapshot must reach the oracle while the main actor is \
+        occupied; a fetch that first waits for the main actor cannot, and the \
+        occupying block then ends on its fail-safe instead of on the consultation
+        """)
+    }
+  }
 }
+
 
 /// Hand-advanced logical clock for the tick-rate test. Local `@MainActor` copy:
 /// the `ManualClock` in `LoadProgressWatcherTests` is `private` to that suite and


### PR DESCRIPTION
Part of #1946. **Chunk 1 of two. This does not close the issue.**

Lane: **Code** · Tier: **MEDIUM** · Modules: Pipeline (change), PostProcessing + Core (read only)
Plan: `docs/feature-requests/issue-1946-2026-09-08-casing-deadline-off-main-actor.md` (gitignored, main checkout)

## What was wrong

Continuation capitalisation switches itself off for the rest of an app process, and only a relaunch
brings it back. 23 users on v2.4.5-2.4.8.

The finalization wiring fetched the seam-casing snapshot through `MainActor.run`.
`SeamCasingOracleRuntime.snapshot(for:)` is nonisolated and does its whole job under that type's own
lock, making no synchronous spell-checker call, so the hop bought nothing and cost exactly as long as
the main thread happened to be occupied (measured 1:1, `issue-1946-artifacts/2026-08-10-hop-vs-pool.out`,
2026-08-10). That waiting sits INSIDE the 100 ms language-and-repair deadline, so an unrelated busy
main thread could consume the whole budget before the oracle was ever consulted, and the resulting
timeout latches casing off permanently for that process.

## What this claims, and what it does not

**Narrower claim, stated deliberately:** this removes unnecessary waiting from healthy casing work.

**It does NOT fix the deadline's own timer**, which is `Task { @MainActor in }` inside
`withOrderedDeadline` (`Sources/EnviousWisprCore/TaskTimeout.swift:127-132`) and therefore cannot fire
while the main actor is blocked. That is chunk 2 and is not claimed here.

Also unchanged, all three refused by the founder on 2026-08-10: the deadline is not removed, its value
is not raised, and the latch is neither removed nor weakened.

## Why the lease handshake survives

`snapshot(for:)` takes the decision lease and `drain` admits a preparation under the SAME
`OSAllocatedUnfairLock`, so that handshake is serialised by the lock and never by the main actor. The
runtime's own header argument for why one lock is enough does not rest on the fetch being main-actor
isolated: it rests on decisions being sequential (one recording session, `@MainActor` delivery
closure), which this does not change.

## Test

The regression test uses the **production default** closure rather than `makeWiring`'s injected fake,
because the fake is `@MainActor` and hops by construction, so it could never pose the question. It is
driven through the real `deliver` rather than called on its own: a default argument has no call site
to grep, so testing the closure in isolation would leave "and the wiring uses it" unproven.

**Preconditions.** Each one is its own expectation with its own message, because a fixture that did
not establish its scenario must not be read as an answer about the code: the installed oracle comes
back available; the occupying block finishes; the occupying block holds the main actor BEFORE the
fetch; the 100 ms deadline has not already claimed. Then one assertion about the code — the
consultation, not the fail-safe, is what released the block.

**Known limit, written into the test rather than machined around.** It cannot establish that the
operation task got CPU between `beginRepair` and the occupying block's bound, so a starved worker
fails it against correct code. Healthy cost is 35-44 ms, so that is rare; the comment says to re-run
once before reading a red as the hop returning.

**Three review rounds, one shape, and the machinery deleted rather than extended.** All three landed
on "a fixture precondition whose result is unchecked". Round 1 (local second pass): the deadline can
claim before repair begins. Round 2 (cloud, r3962719469): the occupancy wait's result was discarded.
Round 3 (local reachability lens): the retry loop and result enum added to survive rounds 1 and 2 did
not close the class, because a starved worker produces the same reading with correct code. Per
`workflow-process.md` RULE: grounded-review-mechanics that is where the machinery goes, so
`CasingSnapshotAttempt` and the three-attempt loop are gone.

## Validation

| check | result |
|---|---|
| baseline red (`git apply -R` the source hunk) | exactly 1 issue in 65 after 5.057 s, on the FINAL expectation — `(sawConsultation -> .timedOut) == .success`. All three preconditions held, so the red is about the code, not the fixture |
| suite green | 65/65 in 3.086 s |
| full Debug lane | `Debug lane executed 7561 tests` · verdict **PASS** |
| Dev build | `** BUILD SUCCEEDED **` |
| Codex review `--base origin/main` | clean, twice |
| Codex second-pass behavioural | one P2 (deadline-claims-first), fixed |
| Codex local reachability + deletion lens | said the retry machinery did not close the class; machinery deleted |
| Cloud review round 1 | one P2 (discarded occupancy result), fixed |

**Release lane is red for an unrelated, pre-existing reason: #2718.**
`WhisperKitBackendLoadOrchestrationTests.singleFlightJoinsOneLoad()` aborts with `freed pointer was not
the last allocation` in Release only. Reproduced on a detached worktree at clean `origin/main`
(`60a66ebd`) with no local changes, and `EnviousWisprASRTests` does not link `EnviousWisprPipeline`, the
only module this PR touches. `main-post-merge` run 34274256566 was already failing its release lane
before this branch existed.

## One adjacent observation, recorded and not acted on

Releasing the decision lease still hops to the main actor (`Task { @MainActor in releaseOracleLease() }`),
so a busy main actor can still delay a *later* language's preparation. That is a delay after repair
finishes rather than a deadline miss, so it is out of scope here and noted for chunk 2.

## Blast radius

One closure body and two comments in one file, plus one test. Single-commit revert. Every other
construction site of `KernelFinalizationWiring` — the production factory and four test files — takes
the default and is covered by the full lane above.

## Still owed on #1946

Chunk 2 (the deadline decision itself moves off the main actor), the two implementation-validation
tests that replaced the retired #2711 bake-off, and a `test-hardening` issue carrying this test's recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8awCNeoTLgCLFWVmBDeJZ
