### PR TITLE
fix(providers): a new engine can no longer land in the wrong branch silently (#2651)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
+++ b/Sources/EnviousWisprAppKit/App/BackendMetadata.swift
@@ -51,7 +51,12 @@ final class BackendMetadata {
     // `s1-mini`, and the licence requires the exact spelling wherever the
     // model is identified. One owner for that string.
     case .s1Mini: LLMProvider.s1Mini.displayName
-    default: llmLabel
+    // #2651: enumerated rather than `default:`. `llmLabel` renders
+    // `settings.effectiveLLMModel`, which is the right answer only where the
+    // user CHOOSES the model. A fixed-model engine reaching this arm would
+    // show its internal id, which is the defect #1271 fixed for EG-1 and #2649
+    // fixed again for S1-mini. The compiler now asks the question instead.
+    case .openAI, .gemini, .claude, .ollama: llmLabel
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/LLMModelDiscoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/LLMModelDiscoveryCoordinator.swift
@@ -49,7 +49,12 @@ final class LLMModelDiscoveryCoordinator {
       case .openAI: keychainId = KeychainManager.openAIKeyID
       case .gemini: keychainId = KeychainManager.geminiKeyID
       case .claude: keychainId = KeychainManager.claudeKeyID
-      default: keychainId = ""
+      // #2651: enumerated rather than `default:`. These providers hold no API
+      // key, so there is no id to look up and the guard below reports the
+      // missing key that is correctly absent. A NEW key-carrying provider
+      // reaching a `default:` here would have got `""` and reported "No API
+      // key found" forever, with no compiler complaint.
+      case .ollama, .appleIntelligence, .egOne, .s1Mini, .none: keychainId = ""
       }
       guard let key = try? keychainManager.retrieve(key: keychainId), !key.isEmpty else {
         // Missing-key guard: no validation actually ran, so NO

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -425,10 +425,19 @@ final class PipelineSettingsSync {
   /// switch back to the frozen engine is not needlessly deferred.
   func pinnedLocalProvider() -> LLMProvider? {
     for cfg in [kernelDriver.currentSessionConfig, whisperKitKernelDriver.currentSessionConfig] {
-      switch cfg?.llmProvider {
+      // #2651: the optional is unwrapped BEFORE the switch, so `.none` means
+      // `LLMProvider.none` and nothing else. Matching on `cfg?.llmProvider`
+      // directly makes `.none` read as `Optional.none`, which leaves the
+      // provider's own `.none` case uncovered and does not compile.
+      guard let provider = cfg?.llmProvider else { continue }
+      switch provider {
       case .egOne: return .egOne
       case .s1Mini: return .s1Mini
-      default: continue
+      // Enumerated rather than `default:`. This answers "is a bundled local
+      // server load-bearing for a take that is still running", so a NEW
+      // bundled engine on a `default:` arm would report NOT pinned, and a
+      // provider switch would tear its server down under a live recording.
+      case .openAI, .gemini, .claude, .ollama, .appleIntelligence, .none: continue
       }
     }
     return nil

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -427,8 +427,15 @@ package final class WisprBootstrapper {
     case .s1Mini:
       s1MiniRuntime.startIfActiveProvider()
       egOneRuntime.sweepStaleServersAtLaunch()
-    default:
+    // No bundled server is the active provider, so neither starts and BOTH
+    // sweep. #2651: the `default:` this replaces swept EG-1 only, so an S1-mini
+    // server left running from a previous launch survived every subsequent
+    // launch under a cloud provider, Ollama, Apple Intelligence or Off. Nothing
+    // spawns on this arm, so the race the comment above guards against cannot
+    // occur here.
+    case .openAI, .gemini, .claude, .ollama, .appleIntelligence, .none:
       egOneRuntime.sweepStaleServersAtLaunch()
+      s1MiniRuntime.sweepStaleServersAtLaunch()
     }
 
     // PR-5 Rung 5 (#827): the VAD signal source is App-owned and shared

--- a/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/AIPolishSettingsView.swift
@@ -400,7 +400,11 @@ struct AIPolishSettingsView: View {
     case .openAI: cloudKeyPresent = !openAIKey.isEmpty
     case .gemini: cloudKeyPresent = !geminiKey.isEmpty
     case .claude: cloudKeyPresent = !claudeKey.isEmpty
-    default: cloudKeyPresent = false
+    // #2651: enumerated rather than `default:`. These providers carry no API
+    // key, so "no key present" is the true answer and
+    // `ProviderStatusMapping.status` ignores it for them. A NEW cloud provider
+    // reaching a `default:` would have read as permanently key-less.
+    case .ollama, .appleIntelligence, .egOne, .s1Mini, .none: cloudKeyPresent = false
     }
     return ProviderStatusMapping.status(
       for: settings.llmProvider,
@@ -428,7 +432,11 @@ struct AIPolishSettingsView: View {
     case .openAI: return openAIKeySaved == false
     case .gemini: return geminiKeySaved == false
     case .claude: return claudeKeySaved == false
-    default: return false
+    // #2651: enumerated rather than `default:`. No key is stored for these, so
+    // the missing-key notice must stay suppressed. A NEW cloud provider on a
+    // `default:` arm would never show that notice, which is the direction that
+    // hides a real problem from the user.
+    case .ollama, .appleIntelligence, .egOne, .s1Mini, .none: return false
     }
   }
 
@@ -905,7 +913,14 @@ struct AIPolishSettingsView: View {
         // arm, which flipped the key-validation state for a model that has
         // no key.
         break
-      default:
+      // #2651: enumerated rather than `default:`. This arm is the key-provider
+      // path, and the `.egOne, .s1Mini` comment above records what it costs to
+      // reach it by accident: the discovery coordinator gets an empty model
+      // list and overwrites `llmModel`. That is the defect #1271 fixed for
+      // EG-1 and #2649 fixed again for S1-mini, both after a fixed-model
+      // engine fell into a `default:`. Twice is the argument for the compiler
+      // asking instead.
+      case .openAI, .gemini, .claude:
         llmDiscovery.loadCachedModels(for: newProvider)
         Task {
           await llmDiscovery.validateKeyAndDiscoverModels(
@@ -993,8 +1008,12 @@ struct AIPolishSettingsView: View {
         privacySentence:
           "Claude polish sends your transcribed text, plus the active app name and any custom words you've added, but never audio. Anthropic's own retention policy for your API account governs how long the request is kept."
       )
-    default:
-      // Unreachable: apiKeyRow only renders when isCloudProvider is true.
+    // #2651: enumerated rather than `default:`. The empty descriptor is only
+    // safe because `apiKeyRow` renders for cloud providers alone, and that
+    // claim stops being true the moment a cloud provider is added without its
+    // own arm — the row would render with a blank label and no privacy
+    // sentence. Naming the non-cloud set makes the compiler ask.
+    case .ollama, .appleIntelligence, .egOne, .s1Mini, .none:
       return APIKeyDescriptor(
         label: "", placeholder: "", keychainId: "", accessibilityLabel: "", privacySentence: "")
     }
@@ -1005,7 +1024,11 @@ struct AIPolishSettingsView: View {
     case .openAI: return $openAIKey
     case .gemini: return $geminiKey
     case .claude: return $claudeKey
-    default: return .constant("")
+    // #2651: enumerated rather than `default:`. A constant binding silently
+    // discards every keystroke, which is the right answer only where no key
+    // field is shown. A NEW cloud provider on a `default:` arm would render a
+    // field the user could type into and nothing would be saved.
+    case .ollama, .appleIntelligence, .egOne, .s1Mini, .none: return .constant("")
     }
   }
 
@@ -1014,7 +1037,11 @@ struct AIPolishSettingsView: View {
     case .openAI: openAIKeySaved = saved
     case .gemini: geminiKeySaved = saved
     case .claude: claudeKeySaved = saved
-    default: break
+    // #2651: enumerated rather than `default:`. There is no saved-key flag to
+    // set for these. A NEW cloud provider on a `default:` arm would save its
+    // key and never record that it had, so the missing-key notice would stay
+    // on screen after a successful save.
+    case .ollama, .appleIntelligence, .egOne, .s1Mini, .none: break
     }
   }
 

--- a/Sources/EnviousWisprLLM/LLMNetworkSession.swift
+++ b/Sources/EnviousWisprLLM/LLMNetworkSession.swift
@@ -305,13 +305,19 @@ public final class LLMNetworkSession: Sendable {
   /// `LLMModelDiscovery.claudePaginationDecision`) after this exact
   /// selection was a two-way ternary that routed any non-OpenAI provider to
   /// Gemini's key id (Grounded Review R2/R3, issue #158). `nil` for any
-  /// non-cloud or future provider — the caller's early guard.
+  /// non-cloud provider — the caller's early guard.
+  ///
+  /// #2651: the no-key set is ENUMERATED, and the sentence this replaces said
+  /// nil was right for "any non-cloud or FUTURE provider". The second half was
+  /// the silent part: a future CLOUD provider needs an arm here, and on a
+  /// `default:` it would have got nil, skipped warm-up, and nothing would have
+  /// said so.
   static func warmupKeychainId(for provider: LLMProvider) -> String? {
     switch provider {
     case .openAI: return KeychainManager.openAIKeyID
     case .gemini: return KeychainManager.geminiKeyID
     case .claude: return KeychainManager.claudeKeyID
-    default: return nil
+    case .ollama, .appleIntelligence, .egOne, .s1Mini, .none: return nil
     }
   }
 
@@ -451,7 +457,12 @@ public final class LLMNetworkSession: Sendable {
       request.httpBody = try? JSONSerialization.data(withJSONObject: body)
       return request
 
-    default:
+    // #2651: enumerated rather than `default:`. Building an HTTP request is as
+    // provider-specific as code gets, so nil is only right where there is no
+    // warm-up request to send. A NEW cloud provider on a `default:` arm would
+    // silently lose its warm-up, which costs latency on the first polish and
+    // shows up as nothing at all.
+    case .ollama, .appleIntelligence, .egOne, .s1Mini, .none:
       return nil
     }
   }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -697,7 +697,12 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       switch provider {
       case .egOne: (egOneRuntime, makeEGOnePolisher)
       case .s1Mini: (s1MiniRuntime, makeS1MiniPolisher)
-      default: nil
+      // #2651: enumerated rather than `default:`. nil means "not served by a
+      // bundled server", which sends the provider down `makePolisher` and its
+      // keychain lookup. A NEW bundled-server engine reaching a `default:`
+      // would take the cloud path, ask a keychain for a key that does not
+      // exist, and fail as `providerUnavailable` rather than starting.
+      case .openAI, .gemini, .claude, .ollama, .appleIntelligence, .none: nil
       }
     if let handles = localServerHandles {
       guard let runtime = handles.runtime else {
@@ -748,7 +753,10 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
       case .openAI: KeychainManager.openAIKeyID
       case .gemini: KeychainManager.geminiKeyID
       case .claude: KeychainManager.claudeKeyID
-      default: nil
+      // #2651: enumerated rather than `default:`. These providers hold no API
+      // key, so nil is the true answer. A NEW key-carrying provider reaching a
+      // `default:` would silently send no key.
+      case .ollama, .appleIntelligence, .egOne, .s1Mini, .none: nil
       }
 
     // Resolved from the ENTRY snapshot, never from `self` — this function's


### PR DESCRIPTION
## What this stops

A `switch` over `LLMProvider` with a `default:` arm compiles cleanly when a provider is added, and sends it wherever that arm goes. For a few sites that is right. For most it is not, and **the compiler cannot tell you which**, because a `default:` is how an author says "I have thought about the rest".

Twelve such sites. All twelve are now exhaustive.

Closes #2651.

`Tier: MEDIUM | Test: the compiler (see below) | Modules: EnviousWisprAppKit, EnviousWisprPipeline, EnviousWisprLLM`
`Lane: Code`

## One is a defect users have today

`WisprBootstrapper`'s launch switch starts the selected bundled engine and sweeps the other one's orphaned servers. Its `default:` swept **EG-1 alone**.

So with OpenAI, Gemini, Claude, Ollama, Apple Intelligence or Off selected, an S1-mini server left running by a previous launch was never swept, and survived every launch after that. Both now sweep on that arm. Nothing spawns there, so the spawn-versus-sweep race the surrounding comment guards against cannot occur.

## The classification, all twelve

| site | what a new provider silently got |
|---|---|
| `WisprBootstrapper` launch switch | **live defect**: only EG-1's orphans swept, so S1-mini's survived every launch |
| `AIPolishSettingsView` provider-change | the key-provider path: empty model list, `llmModel` overwritten (#1271, then #2649) |
| `BackendMetadata.polishLabel` | `llmLabel`, which renders the raw model id rather than the product name |
| `LLMModelDiscoveryCoordinator` keychain id | `""`, so a permanent "No API key found" |
| `LLMPolishStep` keychain id | nil, so the request goes out with no key |
| `LLMPolishStep` local-server handles | the cloud path, a keychain lookup that cannot succeed, then `providerUnavailable` |
| `AIPolishSettingsView.currentProviderStatus` | reads as permanently key-less |
| `AIPolishSettingsView.savedKeyIsEmpty…` | the missing-key notice never appears |
| `AIPolishSettingsView.activeKeyDescriptor` | a blank API-key row with no privacy sentence |
| `AIPolishSettingsView.activeKeyBinding` | a constant binding that discards every keystroke |
| `AIPolishSettingsView.setKeySaved` | the saved flag is never set, so the notice stays after a successful save |
| `LLMNetworkSession.warmupKeychainId` | no warm-up |
| `LLMNetworkSession.buildWarmupRequest` | no warm-up request at all |
| `PipelineSettingsSync.pinnedLocalProvider` | NOT PINNED during a live recording, so a provider switch tears its server down mid-take |

**No `default:` was retained.** The issue allows keeping one that is genuinely right for any future provider, with a stated reason. Two candidates were examined — the two warm-up sites, whose doc comment said nil was right for "any non-cloud or FUTURE provider" — and the second half of that sentence is exactly the silent part: a future CLOUD provider needs an arm there.

## The two the issue found by hand are both still live

`AIPolishSettingsView`'s provider-change switch and `BackendMetadata.polishLabel`. #2649 added an S1-mini arm to each, which fixed those two engines and left the arm that produced them.

## The binding evidence is the compiler, not a test

The issue asks for a test that adds a hypothetical provider, and says to state it plainly if that is not practical. It is not practical: a case added to `LLMProvider` cannot ship.

It was still run, and the result needs stating precisely rather than flatteringly. Adding `case hypothetical` refuses the build, but Swift stops at the first module that fails, so exactly one site is named per attempt. It also refuses on the parent commit, because switches that were ALREADY exhaustive fail there too. So "the build goes red" does not distinguish this change from its parent, and claiming it did would be the vacuous receipt this repo refuses.

**The property that does distinguish them is per-site, and it is checked mechanically**: every switch naming two or more `LLMProvider` cases must name all eight. It returns **19 switches, all complete, none incomplete** — and before this change, twelve of them answered a provider-specific question from a `default:` arm instead.

That check is the one to re-run, not the enum experiment. A test asserting the same property would be weaker anyway: it would check that somebody remembered to write an arm; the compiler checks that one exists.

## Scope swept

`grep` for a switch naming two or more `LLMProvider` cases and carrying a `default:` arm returns **zero**. The sweep is mechanical and re-runnable, and it is what found the three sites the issue's own starting grep missed (`PipelineSettingsSync` twice and the provider-change switch, all of which switch on a differently-named variable).

## Pre-Merge Checklist

### Build Verification
- [x] Debug build and `ProviderStatusMappingTests`.
- [x] Hypothetical-case experiment, both directions.
- [ ] CI pending on this push.

### Behavioral Testing (Local UAT)
- [ ] **Not run.** Every arm preserves the behaviour that reached it through the `default:`, except `WisprBootstrapper`, where the added sweep is the fix. Anyone wanting the runtime proof: select a cloud provider, leave an S1-mini server running, relaunch, and check it is gone.

### Code Quality
- [x] Self-review grep across `Sources/` for every provider-switch spelling.
- [x] Conventional commit format, no secrets.
