### PR TITLE
fix(build): pin the Parakeet backup download source to the manifest revision (#2693)

### DIFF
--- a/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
@@ -159,7 +159,7 @@
     },
     {
       "id": "backup",
-      "baseURL": "https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/resolve/main/"
+      "baseURL": "https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/resolve/aed02740059203c4a87495924f685de3722ae9ce/"
     }
   ],
   "license": {
@@ -172,5 +172,5 @@
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": false
   },
-  "manifestDigest": "65db6162cd87891d15b4e6becbb4ecea2e5b3c41ef32dc98de103f5803c2d24c"
+  "manifestDigest": "bc1aae28fe94f2bff66b47f85a395188c88e01e4f59b23d9aaba92d6739217fb"
 }

--- a/Tests/EnviousWisprTests/Architecture/DeliveryManifestSourcePinningTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DeliveryManifestSourcePinningTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+
+/// Every delivery source URL is one of exactly two shapes, and the Hugging Face shape
+/// carries its own manifest's immutable commit.
+///
+/// #2693: `parakeet-delivery-manifest.json` pinned revision `aed0274…` and pointed its
+/// backup source at `.../resolve/main/`, a moving branch. On a FIRST INSTALL every
+/// component is fetched, so the file upstream had replaced was always in the set and
+/// failover always failed. Parakeet is the default engine.
+///
+/// **Why a folder sweep when `DeliveryManifestTests` already pins three manifests by
+/// hand.** Those three stay; each also pins its own repository, variant path and source
+/// order. Parakeet had no row, and a hand-written row can only cover the manifest its
+/// author was looking at. This one is generated from the FOLDER, so a manifest added
+/// tomorrow is covered on arrival.
+///
+/// **An ALLOWLIST over every source, because four review rounds each found a different
+/// spelling that escaped a semantic check.** `contains(revision)` accepted
+/// `revision: "main"` beside `.../resolve/main/`. `Character.isHexDigit` is true for
+/// fullwidth forms, so 40 `U+FF41`-class characters passed as a commit. Reading
+/// `URL.path` hands the decision to Foundation, which percent-decodes before you split,
+/// keeps a host's trailing dot and normalises `..`. And a raw `contains("huggingface")`
+/// TRIGGER missed `hugg%69ngface.co`, which skipped the source entirely.
+///
+/// The first three were the pattern; the fourth was the TRIGGER, which is the same defect
+/// one level up — deciding whether a rule APPLIES is as open-ended as the rule itself. So
+/// there is no trigger any more. **Every source must match one of two anchored patterns
+/// over its literal bytes, and anything else FAILS.** A new host, a percent-encoded one,
+/// a homoglyph, an unpinned Hugging Face URL: none of them need to be recognised, because
+/// none of them match. Adding a genuinely new CDN is a deliberate edit here, which is the
+/// point rather than a cost.
+///
+/// **Falsification, published so closure is a claim rather than a hope:** a further
+/// finding of ANY URL spelling that this suite accepts and should not means the patterns
+/// are deleted in favour of a literal per-source string table. Findings on discovery
+/// (which manifests are read) or vacuity (whether anything was checked) are different
+/// questions.
+///
+/// **Network-free by design.** This proves URL shape, never availability and never the
+/// bytes a source serves. Byte verification belongs in the PR that changes a revision.
+///
+/// Fails closed: no manifests found, a manifest with no `sources`, an empty `sources`, a
+/// source matching neither pattern, and zero Hugging Face sources in the whole folder.
+@Suite("Delivery manifests pin every Hugging Face source (#2693)", .tags(.driftGuard))
+struct DeliveryManifestSourcePinningTests {
+
+  private struct Manifest: Decodable {
+    struct Identity: Decodable { let revision: String }
+    struct Source: Decodable {
+      let id: String
+      let baseURL: String
+    }
+    let identity: Identity?
+    let sources: [Source]?
+  }
+
+  /// Resolved through `RepoRoot`, never a fixed-depth trim of `#filePath`: this
+  /// worktree lives under `/private/tmp`, where `/tmp` being a symlink perturbs a
+  /// component count (#1675).
+  private static var resourcesDirectory: URL {
+    RepoRoot.sourceURL("Sources/EnviousWispr/Resources")
+  }
+
+  /// Every `*-delivery-manifest.json`, with its repo-relative path.
+  ///
+  /// An empty or unreadable directory would make every assertion below vacuously
+  /// true, which is the shape where a guard stops guarding with nothing going red.
+  private static func deliveryManifests() throws -> [(path: String, manifest: Manifest)] {
+    let dir = resourcesDirectory
+    let names = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+      .filter { $0.hasSuffix("-delivery-manifest.json") }
+      .sorted()
+    try #require(
+      !names.isEmpty,
+      "no *-delivery-manifest.json found under \(dir.path) — the guard has lost its subject")
+    return try names.map { name in
+      let data = try Data(contentsOf: dir.appendingPathComponent(name))
+      return (
+        "Sources/EnviousWispr/Resources/\(name)",
+        try JSONDecoder().decode(Manifest.self, from: data)
+      )
+    }
+  }
+
+  /// One path segment: opens with an alphanumeric, so `..` is unrepresentable, and `%`
+  /// is outside the class, so percent-encoding is unrepresentable.
+  private static let segment = "[A-Za-z0-9][A-Za-z0-9._-]*"
+
+  /// An explicit ASCII set, never `Character.isHexDigit`, which is TRUE for fullwidth
+  /// forms — `U+FF41` reports `isHexDigit == true` and `isUppercase == false`.
+  private static let asciiHexDigits = Set("0123456789abcdef")
+
+  private static func isFullCommitSHA(_ revision: String) -> Bool {
+    revision.count == 40 && revision.allSatisfy { asciiHexDigits.contains($0) }
+  }
+
+  /// Our own mirror. Revision-scoping is per-family and not asserted here; the sibling
+  /// suites own that.
+  private static var mirrorPattern: String {
+    "^https://models\\.enviouslabs\\.co/(\(segment)/)+$"
+  }
+
+  /// `https://huggingface.co/<owner>/<repo>/resolve/<revision>/[<path>/]*`. The revision
+  /// is interpolated only after `isFullCommitSHA`, so it carries no regex metacharacter.
+  private static func huggingFacePattern(revision: String) -> String {
+    "^https://huggingface\\.co/\(segment)/\(segment)/resolve/\(revision)/(\(segment)/)*$"
+  }
+
+  private static func matches(_ pattern: String, _ value: String) -> Bool {
+    guard let regex = try? Regex(pattern) else { return false }
+    return (try? regex.wholeMatch(in: value)) != nil
+  }
+
+  @Test("every delivery source is our mirror or a commit-pinned Hugging Face URL")
+  func everySourceMatchesAnAllowedShape() throws {
+    var huggingFaceSourcesSeen = 0
+    for (path, manifest) in try Self.deliveryManifests() {
+      // A manifest with no sources, or none listed, is a failure rather than a skip: the
+      // production loader rejects it, and skipping lets a new manifest hide behind the
+      // others.
+      let sources = try #require(manifest.sources, "\(path): declares no sources")
+      try #require(!sources.isEmpty, "\(path): declares an empty sources list")
+
+      for source in sources {
+        if Self.matches(Self.mirrorPattern, source.baseURL) { continue }
+
+        // Everything that is not our mirror must be a pinned Hugging Face URL. There is
+        // no test for whether it "looks like" Hugging Face — that decision is what the
+        // fourth review round escaped.
+        let revision = try #require(
+          manifest.identity?.revision,
+          "\(path): source '\(source.id)' is not our mirror and the manifest declares no identity.revision, so nothing can pin it"
+        )
+        guard Self.isFullCommitSHA(revision) else {
+          Issue.record(
+            "\(path): identity.revision '\(revision)' must be 40 lowercase ASCII hex characters; a tag or a branch name can move"
+          )
+          continue
+        }
+        let pinned = Self.huggingFacePattern(revision: revision)
+        #expect(
+          Self.matches(pinned, source.baseURL),
+          "\(path): source '\(source.id)' baseURL \(source.baseURL) matches neither \(Self.mirrorPattern) nor \(pinned). A source outside both shapes is either an unpinned ref — which fetches whatever upstream pushed since, so a first install's failover dies on integrity_mismatch (#2693) — or a host nobody has reviewed. Add it here deliberately."
+        )
+        if Self.matches(pinned, source.baseURL) { huggingFaceSourcesSeen += 1 }
+      }
+    }
+    #expect(
+      huggingFaceSourcesSeen > 0,
+      "no pinned Hugging Face source was found in the whole folder — this guard passed without guarding anything"
+    )
+  }
+}

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -427,7 +427,12 @@ enum ManifestFixture {
   // `scripts/regen-delivery-manifest-digest.py`, which reproduces a manifest's
   // existing digest before writing a new one; that control is what makes the
   // value below trustworthy rather than merely fresh.
-  static let goldenDigest = "65db6162cd87891d15b4e6becbb4ecea2e5b3c41ef32dc98de103f5803c2d24c"
+  // Updated 2026-09-09 (#2693): `backup` repointed off the moving `resolve/main/`.
+  // Source-only; file hashes, sizes and identity unchanged. The new digest invalidates
+  // existing admission markers, so a clean writable install revalidates and re-admits
+  // without downloading — re-admission still runs cleanup and rewrites the marker
+  // (`CacheAdmission.promoteAndAdmit` 3 and 4), so a dirty or unwritable one can fetch.
+  static let goldenDigest = "bc1aae28fe94f2bff66b47f85a395188c88e01e4f59b23d9aaba92d6739217fb"
 
   @Test func shippedManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.shippedManifestURL)


