### PR TITLE
fix(quickadd): the panel keeps naming the word when nothing matches (#2477)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
+++ b/Sources/EnviousWisprAppKit/Views/QuickAdd/QuickAddPanelView.swift
@@ -140,6 +140,7 @@ enum QuickAddPanelCopy {
     case .lowConfidence: "No close match for \"\(word)\" · pick one or keep typing"
     case .alreadySaved: "Already knows \"\(word)\" · nothing to add"
     case .searching: "Add \"\(word)\" to"
+    case .noMatches: "No match for \"\(word)\""
     }
   }
 
@@ -155,6 +156,13 @@ enum QuickAddPanelCopy {
     /// The user is filtering. Same verb as `confident`; the header must not change under them
     /// mid-keystroke, which is the one thing a header that also carries state can get wrong.
     case searching
+    /// The list is EMPTY: a query nobody matches, or a library with nothing in it yet (#2477).
+    ///
+    /// **No verb, because there is no row to complete one.** Every other state's sentence is
+    /// finished by the rows beneath it — `Add "x" to` reads as a fragment over nothing, and
+    /// `pick one` names an action with nothing to pick. This state names what was read and stops;
+    /// `Create a new word` sits directly below and is the only offer the panel can honour here.
+    case noMatches
   }
 
   /// The right-hand meta on a row. A count, not a sentence.
@@ -355,16 +363,19 @@ struct QuickAddPanelView: View {
         .padding(.top, 14)
     }
     failureBanner
-    if !model.ranking.candidates.isEmpty {
+    // Two conditions, because they answer different questions: the header's is the WORD and the
+    // rows' is the LIST. They were one, which is #2477 — see `showsGroupHeader`.
+    if showsGroupHeader {
       Text(QuickAddPanelCopy.groupHeader(headerState, heard: model.heard))
         .font(.stSectionHeader)
         .tracking(0.5)
-        .foregroundStyle(headerState == .lowConfidence ? .stTextTertiary : .stAccent)
+        .foregroundStyle(
+          headerState == .lowConfidence || headerState == .noMatches ? .stTextTertiary : .stAccent)
         .padding(.horizontal, 16)
         .padding(.top, 14)
         .padding(.bottom, 6)
-      candidateRows
     }
+    if !model.ranking.candidates.isEmpty { candidateRows }
   }
 
   /// One field, and the sentence saying what it is for.
@@ -471,9 +482,26 @@ struct QuickAddPanelView: View {
     }
   }
 
