### PR TITLE
test(pipeline): bind the condition on the casing lease release (#2723)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelFinalizationWiringTests.swift
@@ -2878,6 +2878,70 @@ import os
     }
   }
 
+  /// #1946 chunk 2 — the CONDITION on the lease release, which nothing bound.
+  ///
+  /// The operation's `defer` reads `if holdsOracleLease { releaseOracleLease() }`.
+  /// `timedOutCasingDecisionPreservesLatchEvidenceAndLeases` drives a scenario whose
+  /// snapshot comes back READY, so `holdsOracleLease` is true there and removing the
+  /// condition changes nothing it can observe — measured 2026-09-09 on #2723's battery,
+  /// where that mutant survived with not one test changing status. The row was not weak;
+  /// the mutant was a no-op on the only path any case reached.
+  ///
+  /// **The condition is load-bearing exactly when the snapshot REFUSES.** Leases carry no
+  /// identity, so `releaseDecisionLease()` decrements whichever decision currently holds
+  /// the count. A decision that took no lease and released one anyway takes somebody
+  /// else's, and the drain may then start preparing while that other decision is still
+  /// inside the shared spell checker — the race the lease exists to close.
+  ///
+  /// The WITNESS is what makes an extra release visible: `releaseDecisionLease()` silently
+  /// refuses at zero, so a count that starts at zero cannot show one.
+  ///
+  /// No timing, no semaphores, no main-actor occupancy. The refusal is injected through
+  /// the wiring's own seam while the runtime keeps a real lease, so the two halves are
+  /// independent by construction.
+  @Test("#1946 a casing decision that took no lease releases none")
+  func casingDecisionWithoutALeaseReleasesNothing() async throws {
+    try await withSeamCasingOracleExclusion {
+      SeamCasingOracleRuntime.resetForTesting()
+      SeamCasingOracleRuntime.installForTesting(
+        SeamCasingOracle(
+          unavailableReason: nil,
+          dictionaryVerdict: { _ in .ordinary },
+          isLearnedWord: { _ in false },
+          isRecognizedName: { _, _ in false },
+          isNoun: { _ in false }))
+
+      let witness = SeamCasingOracleRuntime.snapshot(for: "en")
+      #expect(witness.isAvailable, "precondition: English must be ready to lease")
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 1,
+        "precondition: the witness must hold a lease, or an extra release is invisible")
+
+      let context = KernelSessionContext()
+      context.config = .testDefault(autoPasteToActiveApp: true, smartInsertion: true)
+      context.targetElement = Self.stubCaretElement()
+      let wiring = makeWiring(
+        context: context,
+        readCaretContext: { _, _, _ in Self.midSentenceCaret },
+        // The refusal is the whole scenario: no lease is taken, so nothing is owed.
+        seamCasingOracle: { _ in .unavailable(.oracleWarming) },
+        // The PRODUCTION release, not a no-op — a no-op seam could not tell the two
+        // code shapes apart, which is how this went unbound in the first place.
+        releaseOracleLease: { SeamCasingOracleRuntime.releaseDecisionLease() })
+
+      _ = await wiring.deliver("Review this before the meeting", .ordinary)
+
+      #expect(
+        SeamCasingOracleRuntime.outstandingLeasesForTesting() == 1,
+        """
+        a decision that never took a lease must release none; releasing unconditionally \
+        decrements the witness, which is another decision's count
+        """)
+
+      SeamCasingOracleRuntime.releaseDecisionLease()
+    }
+  }
+
 }
 
 


### PR DESCRIPTION
## Summary

#2723's battery ran on the overnight lane, 2026-09-09: **12 of 14 rows matched**. Row B2 — *the lease is released whether or not one was taken* — SURVIVED, with not one test changing status. This closes it.

Part of #2723.

`Tier: SMALL | Test: n/a (this IS the test) | Modules: Pipeline`
`Lane: Code`

## The row was not weak. The mutant was a no-op on the only path any case reached.

`timedOutCasingDecisionPreservesLatchEvidenceAndLeases` installs a READY oracle, so the operation's snapshot comes back available, `holdsOracleLease` is true, and removing the condition changes nothing that case can observe. Same shape as `testing-philosophy.md` RULE: redundant-protections-make-single-line-mutants-survive-and-that-is-not-vacuity, reason 1: check whether the mutant is a no-op before concluding anything about the test.

## Where the condition is actually load-bearing

When the snapshot REFUSES. Leases carry no identity, so `releaseDecisionLease()` decrements whichever decision currently holds the count. A decision that took no lease and released one anyway takes somebody else's, and the drain may then start preparing while that other decision is still inside the shared spell checker — the race the lease exists to close.

The `defer`'s own comment already says this. Nothing executed it.

## The case

`casingDecisionWithoutALeaseReleasesNothing`, one case, no timing:

1. A witness lease is taken through the real runtime API. It is what makes an extra release visible at all — `releaseDecisionLease()` silently refuses at zero, so a count that starts at zero cannot show one.
2. The wiring's own oracle seam is given a refusal, so the decision takes no lease of its own.
3. The **production** `releaseDecisionLease` is passed as the release seam, deliberately. A no-op recorder cannot tell the two code shapes apart, which is how this went unbound in the first place.
4. The witness must still hold its lease afterwards.

The refusal is injected while the runtime keeps a real lease, so the two halves are independent by construction — no semaphores, no main-actor occupancy, no schedule to stage.

## Verified both ways

| | result |
|---|---|
| shipped | `EnviousWisprTests/KernelFinalizationWiringTests` **69/69 green** |
| `if holdsOracleLease { releaseOracleLease() }` → `releaseOracleLease()` | **exact `must_fire` set matched** — `casingDecisionWithoutALeaseReleasesNothing()` red, and `timedOutCasingDecisionPreservesLatchEvidenceAndLeases()` named as a silent control stayed unchanged |

That silent control is the point: it confirms the old case still cannot see this mutant, so the new one is carrying the property rather than duplicating an existing guard.

## The other row that needed work, and why it needs no code

Row C2 — *a late completion rewrites the frozen gate snapshot* — came back CAUGHT-ELSEWHERE: `deadlineGateFourPhaseMatrix()` went red while the named test stayed green. The freeze's idempotence IS bound, by a different case. That is a wrong expectation in the row rather than a hole in the suite, so nothing is added for it. Reported on the issue.

## Pre-Merge Checklist

### Build Verification
- [x] Logic tests pass locally — 69/69 in this branch's own worktree.
- [x] Mutation control run against this branch: baseline green before and after, every file byte-identical on restore.
- [ ] Dev build — N/A, no production code touched.
- [ ] CI `build-check` — pending on this push.

### Code Quality
- [x] Conventional commit format, no secrets.
- [x] Self-review grep over `holdsOracleLease`, `releaseDecisionLease`, `outstandingLeasesForTesting` across `Sources/ Tests/ docs/ .claude/`.
- [x] No `#if DEBUG` production member used, so no Release-build guard is needed (`swift-testing-patterns.md` `swift-testing-debug-seam-needs-if-debug`) — `outstandingLeasesForTesting`, `installForTesting` and `resetForTesting` are all `package`, and the suite already calls them unguarded.
- [ ] `codex review` — not run. Test-only diff, no production code; `GR-REVIEW-GATE`'s six mandatory categories do not apply.

### Process note

Ran during the founder's night, the only window `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night permits a mutant run.