### PR DESCRIPTION
Closes #2693.

## What was broken

`parakeet-delivery-manifest.json` pinned revision `aed02740059203c4a87495924f685de3722ae9ce` and pointed its backup download source at `.../resolve/main/`. `resolve/main` is a moving branch, so the backup fetched whatever upstream had pushed since the pin. Upstream replaced a 2-byte `config.json` with a 475-byte one, so a failover that needs that file gets 475 bytes where the manifest expects 2 and dies on `integrity_mismatch`.

Parakeet is the default engine, so this is the manifest every first-run user downloads. **Scoped precisely, because the first draft of this said more than the code proves:** a FIRST INSTALL fetches every component, so `config.json` is always in the set and failover always fails. A partial repair whose `componentsToFetch` excludes that file is unaffected (`ManifestFetchTask.swift:129`). The reported install is the first case, three times in seven minutes.

## Measured, this session, against the live sources

Re-verified independently rather than taken on report. 18 files at or under 200 KB downloaded in full and SHA-256'd against the manifest; the 5 large files probed with a ranged `GET` (`Range: bytes=0-0`) and compared on `Content-Range`'s total, because a HEAD proves existence and not retrievability. **So "23 match" means 18 by HASH and 5 by LENGTH — it does not establish SHA-256 equality for all 23**, and the 5 unhashed are the large model weights.