+  /// Whether the group header is on screen at all. Derived, and separate from `headerState` so the
+  /// two questions — is it shown, what does it say — are each answerable without rendering.
+  ///
+  /// **The condition is the WORD, not the list (#2477).** It was the list, so an empty list took the
+  /// header with it and the heard word appeared nowhere: a search field, a create row and a legend,
+  /// and no witness that the right text had been picked up. That matters since #2465, where a
+  /// selection can be acquired by borrowing the clipboard and has no other on-screen confirmation.
+  /// An empty `heard` is the refusal path, which renders its own sentence and must not be handed a
+  /// header naming nothing.
+  var showsGroupHeader: Bool { !model.heard.isEmpty }
+
   /// Which sentence the group header is saying. Derived, never stored: a second copy of this on the
   /// model is a second thing to keep in step with the ranking.
   var headerState: QuickAddPanelCopy.GroupHeaderState {
+    // **Emptiness is decided FIRST, ahead of `searching` (#2477).** The way in that reaches a real
+    // user is typing until nothing matches, and that path sets `isSearching`, so an emptiness check
+    // placed after it would never run on the case it exists for. The mid-keystroke stability
+    // `searching` protects is about the header not rewriting itself between two states that both
+    // have rows; going quiet when the rows are gone is the header reporting, not flickering.
+    if model.ranking.candidates.isEmpty { return .noMatches }
     if model.ranking.preselected?.alreadyHasHeardSpelling == true { return .alreadySaved }
     if model.isSearching { return .searching }
     return model.ranking.preselectedID == nil ? .lowConfidence : .confident

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelCopyTests.swift
@@ -150,14 +150,26 @@ struct QuickAddPanelCopyTests {
     #expect(already.lowercased().contains("nothing to add"))
   }
 
+  @Test("The empty-list header names the word and offers no verb it cannot honour")
+  func noMatchesHeaderOffersNothing() {
+    // #2477: with no rows, `Add "x" to` is a fragment over nothing and `pick one` names an action
+    // with nothing to pick. `Create a new word` sits directly below and is the only offer the panel
+    // can honour, so the header says what was read and stops.
+    let none = QuickAddPanelCopy.groupHeader(.noMatches, heard: "keybinds")
+    #expect(none.contains("keybinds"), "the only on-screen witness that the right text was read")
+    #expect(!none.contains("Add"), "there is no row to add to")
+    #expect(!none.lowercased().contains("pick"), "there is nothing to pick")
+  }
+
   @Test("Searching keeps the confident sentence, so the header cannot change mid-keystroke")
   func searchingKeepsTheVerb() {
-    // Four states, three distinct sentences, and the collision is deliberate: a header that also
-    // carries state must not rewrite itself under someone who is typing.
+    // Five states, four distinct sentences, and the one collision is deliberate: a header that also
+    // carries state must not rewrite itself under someone who is typing. `noMatches` is the fifth
+    // sentence and shares with nothing (#2477).
     let all = QuickAddPanelCopy.GroupHeaderState.allCases.map {
       QuickAddPanelCopy.groupHeader($0, heard: "codecs")
     }
-    #expect(Set(all).count == 3)
+    #expect(Set(all).count == 4)
     #expect(all.allSatisfy { !$0.isEmpty })
     #expect(
       QuickAddPanelCopy.groupHeader(.searching, heard: "codecs")

--- a/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
+++ b/Tests/EnviousWisprTests/Views/QuickAdd/QuickAddPanelModelTests.swift
@@ -266,18 +266,26 @@ struct QuickAddPanelModelTests {
   }
   // MARK: - Which sentence the group header says (#2381, the command-bar layout)
 
+  private func panel(
+    heard: String = "codecs",
+    refusal: SelectionReader.Refusal? = nil,
+    heardRanking: QuickAddRanker.Ranking,
+    query: String = ""
+  ) -> QuickAddPanelView {
+    let (model, _) = makeModel(
+      heard: heard, refusal: refusal, heardRanking: heardRanking, searchRanking: heardRanking)
+    if !query.isEmpty { model.updateQuery(query) }
+    return QuickAddPanelView(
+      model: model, onAccept: { _ in }, onCreateNew: {}, onCreate: { _ in }, onCancel: {})
+  }
+
   private func headerState(
     heard: String = "codecs",
     refusal: SelectionReader.Refusal? = nil,
     heardRanking: QuickAddRanker.Ranking,
     query: String = ""
   ) -> QuickAddPanelCopy.GroupHeaderState {
-    let (model, _) = makeModel(
-      heard: heard, refusal: refusal, heardRanking: heardRanking, searchRanking: heardRanking)
-    if !query.isEmpty { model.updateQuery(query) }
-    let view = QuickAddPanelView(
-      model: model, onAccept: { _ in }, onCreateNew: {}, onCreate: { _ in }, onCancel: {})
-    return view.headerState
+    panel(heard: heard, refusal: refusal, heardRanking: heardRanking, query: query).headerState
   }
 
   @Test("A preselected row means the header states the verb")
@@ -309,6 +317,42 @@ struct QuickAddPanelModelTests {
     let r = QuickAddRanker.Ranking(candidates: [owned], preselectedID: owned.id)
 
     #expect(headerState(heardRanking: r) == .alreadySaved)
+  }
+
+  @Test("The word stays on screen when the list is empty")
+  func theHeaderSurvivesAnEmptyList() {
+    // #2477, the defect itself: the header was rendered only when rows existed, so an empty list
+    // left the panel showing a search field, a create row and a legend, and the word that was read
+    // appeared nowhere. Since #2465 a selection can be acquired by borrowing the clipboard, and this
+    // header is the only on-screen confirmation that the right text was picked up.
+    #expect(panel(heardRanking: .empty).showsGroupHeader)
+    #expect(panel(heardRanking: .empty, query: "zzz").showsGroupHeader)
+  }
+
+  @Test("A refusal gets no header, because there is no word to name")
+  func aRefusalRendersNoHeader() {
+    // The negative twin. Without it `showsGroupHeader` could be `true` unconditionally and every
+    // assertion above would still pass — and the refusal path would render `No match for ""`
+    // above the sentence that already explains what went wrong.
+    #expect(!panel(heard: "", heardRanking: .empty).showsGroupHeader)
+  }
+
+  @Test("An empty list says there is no match, rather than a verb with nothing to complete it")
+  func headerIsNoMatchesWhenTheListIsEmpty() {
+    // #2477: the header used to be rendered only when rows existed, so the panel showed a search
+    // field, a create row and a legend with the heard word nowhere on screen. Reachable on a new
+    // user's first Quick Add, whose library is empty.
+    #expect(headerState(heardRanking: .empty) == .noMatches)
+  }
+
+  @Test("No matches outranks searching, because typing to zero rows is how a user gets here")
+  func noMatchesOutranksSearching() {
+    // The ordering pair for #2477. Typing until nothing matches sets `isSearching`, so an emptiness
+    // check placed after it would never run on the way in that reaches a real user — and the
+    // header would say `Add "codecs" to` over no rows at all. Its negative twin already exists:
+    // `headerStaysConfidentWhileSearching` types against a list that HAS rows and still expects
+    // `.searching`, so an emptiness check that fired unconditionally fails there.
+    #expect(headerState(heardRanking: .empty, query: "zzz") == .noMatches)
   }
 
   @Test("Already-saved outranks searching, because typing does not make the row addable")


### PR DESCRIPTION
## Summary

The Quick Add group header was rendered only when the candidate list had rows, so an empty list took the header away with it. The panel then showed a search field, "Create a new word" and the key legend, and the word that was read appeared nowhere on screen.

Closes #2477.

`Tier: SMALL | Test: required (AppKit view) | Modules: AppKit`
`Lane: Code`

## Two ways in, neither exotic

1. Typing into the search field until nothing matches. `QuickAddPanelModel.updateQuery` routes a non-empty query to `searchLibrary`, which can return zero candidates, and the header disappeared mid-keystroke.
2. A new user whose custom-words library is empty sees it on their first Quick Add.

It costs most exactly where the user has least. Since #2465 a selection can be acquired by borrowing the clipboard, and that path has no other on-screen confirmation anywhere that the right text was picked up.

## Changes

- **`showsGroupHeader` is the header's own condition, and it is the WORD rather than the LIST.** The rows keep the list condition. An empty `heard` is the refusal path, which renders its own sentence and must not be handed a header naming nothing. It is a computed property on the view beside `headerState`, so both questions — is it shown, what does it say — are answerable without rendering, which is the pattern `headerState` already established.
- **A fifth `GroupHeaderState`, `noMatches`, reading `No match for "<word>"`.** No verb: every other state's sentence is finished by the rows beneath it, so `Add "x" to` is a fragment over nothing and `pick one` names an action with nothing to pick. "Create a new word" sits directly below and is the only offer the panel can honour in this state. Tinted like `lowConfidence`, because it is the same "nothing is preselected" signal.
- **`headerState` decides emptiness FIRST, ahead of `searching`.** Way in (1) sets `isSearching`, so a check placed after it would never run on the case it exists for.

## Tests

Five cases, all green (`QuickAddPanelModelTests` 48, `QuickAddPanelCopyTests` 31).

| case | binds |
|---|---|
| `theHeaderSurvivesAnEmptyList` | the defect itself, in both ways in |
| `aRefusalRendersNoHeader` | the negative twin — without it `showsGroupHeader` could be `true` unconditionally |
| `headerIsNoMatchesWhenTheListIsEmpty` | the state on an empty list |
| `noMatchesOutranksSearching` | the ordering. Its negative twin `headerStaysConfidentWhileSearching` already existed |
| `noMatchesHeaderOffersNothing` | the copy names the word and offers no verb |

`searchingKeepsTheVerb`'s distinct-sentence count moves 3 → 4. That assertion is what stops a fifth state being added silently, so it is updated rather than removed.

## Deliberately not changed

- The legend's own `candidates.isEmpty` branch at the bottom of the panel. It correctly drops the up/down hint when there is nothing to move between.
- `user_copy` in the cross-platform catalog carries the Quick Add refusals and row copy but has never carried the group-header sentences, so there is no stale row to correct. Adding them is catalog maintenance, not this change.

## Pre-Merge Checklist

### Build Verification
- [x] Logic tests pass locally — `EnviousWisprTests/QuickAddPanelModelTests` 48/48, `EnviousWisprTests/QuickAddPanelCopyTests` 31/31. Full-suite baseline on `main` green before the change.
- [ ] Dev build + Live UAT — **not run.** This landed during an unattended overnight session with no operator at the machine; the change is a SwiftUI view condition and a copy string, and the panel's state machine is covered by the cases above. A human should open Quick Add with an empty library and with a no-match query before this is treated as visually confirmed.
- [ ] CI `build-check` — pending on this push.

### Code Quality
- [x] `codex review --base origin/main` clean: "No actionable regressions found in the empty-list header, refusal handling, or existing selection states."
- [x] Self-review grep sweep across `Sources/ Tests/ docs/ .claude/ scripts/ website/` for `showsGroupHeader`, `noMatches`, `GroupHeaderState`, `No close match` — only dated audit transcripts outside the diff, which describe a past state and are left alone.
- [x] Conventional commit format, no secrets, no `@preconcurrency import` removed.

### Process note

Gates 1 and 2 were not taken: the founder was asleep. The direction is the one #2477 itself proposes ("worth a look at whether the header should simply render whenever there is a heard word, with the list condition applying only to the rows beneath it"), and the empty-state copy is the one product judgement in here. It is one string and a single-commit revert if the founder wants it worded differently.

## Follow-up

A `test-hardening` issue carrying this change's mutation recipe is filed per `workflow-process.md` RULE: definition-of-done.
