### PR TITLE
fix(validation): a file-private gate stops hiding another file's live test (#2688)

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-hardening.md
+++ b/.github/ISSUE_TEMPLATE/test-hardening.md
@@ -53,8 +53,10 @@ labels: test-hardening
 <!--
   expect_fail is the single-guard form and tolerates other tests also failing.
   Use must_fire/must_not_fire when the EXACT set matters. Never both in one row.
-  Name a parameterized case by its declared argument labels — f(id:writer:) —
-  never f(_:), which is the spelling of an UNLABELLED parameter.
+  Name a parameterized case by its declared external argument labels, exactly as
+  written — f(id:writer:). An unlabelled parameter's label IS `_`, so a test
+  declaring one is f(_:) and that spelling is correct; copy what the function
+  declares rather than choosing a form.
   A row that cannot be an anchor/replacement pair carries "mode": "human". It then
   needs a non-empty "label" and "instruction" plus a target-qualified "suite", and
   "file"/"anchor"/"replacement" are not read at all — the runner reports it

--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2482,6 +2482,88 @@ else:
     print("  ok  the filing-time oracle applies a declaration's gate to an extension in "
           "another file")
 ran += 1
+
+# #2688: the cross-file propagation above must NOT reach a file-private declaration. Two
+# files may each declare `private struct S`, and they are different types — Swift cannot
+# extend one from the other file. Keying both as `Target/S` and ORing them made a gated
+# one suppress an ungated one hosting a live @Test, so a VALID recipe was reported
+# UNRUNNABLE and the filer was sent to repair a recipe that was already right.
+#
+# Two-way, and the pair is the point: the same shape WITHOUT `private` must still gate
+# across files, or the fix would have bought this by disabling #2669's propagation.
+_private_gated = """
+import Testing
+
+@Suite(.disabled("file-private gate")) private struct PrivateNameCollision {
+  @Test("a gated test in the gated file") func gatedSibling() {}
+}
+"""
+_private_ungated = """
+import Testing
+
+private struct PrivateNameCollision {
+  @Test("a live test under a same-named private type") func liveUnderPrivateName() {}
+}
+"""
+_shared_gated = """
+import Testing
+
+@Suite(.disabled("shared gate")) struct SharedNameCollision {
+  @Test("a gated test in the gated file") func gatedSharedSibling() {}
+}
+"""
+_shared_ungated = """
+import Testing
+
+extension SharedNameCollision {
+  @Test("a test the shared gate must still reach") func reachedAcrossFiles() {}
+}
+"""
+with tempfile.TemporaryDirectory() as _ptd:
+    _proot = Path(_ptd)
+    shutil.copytree(BATTERY.parent.parent / "Tests", _proot / "Tests")
+    _pdir = _proot / "Tests" / "EnviousWisprTests"
+    (_pdir / "PrivateGateDeclaration.swift").write_text(_private_gated)
+    (_pdir / "PrivateGateLiveTest.swift").write_text(_private_ungated)
+    (_pdir / "SharedGateDeclaration.swift").write_text(_shared_gated)
+    (_pdir / "SharedGateExtension.swift").write_text(_shared_ungated)
+    _pnames = validator.test_oracle(_proot)
+_plive = _pnames.get("EnviousWisprTests/PrivateNameCollision", {})
+_pcanonical = "PrivateNameCollision/liveUnderPrivateName()"
+if _plive.get("liveUnderPrivateName()") != {_pcanonical}:
+    failures.append(
+        "a file-private gate does not reach a same-named private type in another file — "
+        f"the live test was lost: got {_plive!r}")
+else:
+    print("  ok  a file-private gate does not reach a same-named private type in another "
+          "file")
+ran += 1
+if "gatedSibling()" in _plive or any("gatedSibling()" in names for names in _pnames.values()):
+    failures.append(
+        "a file-private gate still gates the tests written beside it — it did not")
+else:
+    print("  ok  a file-private gate still gates the tests written beside it")
+ran += 1
+_pshared = sorted(key for key in _pnames if "SharedNameCollision" in key)
+if _pshared or any("reachedAcrossFiles()" in names for names in _pnames.values()):
+    failures.append(
+        "scoping file-private gates left a NON-private gate reaching another file — "
+        f"it no longer does: found {_pshared!r}")
+else:
+    print("  ok  a non-private gate still reaches another file")
+ran += 1
+for _modifiers, _scoped in (
+    ("private ", True), ("fileprivate ", True), ("private final ", True),
+    ("@MainActor private ", True), ("", False), ("public ", False),
+    ("package ", False), ("private(set) ", False),
+):
+    if validator.SuiteGateMap.file_scoped(_modifiers) != _scoped:
+        failures.append(
+            f"file_scoped reads {_modifiers!r} as file-scoped={not _scoped}, wanted {_scoped}")
+        break
+else:
+    print("  ok  file_scoped reads the access modifiers that make a declaration file-scoped")
+ran += 1
 result = subprocess.run(
     [sys.executable, str(VALIDATOR), "--issue", "0",
      "--checkout", str(BATTERY.parent.parent)],

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -186,6 +186,52 @@ def has_runtime_gate(attribute_code):
     return re.search(r"\.(?:enabled|disabled)\s*\(", attribute_code) is not None
 
 
+class SuiteGateMap:
+    """Which declaration paths carry a runtime gate, and how far each gate reaches.
+
+    A `.enabled(if:)`/`.disabled` on a declaration skips every test beneath it, including
+    tests written in ANOTHER file inside a qualified extension of that type, which is why
+    gates are keyed by target-qualified path rather than by brace range (#2669 review,
+    round 3).
+
+    A FILE-PRIVATE declaration is the exception, and #2688 is what the missing exception
+    cost: two files each declaring `private struct S` both key to `Target/S`, so a gated
+    one suppressed an ungated one hosting a live `@Test` in the other file and a VALID
+    recipe was reported UNRUNNABLE. That direction is the expensive one — it sends a filer
+    to fix a recipe that was already right. `private` cannot be extended from another file,
+    so such a gate is recorded against its own file and read back only for tests written in
+    that same file.
+
+    One owner, because the write side and the read side must agree on the scope: recording
+    a gate per file and reading it back globally would silently drop it.
+    """
+
+    @staticmethod
+    def file_scoped(modifiers):
+        """Does this declaration's modifier text make it FILE-scoped?
+
+        `private(set)` is an access level on a property's setter and never on a type, so
+        the lookahead keeps it out — it would otherwise scope a whole declaration to its
+        file for a reason that has nothing to do with the declaration.
+        """
+        return re.search(r"\b(?:private|fileprivate)\b(?!\s*\()", modifiers) is not None
+
+    def __init__(self):
+        self._shared = {}
+        self._by_file = {}
+
+    def record(self, file_key, qualified, gated):
+        """Remember a declaration's gate. `file_key` is None for a declaration other files
+        can extend, and the file's path for a file-private one."""
+        scope = self._shared if file_key is None else self._by_file.setdefault(file_key, {})
+        scope[qualified] = scope.get(qualified, False) or gated
+
+    def gated(self, file_key, qualified):
+        """Is a test written in `file_key` gated by a declaration at `qualified`?"""
+        return (self._shared.get(qualified, False)
+                or self._by_file.get(file_key, {}).get(qualified, False))
+
+
 def test_oracle(root):
     test_root = root / "Tests"
     sources = []
@@ -205,8 +251,9 @@ def test_oracle(root):
     # is extracted. Gates are keyed by target-qualified path (`Target/Outer/Inner`) so a
     # `.disabled` on a declaration in one file reaches a qualified extension of that type
     # in another file; a map rebuilt per file could not see across (#2669 review, round 4).
+    # `SuiteGateMap` owns the one exception, a file-private declaration (#2688).
     parsed = []
-    gate_by_path = {}
+    gates = SuiteGateMap()
     for path, part in sources:
         target = path.relative_to(test_root).parts[0]
         code = mask_inactive_debug_branches(mask_noncode(part))
@@ -232,10 +279,17 @@ def test_oracle(root):
                 suite_attribute = code[suite_start:declaration.start()] if suite_start >= 0 else ""
                 if "{" in suite_attribute or "}" in suite_attribute:
                     suite_attribute = ""
+                # Modifiers on the declaration's own line. `private`/`fileprivate` make it
+                # FILE-scoped, which is what decides how far its gate may reach (#2688).
+                # `private(set)` is an access level on a property, never on a type, so the
+                # lookahead keeps it out.
+                line_start = code.rfind("\n", 0, declaration.start()) + 1
+                modifiers = code[line_start:declaration.start()]
                 ranges.append((
                     opening, closing,
                     re.sub(r"[\s`]", "", declaration.group(1)).replace(".", "/"),
-                    has_runtime_gate(suite_attribute)
+                    has_runtime_gate(suite_attribute),
+                    SuiteGateMap.file_scoped(modifiers),
                 ))
 
         # Gates by QUALIFIED PATH, not only by brace range. A test hosted in a top-level
@@ -244,18 +298,18 @@ def test_oracle(root):
         # Testing skips that test through the parent trait (#2669 review, round 3). Every
         # declaration records the gate on its own path, and a test is gated when any
         # prefix of its path is, whichever braces — and whichever file — it was written in.
-        for opening, closing, name, gated in ranges:
+        for opening, closing, name, gated, file_private in ranges:
             outer = sorted(
-                ((end - start, outer_name) for start, end, outer_name, _ in ranges
+                ((end - start, outer_name) for start, end, outer_name, _, _ in ranges
                  if start < opening < end),
                 key=lambda entry: -entry[0],
             )
             qualified = "/".join([target] + [outer_name for _, outer_name in outer] + [name])
-            gate_by_path[qualified] = gate_by_path.get(qualified, False) or gated
-        parsed.append((target, part, code, ranges))
+            gates.record(str(path) if file_private else None, qualified, gated)
+        parsed.append((path, target, part, code, ranges))
 
     # Pass two: the tests, each judged against the whole target's gates.
-    for target, part, code, ranges in parsed:
+    for path, target, part, code, ranges in parsed:
         for attribute in re.finditer(r"@Test\b", code):
             function_match = re.search(r"\bfunc\s+(\w+)\s*\(", code[attribute.end():])
             if not function_match:
@@ -282,7 +336,7 @@ def test_oracle(root):
             # bare inner name, a filter that executes zero tests (#2525). A top-level suite
             # is a chain of one, so its name is unchanged.
             containing = sorted(
-                ((end - start, name, gated) for start, end, name, gated in ranges
+                ((end - start, name, gated) for start, end, name, gated, _ in ranges
                  if start < attribute.start() < end),
                 key=lambda entry: -entry[0],
             )
@@ -298,7 +352,7 @@ def test_oracle(root):
             # chain entry whose name already holds a `/`, and the gate it must inherit sits
             # on the shorter path (`Target/Outer`) that only a component walk reaches.
             components = enclosing.split("/")
-            if any(gate_by_path.get("/".join([target] + components[:depth]), False)
+            if any(gates.gated(str(path), "/".join([target] + components[:depth]))
                    for depth in range(1, len(components) + 1)):
                 continue
             body = part[attribute.end():function_start]


### PR DESCRIPTION
## What this fixes

Two ways the recipe toolchain told a filer that a **valid** recipe was broken.

That direction is the expensive one. A rejected bad recipe costs nothing. A rejected GOOD recipe costs a session repairing something that was already right, and it teaches people to distrust the validator the whole overnight battery depends on.

Closes #2688.

`Tier: SMALL | Test: required (harness) | Modules: scripts`
`Lane: Tooling`

## D1 — a file-private gate hid another file's live test

`.enabled(if:)`/`.disabled` gates are keyed by target-qualified path so a gate on a declaration in one file reaches a qualified extension of that type in another file. That is #2669 and it is correct.

A **file-private** declaration cannot be extended from another file, and nothing said so. Two files each declaring `private struct S` both keyed to `Target/S`, the gates were ORed, and a gated one suppressed an ungated one hosting a live `@Test`. Every row naming that test was reported UNRUNNABLE.

`SuiteGateMap` is now the one owner of how far a gate reaches:

- a declaration other files can extend records into the **shared** scope
- a file-private one records against **its own file** and is read back only for tests written in that same file

One type, because the write side and the read side have to agree on the scope. A gate recorded per file and read back globally would silently vanish, which is the same defect facing the other way.

**Latent, not live.** The corpus has 48 duplicate file-private type names today and two gated paths, with no overlap between them. The oracle is unchanged on the real tree: 673 suites and 22,019 names, before and after.

## D2 — the template forbade a spelling that is correct

`.github/ISSUE_TEMPLATE/test-hardening.md` said to name a parameterized case by its argument labels and *"never f(_:), which is the spelling of an UNLABELLED parameter."*

An unlabelled parameter's label **is** `_`. `f(_:)` is the correct spelling whenever a test declares one, and **65 tests in this corpus are named that way**. A filer obeying the blanket rule wrote a name the validator then refused.

The template now says to copy what the function declares, including `_`.

## Four cases, each half of a pair

| case | direction |
|---|---|
| a gated `private struct` must not hide a live `@Test` under a same-named `private struct` in another file | the defect |
| the tests written BESIDE the gated one must still be gated | the gate still works where it should |
| a NON-private declaration must still gate an extension in another file | this was not bought by disabling #2669's propagation |
| `file_scoped` reads the modifier text | `private`, `fileprivate`, `private final`, `@MainActor private` yes; nothing, `public`, `package`, `private(set)` no |

The first three run `test_oracle` against a copy of the real corpus plus four fixture files, which is the mechanism #2669's own cases already use.

**D2 gets no new case, deliberately.** `the filing validator derives a real parameter suffix` already accepts `(_:)` against a real test. The validator was never wrong here; the template was prose contradicting a behaviour that was already bound.

## Pre-Merge Checklist

### Build Verification
- [x] `scripts/mutation-battery-test.py` full run.
- [x] `test_oracle` unchanged on the real corpus: 673 suites, 22,019 names.
- [ ] CI pending on this push.

### Code Quality
- [x] Self-review grep over `gate_by_path`, `SuiteGateMap`, `has_runtime_gate`, `file_scoped` across `scripts/ .github/` — no stale references to the old map.
- [x] Conventional commit format, no secrets.
