### PR TITLE
test(overlay): refuse a live pill an action for another transcript (#2529)

### DIFF
--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillTests.swift
@@ -111,6 +111,52 @@ struct EscapeRecoveryPillTests {
     #expect(pasted == [live.transcriptID], "the live offer did not forward its own payload")
   }
 
+  /// The OTHER half of the same guard, and nothing reached it until now.
+  ///
+  /// `supersededPillCannotTouchTheNewerPayload` above replays a stale receipt, so the
+  /// root's presentation-id gate refuses the action BEFORE the binding runs and the
+  /// `held.id == transcriptID` comparison inside it never executes. Measured 2026-09-09
+  /// re-running #2352's row M4 against current `main`: deleting that comparison changed
+  /// no test's status. Two mechanisms cover one outcome, so a single-line mutation of
+  /// either is invisible while the other still refuses — `redundant-protections-make-
+  /// single-line-mutants-survive-and-that-is-not-vacuity`.
+  ///
+  /// They are not the same guard, though. The root gate answers "is this pill still the
+  /// one on screen". The comparison answers "does this action belong to the payload this
+  /// pill is holding", and a LIVE receipt carrying a foreign transcript id passes the
+  /// first and must be refused by the second.
+  ///
+  /// Production cannot build that action today — the pill sends the id it was presented
+  /// with — so this is a hypothetical, and it is written because of the DIRECTION it
+  /// fails in: without the comparison, the held payload is pasted for an action that did
+  /// not ask for it, which is wrong text delivered with nothing on screen to say so.
+  /// That is the one shape `testing-philosophy.md` RULE: dont-test-what-cannot-happen
+  /// keeps.
+  @Test("a live pill refuses an action carrying somebody else's transcript id")
+  func livePillRefusesAForeignTranscriptID() throws {
+    let (d, host) = OverlayTestDouble.headlessDirectorWithHost()
+    let live = CancelUndoPayload(transcriptID: UUID(), targetApp: nil, targetElement: nil)
+    var pasted: [UUID] = []
+
+    let receipt = d.present(
+      .escapeRecovery(payload: live, onPaste: { pasted.append($0.transcriptID) }))
+
+    // The receipt is the LIVE one, so the presentation-id gate admits this action. Only
+    // the payload comparison can refuse it.
+    try host.sendUserActionThroughRoot(
+      .pasteEscapeRecovery(transcriptID: UUID()), for: try #require(receipt))
+
+    #expect(
+      pasted.isEmpty,
+      "an action for a different transcript reached the held payload, so it would paste")
+
+    // And the offer is still there to be taken by its OWN action — a guard that refused
+    // by tearing the custody down would pass the assertion above and lose the recording.
+    try host.sendUserActionThroughRoot(
+      .pasteEscapeRecovery(transcriptID: live.transcriptID), for: try #require(receipt))
+    #expect(pasted == [live.transcriptID], "the refusal must not have consumed the offer")
+  }
+
   // **`payloadIsTakenOnce` was DELETED here and in `OverlayDirectorTests`**
   // (#2292 C4a), on a supervisor ruling, and the reason is worth keeping.
   //


### PR DESCRIPTION
## Summary

#2529 split six frozen recipe rows by whether re-aiming them is mechanical or a judgement. Five were mechanically recoverable and ran on the overnight lane, 2026-09-09. Four CAUGHT. #2352's row M4 SURVIVED, and this closes it.

Part of #2529.

`Tier: SMALL | Test: n/a (this IS the test) | Modules: AppKit`
`Lane: Code`

## The re-aim, and what it measured

The battery's own `indentation_hint` now names the offset when an anchor only MOVED, which is the cheap improvement #2529 asked for and which has since shipped. Feeding those offsets back:

| row | offset | result |
|---|---|---|
| #2352 M1 no-silent-dismissal | +4 | **CAUGHT** — `pressingPasteDismissesTheOffer()` |
| #2352 M2 dismiss-after-forwarding | +4 | **CAUGHT** — `pasteOrdering()` |
| #2352 M3 never-forwards | +4 | **CAUGHT** — `pressingPasteDismissesTheOffer()` plus three others |
| #2352 M4 no-transcript-id-check | +4 | **SURVIVED** |
| #2351 M4 cross-gotIt-and-close | +2 | **CAUGHT** — `bluetoothActionsPreserveExactTelemetryIdentity()` plus two others |

#2351's row 4 is worth noting on its own: #2529 filed it under *needs a judgement*, and the offset check moved it to *mechanically recoverable*. It caught.

## Why M4 survived, and why that is not vacuity

`supersededPillCannotTouchTheNewerPayload` replays a STALE receipt, so the root's presentation-id gate refuses the action **before the binding runs** and the `held.id == transcriptID` comparison never executes. Two mechanisms cover one outcome, so a single-line mutation of either is invisible while the other still refuses — `testing-philosophy.md` RULE: redundant-protections-make-single-line-mutants-survive-and-that-is-not-vacuity, reason 3.

**They are not the same guard, though.** The root gate answers *is this pill still the one on screen*. The comparison answers *does this action belong to the payload this pill is holding*. A LIVE receipt carrying a foreign transcript id passes the first and must be refused by the second, and nothing reached that.

## The case

`livePillRefusesAForeignTranscriptID`. Presents an offer, sends a paste action carrying a different transcript id through the LIVE receipt, and requires no paste. Then sends the offer's OWN action and requires the paste — a guard that refused by tearing the custody down would satisfy the first assertion and lose the recording.

Production cannot build that action today, because the pill sends the id it was presented with. It is written because of the DIRECTION it fails in: without the comparison the held payload is pasted for an action that did not ask for it, which is wrong text delivered with nothing on screen to say so. That is the one shape `testing-philosophy.md` RULE: dont-test-what-cannot-happen keeps.

## Verified both ways

| | result |
|---|---|
| shipped | `EnviousWisprTests/EscapeRecoveryPillTests` **8/8 green** |
| `held.id == transcriptID` deleted | **exact `must_fire` set matched** — `livePillRefusesAForeignTranscriptID()` red, and `supersededPillCannotTouchTheNewerPayload()` named as a silent control stayed unchanged |

The silent control is the point: it confirms the old case still cannot see this mutant, so the new one carries the property rather than duplicating an existing guard.

## Pre-Merge Checklist

### Build Verification
- [x] Logic tests pass locally — 8/8 in this branch's own worktree.
- [x] Mutation control run against this branch: baseline green before and after, every file byte-identical on restore.
- [ ] Dev build — N/A, no production code touched.
- [ ] CI `build-check` — pending on this push.

### Code Quality
- [x] Conventional commit format, no secrets.
- [x] Self-review grep over `held.id == transcriptID`, `pasteEscapeRecovery`, `escapeRecoveryPayload` across `Sources/ Tests/ docs/ .claude/`.
- [x] No `#if DEBUG` production member used — the case drives `present` and `sendUserActionThroughRoot`, the same production route its neighbours use.
- [ ] `codex review` — not run. Test-only diff, no production code; `GR-REVIEW-GATE`'s six mandatory categories do not apply.

### Process note

Ran during the founder's night, the only window `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night permits a mutant run.