```
manifest revision: aed02740059203c4a87495924f685de3722ae9ce
  source our_copy: https://models.enviouslabs.co/parakeet/FluidInference/parakeet-tdt-0.6b-v3-coreml/
  source backup:   https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/resolve/main/

manifest wants config.json sizeBytes= 2
backup main         475B  sha_ok=False
backup PINNED         2B  sha_ok=True
our_copy              2B  sha_ok=True
```

And against the newly pinned base, every file:

```
pinned backup base: https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/resolve/aed02740059203c4a87495924f685de3722ae9ce/
RESULT: 23 match, 0 mismatch, of 23 files
```

Our own mirror was already clean and is exonerated.

## The change

Three files.

**1. The URL.** `Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json:162`, from `resolve/main/` to `resolve/aed02740059203c4a87495924f685de3722ae9ce/`.

**2. The manifest's own digest, which the URL edit invalidates.** `DeliveryManifest.loadBundled` recomputes `manifestDigest` on every launch and throws on mismatch, so an unregenerated digest bricks model loading. Regenerated with `scripts/regen-delivery-manifest-digest.py`, whose control reproduces the committed digest before writing a new one, and the golden copy in `DeliveryManifestTests` updated with it.

`65db6162cd87891d15b4e6becbb4ecea2e5b3c41ef32dc98de103f5803c2d24c` → `bc1aae28fe94f2bff66b47f85a395188c88e01e4f59b23d9aaba92d6739217fb`

