### PR TITLE
test(uat): bind the paste bake-off's editable-role filter (#2653)

### DIFF
--- a/Tests/RuntimeUAT/paste_bakeoff.py
+++ b/Tests/RuntimeUAT/paste_bakeoff.py
@@ -1035,6 +1035,26 @@ def selftest() -> int:
     verdict, _ = classify(pre, marker, [textarea, mirror])
     check("a non-editable mirror is not a duplicate", verdict, "once")
 
+    # 2b. The row above passes for the WRONG REASON on its own, so it does not bind the
+    #     role filter. Measured 2026-09-09 by deletion, running #2653's battery: with
+    #     `EDITABLE_ROLES` removed from the candidate filter the whole selftest still
+    #     reported 0 failures, because the textarea in row 2 is FOCUSED and the
+    #     focused-first choice picks it whatever roles are in the list.
+    #
+    #     This is the case where the filter is the only thing standing between the bench
+    #     and a verdict about nothing: ONLY a read-only mirror carries the pre-image, so
+    #     no editable field does. Shipped answers `invalid`, which is the honest
+    #     unscoreable state; without the filter it answers `once` on an `AXStaticText`,
+    #     scoring a trial in which nothing reached an editable field as a clean delivery.
+    #     A fabricated `once` is the direction that cannot be caught downstream — it looks
+    #     exactly like a good trial.
+    verdict, detail = classify(pre, marker, [mirror])
+    check("only a read-only mirror carries it — unscoreable, not scored", verdict, "invalid")
+    # `.get`, not `[...]`: on the failing side `detail` is a SCORED row and carries no
+    # `why` at all, so a subscript raises and the selftest dies mid-run instead of
+    # reporting. A control that crashes names no case and reads as a broken harness.
+    check("and says which state it is in", detail.get("why"), "pre_image_in_no_editable_field")
+
     # 3. A real duplicate must still read as one.
     doubled = F(role="AXTextArea", depth=8, chars=65, focused=True,
                 value=f"The quick brown fox jumps. The quick brown fox jumps. {pre}")


### PR DESCRIPTION
## Summary

#2653 asks for three harness-side checks to be verified **by deletion** rather than by reading, because each one silently produces a WRONG verdict instead of an error if it is removed. Running the second of them found that the row which reads as covering it does not.

Part of #2653.

`Tier: SMALL | Test: harness | Modules: Tests/RuntimeUAT`
`Lane: Code`

## What deletion found

Removing `EDITABLE_ROLES` from `classify`'s candidate filter left the whole `--selftest` reporting **0 failures**.

The existing mirror row passes for a different reason than the one it names. Its textarea is FOCUSED, and the focused-first choice picks that field whatever roles are in the candidate list, so the row never touches the filter.

The case where the filter is the only thing between the bench and a verdict about nothing was the one nothing asserted: **only a read-only mirror carries the pre-image**, so no editable field does.

| | verdict |
|---|---|
| shipped | `invalid` — the honest unscoreable state |
| filter deleted | `once` on an `AXStaticText` |

A fabricated `once` scores a trial in which nothing reached an editable field as a clean delivery. That direction cannot be caught downstream, because it looks exactly like a good trial — and this bench's whole job is to decide which paste variant ships.

## The change

One row, two assertions, in `selftest()`.

Its own two-way control ran: the shipped file reports 0 failures, the same file with the filter deleted reports 2, both naming this case.

The second assertion reads `detail.get("why")` rather than subscripting. On the failing side `detail` is a SCORED row and carries no `why`, so a subscript raises and the selftest dies mid-run instead of reporting — a control that crashes names no case and reads as a broken harness rather than a caught defect.

Harness only. No production code, no bench behaviour change, no change to `classify` itself.

## What is NOT in this PR, and stays open on #2653

- **`assert_precondition` in `run_trial`.** Verifying it by deletion needs a live browser and a real stale window; it is not reachable from `--selftest` and was not runnable on an unattended machine tonight.
- **Row 7's stated gap** — the policy `precondition` has no killer because `resolve` never builds an invalid combination. Still a decision between adding a row that constructs an invalid pair directly and recording it as documentation at the call site.

## Pre-Merge Checklist

### Build Verification
- [x] `python3 Tests/RuntimeUAT/paste_bakeoff.py --selftest` — 0 failures.
- [x] Two-way control — the same file with the role filter deleted reports 2 failures, both this case.
- [x] Test bundle built in this branch's own worktree; `QuickAddPanelCopyTests` 30/30 as the build receipt.
- [ ] CI `build-check` — pending on this push.

### Code Quality
- [x] Conventional commit format, no secrets.
- [x] Self-review grep for `EDITABLE_ROLES` and `pre_image_in_no_editable_field` across `Tests/ Sources/ scripts/ docs/ .claude/`.
- [ ] `codex review` — not run. Python test harness only, no production code and no CI step invokes it; `GR-REVIEW-GATE`'s six mandatory categories do not apply.

### Process note

The battery half of #2653 also ran tonight and matched 8/8 filed rows plus 2 independent mutants; that is reported on the issue.
