### PR TITLE
test(hotkeys): the dropped modifier is reachable on EITHER binding (#2743)

### DIFF
--- a/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
+++ b/Tests/EnviousWisprTests/Services/HotkeyQuickAddShortcutTests.swift
@@ -425,6 +425,33 @@ struct HotkeyQuickAddShortcutTests {
         isCancelArmed: false))
   }
 
+  /// The MIRROR of the case above, and the reason the comparison narrows BOTH sides rather than
+  /// one. A user can save the dropped modifier on either binding, so the pair where CANCEL carries
+  /// Caps Lock is as reachable as the pair where Quick Add does — and `quickAddMayHoldItsChord`
+  /// always passes Quick Add first, so only this case exercises the second argument's narrowing.
+  ///
+  /// #2743 found the gap: narrowing one side only is a NO-OP against the case above, because Quick
+  /// Add is the side that carries the extra bit there. The mutant survived, the test was not weak,
+  /// and the missing half is this.
+  @Test("A chord Quick Add holds is cancel's even when CANCEL is the side carrying the dropped modifier")
+  func carbonEquivalentChordsContendWhenCancelCarriesTheLatch() {
+    let quickAdd = ShortcutBinding.keyboard(keyCode: 13, modifiers: [.control, .shift])
+    let cancel = ShortcutBinding.keyboard(
+      keyCode: 13, modifiers: [.control, .shift, .capsLock])
+
+    #expect(
+      !HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel,
+        isCancelArmed: true),
+      "Carbon registers one chord for both whichever side carries Caps Lock")
+    // The paired accepted case, so a rule that refused whenever cancel was armed cannot pass.
+    #expect(
+      HotkeyService.quickAddMayHoldItsChord(
+        isEnabled: true, isSuspended: false, quickAdd: quickAdd, cancel: cancel,
+        isCancelArmed: false))
+    #expect(ShortcutMatcher.carbonEquivalent(quickAdd, cancel))
+  }
+
   /// The other direction, and the reason the comparison is an INTERSECTION rather than a mask
   /// applied to one side: a modifier Carbon DOES keep still makes two different chords.
   @Test("A modifier Carbon keeps still separates two chords")


### PR DESCRIPTION
## What this closes

#2743's battery ran the six rows filed with #2432's dispatch fix. **Row 4 survived**, and the reason is the useful part.

Row 4 narrows only ONE side of the Carbon comparison. `quickAddMayHoldItsChord` always passes Quick Add first, and Quick Add is the side carrying Caps Lock in every case in the suite. Narrowing the first argument strips a bit the second never had, so the answer does not move.

That is reason 1 of `redundant-protections-make-single-line-mutants-survive-and-that-is-not-vacuity`: **the mutant is a no-op for the inputs the tests reach.** No test needed tightening.

Part of #2743.

`Tier: SMALL | Test: this IS the test | Modules: Tests`
`Lane: Code`

## But the asymmetry is reachable

A binding is saved per role. The dropped modifier lands on whichever one the user recorded, and `HotkeyRecorderView.binding(for:)` only started narrowing captures in #2613 — nothing narrows on load and the stored values are not migrated.

So the pair where **CANCEL** carries Caps Lock is as ordinary as the pair where Quick Add does, and it had no case.

## The case

`carbonEquivalentChordsContendWhenCancelCarriesTheLatch`, the same shape as its twin:

- the contended pair must refuse while cancel is armed
- the disarmed pair must be **accepted**, so it cannot pass by refusing everything
- `carbonEquivalent` is asked directly, so the dispatch path and the matcher stay one answer

## Proved both directions

| | result |
|---|---|
| row 4's mutant applied (narrowing on one side only) | this case FAILS, and it is the only one — **20 of 21 hold** |
| comparison restored | **21 of 21 pass** |

No production code changed.

## The other two rows that needed work are corrected on the issue, not here

- **R2** named `quickAddWinsWhenCancelIsNotArmed()`, which exercises BARE MODIFIERS and cannot reach the chord path. `cancelWinsASharedChord()` is the guard that fires; the bare-modifier case is now the silent control.
- **R6** added `.control` to a set that already contains it. `NSEvent.ModifierFlags` is an `OptionSet`, so that is an identity rather than a widening. It now adds `.capsLock`.

#2743 carries the corrected recipe and stays open until all six are re-run.

## Pre-Merge Checklist

### Build Verification
- [x] `HotkeyQuickAddShortcutTests` 21/21.
- [x] Red proved against the surviving mutant, one named case.
- [x] Dev build for the push gate.
- [ ] CI pending on this push.

### Code Quality
- [x] Self-review grep over `carbonEquivalent`, `carbonEffectiveModifiers` across `Sources/ Tests/`.
- [x] Tests only. No `GR-REVIEW-GATE` Codex round: nothing here ships to users, touches money, secrets, production data, infrastructure or a migration.
