### PR TITLE
fix(hotkeys): cancel wins a shared chord Carbon cannot tell apart (#2432)

### DIFF
--- a/Sources/EnviousWisprServices/HotkeyService.swift
+++ b/Sources/EnviousWisprServices/HotkeyService.swift
@@ -1056,7 +1056,20 @@ public final class HotkeyService {
     guard isEnabled, !isSuspended else { return false }
     // Cancel outranks Quick Add on a shared chord, for as long as cancel is armed — the same
     // severity order `ShortcutRole` declares and the bare-modifier matcher already applies.
-    return !(quickAdd == cancel && isCancelArmed)
+    //
+    // **CARBON-equivalent, not `==` (#2432).** `RegisterEventHotKey` never sees Caps Lock,
+    // Function or Numeric Pad, so two bindings differing only there are ONE chord to the
+    // system while raw equality calls them different. This function decides whether Quick Add
+    // KEEPS its registration, so the wrong answer left both roles claiming one chord: Quick
+    // Add registers at start and holds it, cancel arrives second during a recording and is
+    // refused, and the user's cancel key opens the Quick Add panel while the recording runs.
+    // That is the same failure `cancelWinsASharedChord` already covers, reachable through a
+    // modifier Carbon discards.
+    //
+    // `ShortcutMatcher` owns the comparison. It was written there and asked again here with
+    // `==`, and the note above `quickAddOwnsItsBinding` records that as a defect on this path
+    // rather than that one.
+    return !(ShortcutMatcher.carbonEquivalent(quickAdd, cancel) && isCancelArmed)
   }
 
   /// Pure mechanism, no policy: `reconcileQuickAddRegistration` above decides whether to call it.

--- a/Sources/EnviousWisprServices/ShortcutBinding.swift
+++ b/Sources/EnviousWisprServices/ShortcutBinding.swift
@@ -230,16 +230,33 @@ package enum ShortcutMatcher {
     // are runtime state a menu label does not have, so calling it means inventing values to get an
     // answer. And it compares bindings with raw `==`, which is the very defect three review rounds
     // found in this label — so delegating to it would reintroduce the bug in the name of reuse.
-    // That raw comparison looks like a real defect in the REGISTRATION path too (Quick Add would
-    // not be unregistered for a cancel chord differing only in a dropped modifier); it is reported
-    // separately rather than fixed from here, because it is the heart path.
-    guard case .keyboard(let qk, let qm) = quickAdd else { return true }
-    let mine = qm.intersection(carbonEffectiveModifiers)
-    for other in [record, cancel] {
-      guard case .keyboard(let ok, let om) = other else { continue }
-      if qk == ok, mine == om.intersection(carbonEffectiveModifiers) { return false }
-    }
+    // That raw comparison WAS a real defect in the REGISTRATION path too — Quick Add was not
+    // unregistered for a cancel chord differing only in a dropped modifier. Fixed in #2432:
+    // `quickAddMayHoldItsChord` now asks `carbonEquivalent` below, so both paths compare the
+    // way Carbon compares and there is one spelling of the question rather than two.
+    for other in [record, cancel] where carbonEquivalent(quickAdd, other) { return false }
     return true
+  }
+
+  /// Do these two bindings reach Carbon as ONE chord?
+  ///
+  /// Same key code, and the same modifiers AFTER dropping everything
+  /// `RegisterEventHotKey` never sees. Two bindings differing only in Caps Lock, Function or
+  /// Numeric Pad are one chord to the system, so `==` on the raw values answers a question
+  /// nobody asked — and answers it wrongly in the direction that lets two roles both claim
+  /// the same registration.
+  ///
+  /// **One owner, because there were two.** This comparison was written inline here and
+  /// asked again with raw `==` in `HotkeyService.quickAddMayHoldItsChord`, where the second
+  /// spelling was a live defect on the dispatch path (#2432). Two spellings of one question
+  /// is how the record and cancel paths drifted apart in the first place.
+  package static func carbonEquivalent(_ one: ShortcutBinding, _ other: ShortcutBinding) -> Bool {
+    guard case .keyboard(let oneKey, let oneModifiers) = one,
+      case .keyboard(let otherKey, let otherModifiers) = other
+    else { return false }
+    return oneKey == otherKey
+      && oneModifiers.intersection(carbonEffectiveModifiers)
+        == otherModifiers.intersection(carbonEffectiveModifiers)
   }
 
   package static func role(

--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -396,6 +396,62 @@ struct HotkeyQuickAddShortcutTests {
       ))
   }
 
