### PR TITLE
fix(pipeline): dictated measurements keep their unit (#2728)

### DIFF
--- a/Sources/EnviousWisprPipeline/FillerRemovalStep.swift
+++ b/Sources/EnviousWisprPipeline/FillerRemovalStep.swift
@@ -15,10 +15,46 @@ public final class FillerRemovalStep: TextProcessingStep {
 
   private static let logger = Logger(subsystem: "com.enviouswispr.app", category: "FillerRemoval")
 
+  /// **Two alternatives, and the split is the fix for #2728.**
+  ///
+  /// Eight of these ten tokens are onomatopoeic and collide with nothing, so they are
+  /// removed wherever they appear. `mm` and `ah` are also UNITS — millimetre, and the
+  /// `mm Hg` of a blood-pressure reading; amp-hour — so those two, and only those two,
+  /// refuse to be removed when they follow a digit.
+  ///
+  /// What shipped before deleted them: "the gap is 5 mm" pasted as "the gap is 5", on
+  /// the default path for every English speaker, because `fillerRemovalEnabled` is true
+  /// out of the box. The failure is a DELETION, so the sentence still reads fluently and
+  /// nothing looks broken — the shape `grounding-discipline.md`
+  /// RULE: public-claims-need-binding-evidence names, where a promise that is not
+  /// observable drifts for as long as nobody looks.
+  ///
+  /// **The guard is deliberately NOT applied to the other eight.** A broad version was
+  /// proposed and measured first, and it also stopped removing a genuine hesitation after
+  /// a number — "give me 3 um copies" kept its "um". That is a real behaviour change on
+  /// the same default path, in the direction of doing LESS of what the feature is for, so
+  /// the narrow split is what ships. Both tables are on #2728.
+  ///
+  /// Three fixed-width lookbehinds rather than one variable-width one, because ICU
+  /// (`NSRegularExpression`) supports only fixed width: bare digit, digit-space,
+  /// digit-hyphen. The closed-up spelling `50mm` was never affected — `\b` refuses
+  /// between `0` and `m` — but dictation produces the SPACED form, which is why this was
+  /// reachable at all.
+  ///
+  /// **`match.range(at: 1)` must keep holding the token.** `removingFillers` looks the
+  /// protected-token table up with it, so the outer parenthesis is the only capturing
+  /// group and both alternatives sit inside it as non-capturing.
+  ///
+  /// `.caseInsensitive` is unchanged, so `Ah`, `AH`, `MM` and `Mm` all take the guard
+  /// too — `Ah` matters most, since that is the spelling a dictated "amp hours" produces.
   public static let fillerPattern: NSRegularExpression? = {
     do {
       return try NSRegularExpression(
-        pattern: #"(?:^|\s*)\b(um|umm|uh|uhh|hmm|mm|mhm|mmm|ah|er)\b[-.,!?…:;—]*(?=\s|$)"#,
+        // ONE line, deliberately. A multi-line raw string would need `\#` for its
+        // continuations, and a bare `\` there is a literal backslash IN THE PATTERN —
+        // a break that compiles and silently changes what matches.
+        pattern:
+          #"(?:^|\s*)((?:\b(?:um|umm|uh|uhh|hmm|mhm|mmm|er)\b)|(?:(?<![0-9])(?<![0-9] )(?<![0-9]-)\b(?:mm|ah)\b))[-.,!?…:;—]*(?=\s|$)"#,
         options: .caseInsensitive
       )
     } catch {

--- a/Tests/EnviousWisprTests/Pipeline/FillerRemovalMeasurementUnitTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FillerRemovalMeasurementUnitTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// Issue #2728: filler removal deleted the UNIT from a dictated measurement. "The gap is
+/// 5 mm" pasted as "the gap is 5", "120 mm Hg" as "120 Hg", "a 5 Ah battery" as "a 5
+/// battery" — on the default path for every English speaker, because
+/// `fillerRemovalEnabled` ships true.
+///
+/// **This collides INSIDE English, so no language row can fix it.** #2259 and #2614 are a
+/// different defect: a token that means something in another language, handled by
+/// `protectedTokens(forLanguage:)`. `mm` and `ah` mean something in the SAME language the
+/// filler list is written for.
+///
+/// **Why it survived this long: the failure is a DELETION.** The sentence still reads
+/// fluently with the unit gone, so nothing looks broken. That is the shape
+/// `grounding-discipline.md` RULE: public-claims-need-binding-evidence names — a promise
+/// that is not observable drifts for as long as nobody looks. These cases are what looks.
+///
+/// **Every row here is one half of a PAIR.** A unit that must survive sits beside a
+/// hesitation spelled the same way that must still go, because a fix that buys units by
+/// weakening filler removal is not a fix. `code-design-rules.md`
+/// RULE: matcher-set-adversarial-tests.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct FillerRemovalMeasurementUnitTests {
+
+  private func process(_ text: String) async throws -> String {
+    let step = FillerRemovalStep()
+    step.fillerRemovalEnabled = true
+    return try await step.process(TextProcessingContext(text: text, language: "en")).text
+  }
+
+  // MARK: - The units, which used to disappear
+
+  @Test("a millimetre measurement keeps its unit")
+  func millimetreSurvives() async throws {
+    #expect(try await process("The gap is 5 mm.") == "The gap is 5 mm.")
+    #expect(try await process("Cut it to 250 mm and stop.") == "Cut it to 250 mm and stop.")
+  }
+
+  /// The reading a nurse or a patient dictates. It lost the `mm` and kept the `Hg`, which
+  /// is worse than losing both: `120 Hg` looks like a value rather than a broken one.
+  @Test("a blood-pressure reading keeps its unit")
+  func millimetresOfMercurySurvive() async throws {
+    #expect(try await process("120 mm Hg") == "120 mm Hg")
+  }
+
+  @Test("an amp-hour rating keeps its unit")
+  func ampHourSurvives() async throws {
+    #expect(try await process("a 5 Ah battery") == "a 5 Ah battery")
+  }
+
+  /// The pattern is `.caseInsensitive`, so the guard has to hold for every spelling the
+  /// recogniser can produce. `Ah` is the one that matters most — it is how a dictated
+  /// "amp hours" is normally written, and a lowercase-only fix would miss exactly it.
+  @Test("the guard holds whatever case the unit is written in")
+  func upperCaseUnitsSurvive() async throws {
+    #expect(try await process("The file is 20 MM long") == "The file is 20 MM long")
+    #expect(try await process("a 5 AH battery") == "a 5 AH battery")
+    #expect(try await process("The gap is 5 Mm.") == "The gap is 5 Mm.")
+  }
+
+  /// The hyphenated form, which lost the unit and left the hyphen: `A 3- clearance`.
+  @Test("a hyphenated measurement keeps its unit")
+  func hyphenatedUnitSurvives() async throws {
+    #expect(try await process("A 3-mm clearance") == "A 3-mm clearance")
+  }
+
+  /// Never broken, pinned so it cannot start being: `\b` refuses between `0` and `m`, so
+  /// the closed-up spelling was always safe. It is the SPACED form that dictation
+  /// produces — a speaker saying "fifty millimetres" gets `50 mm` from the recogniser —
+  /// which is why this defect was reachable at all.
+  @Test("the closed-up spelling was never affected, and stays that way")
+  func closedUpUnitSurvives() async throws {
+    #expect(try await process("a 50mm lens") == "a 50mm lens")
+  }
+
+  // MARK: - The hesitations, which must still go
+
+  @Test("a bare hesitation spelled like a unit is still removed")
+  func bareUnitSpelledHesitationsAreRemoved() async throws {
+    #expect(try await process("mm, that's interesting") == "that's interesting")
+    #expect(try await process("He said ah well.") == "He said well.")
+  }
+
+  @Test("the other eight tokens are untouched by this change")
+  func ordinaryFillersAreRemoved() async throws {
+    #expect(try await process("er, I think so") == "I think so")
+    #expect(try await process("I was, um, thinking") == "I was, thinking")
+  }
+
+  /// **The row that chooses the narrow fix over the broad one.**
+  ///
+  /// A first version guarded every token after a digit, which also stopped removing a
+  /// genuine hesitation there — "give me 3 um copies" kept its "um". That is a real
+  /// behaviour change on the same default path, in the direction of doing LESS of what
+  /// the feature exists for. Only `mm` and `ah` are units, so only they carry the guard,
+  /// and this case fails against the broad version.
+  @Test("a genuine hesitation after a number is still removed")
+  func hesitationAfterADigitIsStillRemoved() async throws {
+    #expect(try await process("give me 3 um copies") == "give me 3 copies")
+    #expect(try await process("I need 5 uh more") == "I need 5 more")
+  }
+
+  /// Both rules in one sentence, which is what a real dictation looks like: the leading
+  /// hesitation goes, the measurement stays.
+  @Test("a hesitation and a measurement in one sentence are each handled")
+  func aSentenceCarryingBothIsHandled() async throws {
+    #expect(try await process("Um, the gap is 5 mm.") == "the gap is 5 mm.")
+  }
+
+  // MARK: - The plumbing the fix must not break
+
+  /// `removingFillers` looks the per-language protection table up with
+  /// `match.range(at: 1)`, so splitting the alternation had to keep the outer parenthesis
+  /// as the only capturing group. If it did not, a protected token would stop being
+  /// recognised and #2259's German rows would start failing instead of this one — which
+  /// is why the check lives here, beside the change that could break it.
+  @Test("the token is still capture group 1, so per-language protection still resolves")
+  func perLanguageProtectionStillResolves() async throws {
+    let step = FillerRemovalStep()
+    step.fillerRemovalEnabled = true
+    let german = try await step.process(
+      TextProcessingContext(text: "Ich glaube er kommt morgen", language: "de")).text
+    #expect(german == "Ich glaube er kommt morgen", "the protected token was not looked up")
+  }
+}


### PR DESCRIPTION
## What a user sees

Dictate **"the gap is 5 mm"** and the pasted text reads **"the gap is 5"**. The unit is gone. Same for **"120 mm Hg"** → **"120 Hg"** and **"a 5 Ah battery"** → **"a 5 battery"**.

On the **default path for every English speaker** — `fillerRemovalEnabled` ships true.

Closes #2728.

`Tier: SMALL | Test: required (Pipeline) | Modules: EnviousWisprPipeline`
`Lane: Code`

## Why it happened, and why no existing mechanism could catch it

`mm` and `ah` sat in the filler list beside `um`, `uh` and `hmm`. They are also units: millimetre, the `mm Hg` of a blood-pressure reading, amp-hour.

The existing protection is `protectedTokens(forLanguage:)`, a CROSS-language table from #2259 and #2614 — "er" means *he* in German, "um" means *a* in Portuguese. **This collides INSIDE English**, so no row in that table can reach it.

**It survived because the failure is a DELETION.** "the gap is 5" still reads fluently, so nothing looks broken. `grounding-discipline.md` RULE: public-claims-need-binding-evidence names exactly this: ask whether the thing promised is OBSERVABLE, because a promise that is not drifts for as long as nobody looks.

## The change

One pattern, split into two alternatives. Eight tokens are onomatopoeic and collide with nothing, so they are still removed wherever they appear. `mm` and `ah` refuse removal when they follow a digit.

```
(?:^|\s*)((?:\b(?:um|umm|uh|uhh|hmm|mhm|mmm|er)\b)|(?:(?<![0-9])(?<![0-9] )(?<![0-9]-)\b(?:mm|ah)\b))[-.,!?…:;—]*(?=\s|$)
```

Three fixed-width lookbehinds rather than one variable-width one, because ICU supports only fixed width: bare digit, digit-space, digit-hyphen.

**A BROAD version was measured first and rejected.** Guarding every token after a digit also stopped removing a genuine hesitation there — `give me 3 um copies` kept its `um`. That is a real behaviour change on the same default path, in the direction of doing LESS of what the feature exists for. `enviouswispr-6a` found it on the issue; only the two unit tokens carry the guard now, and the case that distinguishes the two versions is in the suite.

**`match.range(at: 1)` still holds the token.** `removingFillers` looks the per-language table up with it, so the outer parenthesis is the only capturing group and both alternatives are non-capturing inside it. That is bound by a case rather than asserted in a comment — if it broke, #2259's German rows would fail instead of this file's.

## Proved against the parent commit, not a synthetic mutant

`testing-philosophy.md` prefers this: the broken code already exists one commit back, so the failure is the real one.

With the shipped pattern restored and these eleven cases in place — **six red, five green.**

| red against the shipped pattern | green in both |
|---|---|
| a millimetre measurement keeps its unit | a bare hesitation spelled like a unit is still removed |
| a blood-pressure reading keeps its unit | the other eight tokens are untouched |
| an amp-hour rating keeps its unit | **a genuine hesitation after a number is still removed** |
| the guard holds whatever case the unit is written in | the closed-up spelling was never affected |
| a hyphenated measurement keeps its unit | the token is still capture group 1 |
| a hesitation and a measurement in one sentence | |

**The five that stay green are the point.** They are what says the fix does not buy units at the cost of filler removal — and the third of them is the row that fails against the broad variant.

## Scope swept

- `TextLexicalContent.hasLexicalContentAfterRemovingFillers` delegates to this one transform and inherits the change. No emptiness verdict moves: `5 mm` was non-empty before as `5` and is non-empty now as `5 mm`.
- `LocalPolishEmptyDisposition` keeps its own token list. It answers a different question — is a local-polish OUTPUT an acknowledgement — and takes no digits.
- No Python or worker mirror of this pattern exists; `scripts/eval/classify_redundant.py` mentions the tokens in a docstring only.
- The closed-up spelling `50mm` was never affected, because `\b` refuses between `0` and `m`. Dictation produces the SPACED form, which is what made this reachable. Pinned so a future pattern change cannot break it silently.

## Pre-Merge Checklist

### Build Verification
- [x] Logic tests pass locally — `FillerRemovalMeasurementUnitTests` 11/11, `FillerRemovalLanguageProtectionTests` 16/16, `Issue1358FillerEmptyReproTests` 3/3.
- [x] Red-against-parent proved, six cases, each naming its own input.
- [x] Dev build for the push gate.
- [ ] CI `build-check` — pending on this push.

### Behavioral Testing (Local UAT)
- [ ] **Not run**, and deliberately: taking the dev-app slot means terminating an instance this unattended session could not place in its own history, with other sessions active on the machine. The change is one regex with eleven cases either side of it. Anyone wanting the runtime proof: dictate "the gap is five millimetres" with filler removal on and read the `CORRECTION_DEBUG [Filler Removal]` line in `app.log`.

### Code Quality
- [x] `codex review --base origin/main` clean: "No actionable regressions found. The regex preserves the targeted measurement units and capture group while retaining ordinary filler removal."
- [x] Self-review grep over `fillerPattern`, `removingFillers`, `mhm` across `Sources/ Tests/ scripts/ workers/ docs/`.
- [x] Conventional commit format, no secrets.
- [x] New suite carries its class tag (`.productOutcome`) — when it fails, the user's unit is deleted.

## Credit

Found and diagnosed by `enviouswispr-b9` while narrowing #2264, with the side effect in the first fix caught by `enviouswispr-6a`. Both declined to take it. This is their narrow version, built and tested.