**User-visible effect of the digest change, stated because it is not zero, and scoped because "no re-download" is the clean case rather than every case:** file paths, sizes, hashes and model identity are untouched, so a CLEAN, WRITABLE install is revalidated and admitted with no download. Re-admission also runs orphan cleanup and rewrites the marker (`CacheAdmission.promoteAndAdmit` steps 3 and 4), so an install carrying leftover files, or one whose metadata cannot be written, can still fetch or fail admission. Same family as #1981 and #1678.

Nine tests were red before this was regenerated, not the three that name the digest — every one of them loads the bundled manifest, and the loader throws before any of their own assertions run.

**3. The guard.** `Tests/EnviousWisprTests/Architecture/DeliveryManifestSourcePinningTests.swift`, tagged `.driftGuard`. Over every `*-delivery-manifest.json` in `Sources/EnviousWispr/Resources/`, EVERY source's `baseURL` must match one of exactly two anchored patterns over its literal bytes:

```
^https://models\.enviouslabs\.co/(<seg>/)+$                                    our own mirror
^https://huggingface\.co/<seg>/<seg>/resolve/<this manifest's 40-hex revision>/(<seg>/)*$
        where <seg> is [A-Za-z0-9][A-Za-z0-9._-]*
```

Anything else fails. There are seven sources across five manifests today and all seven match.

**Four review rounds each produced a different spelling that escaped a semantic check, so the check was replaced twice rather than patched four times.**

| round | escape | what it beat |
|---|---|---|
| local second pass | `identity.revision: "main"` beside `.../resolve/main/` | `baseURL.contains(revision)` |
| cloud r1 | 40 fullwidth `U+FF41`-class characters | `Character.isHexDigit`, which is TRUE for them (verified with `swiftc`) |
| local round | `%2F`, `huggingface.co.`, `/resolve/<sha>/../main/` | reading `URL.path`, which hands the decision to Foundation — it percent-decodes before the split, keeps a trailing dot, and normalises `..` |
| cloud r2 | `hugg%69ngface.co` | the raw `contains("huggingface")` TRIGGER, which SKIPPED the source entirely |

The first three beat the RULE. The fourth beat the decision about whether the rule APPLIES, which is the same defect one level up: deciding what counts as a Hugging Face URL is exactly as open-ended as validating one. **So there is no trigger any more.** An allowlist needs no recognition step — a percent-encoded host, a homoglyph, or a brand-new CDN matches neither pattern and fails. Adding a real new host is a deliberate edit to this file, which is the point rather than a cost.

**The rewrite was not a judgement call at the time.** The suite published a falsification condition after round three — *a fourth URL-spelling finding deletes this in favour of an allowlist* — and round four produced one. `workflow-process.md` RULE: grounded-review-mechanics requires that consequence be pre-committed and named before the next verdict is read, precisely so it binds when it costs something. The current suite publishes the next one: a further accepted-and-shouldn't-be spelling means the patterns go and a literal per-source string table replaces them.

## Why a guard when three already assert this