+  /// #2432. `RegisterEventHotKey` never sees Caps Lock, Function or Numeric Pad, so two
+  /// bindings differing only there are ONE chord to the system. This function decides whether
+  /// Quick Add KEEPS its registration, and it asked with raw `==`, which called them different.
+  ///
+  /// The consequence is the one `cancelWinsASharedChord` above describes, reached through a
+  /// modifier Carbon discards: Quick Add registers at start and holds the chord, cancel arrives
+  /// second during a recording and is refused, and the user's cancel key opens the Quick Add
+  /// panel while the recording keeps running.
+  ///
+  /// Caps Lock is the reachable spelling — it is a LATCH, so a user who left it on while
+  /// recording one of the two shortcuts stores it in that binding and not the other.
+  @Test("A chord cancel holds is cancel's even when the two differ only in a modifier Carbon drops")
+  func carbonEquivalentChordsContend() {
+    let quickAdd = ShortcutBinding.keyboard(
+      keyCode: 13, modifiers: [.control, .shift, .capsLock])
+    let cancel = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift])
+
+    #expect(
+      !HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel,
+        isCancelArmed: true),
+      "Carbon registers one chord for both, so Quick Add must give it up while cancel is armed")
+    // The paired accepted case, so a rule that refused whenever cancel was armed cannot pass.
+    #expect(
+      HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel,
+        isCancelArmed: false))
+  }
+
+  /// The other direction, and the reason the comparison is an INTERSECTION rather than a mask
+  /// applied to one side: a modifier Carbon DOES keep still makes two different chords.
+  @Test("A modifier Carbon keeps still separates two chords")
+  func carbonKeptModifiersStillSeparate() {
+    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift])
+    let cancel = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control])
+
+    #expect(
+      HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel,
+        isCancelArmed: true))
+  }
+
+  /// The comparison has ONE owner now, and this is what says so: the same pair the dispatch
+  /// path refuses is the pair `ShortcutMatcher` calls equivalent. Two spellings of this
+  /// question is how the record and cancel paths drifted apart in the first place.
+  @Test("the dispatch path and the matcher agree on what one Carbon chord means")
+  func oneOwnerForCarbonEquality() {
+    let withLatch = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift, .capsLock])
+    let without = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift])
+    let differentKey = ShortcutBinding.keyboard(keyCode: 14, modifiers: [.control, .shift])
+
+    #expect(ShortcutMatcher.carbonEquivalent(withLatch, without))
+    #expect(ShortcutMatcher.carbonEquivalent(withLatch, differentKey) == false)
+    #expect(withLatch != without, "raw equality still disagrees, which is the whole point")
+  }
+
   @Test("A stopped or suspended service holds no Quick Add chord, collision or not")
   func stoppedOrSuspendedHoldsNothing() {
     let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift])


### PR DESCRIPTION
## What a user sees

Bind Quick Add to a chord, and bind cancel to the SAME chord plus Caps Lock. Start a recording and press cancel. The Quick Add panel opens. The recording keeps running. Cancel does nothing.

Part of #2432.

`Tier: SMALL | Test: required (Services) | Modules: EnviousWisprServices`
`Lane: Code`

## Why

`RegisterEventHotKey` keeps Command, Option, Control and Shift and drops everything else, so Caps Lock, Function and Numeric Pad never reach it. Two bindings differing only in one of those are ONE chord to the system.

`HotkeyService.quickAddMayHoldItsChord` compared them with raw `==` on `NSEvent.ModifierFlags` and called them different. Quick Add kept the registration it took at start, cancel was refused when it armed during a recording, and both roles claimed one Carbon slot with Quick Add holding it.

This is the failure `cancelWinsASharedChord` already covers, reached through a modifier Carbon discards.

## How a contaminated binding gets saved

`HotkeyRecorderView.binding(for:)` narrows a captured chord to the four modifiers Carbon keeps, so a binding recorded TODAY cannot carry Caps Lock. That narrowing arrived in #2613, nothing narrows a binding on LOAD, and the stored values are not migrated. A pair saved before #2613 still carries the bit and still reaches this comparison.

## The change

`ShortcutMatcher.carbonEquivalent(_:_:)` is now the one owner of the question "do these two bindings reach Carbon as one chord". It was written inline in `quickAddOwnsItsBinding` (the menu-label path) and asked again with `==` in `quickAddMayHoldItsChord` (the dispatch path). Both now call the same function.

The note above `quickAddOwnsItsBinding` said this second spelling was a live defect on the registration path, reported rather than fixed. It is fixed here, and that note now says so.

Non-keyboard bindings answer exactly as before. A bare-modifier Quick Add returned true from the old `guard case .keyboard` and returns true now, because `carbonEquivalent` refuses a non-keyboard binding and the loop never fires. Bare modifiers are matched by `role(forBareModifierKeyCode:)`, untouched.

## Three cases, each half of a pair

| case | direction |
|---|---|
| `carbonEquivalentChordsContend` | a Quick Add and a cancel differing only in Caps Lock must contend while cancel is armed, with the disarmed twin ACCEPTED so it cannot pass by refusing everything |
| `carbonKeptModifiersStillSeparate` | a modifier Carbon KEEPS still separates two chords, so the fix did not collapse every pair |
| `oneOwnerForCarbonEquality` | the dispatch path and the matcher give the same answer, and raw `==` still disagrees, so it fails if the two spellings drift apart again |

## Proved against the parent commit

With the raw `==` restored in `quickAddMayHoldItsChord`, `carbonEquivalentChordsContend` fails and the other nineteen hold. Not a synthetic mutant: the broken code is one commit back.

## Scope

This is the DISPATCH half of #2432 only. The capture-time refusal, the user-visible copy for a rejected chord, and the founder's open decision about pairs already saved in conflict are that issue's unstarted feature work and are not touched here. #2432 stays open.

## Pre-Merge Checklist

### Build Verification
- [x] `HotkeyQuickAddShortcutTests` 20/20 locally.
- [x] Red-against-parent proved, one named case.
- [x] Dev build for the push gate.
- [ ] CI `build-check` pending on this push.

### Behavioral Testing (Local UAT)
- [ ] **Not run**, and deliberately: taking the dev-app slot means terminating an instance this unattended session could not place in its own history, with other sessions active on the machine. Anyone wanting the runtime proof: save Quick Add as one chord and cancel as the same chord plus Caps Lock, start a recording, press cancel, and check the recording stops instead of the Quick Add panel opening.

### Code Quality
- [x] Self-review grep over `carbonEffectiveModifiers`, `quickAddMayHoldItsChord`, `quickAddOwnsItsBinding`, `carbonEquivalent` across `Sources/ Tests/ docs/`. Every other hit is the menu-label path or a comment reference.
- [x] Conventional commit format, no secrets.
