### PR TITLE
feat(validation): --fix prints corrected rows for mechanically dead recipes (#2703)

### DIFF
--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2188,8 +2188,14 @@ check_validator("the filing validator decodes escaped Swift display names",
                      expect_fail='hardware class is real, never "unknown"',
                      suite="EnviousWisprTests/LaunchAvailabilitySnapshotTests"),
                 expected_rc=0, expected_text="1/1 rows runnable")
+# Re-aimed 2026-09-09. It named `proxyErrorRecyclesConnection()`, which went away with the
+# ASR XPC boundary in #1908 — nothing in `Tests/` carries that name any more, so this case
+# had been asserting `1/1 rows runnable` about a test that does not exist and had been red
+# for anyone who ran the file. Nothing runs it: no workflow invokes
+# `scripts/mutation-battery-test.py`, which is why a stale oracle here is silent. The claim
+# is preserved by naming the LATER of the two surviving cases in the same file.
 check_validator("the filing validator keeps later tests in their enclosing suite",
-                dict(_validator_base, expect_fail="proxyErrorRecyclesConnection()",
+                dict(_validator_base, expect_fail="progressMappingCoversAllVendorPhases()",
                      suite="EnviousWisprASRTests/ParakeetDeliveryModeTests"),
                 expected_rc=0, expected_text="1/1 rows runnable")
 check_validator("the filing validator does not invent a parameter suffix",
@@ -2514,6 +2520,136 @@ if result.returncode != 2 or "carries 2 explicit recipe blocks" not in _issue_ou
         f"exit {result.returncode}: {_issue_output[:250]!r}")
 else:
     print("  ok  the filing validator shares the runner's single-recipe issue contract")
+
+# #2703 candidate 2: `--fix` prints corrected rows for the two mechanical drift classes and
+# refuses everything else. Two-way in both directions that matter — a clean recipe must
+# produce NO repairs (a repairer that fires on a healthy tree is invalid by construction,
+# `code-validation.md` RULE: check-must-not-fire-on-a-clean-tree), and the corrected rows
+# must RUN, which is the only thing that makes the repair worth printing.
+
+
+def check_fix(name, row=None, *, document=None, expect_text, expect_no_block=False,
+              expect_runnable=None):
+    """`expect_runnable` re-validates `--fix`'s own output as a recipe.
+
+    Asserting the printed block PARSES would pass against a repair that produces a
+    well-formed row the runner still refuses, which is the whole failure this flag exists
+    to remove. The round trip is the assertion.
+    """
+    global ran
+    ran += 1
+    with tempfile.TemporaryDirectory() as td:
+        recipe = Path(td) / "recipe.json"
+        payload = json.dumps(document if document is not None else {"rows": [row]})
+        recipe.write_text(payload)
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), "--recipes", str(recipe), "--fix",
+             "--checkout", str(BATTERY.parent.parent)],
+            capture_output=True, text=True,
+        )
+        # `--fix` PRINTS. A repairer that edited the recipe under the author would be
+        # editing a frozen row in place, which is the thing it exists not to do.
+        untouched = recipe.read_text() == payload
+    output = result.stdout + result.stderr
+    problems = []
+    if not untouched:
+        problems.append("the recipe file was modified")
+    expected = (expect_text,) if isinstance(expect_text, str) else tuple(expect_text)
+    problems += [f"missing {text!r}" for text in expected if text not in output]
+    block = output.partition("```json")[2].partition("```")[0]
+    if expect_no_block and block.strip():
+        problems.append("printed a corrected block when nothing was repairable")
+    if expect_runnable is not None:
+        if not block.strip():
+            problems.append("printed no corrected block to re-validate")
+        else:
+            with tempfile.TemporaryDirectory() as td2:
+                fixed = Path(td2) / "fixed.json"
+                fixed.write_text(block)
+                again = subprocess.run(
+                    [sys.executable, str(VALIDATOR), "--recipes", str(fixed),
+                     "--checkout", str(BATTERY.parent.parent)],
+                    capture_output=True, text=True,
+                )
+            if expect_runnable not in again.stdout + again.stderr:
+                problems.append(
+                    f"corrected rows did not re-validate: {(again.stdout + again.stderr)[-200:]!r}")
+    if problems:
+        failures.append(f"{name}: {'; '.join(problems)} in {output[-400:]!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+# The shipped line sits at FOUR spaces, so this fixture is written at SIX: the file no
+# longer contains the text at all, and exactly one offset (-2) brings it back. Six rather
+# than the obvious two, because `load_recipes` counts a plain SUBSTRING — at two the
+# shifted text is still found inside the real line's own indentation and the row stays
+# runnable, which would make this case pass against a `--fix` that does nothing.
+_drifted = dict(
+    _validator_base,
+    anchor="      " + _validator_base["anchor"].lstrip(" "),
+    replacement="      " + _validator_base["replacement"].lstrip(" "),
+    expect_fail=_guard_name)
+check_fix("--fix re-cuts an anchor that only moved in indentation, and the row then runs",
+          _drifted,
+          expect_text=["anchor re-cut at -2 spaces", "Nothing was written"],
+          expect_runnable="1/1 rows runnable")
+
+check_fix("--fix completes an expectation naming a prefix of exactly one test",
+          dict(_validator_base, expect_fail="egOneNotInstalled"),
+          expect_text="repairable — must_fire: 'egOneNotInstalled' -> 'egOneNotInstalled()'",
+          expect_runnable="1/1 rows runnable")
+
+check_fix("--fix refuses an anchor no offset recovers, and prints no block",
+          dict(_validator_base, anchor="this text is in no file in this repository at all",
+               expect_fail=_guard_name),
+          expect_text=["NOT mechanically repairable", "no offset matches"],
+          expect_no_block=True)
+
+check_fix("--fix on a healthy row repairs nothing",
+          dict(_validator_base, expect_fail=_guard_name),
+          expect_text="Nothing was written",
+          expect_no_block=True)
+
+# #2703 review, P2 x3. Each of these reproduced a corrected block that was WRONG rather
+# than absent, which is the direction that costs somebody a run.
+_drifted_no_suite = {k: v for k, v in _drifted.items() if k != "suite"}
+check_fix("--fix carries the suite_default onto a corrected row",
+          document={"suite_default": _validator_base["suite"],
+                    "rows": [_drifted_no_suite]},
+          expect_text="anchor re-cut at -2 spaces",
+          expect_runnable="1/1 rows runnable")
+
+check_fix("--fix refuses a row whose OTHER defect survives the mechanical repair",
+          dict(_drifted, expect_fail="noSuchTestExistsAnywhere()"),
+          expect_text=["the mechanical part repairs", "still does not validate",
+                       "DOES NOT EXIST"],
+          expect_no_block=True)
+
+# #2703 review r3, and the fixture is the reason this needs its own case rather than a
+# comment. `"  }\n"` occurs 55 times in that file AND has exactly ONE offset (+10) at which
+# it matches exactly once. So an indentation repair reached from a MANY-match anchor would
+# report it as recoverable and re-cut the row onto one arbitrary closing brace — a
+# corrected row that validates cleanly and mutates a line nothing says it meant.
+check_fix("--fix refuses an ambiguous anchor rather than shifting it into a unique one",
+          dict(_validator_base, anchor="  }\n", replacement="  } // shifted\n",
+               expect_fail=_guard_name),
+          expect_text="matches 55 times, so it is AMBIGUOUS rather than moved",
+          expect_no_block=True)
+
+check_fix("--fix combines both repair classes on one row",
+          document={"suite_default": _validator_base["suite"],
+                    "rows": [dict(_drifted_no_suite, expect_fail="egOneNotInstalled")]},
+          expect_text="anchor re-cut at -2 spaces; must_fire: 'egOneNotInstalled' -> "
+                      "'egOneNotInstalled()'",
+          expect_runnable="1/1 rows runnable")
+
+check_fix("a malformed row is refused without stopping the rows behind it",
+          document={"rows": [dict(_validator_base, anchor=42, expect_fail=_guard_name),
+                             _drifted]},
+          expect_text=["row 1: NOT mechanically repairable — the row's anchor is not a string",
+                       "row 2: repairable — anchor re-cut at -2 spaces"],
+          expect_runnable="1/1 rows runnable")
 
 # #2672 review: `self_test_problems` accepted ANY `"--self-test"` constant that was not a bare
 # docstring statement, so a module constant, a help message or an unreachable branch made a

--- a/scripts/mutation-battery.py
+++ b/scripts/mutation-battery.py
@@ -1361,6 +1361,39 @@ def line_start_occurrences(src, text):
     return total
 
 
+def indentation_offsets(src, anchor):
+    """Every non-zero indentation shift at which `anchor` matches EXACTLY ONCE in `src`.
+
+    The offset computation `indentation_hint` reports and `--fix` re-cuts a row at, in
+    one place. Two readers of one question is how they start disagreeing, and the
+    disagreement would be invisible: the sentence would name an offset the repair did
+    not use, or the repair would use one the sentence never named.
+    """
+    first = next((line for line in anchor.split("\n") if line.strip()), None)
+    if first is None:
+        return []
+    anchor_indent = len(first) - len(first.lstrip(" "))
+
+    candidates = {
+        (len(line) - len(line.lstrip(" "))) - anchor_indent
+        for line in src.split("\n")
+        if line.strip()
+    }
+    return [
+        delta
+        for delta in sorted(candidates)
+        if delta != 0
+        and (shifted := reindented(anchor, delta)) is not None
+        # BOTH counts, because an offset is only useful as advice if a row re-cut at
+        # it would RUN. A shifted text unique at a line start but repeated mid-line —
+        # duplicate bytes inside a comment or a string — passes the first count and is
+        # then refused as non-unique by the check above. Naming it points the reader at
+        # a number that cannot work, which is worse than naming none. Ref: #2529 r4.
+        and line_start_occurrences(src, shifted) == 1
+        and src.count(shifted) == 1
+    ]
+
+
 def indentation_hint(src, anchor):
     """A sentence naming the offsets at which this anchor matches exactly once, or ''.
 
@@ -1385,29 +1418,7 @@ def indentation_hint(src, anchor):
     shifted anchor, occurring exactly once, BEGINNING A LINE — is what decides.
     Ref: #2529 review r1 and r2.
     """
-    first = next((line for line in anchor.split("\n") if line.strip()), None)
-    if first is None:
-        return ""
-    anchor_indent = len(first) - len(first.lstrip(" "))
-
-    candidates = {
-        (len(line) - len(line.lstrip(" "))) - anchor_indent
-        for line in src.split("\n")
-        if line.strip()
-    }
-    offsets = [
-        delta
-        for delta in sorted(candidates)
-        if delta != 0
-        and (shifted := reindented(anchor, delta)) is not None
-        # BOTH counts, because an offset is only useful as advice if a row re-cut at
-        # it would RUN. A shifted text unique at a line start but repeated mid-line —
-        # duplicate bytes inside a comment or a string — passes the first count and is
-        # then refused as non-unique by the check above. Naming it points the reader at
-        # a number that cannot work, which is worse than naming none. Ref: #2529 r4.
-        and line_start_occurrences(src, shifted) == 1
-        and src.count(shifted) == 1
-    ]
+    offsets = indentation_offsets(src, anchor)
     if not offsets:
         return ""
     named = ", ".join(f"{delta:+d}" for delta in sorted(offsets))

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -324,6 +324,147 @@ def test_oracle(root):
     return names_by_suite
 
 
+def prefix_successor(name, known_names):
+    """The one full test name `name` is a prefix of, or None when that is not decidable.
+
+    Same population and the same rule `missing_test_problem` reports on, read here as a
+    VALUE rather than as a sentence. Refuses on two candidates: a repair that picks one
+    of several is a guess, which is the thing freezing a recipe exists to prevent.
+    """
+    if not name or name in known_names:
+        return None
+    near = [
+        candidate for candidate in known_names
+        if candidate and candidate != name and candidate.startswith(name)
+    ]
+    return near[0] if len(near) == 1 else None
+
+
+def repaired_row(row, index, default_suite, root, battery, names_by_suite):
+    """A corrected copy of an UNRUNNABLE row, or (None, why-not).
+
+    Two classes, and no others. Both are decidable from the checkout with no model of
+    what the recipe MEANT, which is the line this stops at:
+
+    - **The anchor only moved in indentation.** Exactly one offset makes it match
+      exactly once, and the replacement shifts with it. A formatter reflow or an
+      extract-to-another-file retires a row while the behaviour it binds is untouched,
+      and this is that case and only that case (#2529).
+    - **An expectation names a PREFIX of exactly one real test.** The full name is read
+      off the same oracle the refusal used.
+
+    **Never applied, never written back.** It returns a row for a human to file on a NEW
+    issue, because a frozen row is not edited in place — re-pointing one at what LOOKS
+    like its successor is a guess about what the recipe meant, and that judgement is the
+    author's rather than a script's (#2703 candidate 2).
+    """
+    if not isinstance(row, dict):
+        return None, "the row is not an object"
+
+    fixed = dict(row)
+    notes = []
+
+    anchor = row.get("anchor")
+    path = row.get("file")
+    # TYPE first, because a malformed row is exactly what the ordinary validator refuses
+    # cleanly and what this path must not turn into a crash. `source.count(42)` raises
+    # `TypeError` and takes every LATER row down with it, so one bad row would stop the
+    # whole recipe being reported (#2703 review, P2).
+    for field, value in (("anchor", anchor), ("file", path), ("replacement",
+                                                              row.get("replacement"))):
+        if value is not None and not isinstance(value, str):
+            return None, f"the row's {field} is not a string"
+    if anchor and path:
+        target = (root / path).resolve()
+        try:
+            inside = target.is_relative_to(root.resolve())
+        except (AttributeError, ValueError):
+            inside = str(target).startswith(str(root.resolve()))
+        if not inside:
+            return None, f"the row's file resolves outside the checkout: {path}"
+        if not target.is_file():
+            return None, f"the row's file no longer exists: {path}"
+        source = target.read_text(errors="replace")
+        # ZERO, not "anything but one", and the difference is the whole safety property.
+        #
+        # The runner refuses an anchor that matches once (fine), never (moved or gone) and
+        # MANY (ambiguous). Only the middle one is an indentation question. Re-cutting an
+        # AMBIGUOUS anchor does not repair it — it silently picks one of its matches: a
+        # `return false` at four spaces and again at eight matches twice, and shifting it
+        # to eight makes it "unique" at a statement nothing says the row meant. The
+        # corrected row would then validate and mutate the wrong line, which is the exact
+        # guess this whole flag exists to refuse (#2703 review r3).
+        #
+        # A count of one is left alone for a different reason: the runner would apply it,
+        # so it is not broken, and re-cutting it would rewrite a row that had nothing wrong.
+        occurrences = source.count(anchor)
+        if occurrences > 1:
+            return None, (
+                f"the anchor matches {occurrences} times, so it is AMBIGUOUS rather than "
+                "moved — which of them the row meant is the author's call, not a shift")
+        if occurrences == 0:
+            offsets = battery.indentation_offsets(source, anchor)
+            if len(offsets) != 1:
+                return None, (
+                    "the anchor is not recoverable by indentation alone — "
+                    + (f"{len(offsets)} offsets match" if offsets else "no offset matches")
+                    + "; what the row MEANT has to be decided before it is re-pointed")
+            delta = offsets[0]
+            shifted = battery.reindented(anchor, delta)
+            replacement = row.get("replacement")
+            # The replacement moves with the anchor or the pair stops describing one edit.
+            # `reindented` returns None when a dedent would eat a non-space character, and
+            # an empty replacement (a deletion) has nothing to shift.
+            if replacement:
+                shifted_replacement = battery.reindented(replacement, delta)
+                if shifted_replacement is None:
+                    return None, (
+                        f"the anchor re-cuts at {delta:+d} spaces but the replacement "
+                        "cannot be shifted with it without changing its text")
+                fixed["replacement"] = shifted_replacement
+            fixed["anchor"] = shifted
+            notes.append(f"anchor re-cut at {delta:+d} spaces")
+
+    # RE-READ the row before touching expectations, ALWAYS.
+    #
+    # `load_recipes` refuses at its FIRST defect and returns nothing, so every field it
+    # would have resolved — the suite, `_must_fire`, `_must_not_fire`, the mode — is
+    # absent for exactly the rows that have something to repair. Two review rounds each
+    # found a different member of that one class: the corrected row lost its
+    # `suite_default`, then a row with drift AND a resolvable prefix had the prefix
+    # skipped. Reading the caller's post-refusal `normalized` at all is the defect, so it
+    # is not read here — this recomputes from the row as it stands, whether or not the
+    # anchor was touched, and there is no member left to find (#2703 review r1 and r2).
+    _, normalized, suite, _ = row_problems(
+        fixed, index, default_suite, root, battery, names_by_suite)
+    suite_names = names_by_suite.get(suite, {})
+
+    for field, key in (("_must_fire", "must_fire"), ("_must_not_fire", "must_not_fire")):
+        names = normalized.get(field) or []
+        if not names:
+            continue
+        rewritten = []
+        changed = False
+        for name in names:
+            successor = prefix_successor(name, suite_names)
+            rewritten.append(successor or name)
+            if successor:
+                changed = True
+                notes.append(f"{key}: {name!r} -> {successor!r}")
+        if changed:
+            # `expect_fail` is the single-guard spelling of a one-element `must_fire`, so
+            # a row that arrived in that form goes back out in it rather than silently
+            # changing which contract it declares.
+            if key == "must_fire" and "expect_fail" in fixed:
+                fixed["expect_fail"] = rewritten[0]
+            else:
+                fixed[key] = rewritten
+
+    if not notes:
+        return None, "no mechanical class applies"
+    return fixed, "; ".join(notes)
+
+
 def missing_test_problem(name, known_names):
     if name in known_names:
         if len(known_names[name]) > 1:
@@ -436,12 +577,86 @@ def self_test_problems(battery, suite, root):
     return []
 
 
-def validate(recipes, root, label):
+def row_problems(row, index, default_suite, root, battery, names_by_suite):
+    """Every problem with ONE row, plus what the runner made of it.
+
+    Extracted so `--fix` can ask the SAME question of a corrected row that this asks of
+    the filed one. A repair judged only by the defect it targeted prints a row that
+    parses and that the runner still refuses — a drifted anchor whose expectation ALSO
+    names a missing test comes back "repairable" and fails on the very next run
+    (#2703 review, P2).
+    """
+    problems = []
+    normalized = {}
+    # One row per call, so the runner's first refusal cannot hide the rows behind
+    # it. The cost is that the runner numbers every row as `row 1`; printed after
+    # this loop's own `row N:` label that read as an anchor index (#2525). Only the
+    # leading prefix is renumbered — a `row 1` inside a quoted path is left alone.
+    single_row = {"suite_default": default_suite, "rows": [row]}
+    try:
+        normalized = battery.load_recipes(
+            None, root, raw=json.dumps(single_row))[0]
+    except battery.Refusal as error:
+        problems.append(re.sub(
+            r"^((?:human )?row )1\b", rf"\g<1>{index}", str(error)))
+
+    suite = normalized.get("suite")
+    suite_names = names_by_suite.get(suite, {})
+    for name in normalized.get("_must_fire", []) + normalized.get("_must_not_fire", []):
+        problem = missing_test_problem(name, suite_names)
+        if problem:
+            problems.append(problem)
+
+    fire_ids = set().union(*(
+        suite_names.get(name, set()) for name in normalized.get("_must_fire", [])
+    ))
+    silent_ids = set().union(*(
+        suite_names.get(name, set()) for name in normalized.get("_must_not_fire", [])
+    ))
+    alias_overlap = sorted(fire_ids & silent_ids)
+    if alias_overlap:
+        problems.append(
+            "must_fire and must_not_fire resolve to the same test(s): "
+            + ", ".join(alias_overlap))
+    for field in ("_must_fire", "_must_not_fire"):
+        aliases_by_test = {}
+        for name in normalized.get(field, []):
+            for test_id in suite_names.get(name, set()):
+                aliases_by_test.setdefault(test_id, []).append(name)
+        duplicates = {
+            test_id: aliases for test_id, aliases in aliases_by_test.items()
+            if len(aliases) > 1
+        }
+        if duplicates:
+            problems.append(
+                f"{field.removeprefix('_')} names the same test through multiple aliases: "
+                + "; ".join(
+                    f"{test_id}: {', '.join(aliases)}"
+                    for test_id, aliases in sorted(duplicates.items())
+                ))
+
+    # A `RuntimeUAT/<module>` suite is a Python self-test, not a Swift suite (#2570):
+    # the oracle cannot know it, so it is proved against the checkout instead. The
+    # runner has already refused it on a mechanical row and with test names attached.
+    command = battery.self_test_command(suite, root)
+    if command:
+        if suite in names_by_suite:
+            problems.append(
+                f"suite {suite} is both a Swift suite and a self-test target — ambiguous")
+        problems.extend(self_test_problems(battery, suite, root))
+    elif suite and suite not in names_by_suite:
+        problems.append(f"suite {suite} NOT FOUND in Tests/")
+    return problems, normalized, suite, command
+
+
+def validate(recipes, root, label, fix=False):
     names_by_suite = test_oracle(root)
     battery = load_battery()
     root = root.resolve()
     bad = 0
     total = 0
+    repairs = []
+    refusals = []
 
     for document in recipes:
         if not isinstance(document, dict) or not isinstance(document.get("rows"), list):
@@ -453,72 +668,45 @@ def validate(recipes, root, label):
         default_suite = document.get("suite_default")
         for index, row in enumerate(document["rows"], 1):
             total += 1
-            problems = []
-            normalized = {}
-            # One row per call, so the runner's first refusal cannot hide the rows behind
-            # it. The cost is that the runner numbers every row as `row 1`; printed after
-            # this loop's own `row N:` label that read as an anchor index (#2525). Only the
-            # leading prefix is renumbered — a `row 1` inside a quoted path is left alone.
-            single_row = {"suite_default": default_suite, "rows": [row]}
-            try:
-                normalized = battery.load_recipes(
-                    None, root, raw=json.dumps(single_row))[0]
-            except battery.Refusal as error:
-                problems.append(re.sub(
-                    r"^((?:human )?row )1\b", rf"\g<1>{index}", str(error)))
-
-            suite = normalized.get("suite")
+            problems, normalized, suite, command = row_problems(
+                row, index, default_suite, root, battery, names_by_suite)
             suite_names = names_by_suite.get(suite, {})
-            for name in normalized.get("_must_fire", []) + normalized.get("_must_not_fire", []):
-                problem = missing_test_problem(name, suite_names)
-                if problem:
-                    problems.append(problem)
-
-            fire_ids = set().union(*(
-                suite_names.get(name, set()) for name in normalized.get("_must_fire", [])
-            ))
-            silent_ids = set().union(*(
-                suite_names.get(name, set()) for name in normalized.get("_must_not_fire", [])
-            ))
-            alias_overlap = sorted(fire_ids & silent_ids)
-            if alias_overlap:
-                problems.append(
-                    "must_fire and must_not_fire resolve to the same test(s): "
-                    + ", ".join(alias_overlap))
-            for field in ("_must_fire", "_must_not_fire"):
-                aliases_by_test = {}
-                for name in normalized.get(field, []):
-                    for test_id in suite_names.get(name, set()):
-                        aliases_by_test.setdefault(test_id, []).append(name)
-                duplicates = {
-                    test_id: aliases for test_id, aliases in aliases_by_test.items()
-                    if len(aliases) > 1
-                }
-                if duplicates:
-                    problems.append(
-                        f"{field.removeprefix('_')} names the same test through multiple aliases: "
-                        + "; ".join(
-                            f"{test_id}: {', '.join(aliases)}"
-                            for test_id, aliases in sorted(duplicates.items())
-                        ))
-
-            # A `RuntimeUAT/<module>` suite is a Python self-test, not a Swift suite (#2570):
-            # the oracle cannot know it, so it is proved against the checkout instead. The
-            # runner has already refused it on a mechanical row and with test names attached.
-            command = battery.self_test_command(suite, root)
-            if command:
-                if suite in names_by_suite:
-                    problems.append(
-                        f"suite {suite} is both a Swift suite and a self-test target — ambiguous")
-                problems.extend(self_test_problems(battery, suite, root))
-            elif suite and suite not in names_by_suite:
-                problems.append(f"suite {suite} NOT FOUND in Tests/")
 
             if problems:
                 bad += 1
                 print(f"row {index}: UNRUNNABLE — {'; '.join(problems)}")
                 row_label = row.get("label", "(no label)") if isinstance(row, dict) else "(no label)"
                 print(f"        {str(row_label)[:90]}")
+                if fix:
+                    corrected, why = repaired_row(
+                        row, index, default_suite, root, battery, names_by_suite)
+                    if corrected is None:
+                        refusals.append((index, why))
+                    else:
+                        corrected["label"] = (
+                            f"re-cut from row {index} of {label}: "
+                            f"{str(row.get('label', '')).strip()}")
+                        # A corrected row carries its filter EXPLICITLY, because the new
+                        # issue it gets filed on has no `suite_default`. Prefer what the
+                        # runner resolved; fall back to the row's own field and then to
+                        # the document's default, both of which survive a refusal that
+                        # leaves `normalized` empty (#2703 review, P2).
+                        resolved_suite = (
+                            suite or row.get("suite") or default_suite)
+                        if resolved_suite:
+                            corrected["suite"] = resolved_suite
+                        # THE WHOLE CHECK, not the defect the repair aimed at. A row with
+                        # indentation drift AND a second problem would otherwise be
+                        # printed as repairable and refused on the very next run.
+                        remaining, _, _, _ = row_problems(
+                            corrected, index, default_suite, root, battery, names_by_suite)
+                        if remaining:
+                            refusals.append((
+                                index,
+                                "the mechanical part repairs (" + why + ") but the row "
+                                "still does not validate: " + "; ".join(remaining)))
+                        else:
+                            repairs.append((index, why, corrected))
             else:
                 status = "DEFERRED" if normalized.get("_mode") == "human" else "runnable"
                 run = f" — run: {command}" if command else ""
@@ -526,6 +714,22 @@ def validate(recipes, root, label):
 
     print(f"\n{label}: {total - bad}/{total} rows runnable"
           + (f", {bad} UNRUNNABLE" if bad else ""))
+
+    if fix:
+        print("\n--fix: mechanical repairs only. Nothing was written.")
+        for index, why in refusals:
+            print(f"  row {index}: NOT mechanically repairable — {why}")
+        for index, why, _ in repairs:
+            print(f"  row {index}: repairable — {why}")
+        if repairs:
+            print(
+                "\nFile these on a NEW issue; a frozen row is never edited in place.\n"
+                "```json")
+            print(json.dumps({"rows": [row for _, _, row in repairs]}, indent=2))
+            print("```")
+        elif bad:
+            print("\n  Nothing here is repairable without deciding what the row MEANT.")
+
     return 1 if bad else 0
 
 
@@ -535,6 +739,12 @@ def main(argv=None):
     source.add_argument("--issue", type=int)
     source.add_argument("--recipes", type=pathlib.Path)
     parser.add_argument("--checkout", type=pathlib.Path, default=pathlib.Path.cwd())
+    parser.add_argument(
+        "--fix", action="store_true",
+        help="also print corrected rows for the UNRUNNABLE ones whose repair is "
+             "mechanical — an anchor that only moved in indentation, or an expectation "
+             "naming a prefix of exactly one real test. Prints; never writes, and never "
+             "edits the issue: a frozen row is filed corrected on a NEW issue.")
     args = parser.parse_args(argv)
 
     try:
@@ -554,7 +764,7 @@ def main(argv=None):
         if not recipes:
             print(f"{label}: NO PARSEABLE RECIPE — nothing to validate")
             return 2
-        return validate(recipes, args.checkout, label)
+        return validate(recipes, args.checkout, label, fix=args.fix)
     except (OSError, json.JSONDecodeError, RuntimeError) as error:
         print(f"REFUSED — {error}", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary

#2703's second candidate. The validator already knew, and printed, everything needed to repair two classes of dead recipe row — it just made a person retype the answer into a new recipe by hand. That is transcription standing between a frozen row and a run, which is what freezing a row exists to prevent.

Part of #2703. Its third candidate (the issue template) shipped in PR #2704; the first (validate at filing time) is untouched here.

`Tier: SMALL | Test: required | Modules: scripts`
`Lane: Docs/dev-tooling`

## What `--fix` does

Prints corrected rows for exactly two classes, and refuses everything else.

1. **The anchor only moved in indentation.** Exactly one offset makes it match exactly once; the replacement shifts with it or the pair stops describing one edit.
2. **An expectation names a PREFIX of exactly one real test.** The full name comes off the same oracle the refusal used, and a row that arrived as `expect_fail` goes back out as `expect_fail`.

Two candidates for either class is a refusal, not a pick. Everything else is reported as needing a decision about what the row MEANT.

**It prints.** It never writes the recipe, never edits the issue, and says so in its own output: a frozen row is filed corrected on a NEW issue.

## Measured against the real dead recipes this issue is about

| issue | as filed | `--fix` output re-validated |
|---|---|---|
| #2626 | 9 rows, **all UNRUNNABLE** | **9/9 runnable** |
| #2352 | 4 rows, all UNRUNNABLE | **4/4 runnable** |
| #2356 | 2 rows, all UNRUNNABLE | refused, no block printed |

#2626 is the case #2703 names directly: a prefix refusal retired all nine of its rows. They come back with one command.

**The round trip is the assertion**, in the tests too. A printed block that parses but that the runner still refuses would be the exact failure this flag exists to remove, so every repair case re-validates `--fix`'s own output.

## One computation, not two

`indentation_offsets` is extracted in `mutation-battery.py` so the offset the hint NAMES and the offset `--fix` re-cuts at are the same code. Two readers of that question would disagree invisibly — a sentence naming an offset the repair did not use, or the reverse. `indentation_hint` now calls it and is otherwise unchanged.

## Four Codex rounds, and what each one moved

- **r1, three P2s.** A corrected row lost its `suite_default`; a row with drift AND a second defect was printed as repairable and refused on the next run; a non-string `anchor` raised and took every LATER row down with it.
- **r2, one P2 — the same ROOT as the first.** The repair read values `load_recipes` only populates on SUCCESS, and it refuses at its first defect, so those fields are absent for exactly the rows that have something to repair. Rather than extend the list, the class is closed: the caller's post-refusal `normalized` is not read at all, and the two parameters that carried it are gone from the signature.
- **r3, a different AXIS.** A MANY-match anchor is AMBIGUOUS rather than moved, and shifting it does not repair it — it PICKS one of its matches. `"  }\n"` occurs 55 times in `AIPolishProviderRail` and has exactly one offset at which it matches once, so the corrected row would have validated cleanly and mutated an arbitrary closing brace. Indentation recovery is now attempted only at ZERO matches.
- **r4, confirming.** "No actionable regressions found."

## Also: one stale case re-aimed

`the filing validator keeps later tests in their enclosing suite` named `proxyErrorRecyclesConnection()`, which went away with the ASR XPC boundary in #1908. It had been asserting `1/1 rows runnable` about a test that does not exist. **Nothing runs this file** — no workflow invokes `scripts/mutation-battery-test.py` — which is why a stale oracle here is silent. Re-aimed at the later of the two surviving cases in the same file, preserving the claim it was making.

## Pre-Merge Checklist

### Build Verification
- [x] `python3 scripts/mutation-battery-test.py` — **228/228**, including eight new `--fix` cases.
- [x] Round trip on the real issues: #2626 9/9 and #2352 4/4 corrected rows runnable; #2356 correctly refused.
- [x] `indentation_hint` behaviour unchanged after the extraction, checked against the same anchor.
- [ ] Dev build — N/A, no Swift touched.
- [ ] CI `build-check` — pending on this push.

### Code Quality
- [x] `codex review --base origin/main`, four rounds, ending clean.
- [x] Self-review grep over `indentation_offsets`, `repaired_row`, `prefix_successor`, `row_problems` across `scripts/ .claude/ docs/ Tests/`.
- [x] Conventional commit format, no secrets.

### Known, and not fixed here

`.claude/scripts/validate-mutation-recipe.py` is a gitignored August ancestor of the tracked script and does NOT get this flag. It is 15 KB against the tracked 25 KB, so it is already behind on several fixes, and a session invoking it gets refusals the current one would not give. It cannot ride in a PR; `validation-discipline.md` now carries a row for that trap. Deleting it was deliberately not done tonight — another session was actively invoking it while this was written.
