### PR TITLE
test(llm): record the warm-window boundary as a known limit (#2710)

### DIFF
--- a/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMWarmupGateTests.swift
@@ -113,6 +113,19 @@ struct LLMWarmupGateTests {
     // must not depend on scheduling precision.
     let justOutside = now.addingTimeInterval(LLMNetworkSession.warmWindowSeconds + 1)
     #expect(session.claimWarmupSlot(provider: .openAI, model: "gpt-5.4-nano", now: justOutside))
+
+    // KNOWN LIMIT, measured and accepted rather than closed (#2710, battery run
+    // 2026-09-08). The comparison's STRICTNESS is unbound: loosening
+    // `now.timeIntervalSince(last) < warmWindowSeconds` to `<=` changes no
+    // outcome for any input this suite supplies, and that mutant survived with
+    // not one test changing status. It was filed as a PREDICTION before the run,
+    // so the survival is the expected result rather than a discovery.
+    //
+    // A probe at exactly the boundary is deliberately NOT added. One second of
+    // difference in a five-minute window has no user consequence, so a case
+    // written only to kill an inert mutant is assertion-weakening pointed the
+    // other way: it would make the suite look tighter while binding nothing a
+    // person can feel. The two probes stay a full second either side.
   }
 
   /// Warmth is keyed on the PAIR. Switching model inside the window is a


### PR DESCRIPTION
## Summary

The mutation battery for #2710 ran on the overnight lane, 2026-09-08. This is its result, recorded at the test.

Closes #2710.

`Tier: SMALL | Test: n/a (this IS the test) | Modules: LLM`
`Lane: Code`

## What the battery found

| row | mutation | result |
|---|---|---|
| M1 | `warmWindowSeconds` 300 → 30 | **CAUGHT** — `coldWindow()` went Passed → Failed |
| M2 | the window comparison `<` → `<=` | **SURVIVED** — not one test changed status |

M1 is the mutant the pre-#2706 version of this case could not see. Both of its probes are derived FROM the constant, so shrinking the window moves them with it and the arithmetic still holds; #2632 row 2 measured exactly that at a window of zero. The floor assertion PR #2706 added is what catches it, and this run is the first thing to ask whether that line binds anything.

M2 survived, and the issue filed it as a PREDICTION before the run rather than discovering it afterwards. Both probes sit a full second either side of the boundary, so loosening the comparison changes no outcome for any input this suite supplies.

## What this PR does

Records M2's survival as a known limit at `coldWindow()`, which is the issue's own instruction for this outcome.

**No probe is added at exactly the boundary, deliberately.** One second of difference in a five-minute window has no user consequence, so a case written only to kill an inert mutant would make the suite look tighter while binding nothing a person can feel — assertion-weakening pointed the other way. The two probes stay where they are.

Comment only. No production code, no assertion, no new case.

## Pre-Merge Checklist

### Build Verification
- [x] Logic tests pass locally — `EnviousWisprTests/LLMWarmupGateTests` 11/11 in the branch's own worktree.
- [x] Battery baseline green before and after, every file byte-identical on restore.
- [ ] Dev build — N/A, no Swift production code touched.
- [ ] CI `build-check` — pending on this push.

### Code Quality
- [x] Conventional commit format, no secrets.
- [x] Self-review grep over `warmWindowSeconds` across `Sources/ Tests/ docs/ .claude/ scripts/`.
- [ ] `codex review` — not run. The diff is a comment inside one test function, with no production code, no assertion and no control flow; `GR-REVIEW-GATE` scopes the mandatory Codex round to changes that ship to users, touch money, secrets, production data, infrastructure or a migration, and this touches none of them.

### Process note

Ran during the founder's night, which is the only window `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night permits a mutant run at all.
