### PR TITLE
fix(pipeline): the capitalisation deadline stops depending on the main actor (#1946)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -77,7 +77,7 @@ public final class ASRManager: ASRManagerInterface {
   /// completion still passed `ParakeetBackend`'s OWN generation check
   /// (nothing had told it the manager gave up) and leaked a live streaming
   /// session. `nil` for a non-Parakeet backend. Kept addressable past a
-  /// successful publish too (round 10): the outer `withOrderedDeadline` can
+  /// successful publish too (round 10): the outer `withMainActorOrderedDeadline` can
   /// still resolve in the timeout's favor just after the backend publishes,
   /// and that late invalidation still needs a target to reclaim.
   private var streamingStartBackendAttempt: (backend: ParakeetBackend, generation: UInt64)?
@@ -613,7 +613,7 @@ public final class ASRManager: ASRManagerInterface {
   /// deadline that fires after a newer attempt already replaced this one)
   /// must never touch the newer attempt's state.
   ///
-  /// SYNCHRONOUS on purpose: called from `withOrderedDeadline`'s non-async
+  /// SYNCHRONOUS on purpose: called from `withMainActorOrderedDeadline`'s non-async
   /// `onTimeout`, which GUARANTEES this runs before the timed-out caller
   /// resumes — the ordering bare `withDeadline` cannot provide.
   ///

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -212,7 +212,7 @@ public protocol ASRManagerInterface: AnyObject {
   /// SYNCHRONOUS, not `async` — round 5's finding: a caller that awaits an
   /// `async` invalidation before proceeding still leaves a window where the
   /// abandoned vendor call can complete and publish first. A synchronous
-  /// method is callable from `withOrderedDeadline`'s non-async `onTimeout`,
+  /// method is callable from `withMainActorOrderedDeadline`'s non-async `onTimeout`,
   /// which guarantees it runs BEFORE the timed-out caller resumes.
   ///
   /// #1908 round 12: returns the backend's own reclaim `Task` (or `nil` if

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -45,7 +45,7 @@ public actor ParakeetBackend: ASRBackend {
   /// `nonisolated`, lock-backed rather than a plain actor-isolated `var`:
   /// `cancelInFlightStreamingStart()` invalidates THIS attempt's generation
   /// synchronously from `ASRManager`'s `@MainActor`, inside
-  /// `withOrderedDeadline`'s `onTimeout` — which the primitive's own
+  /// `withMainActorOrderedDeadline`'s `onTimeout` — which the primitive's own
   /// contract (`TaskTimeout.swift`) requires to stay synchronous and
   /// non-suspending, so it cannot `await` into this actor to bump an
   /// isolated var. Without this, an abandoned attempt's late vendor
@@ -74,7 +74,7 @@ public actor ParakeetBackend: ASRBackend {
   /// the counter.
   ///
   /// #1908 round 10 (cloud review P2): the bump alone is NOT enough at the
-  /// deadline edge. `withOrderedDeadline` races the OPERATION's own
+  /// deadline edge. `withMainActorOrderedDeadline` races the OPERATION's own
   /// `claim()` (won by publishing `self.streamingManager = manager` and
   /// returning up through `ASRManager.startStreaming()`) against the
   /// TIMER's `claim()` (won by calling `cancelInFlightStreamingStart()`,

--- a/Sources/EnviousWisprCore/TaskTimeout.swift
+++ b/Sources/EnviousWisprCore/TaskTimeout.swift
@@ -86,13 +86,24 @@ public func withDeadline<T: Sendable>(
   }
 }
 
-/// Run `operation` with a wall-clock deadline, guaranteeing `onTimeout` runs
-/// to completion BEFORE the caller is resumed on timeout — the ordering
-/// `withDeadline` does not provide (it resumes the caller immediately once
-/// the deadline claims, with no hook to run cleanup first). Use this instead
-/// of `withDeadline` whenever a timeout must actively supersede/cancel a
-/// resource the operation was mutating, so a later caller (e.g. a fresh
-/// session) can never race an abandoned operation's late cleanup.
+/// Run `operation` with a deadline whose timer is scheduled ON THE MAIN ACTOR,
+/// guaranteeing `onTimeout` runs to completion BEFORE the caller is resumed on
+/// timeout — the ordering `withDeadline` does not provide (it resumes the
+/// caller immediately once the deadline claims, with no hook to run cleanup
+/// first). Use this instead of `withDeadline` whenever a timeout must actively
+/// supersede/cancel a resource the operation was mutating, so a later caller
+/// (e.g. a fresh session) can never race an abandoned operation's late cleanup,
+/// AND that cleanup genuinely needs the main actor.
+///
+/// Both arming the timer and handling its wake require main-actor
+/// availability. While the main actor is blocked, this timer cannot claim a
+/// timeout; an operation completing during that interval can still win.
+/// Measured 2026-09-08 under a 1.2 s main-actor block: 0 of 8 trials timed out
+/// and the caller waited 1466.9 ms against a 100 ms budget
+/// (`docs/feature-requests/issue-1946-artifacts/2026-09-08-which-primitives-are-defective.out`).
+/// This intentionally does not provide an actor-independent elapsed-time
+/// cutoff. When the timeout handler does NOT need the main actor, use
+/// `withOffActorOrderedDeadline`, whose timer runs on the cooperative pool.
 ///
 /// `onTimeout` MUST be synchronous, non-throwing, and MUST NOT suspend — an
 /// async cleanup hook would either leave this call's own wait unbounded, or
@@ -103,7 +114,7 @@ public func withDeadline<T: Sendable>(
 /// contract to admit an async closure. (#1707 — Codex grounded review r3/r4.)
 ///
 /// On success (operation wins the race), `onTimeout` is never called.
-public func withOrderedDeadline<T: Sendable>(
+public func withMainActorOrderedDeadline<T: Sendable>(
   seconds: Double,
   operation: @escaping @Sendable () async -> T,
   onTimeout: @escaping @Sendable @MainActor () -> Void
@@ -126,6 +137,68 @@ public func withOrderedDeadline<T: Sendable>(
     }
     Task { @MainActor in
       try? await Task.sleep(for: .seconds(seconds))
+      if claim() {
+        operationTask.cancel()  // best-effort; cannot preempt a blocked thread
+        onTimeout()  // synchronous — completes before the resume below
+        continuation.resume(returning: nil)
+      }
+    }
+  }
+}
+
+/// The sibling of `withMainActorOrderedDeadline` for timeout handlers that do
+/// NOT need the main actor. It keeps the #1707 ordering property — `onTimeout`
+/// runs to completion before the caller is resumed — and differs in exactly one
+/// respect: the deadline is an absolute instant on the continuous clock taken
+/// at ENTRY, and the timer that waits for it runs on the cooperative pool. A
+/// blocked main actor therefore cannot postpone the timeout DECISION. Measured
+/// 2026-09-08 under the same 1.2 s block, a pool timer fired 8 of 8 and bounded
+/// its own wait at 104.5 ms against a 100 ms budget
+/// (`docs/feature-requests/issue-1946-artifacts/2026-09-08-which-primitives-are-defective.out`).
+///
+/// `onTimeout` MUST be synchronous, non-throwing, MUST NOT suspend, and must be
+/// callable from any executor — the same contract as the main-actor sibling and
+/// for the same reason: widening it to an async closure would leave this call's
+/// own wait unbounded, or need its own inner deadline, recreating the ordering
+/// race one layer down. A handler that touches `@MainActor` state cannot be
+/// passed here; the compiler refuses it, which is why these are two names and
+/// not one name with a comment.
+///
+/// What this does NOT do: it does not bound the CALLER's return when the caller
+/// itself needs the main actor to continue after the resume. Timer execution
+/// still depends on cooperative-pool availability, so this is a FIRST-CLAIM
+/// RACE rather than a guaranteed elapsed-time cutoff — an operation returning
+/// after the deadline can still win when the timer has not yet run. What it
+/// removes is the timer's dependence on one specific, routinely blocked
+/// executor. (#1946.)
+///
+/// On success (operation wins the race), `onTimeout` is never called.
+public func withOffActorOrderedDeadline<T: Sendable>(
+  seconds: Double,
+  operation: @escaping @Sendable () async -> T,
+  onTimeout: @escaping @Sendable () -> Void
+) async -> T? {
+  // Taken here, not inside the timer task, so scheduling delay before the timer
+  // first runs is spent against the budget rather than added to it.
+  let deadline = ContinuousClock.now.advanced(by: .seconds(seconds))
+  let resumed = OSAllocatedUnfairLock(initialState: false)
+  func claim() -> Bool {
+    resumed.withLock { done in
+      done
+        ? false
+        : {
+          done = true
+          return true
+        }()
+    }
+  }
+  return await withCheckedContinuation { (continuation: CheckedContinuation<T?, Never>) in
+    let operationTask = Task(priority: .userInitiated) {
+      let value = await operation()
+      if claim() { continuation.resume(returning: value) }
+    }
+    Task {
+      try? await Task.sleep(until: deadline, clock: .continuous)
       if claim() {
         operationTask.cancel()  // best-effort; cannot preempt a blocked thread
         onTimeout()  // synchronous — completes before the resume below

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -246,7 +246,7 @@ public struct AudioBufferHandoff: @unchecked Sendable {
 /// MUST / MUST NOT clauses in PR-1 §B.2.2 define the behavior every conformer
 /// (`FakeEngine`, and the PR-4 / PR-5 real adapters) must implement.
 // #1707 Phase 2: `Sendable` added so `retryDecode(inputSamples:)` can be
-// captured by name (`[adapter]`) inside `withOrderedDeadline`'s `@Sendable`
+// captured by name (`[adapter]`) inside `withMainActorOrderedDeadline`'s `@Sendable`
 // `operation` closure — capturing the EXISTENTIAL `any ASREngineAdapter`
 // directly (unlike a concrete `@MainActor` class, e.g. Phase 1's own
 // `recoverFromASRInterruption()` capturing `[weak self]`) does not get the
@@ -388,7 +388,7 @@ package protocol ASREngineAdapter: AnyObject, Sendable {
   /// Best-effort, honest "stop waiting" signal for a retry that has timed out
   /// — NOT a claim of active cancellation. Neither adapter's decode call is
   /// genuinely interruptible mid-flight. Synchronous, so it can run directly
-  /// inside `withOrderedDeadline`'s `onTimeout` closure. Bumps an
+  /// inside `withMainActorOrderedDeadline`'s `onTimeout` closure. Bumps an
   /// adapter-local generation token; combined with the attempt/commit split,
   /// this is what actually prevents a late-arriving abandoned result from
   /// mutating state belonging to a session that has since moved on.

--- a/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
+++ b/Sources/EnviousWisprPipeline/BatchDecodeFaultController.swift
@@ -218,12 +218,12 @@ package final class BatchDecodeFaultController {
   private var kernelTimestamps = KernelTimestamps()
 
   /// Called from `RecordingSessionKernel` immediately before
-  /// `withOrderedDeadline`.
+  /// `withMainActorOrderedDeadline`.
   package func recordRetryStarted() {
     kernelTimestamps.retryStartedAtEpochSec = Date().timeIntervalSince1970
   }
 
-  /// Called from `RecordingSessionKernel`'s `withOrderedDeadline` `onTimeout`
+  /// Called from `RecordingSessionKernel`'s `withMainActorOrderedDeadline` `onTimeout`
   /// closure — the kernel genuinely gave up waiting on the retry.
   package func recordRetryTimeoutFired() {
     kernelTimestamps.retryTimeoutFiredAtEpochSec = Date().timeIntervalSince1970

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -641,6 +641,19 @@ public enum KernelDictationDriverFactory {
           asrBackend: backend, polishProvider: provider,
           recordingDurationMs: durationMs, takeID: takeID)
       },
+      // #1946 chunk 2: the retry-deadline observation, routed the same way.
+      asrRetryDeadlineStartedTelemetry: { takeID, backend, budgetMs in
+        TelemetryService.shared.asrRetryDeadlineStarted(
+          takeID: takeID, asrBackend: backend, budgetMs: budgetMs)
+      },
+      asrRetryDeadlineResolvedTelemetry: {
+        takeID, backend, budgetMs, resolution, disposition, operationReturnMs, callerResumeMs,
+        acceptedAfterCutoff in
+        TelemetryService.shared.asrRetryDeadlineResolved(
+          takeID: takeID, asrBackend: backend, budgetMs: budgetMs, resolution: resolution,
+          disposition: disposition, operationReturnMs: operationReturnMs,
+          callerResumeMs: callerResumeMs, acceptedAfterCutoff: acceptedAfterCutoff)
+      },
       engineMutationScope: engineMutationScope,
       // Production wedge-stall window — `RecordingSessionKernel` defaults
       // to 2 ticks (test-only value); with the wiring's 100ms tick clock

--- a/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
+++ b/Sources/EnviousWisprPipeline/KernelFinalizationWiring.swift
@@ -283,10 +283,12 @@ struct KernelFinalizationWiring {
     // deadline, where the language is not yet known).
     // #1946: `async @Sendable`, not `@MainActor`. The async seam exists so a
     // test can inject a closure that stalls HERE without occupying the main
-    // actor. Blocking a synchronous `@MainActor` seam also blocks
-    // `withOrderedDeadline`'s timer, which is `Task { @MainActor }`
-    // (`TaskTimeout.swift:127-132`), so the timeout could never fire and the
-    // hop-stall case was untestable by construction (grounded r1).
+    // actor. That mattered under the main-actor timer, where blocking a
+    // synchronous `@MainActor` seam also blocked the timer and made the
+    // hop-stall case untestable by construction (grounded r1). This site now
+    // uses `withOffActorOrderedDeadline`, whose timer does not need the main
+    // actor, so the seam's isolation no longer gates the timeout; it stays
+    // `@Sendable` because the deadline operation is.
     // The production default no longer hops to the main actor (#1946). The hop
     // was never needed: `SeamCasingOracleRuntime.snapshot(for:)` is nonisolated
     // and does its whole job under that type's own lock, making no synchronous
@@ -303,7 +305,12 @@ struct KernelFinalizationWiring {
     // preparation drain entering the shared spell checker underneath a decision
     // already in flight; releasing is mandatory and happens in a `defer`.
     // Injected tests pass a no-op, because their oracle takes no lease.
-    releaseOracleLease: @escaping @MainActor () -> Void = {
+    // #1946 chunk 2: `@Sendable`, not `@MainActor`. `releaseDecisionLease()` is
+    // nonisolated and does its whole job under the runtime's own lock
+    // (`SeamCasingOracleRuntime.swift:507-513`), so the hop bought nothing and
+    // deferred the release until the main actor was next free — which is
+    // exactly when a queued preparation for the next language could start.
+    releaseOracleLease: @escaping @Sendable () -> Void = {
       SeamCasingOracleRuntime.releaseDecisionLease()
     },
     // #1921 language-resolver seam. `@Sendable`, not `@MainActor`, because
@@ -685,9 +692,12 @@ struct KernelFinalizationWiring {
         // (0.5s); `NSSpellChecker` has no equivalent knob, so the call is bounded
         // here instead — stricter than the 0.5s we already accept.
         //
-        // `withOrderedDeadline`, not bare `withDeadline`: on timeout the runtime
-        // must be latched BEFORE paste resumes, so a later dictation can never
-        // race an abandoned call against AppKit's one shared spell checker.
+        // `withOffActorOrderedDeadline`, not bare `withDeadline`: on timeout the
+        // runtime must be latched BEFORE paste resumes, so a later dictation can
+        // never race an abandoned call against AppKit's one shared spell
+        // checker. The OFF-ACTOR sibling, because this timeout handler touches
+        // only lock-guarded state and the main-actor timer could not fire at all
+        // while the main actor was blocked (#1946).
         // #628. A take that expanded a snippet takes the LEGACY payload: `repair` with no caret
         // context returns exactly that, so refusing the context here is the whole bypass and
         // needs no new branch inside the repair.
@@ -762,7 +772,7 @@ struct KernelFinalizationWiring {
         let timedOutSnapshot =
           OSAllocatedUnfairLock<LanguageRepairDeadlineGate.Snapshot?>(initialState: nil)
 
-        let deadlineResult = await withOrderedDeadline(
+        let deadlineResult = await withOffActorOrderedDeadline(
           seconds: 0.100,
           operation: {
             let resolution = resolveLanguage(
@@ -816,7 +826,11 @@ struct KernelFinalizationWiring {
             // exists to close. Grounded review r3, MED.
             let holdsOracleLease = oracleSnapshot.isAvailable
             defer {
-              if holdsOracleLease { Task { @MainActor in releaseOracleLease() } }
+              // Called directly, not queued onto the main actor (#1946 chunk 2).
+              // The queued form released the lease only once the main actor was
+              // next free, so a blocked main actor held the next language's
+              // preparation behind a decision that had already finished.
+              if holdsOracleLease { releaseOracleLease() }
             }
             let gatedOracle = oracleSnapshot.authorized(
               by: { label in gate.beginOracleUse(label) },
@@ -835,7 +849,7 @@ struct KernelFinalizationWiring {
           },
           onTimeout: {
             // One atomic freeze; everything the timeout reports comes from it.
-            // Synchronous by contract (`TaskTimeout.swift:97-103`): this is one
+            // Synchronous by contract (`TaskTimeout.swift:159-165`): this is one
             // lock take and adds no suspension point.
             let timeout = gate.timeOut()
             timedOutSnapshot.withLock { $0 = timeout }

--- a/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
+++ b/Sources/EnviousWisprPipeline/LanguageRepairDeadlineGate.swift
@@ -5,7 +5,7 @@ import os
 /// resolution and cursor-insertion repair (#1921), and owns the entire
 /// diagnostic record of what that deadline saw (#1946).
 ///
-/// Before #1921 only repair sat inside `withOrderedDeadline`; language
+/// Before #1921 only repair sat inside `withOffActorOrderedDeadline`; language
 /// resolution ran ahead of it, unbounded, on the paste path. Moving resolution
 /// inside the same deadline creates a question the old code never had to answer:
 /// **which stage timed out?** It matters because the existing `onTimeout`
@@ -14,16 +14,16 @@ import os
 /// rest of the process.
 ///
 /// A plain "did the repair stage begin" flag is not enough, and this is the
-/// whole reason a lock exists here. `withOrderedDeadline` cancels
+/// whole reason a lock exists here. `withOffActorOrderedDeadline` cancels
 /// best-effort — its own comment says cancellation "cannot preempt a blocked
-/// thread" (`TaskTimeout.swift:129`) — and `onTimeout()` runs synchronously
+/// thread" (`TaskTimeout.swift:200`) — and `onTimeout()` runs synchronously
 /// before the nil resume. So with a flag, the timeout can observe "still
 /// resolving", decline to disable, and the un-preempted operation can then walk
 /// straight into the oracle anyway.
 ///
 /// Four states rather than three, which grounded review r3 found: `TaskTimeout`
 /// runs `await operation()` and its `claim()` as separate steps
-/// (`TaskTimeout.swift:123-125`), so repair can FINISH and the timeout can still
+/// (`TaskTimeout.swift:193-195`), so repair can FINISH and the timeout can still
 /// win `claim()` in the gap. A three-state gate reads that as still-running,
 /// concludes the oracle is stuck, and disables a component that had just
 /// succeeded. `completed` is that gap.
@@ -42,7 +42,7 @@ import os
 /// by the wiring, on the theory that "where" and "how long" are disjoint facts.
 /// They are not: both answer *"what was true when the timeout claimed?"*, and
 /// two locks cannot answer that atomically. Because the operation is never
-/// preempted (`TaskTimeout.swift:123-132`), a mark written after the phase was
+/// preempted (`TaskTimeout.swift:193-202`), a mark written after the phase was
 /// claimed could contradict evidence the timeout had already returned — a
 /// diagnostic that looks self-consistent and is false, which is worse than the
 /// coarse label it replaces. So every mark lives here, behind this lock, and

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -182,7 +182,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   ///    touches none of this session's own bookkeeping (`sessionID`,
   ///    `retainedPCM`, `decodeOptions`, `isTerminal`, `isCancelled`), so
   ///    calling it a second time mid-session is safe.
-  /// 3. Bounds the attempt with `withOrderedDeadline`, NOT bare `withDeadline`
+  /// 3. Bounds the attempt with `withMainActorOrderedDeadline`, NOT bare `withDeadline`
   ///    — on timeout, `onTimeout` actively invalidates this attempt's token
   ///    and calls the SYNCHRONOUS `cancelInFlightLoad()` (never an async
   ///    cleanup hook), guaranteeing that cleanup completes before this
@@ -199,7 +199,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     let myGeneration = recoveryGeneration
     let mySession = sessionID
 
-    let succeeded = await withOrderedDeadline(
+    let succeeded = await withMainActorOrderedDeadline(
       seconds: asrInterruptionRecoveryDeadlineSec,
       operation: { [weak self] in
         guard let self else { return false }
@@ -215,7 +215,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // attempt's own outer check below (a real bug caught by
         // `recoverFromASRInterruptionTimesOutAndSupersedes`: it made a
         // genuine timeout report `.cancelled` instead of `.failed`).
-        // `withOrderedDeadline`'s own single-winner `claim()` already
+        // `withMainActorOrderedDeadline`'s own single-winner `claim()` already
         // guarantees the operation's late completion can never resume this
         // continuation after timeout wins; the generation check exists to
         // catch a DIFFERENT caller (`beginSession`/`discardSession`)
@@ -575,14 +575,14 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
       // degrades to batch decode instead of parking `beginSession()` (and the
       // kernel awaiting it) forever.
       //
-      // `withOrderedDeadline`, not bare `withDeadline` (round 5 finding): the
+      // `withMainActorOrderedDeadline`, not bare `withDeadline` (round 5 finding): the
       // invalidation must complete BEFORE this function can observe the
       // timeout, or the abandoned vendor call can still finish and resurrect
       // `isStreaming` in the gap between the deadline firing and an `async`
       // cleanup call actually reaching `ASRManager`. `onTimeout` runs
       // synchronously to completion first — matches `recoverFromASRInterruption()`'s
       // own use of this primitive for the exact same reason on the load side.
-      let outcome = await withOrderedDeadline(
+      let outcome = await withMainActorOrderedDeadline(
         seconds: asrInterruptionRecoveryDeadlineSec,
         operation: { [weak self, options] () -> StreamingStartOutcome in
           guard let self else { return .cancelled }
@@ -657,7 +657,7 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
         // `cancelInFlightStreamingStart()` to completion before this branch
         // could ever be reached, so the abandoned attempt is already
         // invalidated by the time this session falls back to batch, same as
-        // `.failed` above. `withOrderedDeadline`'s own best-effort task-cancel
+        // `.failed` above. `withMainActorOrderedDeadline`'s own best-effort task-cancel
         // still cannot preempt a vendor call that ignores `Task.isCancelled` —
         // the generation checks in `ASRManager.startStreaming()` and
         // `ParakeetBackend.startStreaming()` are what actually stop a late

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -4,6 +4,7 @@ import EnviousWisprAudio
 import EnviousWisprCore
 import EnviousWisprServices
 import Foundation
+import os
 
 // MARK: - RecordingSessionKernel (epic #827)
 //
@@ -320,6 +321,20 @@ final class RecordingSessionKernel {
     @MainActor (
       _ asrBackend: String, _ polishProvider: String, _ recordingDurationMs: Int,
       _ takeID: String
+    ) -> Void
+
+  /// #1946 chunk 2. The Phase-2 retry deadline's own observation seam, routed
+  /// exactly as `escapeRecoveryStartedTelemetry` is. Two closures rather than
+  /// one with optional arguments, because the started and resolved halves carry
+  /// different facts and an absent field must not be spellable on the half that
+  /// requires it.
+  private let asrRetryDeadlineStartedTelemetry:
+    @MainActor (_ takeID: String, _ asrBackend: String, _ budgetMs: Int) -> Void
+  private let asrRetryDeadlineResolvedTelemetry:
+    @MainActor (
+      _ takeID: String, _ asrBackend: String, _ budgetMs: Int,
+      _ resolution: ASRRetryDeadlineResolution, _ disposition: ASRRetryDeadlineDisposition,
+      _ operationReturnMs: Int?, _ callerResumeMs: Int, _ acceptedAfterCutoff: Bool
     ) -> Void
 
   // MARK: Wedge-detection tuning
@@ -937,6 +952,12 @@ final class RecordingSessionKernel {
     escapeRecoveryStartedTelemetry: @escaping @MainActor (String, String, Int, String) -> Void = {
       _, _, _, _ in
     },
+    asrRetryDeadlineStartedTelemetry: @escaping @MainActor (String, String, Int) -> Void = {
+      _, _, _ in
+    },
+    asrRetryDeadlineResolvedTelemetry: @escaping @MainActor (
+      String, String, Int, ASRRetryDeadlineResolution, ASRRetryDeadlineDisposition, Int?, Int, Bool
+    ) -> Void = { _, _, _, _, _, _, _, _ in },
     engineMutationScope: EngineMutationScope,
     wedgeStallTicks: Int = 2,
     minimumRecordingTicks: Int = 5,
@@ -984,6 +1005,8 @@ final class RecordingSessionKernel {
     self.deliver = deliver
     self.prepareEscapeRecovery = prepareEscapeRecovery
     self.escapeRecoveryStartedTelemetry = escapeRecoveryStartedTelemetry
+    self.asrRetryDeadlineStartedTelemetry = asrRetryDeadlineStartedTelemetry
+    self.asrRetryDeadlineResolvedTelemetry = asrRetryDeadlineResolvedTelemetry
     self.engineMutationScope = engineMutationScope
     self.wedgeStallTicks = wedgeStallTicks
     self.minimumRecordingTicks = minimumRecordingTicks
@@ -2852,9 +2875,38 @@ final class RecordingSessionKernel {
       // Oracle timestamp — nil no-op unless a Live UAT test wired a real
       // controller (never happens in release).
       batchDecodeFaultController?.recordRetryStarted()
-      let retryOutcome = await withOrderedDeadline(
-        seconds: asrRetryDeadlineSec(forSampleCount: retryInput.count),  // measured, length-aware — see §11.1
-        operation: { [adapter] in await adapter.retryDecode(inputSamples: retryInput) },
+      // #1946 chunk 2. The measurement the founder made a CONDITION of deferring
+      // the other three main-actor deadline call sites. This site is the one
+      // that sees both the budget and the decode's return before the main-actor
+      // caller resumes, so it is where the two clocks can be told apart.
+      //
+      // Entry-based and monotonic on purpose: the quantity is elapsed time from
+      // the wrapper's entry, which is what an absolute cutoff would measure.
+      let retryBudgetSec = asrRetryDeadlineSec(forSampleCount: retryInput.count)
+      let retryTakeID = sid.raw.uuidString
+      let retryBackend = adapter.engineIdentity.backendType.rawValue
+      let retryBudgetMs = Int((retryBudgetSec * 1000).rounded())
+      // Written by the decode itself, not beside it: only the operation closure
+      // knows when `retryDecode` returned, and on a timeout it may never write.
+      let retryOperationReturn = OSAllocatedUnfairLock<Duration?>(initialState: nil)
+      asrRetryDeadlineStartedTelemetry(retryTakeID, retryBackend, retryBudgetMs)
+      // BELOW the started event, not above it. That call captures to PostHog
+      // synchronously, so a clock started before it charges the instrument's own
+      // cost to the decode and can report an on-time retry as late.
+      let retryEntry = ContinuousClock.now
+      let retryOutcome = await withMainActorOrderedDeadline(
+        seconds: retryBudgetSec,  // measured, length-aware — see §11.1
+        // `@MainActor` so the return stamp is taken on the SAME actor the decode
+        // returns on. Without it the stamp waits for a hop back to the pool, and
+        // pool contention is then charged to the decode — an on-time decode
+        // reported as late, which is the one field this measurement is for.
+        // `retryDecode` is already `@MainActor`, so this removes a hop rather
+        // than adding an actor requirement.
+        operation: { @MainActor [adapter] in
+          let decoded = await adapter.retryDecode(inputSamples: retryInput)
+          retryOperationReturn.withLock { $0 = ContinuousClock.now - retryEntry }
+          return decoded
+        },
         // No genuine in-flight-decode cancellation exists on either backend.
         // `onTimeout` is honest about this: it bumps the adapter's own
         // retry-generation token (checked INSIDE the adapter's commit step) so
@@ -2878,12 +2930,48 @@ final class RecordingSessionKernel {
       // stale session's own `finishTerminal` never runs), so stamping it
       // only once currency is confirmed loses nothing for the live case
       // and eliminates the cross-session write for the stale one.
-      guard isCurrent(sid), recordingOutcome == nil else { return }
+      //
+      // #1946 chunk 2. Both clocks, read before any exit takes one of them away.
+      // `callerResume` is entry to THIS point, which is the main-actor caller
+      // continuing; `operationReturn` is entry to the decode returning. A late
+      // caller resume means a blocked main actor, not a late decode, and only a
+      // late decode is evidence about the cutoff.
+      let retryCallerResumeMs = Int((ContinuousClock.now - retryEntry) / .milliseconds(1))
+      let retryOperationReturnDuration = retryOperationReturn.withLock { $0 }
+      let retryOperationReturnMs = retryOperationReturnDuration.map {
+        Int($0 / .milliseconds(1))
+      }
+      // The wrapper returns `nil` only when the timer claimed. Read from the
+      // wrapper's own result rather than from whether the decode had written a
+      // return time, which the decode can still do after losing the race.
+      let retryResolution: ASRRetryDeadlineResolution =
+        retryOutcome == nil ? .timedOut : .operationReturned
+      func emitRetryDeadlineObservation(_ disposition: ASRRetryDeadlineDisposition) {
+        // Estimates EXPOSURE to a stricter cutoff. Never read this as "the timer
+        // would have fired" — the counterfactual scheduler is not observable.
+        // Compared as DURATIONS, never as the reported milliseconds. `Int`
+        // truncates, so a budget of 8150 ms and a return at 8150.7 ms would
+        // compare equal and drop a genuine overrun from the one field the
+        // deferred decision rests on.
+        let acceptedAfterCutoff =
+          disposition == .accepted && retryResolution == .operationReturned
+          && retryOperationReturnDuration.map { $0 > .seconds(retryBudgetSec) } == true
+        asrRetryDeadlineResolvedTelemetry(
+          retryTakeID, retryBackend, retryBudgetMs, retryResolution, disposition,
+          retryOperationReturnMs, retryCallerResumeMs, acceptedAfterCutoff)
+      }
+      guard isCurrent(sid), recordingOutcome == nil else {
+        emitRetryDeadlineObservation(.stale)
+        return
+      }
       // #2087: before `markASRTimingEnd()`, for the same reason the primary
       // decode's check is — the retry's latency belongs to work the user asked
       // to discard, and the `.failed(.asrFailed)` branch just below would
       // otherwise report a deliberate abandonment as a retry failure.
-      guard !finishAbandonedEscapeRecoveryIfNeeded(sid) else { return }
+      guard !finishAbandonedEscapeRecoveryIfNeeded(sid) else {
+        emitRetryDeadlineObservation(.abandoned)
+        return
+      }
       markASRTimingEnd()
       // A TIMEOUT (`nil`) is not a confirmed second failure — `.attempted`
       // remains the honest diagnostic that no decode conclusion was accepted
@@ -2893,6 +2981,14 @@ final class RecordingSessionKernel {
       // live rescue visibly fail, so plain `.failed` now deletes at the
       // coordinator like every concluded live ending. `.cancelled` gets the
       // same treatment below.
+      // Emitted here, above the `switch`, so one call covers every remaining
+      // outcome: this is the acceptance point, and `.transcript` is the only
+      // shape that becomes this take's result.
+      if case .transcript = retryOutcome {
+        emitRetryDeadlineObservation(.accepted)
+      } else {
+        emitRetryDeadlineObservation(.rejected)
+      }
       guard let retryOutcome else {
         finishTerminal(.failed(.asrFailed), sid: sid)
         return

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracle.swift
@@ -168,7 +168,7 @@ package struct SeamCasingOracle: Sendable {
     ///
     /// Why a real blocking sleep rather than a fake: the defect under test is a
     /// consultation that does not return inside the deadline, and
-    /// `withOrderedDeadline` explicitly "cannot preempt a blocked thread". A
+    /// `withOffActorOrderedDeadline` explicitly "cannot preempt a blocked thread". A
     /// cooperative `await` would be preemptible and would therefore exercise a
     /// different path than the one that latches in the field.
     ///

--- a/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
+++ b/Sources/EnviousWisprPostProcessing/SeamCasingOracleRuntime.swift
@@ -12,14 +12,16 @@ import os
 /// The spelling dictionary is served by a separate process. An unbounded call
 /// to it sits on the paste path, so a hang there means a dictation never
 /// pastes — a heart-path failure. The caller bounds each decision with
-/// `withOrderedDeadline`; this type owns what happens around that.
+/// `withOffActorOrderedDeadline`; this type owns what happens around that.
 ///
 /// ## Why ONE lock is enough
 ///
-/// `withOrderedDeadline` runs `onTimeout` to completion *before* resuming the
-/// caller, and `onTimeout` is `@MainActor`. So a lock held across a stalled
-/// system call would block the main actor and hang paste anyway, defeating the
-/// deadline. This avoids that by eliminating concurrency rather than managing
+/// `withOffActorOrderedDeadline` runs `onTimeout` to completion *before* resuming
+/// the caller. So a lock held across a stalled system call would block whatever
+/// runs the handler and stall paste anyway, defeating the deadline. Until #1946
+/// this sentence added "and `onTimeout` is `@MainActor`", which is why the block
+/// was described in main-actor terms; the handler is nonisolated now and the
+/// hazard is unchanged. This avoids that by eliminating concurrency rather than managing
 /// it, which also removes any dependence on `NSSpellChecker`'s undocumented
 /// thread safety:
 ///
@@ -515,7 +517,7 @@ package enum SeamCasingOracleRuntime {
 
   /// Latch permanently after a live decision exceeded its deadline.
   ///
-  /// Synchronous and non-suspending by contract: `withOrderedDeadline` requires
+  /// Synchronous and non-suspending by contract: `withOffActorOrderedDeadline` requires
   /// `onTimeout` to complete before the caller resumes, so anything that could
   /// wait here would recreate the hang the deadline exists to prevent.
   package static func disableAfterTimeout() {
@@ -531,7 +533,7 @@ package enum SeamCasingOracleRuntime {
 
   /// Mark unavailable ONLY while still ready.
   ///
-  /// `withOrderedDeadline.claim()` discards a late decision but cannot roll back
+  /// `withOffActorOrderedDeadline.claim()` discards a late decision but cannot roll back
   /// side effects inside the operation. Without this guard, a stalled call that
   /// later found the identifier missing would write `.dictionaryUnavailable`
   /// over an already-installed `.oracleTimedOut` — it could not re-block paste,

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -179,6 +179,26 @@ public enum RecoveryFailureClass: String, Sendable {
   case other
 }
 
+/// #1946 chunk 2. Which side of the retry deadline's single-claim race won.
+public enum ASRRetryDeadlineResolution: String, Sendable {
+  /// The decode returned and claimed the wrapper's continuation.
+  case operationReturned = "operation"
+  /// The timer claimed first and the decode was abandoned.
+  case timedOut = "timeout"
+}
+
+/// #1946 chunk 2. What the kernel then did with that outcome.
+public enum ASRRetryDeadlineDisposition: String, Sendable {
+  /// A transcript came back and was stamped as this take's result.
+  case accepted
+  /// The attempt reached the acceptance point with no transcript to accept.
+  case rejected
+  /// A newer session had already started, so the result was discarded unread.
+  case stale
+  /// The take was abandoned before the retry resolved.
+  case abandoned
+}
+
 /// Thin wrapper — type-safe event names, no business logic.
 /// Limb: observes facts from domain objects, publishes to PostHog.
 @MainActor
@@ -392,6 +412,90 @@ public final class TelemetryService {
           intProps: ["recording_duration_ms": recordingDurationMs]))
     #endif
     PostHogSDK.shared.capture("escape_recovery.started", properties: props)
+  }
+
+  /// #1946 chunk 2. One Phase-2 retry-decode attempt, started.
+  ///
+  /// The founder deferred moving the three remaining main-actor deadline call
+  /// sites until this path is measured, so this pair of events is a CONDITION
+  /// of that decision rather than an optional extra. Emitted at the attempt so
+  /// unresolved starts are `started` minus `resolved`, rather than a number
+  /// inferred from the resolutions that did arrive.
+  ///
+  /// Shape only, never content: no transcript, no audio, no sample values.
+  public func asrRetryDeadlineStarted(takeID: String, asrBackend: String, budgetMs: Int) {
+    let props: [String: Any] = [
+      "phase": "started",
+      "take_id": takeID,
+      "asr_backend": asrBackend,
+      "budget_ms": budgetMs,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "asr.retry_deadline_observed",
+          stringProps: ["phase": "started", "take_id": takeID, "asr_backend": asrBackend],
+          intProps: ["budget_ms": budgetMs]))
+    #endif
+    PostHogSDK.shared.capture("asr.retry_deadline_observed", properties: props)
+  }
+
+  /// The resolved half of `asrRetryDeadlineStarted`.
+  ///
+  /// Takes the ENUMS, not their raw values, for the same reason
+  /// `escapeRecoveryCompleted` does: an invalid label must be unrepresentable.
+  ///
+  /// `operationReturnMs` is elapsed time from the wrapper's ENTRY to the decode
+  /// returning. It is SAMPLED when the caller resumes, so on a timeout it can
+  /// still carry a return that happened after the timer had already won; it is
+  /// absent only when no return was recorded before that sample. Read it with
+  /// `resolution`, never alone. `callerResumeMs` is entry to the main-actor
+  /// caller continuing. The two are reported separately because a late CALLER
+  /// resume means a blocked main actor, not a late decode, and only a late
+  /// DECODE is evidence about the cutoff.
+  ///
+  /// `acceptedAfterCutoff` is the load-bearing field: a decode that returned
+  /// past its own budget AND was accepted as this take's result. It ESTIMATES
+  /// exposure to a stricter cutoff. It is not a claim about what a different
+  /// scheduler would have done, and must not be read or labelled as "the timer
+  /// would have fired".
+  public func asrRetryDeadlineResolved(
+    takeID: String,
+    asrBackend: String,
+    budgetMs: Int,
+    resolution: ASRRetryDeadlineResolution,
+    disposition: ASRRetryDeadlineDisposition,
+    operationReturnMs: Int?,
+    callerResumeMs: Int,
+    acceptedAfterCutoff: Bool
+  ) {
+    var props: [String: Any] = [
+      "phase": "resolved",
+      "take_id": takeID,
+      "asr_backend": asrBackend,
+      "budget_ms": budgetMs,
+      "resolution": resolution.rawValue,
+      "disposition": disposition.rawValue,
+      "caller_resume_ms": callerResumeMs,
+      "accepted_after_cutoff": acceptedAfterCutoff,
+    ]
+    // Absent rather than a sentinel. A negative or zero stand-in would be
+    // indistinguishable from a real fast return once it reaches a chart.
+    if let operationReturnMs { props["operation_return_ms"] = operationReturnMs }
+    #if DEBUG
+      var intProps: [String: Int] = ["budget_ms": budgetMs, "caller_resume_ms": callerResumeMs]
+      if let operationReturnMs { intProps["operation_return_ms"] = operationReturnMs }
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "asr.retry_deadline_observed",
+          stringProps: [
+            "phase": "resolved", "take_id": takeID, "asr_backend": asrBackend,
+            "resolution": resolution.rawValue, "disposition": disposition.rawValue,
+          ],
+          intProps: intProps,
+          boolProps: ["accepted_after_cutoff": acceptedAfterCutoff]))
+    #endif
+    PostHogSDK.shared.capture("asr.retry_deadline_observed", properties: props)
   }
 
   /// The attempt reached a terminal outcome.

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -773,7 +773,9 @@ import Testing
       classification: .structurallySafe),
     CallSite(
       file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "retryDecode",
-      text: "operation: { [adapter] in await adapter.retryDecode(inputSamples: retryInput) },",
+      // #1946 chunk 2 re-spelled the operation closure so it can stamp the
+      // decode's own return time. Same call, same session-scoped safety.
+      text: "let decoded = await adapter.retryDecode(inputSamples: retryInput)",
       classification: .structurallySafe),
     // Row 22 — "confirmed already safe, no code change" per this file's own
     // doc comment at the site.

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -506,7 +506,7 @@ import Testing
         // `startStreaming()` attempt a caller gave up waiting on — see
         // `ASRManager.cancelInFlightStreamingStart()` / `ASRManagerProxy`'s
         // no-op default (its own signal-watchdog already fully recovers).
-        // SYNCHRONOUS (round 5): must be callable from `withOrderedDeadline`'s
+        // SYNCHRONOUS (round 5): must be callable from `withMainActorOrderedDeadline`'s
         // non-async `onTimeout` for its ordering guarantee.
         MemberSignature(
           condition: nil,

--- a/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/CasingDeadlineEvidenceTests.swift
@@ -133,8 +133,8 @@ struct CasingDeadlineEvidenceTests {
 
   @Test("A completion arriving after the timeout claimed is inert")
   func lateCompletionCannotRewriteReturnedEvidence() {
-    // `withOrderedDeadline` cannot preempt a blocked thread
-    // (`TaskTimeout.swift:123-132`), so the operation keeps running after the
+    // `withOffActorOrderedDeadline` cannot preempt a blocked thread
+    // (`TaskTimeout.swift:193-202`), so the operation keeps running after the
     // timeout returned. If a late completion could still mutate the record, the
     // evidence handed to the caller and the evidence in the gate would disagree
     // — a diagnostic that looks self-consistent and is false.

--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -1804,7 +1804,7 @@ import os
     seamCasingOracle: @escaping @MainActor (String?) -> SeamCasingOracle = { _ in
       Self.testOracle
     },
-    releaseOracleLease: @escaping @MainActor () -> Void = {},
+    releaseOracleLease: @escaping @Sendable () -> Void = {},
     // #1921 language-resolver seam. Defaults to the real resolver so every
     // pre-existing case keeps today's behaviour; the two deadline tests inject a
     // blocking one to drive the REAL 100 ms deadline into its timeout paths.
@@ -1971,8 +1971,8 @@ import os
 
   @Test("#1921 The deadline gate's four phases, including the completed distinction")
   func deadlineGateFourPhaseMatrix() {
-    // Obligation 10's third race order lives inside `withOrderedDeadline`, in the
-    // gap between `await operation()` returning and `claim()` (`TaskTimeout.swift:123-125`).
+    // Obligation 10's third race order lives inside `withOffActorOrderedDeadline`, in the
+    // gap between `await operation()` returning and `claim()` (`TaskTimeout.swift:193-195`).
     // No injected seam reaches it, and timing against the 100 ms boundary would be
     // a clock race. So that ordering is proven HERE, on the state machine itself,
     // and the production call site is verified structurally in the receipt.
@@ -2065,7 +2065,7 @@ import os
     // oracle once the timeout has claimed the phase.
     //
     // Integration review round 2 found this. Cancellation "cannot preempt a
-    // blocked thread" (`TaskTimeout.swift:129`), so a repair authorised before
+    // blocked thread" (`TaskTimeout.swift:200`), so a repair authorised before
     // the deadline keeps running after it. Without this refusal it walks into
     // the real word oracle after the timeout gave up, making exactly the
     // unbounded blocking call the deadline exists to bound.
@@ -2408,6 +2408,476 @@ import os
         """)
     }
   }
+
+  // MARK: - #1946 chunk 2 — the casing deadline off the main actor
+
+  @Test("#1946 The casing timeout is handled while the main actor stays blocked")
+  func casingTimeoutIsHandledWhileTheMainActorStaysBlocked() async throws {
+    // The defect this chunk removes, stated as a schedule. A real oracle
+    // consultation is in flight and the main actor is occupied for far longer
+    // than the 100 ms budget. Under the shipped main-actor timer no timeout
+    // handling could happen at all until the main actor was free again, so the
+    // baseline failure is the ABSENCE of handling while the main actor is held,
+    // never an assumed phase after cleanup.
+    //
+    // The observation happens entirely OFF the main actor, because the main
+    // actor is exactly what is unavailable. It also releases both holds itself,
+    // so a red cannot leave a blocked main actor behind for the rest of the run.
+    //
+    // KNOWN LIMIT, stated rather than machined around. This cannot establish
+    // that the timer task got CPU inside its own bound, so a badly starved
+    // machine fails it against correct code. Re-run once before reading a red
+    // here as the fix regressing. It occupies the shared main actor, so prefer
+    // running it alone when investigating a failure.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+
+      let oracleEntered = DispatchSemaphore(value: 0)
+      let releaseOracle = DispatchSemaphore(value: 0)
+      let oracleExited = DispatchSemaphore(value: 0)
+      let mainOccupied = DispatchSemaphore(value: 0)
+      let releaseMain = DispatchSemaphore(value: 0)
+      let mainReleased = DispatchSemaphore(value: 0)
+      // WHY each wait ended, never merely that it ended. A bare signal fires on
+      // the fail-safe too, so the broken path would report what the fixed one
+      // reports.
+      let occupiedMain = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+      let mainReleaseOutcome = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+      let latchSeen = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+      let decisionElapsedMs = OSAllocatedUnfairLock<Int?>(initialState: nil)
+
+      SeamCasingOracleRuntime.installForTesting(
+        SeamCasingOracle(
+          unavailableReason: nil,
+          dictionaryVerdict: { _ in
+            oracleEntered.signal()
+            // deadline-fallback: `releaseOracle` is the signal; this bound only stops a defect hanging the suite
+            _ = releaseOracle.wait(timeout: .now() + 20)
+            oracleExited.signal()
+            return .ordinary
+          },
+          isLearnedWord: { _ in false },
+          isRecognizedName: { _, _ in false },
+          isNoun: { _ in false }))
+      #expect(
+        Self.oracleIsAvailable(),
+        "precondition: the installed oracle must come back available, or nothing can consult it")
+
+      let started = ContinuousClock.now
+      DispatchQueue.global().async {
+        // Wait for the REAL consultation first, so the watcher cannot report a
+        // latch that some earlier state produced.
+        // deadline-fallback: the consultation is the signal; this bound only stops a defect hanging the suite
+        guard oracleEntered.wait(timeout: .now() + 10) == .success else {
+          releaseMain.signal()
+          releaseOracle.signal()
+          return
+        }
+        var seen = false
+        // bounded poll: the latch is the signal; this bound only stops a defect hanging the suite
+        for _ in 0..<600 {
+          if casingLatchReason() == .oracleTimedOut {
+            seen = true
+            break
+          }
+          usleep(5_000)
+        }
+        // Copied to a `let` first: `withLock` takes an escaping closure, and a
+        // captured `var` is not Sendable.
+        let observed = seen
+        latchSeen.withLock { $0 = observed }
+        decisionElapsedMs.withLock { $0 = Int((ContinuousClock.now - started) / .milliseconds(1)) }
+        // Cleanup ALWAYS, and here rather than in the test body, because the
+        // test body cannot run while the main actor is held.
+        releaseMain.signal()
+        releaseOracle.signal()
+      }
+
+      let outcome = KernelFinalizationOutcome()
+      let context = KernelSessionContext()
+      context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+      context.targetElement = Self.stubCaretElement()
+      let captured = CapturedRequest()
+
+      let wiring = KernelFinalizationWiring(
+        outcome: outcome,
+        context: context,
+        adapter: Self.transcribedEngine(),
+        steps: makeSteps(),
+        textProcessingRunner: TextProcessingRunner(
+          timeoutExecutor: FakeTimeoutExecutor(throwBelowSeconds: 0).run),
+        save: { _, _ in },
+        deliverPaste: { request in
+          captured.request = request
+          return Self.deliveredResult
+        },
+        readCaretContext: { _, _, _ in Self.midSentenceCaret },
+        // `seamCasingOracle` and `releaseOracleLease` are deliberately NOT
+        // passed. The production defaults are the subject of this case.
+        resolveLanguage: { _, _, _, _, _ in
+          DispatchQueue.main.async {
+            mainOccupied.signal()
+            // deadline-fallback: `releaseMain` is the signal; this bound only stops a defect hanging the suite
+            let waited = releaseMain.wait(timeout: .now() + 20)
+            mainReleaseOutcome.withLock { $0 = waited }
+            mainReleased.signal()
+          }
+          // deadline-fallback: the block reaching the main actor is the signal.
+          // Its RESULT is kept, because a block arriving after the consultation
+          // would report a hold this run never had.
+          let occupied = mainOccupied.wait(timeout: .now() + 5)
+          occupiedMain.withLock { $0 = occupied }
+          return DictationLanguageResolver.Resolution(
+            language: "en", source: .dictation, confidenceBucket: .ge90)
+        },
+        pasteCompletionRegistry: nil,
+        copyToClipboard: { text in
+          Issue.record("unexpected clipboard copy: \(text)")
+        })
+
+      let callerStarted = ContinuousClock.now
+      _ = await wiring.deliver("Review this before the meeting", .ordinary)
+      let callerElapsedMs = Int((ContinuousClock.now - callerStarted) / .milliseconds(1))
+
+      #expect(
+        await awaitSignal(mainReleased),
+        "precondition: the occupying block must have finished, or this run measured nothing")
+      #expect(
+        occupiedMain.withLock { $0 } == .success,
+        "precondition: the occupying block must hold the main actor BEFORE the consultation")
+      #expect(
+        outcome.languageResolutionSource == "dictation",
+        """
+        precondition: the deadline must not have claimed before repair began, or \
+        no consultation was attempted and the run says nothing about the timer
+        """)
+      #expect(
+        mainReleaseOutcome.withLock { $0 } == .success,
+        """
+        precondition: the main actor must have been held continuously until the \
+        watcher released it, not freed by its own fail-safe
+        """)
+
+      // The product assertion. Wrapper waiting and the caller's ability to
+      // continue are reported separately on purpose: the decision is bounded
+      // here, the CALLER's return is not, and this chunk never claimed it would
+      // be.
+      #expect(
+        latchSeen.withLock { $0 } == true,
+        """
+        the casing timeout must be handled while the main actor is unavailable. \
+        Decision observed after \(decisionElapsedMs.withLock { $0 } ?? -1)ms; the \
+        main-actor caller could not continue for \(callerElapsedMs)ms
+        """)
+
+      #expect(await awaitSignal(oracleExited), "the blocked consultation must have exited")
+      let request = try #require(captured.request, "the paste route must have been reached")
+      #expect(
+        request.repairedText == nil,
+        "a timed-out repair must offer no candidate, only today's payload")
+    }
+  }
+
+  @Test("#1946 The casing lease is released without waiting for the main actor")
+  func productionLeaseReleaseAllowsQueuedLanguagePreparationWhileMainActorIsBlocked() async throws {
+    // The lease-release seam, folded into this chunk because it is the same
+    // class as the timer: a release queued onto the main actor happens only when
+    // the main actor is next free, and that is exactly when the NEXT language's
+    // preparation can start. The user-visible cost is a second language staying
+    // unprepared behind a decision that already finished.
+    //
+    // `SeamCasingRuntimeSerializationTests` already proves a lease blocks
+    // preparation at the OWNER level. This case is about the WIRING's release,
+    // which that one does not touch.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+
+      let mainOccupied = DispatchSemaphore(value: 0)
+      let releaseMain = DispatchSemaphore(value: 0)
+      let mainReleased = DispatchSemaphore(value: 0)
+      let preparationEntered = DispatchSemaphore(value: 0)
+      let occupiedMain = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+      let mainReleaseOutcome = OSAllocatedUnfairLock<DispatchTimeoutResult?>(initialState: nil)
+      let preparationSeenWhileMainHeld = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+      let leasesDuringPreparation = OSAllocatedUnfairLock<Int?>(initialState: nil)
+      let leasesWhileGermanRefused = OSAllocatedUnfairLock<Int?>(initialState: nil)
+      let germanRefusal = OSAllocatedUnfairLock<CursorInsertionRepair.CaseSkipReason?>(
+        initialState: nil)
+      let queuedGerman = OSAllocatedUnfairLock(initialState: false)
+
+      SeamCasingOracleRuntime.setPreparationOverrideForTesting { _ in
+        // REPORTS the production transition, never performs one: the drain has
+        // genuinely started this builder, which is the fact under test.
+        leasesDuringPreparation.withLock { $0 = SeamCasingOracleRuntime.outstandingLeasesForTesting() }
+        preparationEntered.signal()
+        return SeamCasingOracle(
+          unavailableReason: nil,
+          dictionaryVerdict: { _ in .ordinary },
+          isLearnedWord: { _ in false },
+          isRecognizedName: { _, _ in false },
+          isNoun: { _ in false })
+      }
+      defer { SeamCasingOracleRuntime.setPreparationOverrideForTesting(nil) }
+
+      SeamCasingOracleRuntime.installForTesting(
+        SeamCasingOracle(
+          unavailableReason: nil,
+          dictionaryVerdict: { _ in
+            // Once. Repair consults per word, and this stages a one-time
+            // scenario rather than a per-word one.
+            let first = queuedGerman.withLock { done -> Bool in
+              if done { return false }
+              done = true
+              return true
+            }
+            guard first else { return .ordinary }
+            // The English decision holds its lease right now, so a language that
+            // has never been prepared must ENQUEUE and be refused.
+            let german = SeamCasingOracleRuntime.snapshot(for: "de")
+            germanRefusal.withLock { $0 = german.unavailableReason }
+            leasesWhileGermanRefused.withLock {
+              $0 = SeamCasingOracleRuntime.outstandingLeasesForTesting()
+            }
+            DispatchQueue.main.async {
+              mainOccupied.signal()
+              // deadline-fallback: `releaseMain` is the signal; this bound only stops a defect hanging the suite
+              let waited = releaseMain.wait(timeout: .now() + 20)
+              mainReleaseOutcome.withLock { $0 = waited }
+              mainReleased.signal()
+            }
+            // deadline-fallback: the block reaching the main actor is the signal
+            let occupied = mainOccupied.wait(timeout: .now() + 5)
+            occupiedMain.withLock { $0 = occupied }
+            return .ordinary
+          },
+          isLearnedWord: { _ in false },
+          isRecognizedName: { _, _ in false },
+          isNoun: { _ in false }))
+      #expect(Self.oracleIsAvailable(), "precondition: English must be ready to lease")
+
+      DispatchQueue.global().async {
+        // deadline-fallback: the queued preparation is the signal; this bound only stops a defect hanging the suite
+        let entered = preparationEntered.wait(timeout: .now() + 5)
+        preparationSeenWhileMainHeld.withLock { $0 = entered == .success }
+        releaseMain.signal()
+      }
+
+      let outcome = KernelFinalizationOutcome()
+      let context = KernelSessionContext()
+      context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+      context.targetElement = Self.stubCaretElement()
+
+      let wiring = KernelFinalizationWiring(
+        outcome: outcome,
+        context: context,
+        adapter: Self.transcribedEngine(),
+        steps: makeSteps(),
+        textProcessingRunner: TextProcessingRunner(
+          timeoutExecutor: FakeTimeoutExecutor(throwBelowSeconds: 0).run),
+        save: { _, _ in },
+        deliverPaste: { _ in Self.deliveredResult },
+        readCaretContext: { _, _, _ in Self.midSentenceCaret },
+        // Production `seamCasingOracle` AND production `releaseOracleLease`.
+        // The release is the subject; injecting either would test the fixture.
+        resolveLanguage: { _, _, _, _, _ in
+          DictationLanguageResolver.Resolution(
+            language: "en", source: .dictation, confidenceBucket: .ge90)
+        },
+        pasteCompletionRegistry: nil,
+        copyToClipboard: { text in
+          Issue.record("unexpected clipboard copy: \(text)")
+        })
+
+      _ = await wiring.deliver("Review this before the meeting", .ordinary)
+
+      #expect(
+        await awaitSignal(mainReleased),
+        "precondition: the occupying block must have finished")
+      #expect(
+        occupiedMain.withLock { $0 } == .success,
+        "precondition: the occupying block must hold the main actor before the decision exits")
+      #expect(
+        germanRefusal.withLock { $0 } == .oracleWarming,
+        "precondition: German must have enqueued behind the English lease")
+      #expect(
+        leasesWhileGermanRefused.withLock { $0 } == 1,
+        "a REFUSED snapshot must take no lease, so the count stays at the one English holds")
+
+      // The product assertion.
+      #expect(
+        preparationSeenWhileMainHeld.withLock { $0 } == true,
+        """
+        the queued language's preparation must be able to start while the main \
+        actor is still blocked. A release queued onto the main actor cannot, and \
+        the watcher then ends on its fail-safe instead of on the preparation
+        """)
+      #expect(
+        mainReleaseOutcome.withLock { $0 } == .success,
+        "the main actor must have been held until the watcher released it")
+      #expect(
+        leasesDuringPreparation.withLock { $0 } == 0,
+        "no decision may still hold a lease while preparation is inside the shared checker")
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0,
+        "and the decision's own lease must be back")
+    }
+  }
+
+  @Test("#1946 A timed-out casing decision keeps its latch, its evidence and its neighbours' leases")
+  func timedOutCasingDecisionPreservesLatchEvidenceAndLeases() async throws {
+    // The preservation obligation. Casing's timeout execution and its
+    // lease-release scheduling both change in this chunk, so what the timeout
+    // protects has to be re-established rather than assumed. This one need not
+    // fail on baseline; it is validated against mutations that remove the
+    // protection (recipe on the test-hardening issue).
+    //
+    // Simulated: the external dictionary taking too long. Real: lease
+    // acquisition, timeout handling, latching, snapshot reads, frozen-evidence
+    // protection and cleanup. Nothing is reset or replaced after the timeout —
+    // that would manufacture the outcome.
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+
+      let oracleEntered = DispatchSemaphore(value: 0)
+      let releaseOracle = DispatchSemaphore(value: 0)
+      let cleanupDone = DispatchSemaphore(value: 0)
+      // Joined before this case leaves the exclusion. The reader polls for a
+      // further stretch after cleanup signals, and the NEXT case resets the
+      // runtime — an unjoined reader would then be taking snapshots against
+      // somebody else's state and reporting them here.
+      let readersDone = DispatchSemaphore(value: 0)
+      let readerRefused = OSAllocatedUnfairLock<CursorInsertionRepair.CaseSkipReason?>(
+        initialState: nil)
+      let readersSawOnlyRefusals = OSAllocatedUnfairLock(initialState: true)
+      let leasesAfterCleanup = OSAllocatedUnfairLock<Int?>(initialState: nil)
+
+      SeamCasingOracleRuntime.installForTesting(
+        SeamCasingOracle(
+          unavailableReason: nil,
+          dictionaryVerdict: { _ in
+            oracleEntered.signal()
+            // deadline-fallback: `releaseOracle` is the signal; this bound only stops a defect hanging the suite
+            _ = releaseOracle.wait(timeout: .now() + 20)
+            return .ordinary
+          },
+          isLearnedWord: { _ in false },
+          isRecognizedName: { _, _ in false },
+          isNoun: { _ in false }))
+
+      // The WITNESS lease, taken through the real decision API before the timed
+      // attempt. Asserting zero leases after the abandoned decision unwinds
+      // would MISS an extra release, because releasing at zero silently refuses.
+      let witness = SeamCasingOracleRuntime.snapshot(for: "en")
+      #expect(witness.isAvailable, "precondition: English must be ready to lease")
+      #expect(SeamCasingOracleRuntime.outstandingLeasesForTesting() == 1)
+
+      DispatchQueue.global().async {
+        defer { readersDone.signal() }
+        // deadline-fallback: the consultation is the signal; this bound only stops a defect hanging the suite
+        guard oracleEntered.wait(timeout: .now() + 10) == .success else {
+          releaseOracle.signal()
+          return
+        }
+        // Real readers on the real API, racing the abandoned operation. Require
+        // an observed refusal BEFORE the dictionary is released, so the refusal
+        // cannot be an artefact of the operation having already finished.
+        var refusal: CursorInsertionRepair.CaseSkipReason?
+        // bounded poll: the latch is the signal; this bound only stops a defect hanging the suite
+        for _ in 0..<600 {
+          if let reason = casingLatchReason() {
+            refusal = reason
+            break
+          }
+          usleep(5_000)
+        }
+        let observedRefusal = refusal
+        readerRefused.withLock { $0 = observedRefusal }
+        releaseOracle.signal()
+        // Now race the late completion and its cleanup. Every reader here must
+        // still be refused: the latch outlives anything the abandoned call does.
+        for _ in 0..<200 {
+          if casingLatchReason() != .oracleTimedOut {
+            readersSawOnlyRefusals.withLock { $0 = false }
+            break
+          }
+          usleep(1_000)
+        }
+      }
+
+      let outcome = KernelFinalizationOutcome()
+      let context = KernelSessionContext()
+      context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+      context.targetElement = Self.stubCaretElement()
+      let captured = CapturedRequest()
+
+      let wiring = KernelFinalizationWiring(
+        outcome: outcome,
+        context: context,
+        adapter: Self.transcribedEngine(),
+        steps: makeSteps(),
+        textProcessingRunner: TextProcessingRunner(
+          timeoutExecutor: FakeTimeoutExecutor(throwBelowSeconds: 0).run),
+        save: { _, _ in },
+        deliverPaste: { request in
+          captured.request = request
+          return Self.deliveredResult
+        },
+        readCaretContext: { _, _, _ in Self.midSentenceCaret },
+        // The PRODUCTION release, plus a report that it finished. The signal
+        // has to come from after the lease `defer`; the dictionary stub's own
+        // return is too early, because authorisation completion, repair
+        // completion and the `defer` all follow it.
+        releaseOracleLease: {
+          SeamCasingOracleRuntime.releaseDecisionLease()
+          cleanupDone.signal()
+        },
+        resolveLanguage: { _, _, _, _, _ in
+          DictationLanguageResolver.Resolution(
+            language: "en", source: .dictation, confidenceBucket: .ge90)
+        },
+        pasteCompletionRegistry: nil,
+        copyToClipboard: { text in
+          Issue.record("unexpected clipboard copy: \(text)")
+        })
+
+      _ = await wiring.deliver("Review this before the meeting", .ordinary)
+
+      #expect(
+        await awaitSignal(cleanupDone),
+        "precondition: the abandoned operation must have unwound through its lease defer")
+      #expect(
+        await awaitSignal(readersDone),
+        "precondition: the readers must finish before anything resets the runtime under them")
+      leasesAfterCleanup.withLock { $0 = SeamCasingOracleRuntime.outstandingLeasesForTesting() }
+
+      #expect(
+        readerRefused.withLock { $0 } == .oracleTimedOut,
+        "a reader after the timeout must be refused through the latch, not served")
+      #expect(
+        readersSawOnlyRefusals.withLock { $0 },
+        "and the late completion must not un-latch the runtime for a later reader")
+      #expect(
+        leasesAfterCleanup.withLock { $0 } == 1,
+        """
+        the abandoned decision must release ONLY its own lease. The witness must \
+        survive; releasing at zero silently refuses, so a bare zero here would \
+        hide an extra release
+        """)
+      SeamCasingOracleRuntime.releaseDecisionLease()
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 0,
+        "and the witness must be the thing that takes it back to zero")
+
+      let request = try #require(captured.request, "the paste route must have been reached")
+      #expect(
+        request.repairedText == nil,
+        "the frozen evidence must still say the repair produced no candidate")
+      #expect(
+        outcome.languageResolutionSource == "dictation",
+        "and the resolution the language stage produced must survive the freeze")
+    }
+  }
+
 }
 
 
@@ -2418,6 +2888,23 @@ import os
 private final class ManualClock {
   private(set) var now: TimeInterval = 0
   func advance(by seconds: TimeInterval) { now += seconds }
+}
+
+/// #1946 chunk 2. Reads the casing runtime's latch through the REAL decision
+/// API, from whatever thread calls it, without ever stranding a lease.
+///
+/// Free-standing and nonisolated because the observation has to happen OFF the
+/// main actor — the property under test is that the timeout is handled while
+/// the main actor is unavailable, so a `@MainActor` probe could not run at the
+/// moment that matters. `snapshot(for:)` is the production read and takes a
+/// decision lease when it answers ready; a probe that kept one would stop every
+/// later language preparing.
+private func casingLatchReason(
+  _ base: String = "en"
+) -> CursorInsertionRepair.CaseSkipReason? {
+  let oracle = SeamCasingOracleRuntime.snapshot(for: base)
+  if oracle.isAvailable { SeamCasingOracleRuntime.releaseDecisionLease() }
+  return oracle.unavailableReason
 }
 
 private enum WiringTestError: Error { case storage }

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 import Testing
 
@@ -342,7 +343,7 @@ struct KernelPhase2RetryTests {
     let ctx = makeContext(behavior: .crashOnFinalize)
     // A real, tiny wall-clock deadline — the retry never resolves within it
     // (the fake-clock delay is never advanced during this test), so
-    // `withOrderedDeadline`'s `onTimeout` fires for real.
+    // `withMainActorOrderedDeadline`'s `onTimeout` fires for real.
     ctx.engine.retryDecodeTimeoutSeconds = 0.05
     ctx.engine.retryDecodeDelayTicks = 1
     // #1857: the ONLY caller that opts out of the conclusion wait. This
@@ -567,4 +568,266 @@ struct KernelPhase2RetryTests {
     #expect(kernel.pasteCount == 0)
     #expect(ctx.engine.retryDecodeCallCount == 1)
   }
+
+  // MARK: - #1946 chunk 2 — the retry deadline's own observation
+  //
+  // The founder deferred moving the three remaining main-actor deadline call
+  // sites until this path is measured, so these cases guard the measurement
+  // itself. The load-bearing field is `acceptedAfterCutoff`: a decode that
+  // returned past its own budget AND was accepted. An off-actor timer would
+  // reject exactly those, so the count is what makes the deferred half a
+  // decision with a falsification condition rather than another judgement call.
+  //
+  // Each case asserts what the KERNEL computed, through the kernel's own
+  // observation seam. `TelemetryServiceRetryDeadlineTests` separately asserts
+  // the payload that reaches PostHog, through the existing telemetry test hook.
+
+  /// One resolved observation, exactly as the kernel handed it over.
+  @MainActor
+  private final class RetryDeadlineLog {
+    private(set) var starts: [(takeID: String, backend: String, budgetMs: Int)] = []
+    private(set) var resolutions:
+      [(
+        takeID: String, backend: String, budgetMs: Int,
+        resolution: ASRRetryDeadlineResolution, disposition: ASRRetryDeadlineDisposition,
+        operationReturnMs: Int?, callerResumeMs: Int, acceptedAfterCutoff: Bool
+      )] = []
+
+    func recordStart(_ takeID: String, _ backend: String, _ budgetMs: Int) {
+      starts.append((takeID, backend, budgetMs))
+    }
+    func recordResolution(
+      _ takeID: String, _ backend: String, _ budgetMs: Int,
+      _ resolution: ASRRetryDeadlineResolution, _ disposition: ASRRetryDeadlineDisposition,
+      _ operationReturnMs: Int?, _ callerResumeMs: Int, _ acceptedAfterCutoff: Bool
+    ) {
+      resolutions.append(
+        (takeID, backend, budgetMs, resolution, disposition, operationReturnMs, callerResumeMs,
+          acceptedAfterCutoff))
+    }
+  }
+
+  private func makeObservedContext(
+    behavior: FakeEngineBehavior,
+    log: RetryDeadlineLog,
+    prepareEscapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false }
+  ) -> Context {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: behavior, clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste,
+      prepareEscapeRecovery: prepareEscapeRecovery,
+      onRetryDeadlineStarted: { takeID, backend, budgetMs in
+        log.recordStart(takeID, backend, budgetMs)
+      },
+      onRetryDeadlineResolved: {
+        takeID, backend, budgetMs, resolution, disposition, operationReturnMs, callerResumeMs,
+        accepted in
+        log.recordResolution(
+          takeID, backend, budgetMs, resolution, disposition, operationReturnMs, callerResumeMs,
+          accepted)
+      })
+    return Context(
+      wrapper: wrapper, engine: engine, capture: capture, vad: vad, paste: paste, clock: clock)
+  }
+
+  @Test("#1946 An on-time accepted retry is observed as on time")
+  func retryDeadlineObservationOnTimeSuccess() async {
+    let log = RetryDeadlineLog()
+    let ctx = makeObservedContext(behavior: .crashOnFinalize, log: log)
+    ctx.engine.retryDecodeTimeoutSeconds = 20.0
+    await runToTerminal(ctx)
+
+    #expect(log.starts.count == 1, "every attempt must be counted, or unresolved starts are guesswork")
+    let resolved = log.resolutions
+    #expect(resolved.count == 1)
+    guard let observation = resolved.first else { return }
+    #expect(observation.takeID == log.starts.first?.takeID, "the two halves must join")
+    #expect(observation.budgetMs == 20_000)
+    #expect(observation.resolution == .operationReturned)
+    #expect(observation.disposition == .accepted)
+    let returnMs = observation.operationReturnMs ?? -1
+    #expect(returnMs >= 0, "a decode that returned must carry a return time")
+    #expect(
+      returnMs <= observation.budgetMs,
+      "the fixture is an on-time decode; it returned in \(returnMs)ms against \(observation.budgetMs)ms")
+    #expect(
+      observation.acceptedAfterCutoff == false,
+      "an on-time accepted decode is not exposure to a stricter cutoff")
+  }
+
+  @Test("#1946 A retry accepted AFTER its own budget is counted as such")
+  func retryDeadlineObservationLateAcceptedSuccess() async {
+    // The whole reason this measurement exists. The decode blocks the main
+    // actor for longer than the budget, so the main-actor timer cannot fire and
+    // the decode wins late — which is the field schedule an off-actor timer
+    // would turn into a rejection.
+    let log = RetryDeadlineLog()
+    let ctx = makeObservedContext(behavior: .crashOnFinalize, log: log)
+    ctx.engine.retryDecodeTimeoutSeconds = 0.05
+    // Blocking, not a cooperative wait: the decode must genuinely occupy the
+    // main actor so the main-actor timer cannot run while it does. A
+    // cooperative wait would let that timer fire and stage a timeout instead —
+    // the wrong case, silently. `usleep` because the blocking alternative is
+    // unavailable from an async context.
+    ctx.engine.onRetryDecodeReturning = { usleep(250_000) }
+    await runToTerminal(ctx)
+
+    let resolved = log.resolutions
+    #expect(resolved.count == 1)
+    guard let observation = resolved.first else { return }
+    #expect(
+      observation.resolution == .operationReturned,
+      "staging: the decode must have won the race, or this measures a timeout instead")
+    #expect(observation.disposition == .accepted)
+    let returnMs = observation.operationReturnMs ?? -1
+    #expect(
+      returnMs > observation.budgetMs,
+      "staging: the decode must return past \(observation.budgetMs)ms, saw \(returnMs)ms")
+    #expect(
+      observation.acceptedAfterCutoff,
+      "a decode accepted past its own budget is exactly the exposure being counted")
+  }
+
+  @Test("#1946 A timed-out retry carries no return time and is never counted as late-accepted")
+  func retryDeadlineObservationTimeout() async {
+    let log = RetryDeadlineLog()
+    let ctx = makeObservedContext(behavior: .crashOnFinalize, log: log)
+    ctx.engine.retryDecodeTimeoutSeconds = 0.05
+    ctx.engine.retryDecodeDelayTicks = 1
+    await runToTerminal(ctx, awaitTerminal: false)
+    let kernel = ctx.wrapper.testKernel
+    for _ in 0..<200 where kernel.recordingOutcome == nil {
+      try? await Task.sleep(for: .milliseconds(5))  // settle: poll the real 50ms deadline above
+    }
+
+    let resolved = log.resolutions
+    #expect(resolved.count == 1)
+    guard let observation = resolved.first else { return }
+    #expect(observation.resolution == .timedOut)
+    #expect(observation.disposition == .rejected, "no transcript reached the acceptance point")
+    #expect(
+      observation.operationReturnMs == nil,
+      "the decode had not returned, and an absent time must stay absent rather than become a zero")
+    #expect(observation.acceptedAfterCutoff == false)
+  }
+
+  @Test("#1946 A retry resolving after a new session started is observed as stale")
+  func retryDeadlineObservationStaleSession() async {
+    let log = RetryDeadlineLog()
+    let ctx = makeObservedContext(behavior: .crashOnFinalize, log: log)
+    ctx.engine.retryDecodeDelayTicks = 3
+    ctx.engine.retryDecodeResult = .transcript(
+      ASRResult(
+        text: "stale retry text", language: nil, duration: 0, processingTime: 0,
+        backendType: .parakeet))
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainReadyWork()
+    let kernel = ctx.wrapper.testKernel
+    #expect(log.starts.count == 1, "the attempt is counted at the start, not at the resolution")
+    #expect(log.resolutions.isEmpty, "staging: the retry must still be parked")
+
+    kernel.cancel()
+    await ctx.wrapper.drainUntilConcluded()
+    ctx.engine.behavior = .batchSuccess(text: "session B text")
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    await ctx.wrapper.drainReadyWork()
+    await ctx.wrapper.apply(.stop)
+    await ctx.wrapper.drainUntilConcluded()
+
+    ctx.clock.advance(by: 3)
+    await ctx.wrapper.drainReadyWork()
+
+    let resolved = log.resolutions
+    #expect(resolved.count == 1, "an abandoned resolution must still be reported, not dropped")
+    guard let observation = resolved.first else { return }
+    #expect(observation.disposition == .stale)
+    #expect(
+      observation.acceptedAfterCutoff == false,
+      "nothing was accepted, so no exposure to a stricter cutoff was created")
+  }
+
+  @Test("#1946 A late CALLER resume is not counted as a late DECODE")
+  func retryDeadlineObservationSeparatesTheTwoClocks() async throws {
+    // The separator. A blocked main actor delays the caller's resume without
+    // delaying the decode, and only the decode is evidence about the cutoff.
+    // Reading the wrong clock here would inflate `accepted_after_cutoff` with
+    // main-actor contention and send the deferred decision the wrong way.
+    let log = RetryDeadlineLog()
+    let ctx = makeObservedContext(behavior: .crashOnFinalize, log: log)
+    // A budget the CALLER's resume exceeds and the DECODE does not. At 20 s
+    // both readings sat under budget, so swapping the production comparison to
+    // the caller's clock changed nothing and the case proved only that a fast
+    // decode is not late.
+    ctx.engine.retryDecodeTimeoutSeconds = 0.100
+    ctx.engine.onRetryDecodeReturning = {
+      DispatchQueue.main.async {
+        Thread.sleep(forTimeInterval: 0.3)  // occupies the main actor for the caller's resume only
+      }
+    }
+    await runToTerminal(ctx)
+
+    let resolved = log.resolutions
+    #expect(resolved.count == 1)
+    let observation = try #require(resolved.first)
+    #expect(observation.resolution == .operationReturned)
+    #expect(observation.disposition == .accepted)
+    // The distinguishing schedule, REQUIRED rather than expected: without both
+    // halves the final assertion holds for a reason that is not the subject.
+    let returnMs = try #require(observation.operationReturnMs)
+    try #require(returnMs <= observation.budgetMs)
+    try #require(observation.callerResumeMs > observation.budgetMs)
+    #expect(
+      observation.acceptedAfterCutoff == false,
+      """
+      a late caller resume is a blocked main actor, not a late decode; counting it \
+      would attribute main-actor contention to the retry budget
+      """)
+  }
+
+
+  @Test("#1946 A retry resolving after the take was abandoned is observed as abandoned")
+  func retryDeadlineObservationAbandonedTake() async {
+    let log = RetryDeadlineLog()
+    let ctx = makeObservedContext(
+      behavior: .crashOnFinalize, log: log, prepareEscapeRecovery: { _, _, _ in true })
+    ctx.wrapper.sessionConfigForTesting = .testDefault(escapeRecoveryEnabled: true)
+    ctx.wrapper.cancelOriginForTesting = .user(.shortcut)
+    // Park the retry so the take can be abandoned while it is still in flight.
+    ctx.engine.retryDecodeDelayTicks = 3
+    await ctx.wrapper.apply(.start)
+    await ctx.wrapper.drainReadyWork()
+    deliverVoicedCapture(ctx)
+    await ctx.wrapper.drainReadyWork()
+    // Cancel once: Escape Recovery KEEPS the take and runs the ordinary
+    // pipeline, so the decode fails and the one retry is spent and parked.
+    await ctx.wrapper.apply(.cancel)
+    await ctx.wrapper.drainReadyWork()
+    #expect(log.starts.count == 1, "staging: the retry must have been attempted")
+    #expect(log.resolutions.isEmpty, "staging: the retry must still be parked")
+
+    // Cancel again: the user abandons the recovery while its retry is parked.
+    await ctx.wrapper.apply(.cancel)
+    await ctx.wrapper.drainReadyWork()
+    ctx.clock.advance(by: 3)
+    await ctx.wrapper.drainReadyWork()
+
+    let resolved = log.resolutions
+    #expect(resolved.count == 1, "an abandoned resolution must still be reported, not dropped")
+    guard let observation = resolved.first else { return }
+    #expect(observation.disposition == .abandoned)
+    #expect(
+      observation.acceptedAfterCutoff == false,
+      "nothing was accepted, so no exposure to a stricter cutoff was created")
+  }
+
 }

--- a/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelPhase2RetryTests.swift
@@ -661,29 +661,58 @@ struct KernelPhase2RetryTests {
 
   @Test("#1946 A retry accepted AFTER its own budget is counted as such")
   func retryDeadlineObservationLateAcceptedSuccess() async {
-    // The whole reason this measurement exists. The decode blocks the main
-    // actor for longer than the budget, so the main-actor timer cannot fire and
-    // the decode wins late — which is the field schedule an off-actor timer
-    // would turn into a rejection.
+    // The schedule the whole measurement exists for. The decode blocks the main
+    // actor past the budget, so the main-actor timer cannot run while it does.
+    //
+    // **THIS SCHEDULE CANNOT BE STAGED DETERMINISTICALLY, and pretending
+    // otherwise is what made this case fail on CI while passing here.** Winning
+    // while late means beating a timer that is ALREADY DUE: when the block
+    // releases the main actor, the timer's continuation is queued there, while
+    // the operation must still finish the decode, stamp, leave the main actor
+    // and claim. Either can get there first, and which one does is a property of
+    // the machine. Measured 2026-09-08: the decode won on an M5 Max and the
+    // timer won on the hosted runner, same code, same budget.
+    //
+    // So the timeout outcome is reported as a SKIP with its numbers, never as a
+    // product failure — `validation-discipline.md`
+    // RULE: verify-the-feature-not-the-crash: a red row for a scenario the
+    // harness cannot stage is worse than a skip, because it accuses correct
+    // code. The flag's own arithmetic is covered deterministically by
+    // `TelemetryServiceRetryDeadlineTests` and by
+    // `retryDeadlineObservationSeparatesTheTwoClocks`; what only THIS case can
+    // show is the kernel computing it on a real late acceptance.
     let log = RetryDeadlineLog()
     let ctx = makeObservedContext(behavior: .crashOnFinalize, log: log)
     ctx.engine.retryDecodeTimeoutSeconds = 0.05
     // Blocking, not a cooperative wait: the decode must genuinely occupy the
-    // main actor so the main-actor timer cannot run while it does. A
-    // cooperative wait would let that timer fire and stage a timeout instead —
-    // the wrong case, silently. `usleep` because the blocking alternative is
-    // unavailable from an async context.
+    // main actor. A cooperative wait would let the timer run and stage a timeout
+    // every time. `usleep` because the blocking alternative is unavailable from
+    // an async context.
     ctx.engine.onRetryDecodeReturning = { usleep(250_000) }
     await runToTerminal(ctx)
 
     let resolved = log.resolutions
     #expect(resolved.count == 1)
     guard let observation = resolved.first else { return }
-    #expect(
-      observation.resolution == .operationReturned,
-      "staging: the decode must have won the race, or this measures a timeout instead")
-    #expect(observation.disposition == .accepted)
     let returnMs = observation.operationReturnMs ?? -1
+
+    guard observation.resolution == .operationReturned else {
+      // Loud, with the numbers, so a run that measured nothing can never be read
+      // as a run that measured a pass.
+      print(
+        "SKIP retryDeadlineObservationLateAcceptedSuccess: the timer won the claim on this "
+          + "machine, so no late ACCEPTANCE occurred. budget=\(observation.budgetMs)ms "
+          + "decodeReturn=\(returnMs)ms callerResume=\(observation.callerResumeMs)ms")
+      // Still assert what this run DOES establish: a timeout is never counted as
+      // exposure, whatever the decode later reported.
+      #expect(observation.disposition == .rejected)
+      #expect(
+        observation.acceptedAfterCutoff == false,
+        "a decode that lost the claim was never accepted, so it creates no exposure")
+      return
+    }
+
+    #expect(observation.disposition == .accepted)
     #expect(
       returnMs > observation.budgetMs,
       "staging: the decode must return past \(observation.budgetMs)ms, saw \(returnMs)ms")

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -768,7 +768,7 @@ import Testing
 
     // Force retryDecode down its readiness-repair path so it parks on the
     // gated loadModel() — a deterministic stand-in for "the kernel's
-    // withOrderedDeadline decided this retry took too long."
+    // withMainActorOrderedDeadline decided this retry took too long."
     manager.isModelLoaded = false
     manager.gateLoadModel = true
     manager.transcribeResult = makeResult("should be discarded")

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -100,7 +100,7 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
   /// scenarios assert byte-identical strings.
   var engineIdentity: ASREngineIdentity = ASREngineIdentity(backendType: .parakeet)
 
-  /// #1707 Phase 2: settable so a test can drive `withOrderedDeadline`'s real
+  /// #1707 Phase 2: settable so a test can drive `withMainActorOrderedDeadline`'s real
   /// deadline race deliberately; the fake-clock-driven scenarios in this
   /// simulator never wait anywhere near this long in real wall time, so the
   /// exact default is inert for them. Codex r8/r9: production made this
@@ -177,12 +177,24 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
   /// retry still resolves without hanging. `retryDecodeDelayTicks` mirrors
   /// `asrInterruptionRecoveryDelayTicks`'s place-on-the-fake-clock pattern,
   /// so a scenario can deterministically race a retry against the kernel's
-  /// own `withOrderedDeadline` timeout or a superseding session/cancel.
+  /// own `withMainActorOrderedDeadline` timeout or a superseding session/cancel.
   var retryDecodeResult: ASREngineOutcome = .transcript(
     ASRResult(
       text: "retried transcript", language: nil, duration: 0, processingTime: 0,
       backendType: .parakeet))
   var retryDecodeDelayTicks = 0
+  /// #1946 chunk 2. A REAL blocking wall-clock cost inside `retryDecode`.
+  ///
+  /// Fires on the main actor as `retryDecode` returns, before the value leaves
+  /// the call. A case that blocks here delays the DECODE's return; a case that
+  /// enqueues main-actor work instead delays only the CALLER's resume. Both
+  /// schedules are needed, because reporting those two clocks apart is the
+  /// whole point of the retry measurement.
+  ///
+  /// The wall-clock cost itself lives in the CASE, never here: this directory
+  /// is scanned by `SimulatorWallClockBanTests`, and simulator time comes from
+  /// `FakeClock`.
+  var onRetryDecodeReturning: (@MainActor () -> Void)?
   private(set) var retryDecodeCallCount = 0
   private(set) var lastRetryDecodeInputSamples: [Float]?
   private(set) var bumpRetryGenerationCallCount = 0
@@ -197,6 +209,7 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
     if case .transcript(let result) = retryDecodeResult {
       lastResult = result
     }
+    onRetryDecodeReturning?()
     return retryDecodeResult
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -278,7 +278,15 @@ final class KernelRecordingSession: RecordingSessionDriving {
     /// kernel's own production default, so every existing scenario in the
     /// 37-scenario inventory is unchanged. A scenario that wants to exercise
     /// the denied-mic preflight passes `{ true }` explicitly.
-    microphonePermissionIsDenied: @escaping @MainActor () -> Bool = { false }
+    microphonePermissionIsDenied: @escaping @MainActor () -> Bool = { false },
+    /// #1946 chunk 2: the retry-deadline observation seams. Defaulted to no-ops
+    /// so every existing scenario is unchanged; the five retry-schedule cases
+    /// pass recorders and assert what the kernel computed.
+    onRetryDeadlineStarted: @escaping @MainActor (String, String, Int) -> Void = { _, _, _ in },
+    onRetryDeadlineResolved: @escaping @MainActor (
+      String, String, Int, ASRRetryDeadlineResolution, ASRRetryDeadlineDisposition, Int?, Int,
+      Bool
+    ) -> Void = { _, _, _, _, _, _, _, _ in }
   ) {
     self.vad = vad
     let limb = self.limb
@@ -333,6 +341,8 @@ final class KernelRecordingSession: RecordingSessionDriving {
       // minimum-recording threshold would discard most scenarios. The
       // dedicated #4 coverage lives in `ConductorParitySeamTests`.
       prepareEscapeRecovery: prepareEscapeRecovery,
+      asrRetryDeadlineStartedTelemetry: onRetryDeadlineStarted,
+      asrRetryDeadlineResolvedTelemetry: onRetryDeadlineResolved,
       engineMutationScope: .alwaysAllowedForTesting,
       minimumRecordingTicks: minimumRecordingTicks,
       captureTelemetry: captureTelemetry,

--- a/Tests/EnviousWisprTests/Pipeline/TelemetryServiceRetryDeadlineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TelemetryServiceRetryDeadlineTests.swift
@@ -1,122 +1,131 @@
-import EnviousWisprServices
-import Foundation
-import Testing
-import os
+// `CapturedTelemetryEvent` and `testEventHook` live inside `#if DEBUG` in
+// `TelemetryService`, so this whole suite must be gated the same way — the
+// Release-configuration test target compiles the test sources too, and an
+// ungated reference fails that build while every Debug run stays green.
+// Same shape as `TestSupport/TelemetryEventWaiter.swift`.
+#if DEBUG
 
-// MARK: - #1946 chunk 2 — the retry-deadline event's payload
-//
-// `KernelPhase2RetryTests` proves what the KERNEL computes across the five
-// retry schedules. This suite proves what actually reaches the analytics
-// pipeline, through the existing telemetry test hook rather than a live
-// capture, because a correct computation published under the wrong field names
-// answers nobody's question.
+  import EnviousWisprServices
+  import Foundation
+  import Testing
+  import os
 
-@MainActor
-@Suite("#1946 retry-deadline telemetry payload", .tags(.observabilityContract))
-struct TelemetryServiceRetryDeadlineTests {
+  // MARK: - #1946 chunk 2 — the retry-deadline event's payload
+  //
+  // `KernelPhase2RetryTests` proves what the KERNEL computes across the five
+  // retry schedules. This suite proves what actually reaches the analytics
+  // pipeline, through the existing telemetry test hook rather than a live
+  // capture, because a correct computation published under the wrong field names
+  // answers nobody's question.
 
-  /// Captures one emission and always restores the hook, so a failing case
-  /// cannot leave a recorder installed for the rest of the run.
-  private func captureEvents(
-    _ body: @MainActor () -> Void
-  ) -> [CapturedTelemetryEvent] {
-    // Under a lock, not a captured `var`: the hook is `@Sendable`, so the
-    // compiler refuses a plain capture and a box that ignored that would be
-    // hiding a real cross-thread write rather than answering it.
-    let captured = OSAllocatedUnfairLock<[CapturedTelemetryEvent]>(initialState: [])
-    let prior = TelemetryService.shared.testEventHook
-    TelemetryService.shared.testEventHook = { event in
-      captured.withLock { $0.append(event) }
+  @MainActor
+  @Suite("#1946 retry-deadline telemetry payload", .tags(.observabilityContract))
+  struct TelemetryServiceRetryDeadlineTests {
+
+    /// Captures one emission and always restores the hook, so a failing case
+    /// cannot leave a recorder installed for the rest of the run.
+    private func captureEvents(
+      _ body: @MainActor () -> Void
+    ) -> [CapturedTelemetryEvent] {
+      // Under a lock, not a captured `var`: the hook is `@Sendable`, so the
+      // compiler refuses a plain capture and a box that ignored that would be
+      // hiding a real cross-thread write rather than answering it.
+      let captured = OSAllocatedUnfairLock<[CapturedTelemetryEvent]>(initialState: [])
+      let prior = TelemetryService.shared.testEventHook
+      TelemetryService.shared.testEventHook = { event in
+        captured.withLock { $0.append(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = prior }
+      body()
+      return captured.withLock { $0 }
     }
-    defer { TelemetryService.shared.testEventHook = prior }
-    body()
-    return captured.withLock { $0 }
+
+    @Test("the started half carries the join key, the backend and the budget")
+    func startedPayload() {
+      let events = captureEvents {
+        TelemetryService.shared.asrRetryDeadlineStarted(
+          takeID: "take-1", asrBackend: "parakeet", budgetMs: 1200)
+      }
+      #expect(events.count == 1)
+      guard let event = events.first else { return }
+      #expect(event.name == "asr.retry_deadline_observed")
+      #expect(event.stringProps["phase"] == "started")
+      #expect(
+        event.stringProps["take_id"] == "take-1",
+        "the join key, without which an accepted retry cannot be tied to its delivery")
+      #expect(event.stringProps["asr_backend"] == "parakeet")
+      #expect(event.intProps["budget_ms"] == 1200)
+    }
+
+    @Test("a timed-out resolution reports no decode time rather than a zero")
+    func resolvedPayloadTimeout() {
+      let events = captureEvents {
+        TelemetryService.shared.asrRetryDeadlineResolved(
+          takeID: "take-2", asrBackend: "whisperkit", budgetMs: 900,
+          resolution: .timedOut, disposition: .rejected,
+          operationReturnMs: nil, callerResumeMs: 950, acceptedAfterCutoff: false)
+      }
+      #expect(events.count == 1)
+      guard let event = events.first else { return }
+      #expect(event.stringProps["phase"] == "resolved")
+      #expect(event.stringProps["resolution"] == "timeout")
+      #expect(event.stringProps["disposition"] == "rejected")
+      #expect(
+        event.intProps["operation_return_ms"] == nil,
+        """
+        an absent decode time must stay ABSENT. A zero or a negative stand-in \
+        reads as a fast return once it reaches a chart, which is the opposite of \
+        what happened
+        """)
+      #expect(event.intProps["caller_resume_ms"] == 950)
+      #expect(event.boolProps["accepted_after_cutoff"] == false)
+    }
+
+    @Test("a decode accepted past its budget is flagged, and an on-time one is not")
+    func resolvedPayloadAcceptedAfterCutoff() {
+      let late = captureEvents {
+        TelemetryService.shared.asrRetryDeadlineResolved(
+          takeID: "take-3", asrBackend: "parakeet", budgetMs: 100,
+          resolution: .operationReturned, disposition: .accepted,
+          operationReturnMs: 260, callerResumeMs: 265, acceptedAfterCutoff: true)
+      }
+      #expect(late.first?.boolProps["accepted_after_cutoff"] == true)
+      #expect(late.first?.intProps["operation_return_ms"] == 260)
+      #expect(late.first?.stringProps["resolution"] == "operation")
+      #expect(late.first?.stringProps["disposition"] == "accepted")
+
+      // The two-way control. Without it a field hardcoded to `true` would pass
+      // the case above and the measurement would count every accepted retry.
+      let onTime = captureEvents {
+        TelemetryService.shared.asrRetryDeadlineResolved(
+          takeID: "take-4", asrBackend: "parakeet", budgetMs: 1000,
+          resolution: .operationReturned, disposition: .accepted,
+          operationReturnMs: 120, callerResumeMs: 125, acceptedAfterCutoff: false)
+      }
+      #expect(onTime.first?.boolProps["accepted_after_cutoff"] == false)
+    }
+
+    @Test("stale and abandoned resolutions keep their own labels")
+    func resolvedPayloadNonAcceptanceLabels() {
+      let stale = captureEvents {
+        TelemetryService.shared.asrRetryDeadlineResolved(
+          takeID: "take-5", asrBackend: "parakeet", budgetMs: 1000,
+          resolution: .operationReturned, disposition: .stale,
+          operationReturnMs: 4000, callerResumeMs: 4010, acceptedAfterCutoff: false)
+      }
+      #expect(stale.first?.stringProps["disposition"] == "stale")
+      #expect(
+        stale.first?.boolProps["accepted_after_cutoff"] == false,
+        "a late decode nobody used creates no exposure to a stricter cutoff")
+
+      let abandoned = captureEvents {
+        TelemetryService.shared.asrRetryDeadlineResolved(
+          takeID: "take-6", asrBackend: "parakeet", budgetMs: 1000,
+          resolution: .operationReturned, disposition: .abandoned,
+          operationReturnMs: 4000, callerResumeMs: 4010, acceptedAfterCutoff: false)
+      }
+      #expect(abandoned.first?.stringProps["disposition"] == "abandoned")
+    }
   }
 
-  @Test("the started half carries the join key, the backend and the budget")
-  func startedPayload() {
-    let events = captureEvents {
-      TelemetryService.shared.asrRetryDeadlineStarted(
-        takeID: "take-1", asrBackend: "parakeet", budgetMs: 1200)
-    }
-    #expect(events.count == 1)
-    guard let event = events.first else { return }
-    #expect(event.name == "asr.retry_deadline_observed")
-    #expect(event.stringProps["phase"] == "started")
-    #expect(
-      event.stringProps["take_id"] == "take-1",
-      "the join key, without which an accepted retry cannot be tied to its delivery")
-    #expect(event.stringProps["asr_backend"] == "parakeet")
-    #expect(event.intProps["budget_ms"] == 1200)
-  }
-
-  @Test("a timed-out resolution reports no decode time rather than a zero")
-  func resolvedPayloadTimeout() {
-    let events = captureEvents {
-      TelemetryService.shared.asrRetryDeadlineResolved(
-        takeID: "take-2", asrBackend: "whisperkit", budgetMs: 900,
-        resolution: .timedOut, disposition: .rejected,
-        operationReturnMs: nil, callerResumeMs: 950, acceptedAfterCutoff: false)
-    }
-    #expect(events.count == 1)
-    guard let event = events.first else { return }
-    #expect(event.stringProps["phase"] == "resolved")
-    #expect(event.stringProps["resolution"] == "timeout")
-    #expect(event.stringProps["disposition"] == "rejected")
-    #expect(
-      event.intProps["operation_return_ms"] == nil,
-      """
-      an absent decode time must stay ABSENT. A zero or a negative stand-in \
-      reads as a fast return once it reaches a chart, which is the opposite of \
-      what happened
-      """)
-    #expect(event.intProps["caller_resume_ms"] == 950)
-    #expect(event.boolProps["accepted_after_cutoff"] == false)
-  }
-
-  @Test("a decode accepted past its budget is flagged, and an on-time one is not")
-  func resolvedPayloadAcceptedAfterCutoff() {
-    let late = captureEvents {
-      TelemetryService.shared.asrRetryDeadlineResolved(
-        takeID: "take-3", asrBackend: "parakeet", budgetMs: 100,
-        resolution: .operationReturned, disposition: .accepted,
-        operationReturnMs: 260, callerResumeMs: 265, acceptedAfterCutoff: true)
-    }
-    #expect(late.first?.boolProps["accepted_after_cutoff"] == true)
-    #expect(late.first?.intProps["operation_return_ms"] == 260)
-    #expect(late.first?.stringProps["resolution"] == "operation")
-    #expect(late.first?.stringProps["disposition"] == "accepted")
-
-    // The two-way control. Without it a field hardcoded to `true` would pass
-    // the case above and the measurement would count every accepted retry.
-    let onTime = captureEvents {
-      TelemetryService.shared.asrRetryDeadlineResolved(
-        takeID: "take-4", asrBackend: "parakeet", budgetMs: 1000,
-        resolution: .operationReturned, disposition: .accepted,
-        operationReturnMs: 120, callerResumeMs: 125, acceptedAfterCutoff: false)
-    }
-    #expect(onTime.first?.boolProps["accepted_after_cutoff"] == false)
-  }
-
-  @Test("stale and abandoned resolutions keep their own labels")
-  func resolvedPayloadNonAcceptanceLabels() {
-    let stale = captureEvents {
-      TelemetryService.shared.asrRetryDeadlineResolved(
-        takeID: "take-5", asrBackend: "parakeet", budgetMs: 1000,
-        resolution: .operationReturned, disposition: .stale,
-        operationReturnMs: 4000, callerResumeMs: 4010, acceptedAfterCutoff: false)
-    }
-    #expect(stale.first?.stringProps["disposition"] == "stale")
-    #expect(
-      stale.first?.boolProps["accepted_after_cutoff"] == false,
-      "a late decode nobody used creates no exposure to a stricter cutoff")
-
-    let abandoned = captureEvents {
-      TelemetryService.shared.asrRetryDeadlineResolved(
-        takeID: "take-6", asrBackend: "parakeet", budgetMs: 1000,
-        resolution: .operationReturned, disposition: .abandoned,
-        operationReturnMs: 4000, callerResumeMs: 4010, acceptedAfterCutoff: false)
-    }
-    #expect(abandoned.first?.stringProps["disposition"] == "abandoned")
-  }
-}
+#endif  // DEBUG

--- a/Tests/EnviousWisprTests/Pipeline/TelemetryServiceRetryDeadlineTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TelemetryServiceRetryDeadlineTests.swift
@@ -1,0 +1,122 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+import os
+
+// MARK: - #1946 chunk 2 — the retry-deadline event's payload
+//
+// `KernelPhase2RetryTests` proves what the KERNEL computes across the five
+// retry schedules. This suite proves what actually reaches the analytics
+// pipeline, through the existing telemetry test hook rather than a live
+// capture, because a correct computation published under the wrong field names
+// answers nobody's question.
+
+@MainActor
+@Suite("#1946 retry-deadline telemetry payload", .tags(.observabilityContract))
+struct TelemetryServiceRetryDeadlineTests {
+
+  /// Captures one emission and always restores the hook, so a failing case
+  /// cannot leave a recorder installed for the rest of the run.
+  private func captureEvents(
+    _ body: @MainActor () -> Void
+  ) -> [CapturedTelemetryEvent] {
+    // Under a lock, not a captured `var`: the hook is `@Sendable`, so the
+    // compiler refuses a plain capture and a box that ignored that would be
+    // hiding a real cross-thread write rather than answering it.
+    let captured = OSAllocatedUnfairLock<[CapturedTelemetryEvent]>(initialState: [])
+    let prior = TelemetryService.shared.testEventHook
+    TelemetryService.shared.testEventHook = { event in
+      captured.withLock { $0.append(event) }
+    }
+    defer { TelemetryService.shared.testEventHook = prior }
+    body()
+    return captured.withLock { $0 }
+  }
+
+  @Test("the started half carries the join key, the backend and the budget")
+  func startedPayload() {
+    let events = captureEvents {
+      TelemetryService.shared.asrRetryDeadlineStarted(
+        takeID: "take-1", asrBackend: "parakeet", budgetMs: 1200)
+    }
+    #expect(events.count == 1)
+    guard let event = events.first else { return }
+    #expect(event.name == "asr.retry_deadline_observed")
+    #expect(event.stringProps["phase"] == "started")
+    #expect(
+      event.stringProps["take_id"] == "take-1",
+      "the join key, without which an accepted retry cannot be tied to its delivery")
+    #expect(event.stringProps["asr_backend"] == "parakeet")
+    #expect(event.intProps["budget_ms"] == 1200)
+  }
+
+  @Test("a timed-out resolution reports no decode time rather than a zero")
+  func resolvedPayloadTimeout() {
+    let events = captureEvents {
+      TelemetryService.shared.asrRetryDeadlineResolved(
+        takeID: "take-2", asrBackend: "whisperkit", budgetMs: 900,
+        resolution: .timedOut, disposition: .rejected,
+        operationReturnMs: nil, callerResumeMs: 950, acceptedAfterCutoff: false)
+    }
+    #expect(events.count == 1)
+    guard let event = events.first else { return }
+    #expect(event.stringProps["phase"] == "resolved")
+    #expect(event.stringProps["resolution"] == "timeout")
+    #expect(event.stringProps["disposition"] == "rejected")
+    #expect(
+      event.intProps["operation_return_ms"] == nil,
+      """
+      an absent decode time must stay ABSENT. A zero or a negative stand-in \
+      reads as a fast return once it reaches a chart, which is the opposite of \
+      what happened
+      """)
+    #expect(event.intProps["caller_resume_ms"] == 950)
+    #expect(event.boolProps["accepted_after_cutoff"] == false)
+  }
+
+  @Test("a decode accepted past its budget is flagged, and an on-time one is not")
+  func resolvedPayloadAcceptedAfterCutoff() {
+    let late = captureEvents {
+      TelemetryService.shared.asrRetryDeadlineResolved(
+        takeID: "take-3", asrBackend: "parakeet", budgetMs: 100,
+        resolution: .operationReturned, disposition: .accepted,
+        operationReturnMs: 260, callerResumeMs: 265, acceptedAfterCutoff: true)
+    }
+    #expect(late.first?.boolProps["accepted_after_cutoff"] == true)
+    #expect(late.first?.intProps["operation_return_ms"] == 260)
+    #expect(late.first?.stringProps["resolution"] == "operation")
+    #expect(late.first?.stringProps["disposition"] == "accepted")
+
+    // The two-way control. Without it a field hardcoded to `true` would pass
+    // the case above and the measurement would count every accepted retry.
+    let onTime = captureEvents {
+      TelemetryService.shared.asrRetryDeadlineResolved(
+        takeID: "take-4", asrBackend: "parakeet", budgetMs: 1000,
+        resolution: .operationReturned, disposition: .accepted,
+        operationReturnMs: 120, callerResumeMs: 125, acceptedAfterCutoff: false)
+    }
+    #expect(onTime.first?.boolProps["accepted_after_cutoff"] == false)
+  }
+
+  @Test("stale and abandoned resolutions keep their own labels")
+  func resolvedPayloadNonAcceptanceLabels() {
+    let stale = captureEvents {
+      TelemetryService.shared.asrRetryDeadlineResolved(
+        takeID: "take-5", asrBackend: "parakeet", budgetMs: 1000,
+        resolution: .operationReturned, disposition: .stale,
+        operationReturnMs: 4000, callerResumeMs: 4010, acceptedAfterCutoff: false)
+    }
+    #expect(stale.first?.stringProps["disposition"] == "stale")
+    #expect(
+      stale.first?.boolProps["accepted_after_cutoff"] == false,
+      "a late decode nobody used creates no exposure to a stricter cutoff")
+
+    let abandoned = captureEvents {
+      TelemetryService.shared.asrRetryDeadlineResolved(
+        takeID: "take-6", asrBackend: "parakeet", budgetMs: 1000,
+        resolution: .operationReturned, disposition: .abandoned,
+        operationReturnMs: 4000, callerResumeMs: 4010, acceptedAfterCutoff: false)
+    }
+    #expect(abandoned.first?.stringProps["disposition"] == "abandoned")
+  }
+}

--- a/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SeamCasingOracleTests.swift
@@ -369,7 +369,7 @@ struct SeamCasingOracleTests {
     // and since #1921 a second suite does too. `.serialized` orders this
     // suite only; Swift Testing runs suites concurrently.
     await withSeamCasingOracleExclusion {
-      // `withOrderedDeadline.claim()` discards a late decision but cannot roll
+      // `withOffActorOrderedDeadline.claim()` discards a late decision but cannot roll
       // back side effects inside the abandoned operation. The latch must therefore
       // outlast anything that call does afterwards, or a stalled service could be
       // waited on twice.


### PR DESCRIPTION
Part of #1946. Chunk 2 of 2 in the plan; chunk 1 shipped as `81b1649f` (PR #2719).

## What a user gets

Continuation capitalisation stops switching itself off for the rest of an app session because the app was
busy. It was not the spell checker being slow: a 100 ms guard's timer was scheduled on the main actor, so
while the main actor was blocked the guard could not fire at all, and when it eventually did the runtime
latched capitalisation off until relaunch. 23 users in the v2.4.5-2.4.8 window; 233 latched reports
against 91 fresh misses over 53,188 pastes, and 233 of 233 land after that user's first fresh miss.

**Expect much rarer, not gone.** The latch itself is unchanged (founder 2026-08-10: the safety net stays),
and a consultation that RETURNED can still cause latching while repair remains unfinished.

## What changed

| | |
|---|---|
| `withOffActorOrderedDeadline` | new; absolute continuous-clock deadline at entry, pool timer, synchronous nonisolated handler. #1707 ordering preserved. |
| `withMainActorOrderedDeadline` | the old `withOrderedDeadline`, renamed, with an honest doc comment. Implementation and the three adapter callers' behaviour unchanged. The ambiguous spelling is removed, not aliased. |
| casing deadline | moves to the off-actor primitive. Budget, phase rules, latch and fallback unchanged. |
| casing lease release | `@Sendable`, called directly in `defer` instead of queued onto the main actor. |
| `asr.retry_deadline_observed` | new. One event per retry attempt and one per resolution; decode return time and caller resume time reported separately; flags a decode ACCEPTED past its budget. Shape only, never content. |

## What it does not do

It does not bound a main-actor caller's return while that actor is blocked, it does not change the three
adapter deadlines, and it does not guarantee scheduling at exactly 100 ms.

## The retry measurement is a condition, not a bonus

The founder deferred the other three call sites on the condition that this path is measured first, because
an on-time timer would start rejecting a late retry rescue that succeeds today. The published decision
rule: any confirmed `accepted_after_cutoff` falsifies the claim that enforcing the same cutoff preserves
all currently accepted retry successes; review after 30 days and at least 3,000 resolved retries per
backend. Zero observed late accepted successes permits a controlled before/after evaluation, not automatic
migration. Closing #1946 must not discard this obligation.

## Validation

Two of the three casing cases are verified RED against the shipped behaviour: restoring the main-actor
timer and the queued lease release failed both on their own product assertions, 2 issues in 68, with
nothing else in the suite affected. The third is a preservation case, not red by design, and uses a
witness lease because `releaseDecisionLease()` silently refuses at zero.

Six retry cases cover on-time success, late accepted success, timeout, stale session, abandonment, and the
separator that keeps a late CALLER resume from being counted as a late DECODE.

Test recipes and the mutations each case must survive: see the test-hardening issue.

## Blast radius

The three adapter timer implementations, budgets, timeout handlers and result-acceptance behaviour are
unchanged. Rollback reverts this chunk together.

## Live UAT

Silent, through BlackHole on both output and input, driving this branch's build (pid 83055,
`EnviousWispr-1946-chunk2/build/EnviousWispr Local.app`). Six sound takes, all on the loopback transport:

```
sound takes            6
continuation lowered   6
casing deadline missed 0
latched off            0
oracle fetch ms        min=0.0 max=0.0 median=0.0
PASS
```

Artifact: `docs/feature-requests/issue-1946-artifacts/2026-09-08-chunk2-silent-uat.out`.

## Test hardening

#2723 carries all nine cases' recipes and the mutations each must survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8awCNeoTLgCLFWVmBDeJZ