`DeliveryManifestTests` hand-writes the same pin once per manifest: `sourceIsPinnedToAnImmutableCommitNotABranch` (whisperkit), `previewSourceIsPinnedToAnImmutableCommitNotABranch` (whisperkit-preview), `s1BackupSourceIsPinnedToAnImmutableCommitNotABranch` (s1). All three are correct and all three stay — each also pins its own repository, variant path and source order, which a whole-set sweep cannot, and `s1BackupSourceIsPinnedToAnImmutableCommitNotABranch` is the only one that hardcodes its revision VALUE.

**Parakeet had none.** The failure was not a test asserting the wrong thing; it was the one manifest nobody wrote a test for, and it happens to be the default engine's. A hand-written row can only cover the case its author was looking at, so the new one is generated from the FOLDER: every manifest present, whether or not anybody remembered it, and a manifest added tomorrow is covered on arrival.

Fails closed five ways: zero manifests found, a manifest with no `sources`, an empty `sources` list, a Hugging Face source with no declared revision, and examining zero Hugging Face sources are all failures. The `sources` cases matter because skipping is how a NEW manifest hides behind the four that already pass.

**The three sibling assertions are kept rather than consolidated**, though the anchored pattern strictly implies each one's `contains(revision)`. A whisperkit failure should surface at the whisperkit test with its own message; the duplication is one line per sibling, and deleting a passing assertion carries its own burden.

Deliberately network-free. The defect is a URL SHAPE, decidable from the file, and reaching Hugging Face would make every CI run depend on a third party and on whatever upstream holds today. A byte-level verification of both sources is the stronger check and belongs at release time, not per-PR, at 483 MB per source.

## Evidence the guard binds

Run by hand before this PR, both directions, same filter:

Every escape any review round named, run against the shipped allowlist. Five of these ten passed an earlier version of this guard.

| control | verdict |
|---|---|
| the real defect, `resolve/main` | RED |
| `identity.revision` renamed to `main`, URL following it | RED |
| a 40-character fullwidth revision | RED |
| trailing-dot host `huggingface.co.` | RED |
| percent-encoded slash `%2F` in the path | RED |
| dot-segment `/resolve/<sha>/../main/` | RED |
| uppercase scheme `HTTPS://` | RED |
| percent-encoded host `hugg%69ngface.co` | RED — this skipped the guard entirely one commit ago |
| an entirely unreviewed host | RED |
| a new manifest carrying an empty `sources` list | RED |
| **unmutated tree** | **GREEN** |

Every mutation restored and proved by CONTENT — `cmp` byte-identical per row, then `git diff --exit-code -- Sources/EnviousWispr/Resources/` clean at the end, and the probe manifest's absence. Never by timestamp. One harness mutation refused to apply because its anchor matched twice (the manifest also carries an attribution `url` on the same host, which is not a source and which the guard correctly never reads); it reported the refusal and mutated nothing rather than editing the wrong line.

Full Debug lane on the shipped content: `Debug lane executed 7626 tests`, `Debug lane verdict: PASS`, 3 known issues (pre-existing).

Five further branches — a Hugging Face source with no declared revision, a URL pinned to somebody else's revision, a revision that is a TAG rather than a commit, and the two fail-closed paths — are filed on #2749 as hand-runnable two-way controls rather than measured here, per `testing-philosophy.md` RULE: write-the-test-by-day-run-the-battery-by-night. **They are not a `mutation-battery.py` recipe:** `validate-mutation-recipe.py` refuses every row whose target is not Swift under `Sources/`, so the battery cannot bind any guard whose subject is a resource file. That limit is now recorded in `testing-philosophy.md`.

## Still open, deliberately

The issue's second suggested step — making `integrity_mismatch` after failover across every source tell the user something more actionable — is not in this PR. With the backup fixed, a both-sources failure really does mean something between the user and the internet, so the message can say so with confidence. That is a copy and telemetry change with its own blast radius.

`Tier: SMALL | Test: required (a manifest-pinning assertion) | Modules: Resources, Tests`
`Lane: Code`
