### PR TITLE
perf(itn): bound the neighbour reads behind inverse_normalization_timeout (#2758)

### DIFF
--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -130,8 +130,8 @@ final class InverseTextNormalizationStep: TextProcessingStep {
       // and stamp itself — `operationTask.cancel()` cannot stop a synchronous body from being
       // scheduled. Compare the stamp against the NOMINAL BUDGET, not against `elapsedMs`:
       // `elapsedMs` is the caller's own resume time and on a loaded machine runs well past the
-      // budget, so a closure that entered at 600 ms would clear an 800 ms `elapsedMs` and be
-      // reported as having been running when the timer won, which it was not.
+      // budget, so comparing against an 800 ms `elapsedMs` would accept a 600 ms entry even
+      // though that entry missed the nominal 500 ms budget.
       let engineStartMs = engineStart.withLock { $0 }.map { ($0 - start) * 1000 }
       let queueWaitMs = engineStartMs.flatMap { $0 <= Self.deadlineSeconds * 1000 ? $0 : nil }
       // Deadline hit — the (pathological) normalize was abandoned; the user gets

--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -2,6 +2,7 @@ import EnviousWisprCore
 import EnviousWisprPostProcessing
 import EnviousWisprServices
 import Foundation
+import os
 
 /// Deterministic inverse text normalization (spoken-form → written-form) as a post-ASR
 /// limb: "two zero three nine five four…" → "203-954-8879", "twenty twenty six" → "2026",
@@ -102,12 +103,23 @@ final class InverseTextNormalizationStep: TextProcessingStep {
     // started with (`swift-concurrency-patterns` telemetry-snapshot-not-shared-property).
     let normalizer = self.normalizer
     let spokenPunctuation = self.spokenPunctuationEnabled
+    // `withDeadline` is a FIRST-CLAIM RACE on a shared executor, and the budget is spent from
+    // THIS clock: an operation task still queued for a cooperative thread burns exactly the same
+    // 0.5s a genuinely slow `normalize` does, and `latency_ms` alone reads ~500 either way. #1946
+    // measured that dependence for the ordered siblings; the same one applies here. Stamp the
+    // instant the closure actually BEGINS so a timeout breadcrumb says which of the two it was —
+    // engine work, or a take that never got a thread — instead of leaving the next occurrence as
+    // undiagnosable as the last. `OSAllocatedUnfairLock` because the closure is `@Sendable`; the
+    // read below happens after `withDeadline` returns, back on this actor.
+    let engineStart = OSAllocatedUnfairLock<Double?>(initialState: nil)
     let start = CFAbsoluteTimeGetCurrent()
     let maybeConverted = await withDeadline(seconds: 0.5) {
-      normalizer.normalize(input, spokenPunctuation: spokenPunctuation)
+      engineStart.withLock { $0 = CFAbsoluteTimeGetCurrent() }
+      return normalizer.normalize(input, spokenPunctuation: spokenPunctuation)
     }
     let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
     guard let converted = maybeConverted else {
+      let queueWaitMs = engineStart.withLock { $0 }.map { ($0 - start) * 1000 }
       // Deadline hit — the (pathological) normalize was abandoned; the user gets
       // the pre-ITN text. Anomaly-only breadcrumb (Gemini: a slow run currently
       // looks like a fast no-op). Metadata only (`telemetry-privacy-boundary`).
@@ -115,7 +127,15 @@ final class InverseTextNormalizationStep: TextProcessingStep {
         TimeoutError(seconds: 0.5),
         category: .inverseNormalizationTimeout,
         stage: "inverse_text_normalization",
-        extra: ["latency_ms": elapsedMs, "len_before": lenBefore])
+        extra: [
+          "latency_ms": elapsedMs,
+          "len_before": lenBefore,
+          // nil = the closure never ran: the deadline was spent QUEUED, not normalizing, and
+          // nothing about the engine is implicated. Otherwise the wait before it started, so
+          // `latency_ms - queue_wait_ms` is what the engine itself actually consumed.
+          "engine_started": queueWaitMs != nil,
+          "queue_wait_ms": queueWaitMs ?? -1,
+        ])
       lastRun = RunOutcome(
         ran: true, changed: false, skipReason: nil,
         latencyMs: elapsedMs, lenBefore: lenBefore, lenAfter: lenBefore)

--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -119,7 +119,14 @@ final class InverseTextNormalizationStep: TextProcessingStep {
     }
     let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
     guard let converted = maybeConverted else {
-      let queueWaitMs = engineStart.withLock { $0 }.map { ($0 - start) * 1000 }
+      // Read AFTER `withDeadline` returned, so a closure that the timer already beat can still
+      // enter and stamp itself — `operationTask.cancel()` cannot stop a synchronous body from
+      // being scheduled. A stamp later than the budget therefore means the closure had NOT begun
+      // when the deadline fired, which is the queued case, so it is reported as not-started
+      // rather than as a wait longer than the run it is supposed to sit inside. That guard is
+      // also what keeps `latency_ms - queue_wait_ms` non-negative and readable as engine time.
+      let engineStartMs = engineStart.withLock { $0 }.map { ($0 - start) * 1000 }
+      let queueWaitMs = engineStartMs.flatMap { $0 <= elapsedMs ? $0 : nil }
       // Deadline hit — the (pathological) normalize was abandoned; the user gets
       // the pre-ITN text. Anomaly-only breadcrumb (Gemini: a slow run currently
       // looks like a fast no-op). Metadata only (`telemetry-privacy-boundary`).
@@ -130,9 +137,10 @@ final class InverseTextNormalizationStep: TextProcessingStep {
         extra: [
           "latency_ms": elapsedMs,
           "len_before": lenBefore,
-          // nil = the closure never ran: the deadline was spent QUEUED, not normalizing, and
-          // nothing about the engine is implicated. Otherwise the wait before it started, so
-          // `latency_ms - queue_wait_ms` is what the engine itself actually consumed.
+          // false = the closure had not begun when the deadline fired: the budget was spent
+          // QUEUED, not normalizing, and nothing about the engine is implicated. True carries the
+          // wait before it started, so `latency_ms - queue_wait_ms` is what the engine itself
+          // actually consumed before being abandoned.
           "engine_started": queueWaitMs != nil,
           "queue_wait_ms": queueWaitMs ?? -1,
         ])

--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -26,6 +26,11 @@ final class InverseTextNormalizationStep: TextProcessingStep {
   /// Always-on safety floor (#145, founder Gate-1 2026-06-02: ON for all, no toggle).
   var isEnabled: Bool { true }
 
+  /// The step's own wall-clock budget: the `withDeadline` in `process(...)`, the seconds the
+  /// `TimeoutError` reports, and the line the timeout breadcrumb's `engine_started` is decided
+  /// against. Named once so those three cannot drift apart (#2758).
+  static let deadlineSeconds: Double = 0.5
+
   /// Runner-level runaway BACKSTOP only. The real cap is the step's own 0.5s
   /// `withDeadline` in `process(...)` — a TRUE wall-clock bound that abandons a
   /// pathological `normalize` so the heart path's paste is never held. This outer
@@ -113,34 +118,37 @@ final class InverseTextNormalizationStep: TextProcessingStep {
     // read below happens after `withDeadline` returns, back on this actor.
     let engineStart = OSAllocatedUnfairLock<Double?>(initialState: nil)
     let start = CFAbsoluteTimeGetCurrent()
-    let maybeConverted = await withDeadline(seconds: 0.5) {
+    let maybeConverted = await withDeadline(seconds: Self.deadlineSeconds) {
       engineStart.withLock { $0 = CFAbsoluteTimeGetCurrent() }
       return normalizer.normalize(input, spokenPunctuation: spokenPunctuation)
     }
     let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
     guard let converted = maybeConverted else {
-      // Read AFTER `withDeadline` returned, so a closure that the timer already beat can still
-      // enter and stamp itself — `operationTask.cancel()` cannot stop a synchronous body from
-      // being scheduled. A stamp later than the budget therefore means the closure had NOT begun
-      // when the deadline fired, which is the queued case, so it is reported as not-started
-      // rather than as a wait longer than the run it is supposed to sit inside. That guard is
-      // also what keeps `latency_ms - queue_wait_ms` non-negative and readable as engine time.
+      // Read AFTER `withDeadline` returned, so a closure the timer already beat can still enter
+      // and stamp itself — `operationTask.cancel()` cannot stop a synchronous body from being
+      // scheduled. Compare the stamp against the BUDGET, not against `elapsedMs`: `elapsedMs` is
+      // the caller's own resume time and on a loaded machine runs well past the budget, so a
+      // closure that entered at 600 ms would clear a 800 ms `elapsedMs` and be reported as having
+      // been running when the timer won, which it was not.
       let engineStartMs = engineStart.withLock { $0 }.map { ($0 - start) * 1000 }
-      let queueWaitMs = engineStartMs.flatMap { $0 <= elapsedMs ? $0 : nil }
+      let queueWaitMs = engineStartMs.flatMap { $0 <= Self.deadlineSeconds * 1000 ? $0 : nil }
       // Deadline hit — the (pathological) normalize was abandoned; the user gets
       // the pre-ITN text. Anomaly-only breadcrumb (Gemini: a slow run currently
       // looks like a fast no-op). Metadata only (`telemetry-privacy-boundary`).
       SentryBreadcrumb.captureError(
-        TimeoutError(seconds: 0.5),
+        TimeoutError(seconds: Self.deadlineSeconds),
         category: .inverseNormalizationTimeout,
         stage: "inverse_text_normalization",
         extra: [
           "latency_ms": elapsedMs,
           "len_before": lenBefore,
-          // false = the closure had not begun when the deadline fired: the budget was spent
-          // QUEUED, not normalizing, and nothing about the engine is implicated. True carries the
-          // wait before it started, so `latency_ms - queue_wait_ms` is what the engine itself
-          // actually consumed before being abandoned.
+          // false = no closure entry was observed within the budget, so the deadline was spent
+          // QUEUED rather than normalizing and nothing about the engine is implicated. True
+          // carries the delay to closure ENTRY. Read the pair as "did the engine get a thread in
+          // time, and how long did it wait" — `latency_ms` is the caller's own resume time and
+          // overshoots the budget under load, so `latency_ms - queue_wait_ms` is NOT engine
+          // execution time. Timing the engine itself needs a stamp at the timer's decision, which
+          // is inside `withDeadline` and not available here.
           "engine_started": queueWaitMs != nil,
           "queue_wait_ms": queueWaitMs ?? -1,
         ])

--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -108,14 +108,16 @@ final class InverseTextNormalizationStep: TextProcessingStep {
     // started with (`swift-concurrency-patterns` telemetry-snapshot-not-shared-property).
     let normalizer = self.normalizer
     let spokenPunctuation = self.spokenPunctuationEnabled
-    // `withDeadline` is a FIRST-CLAIM RACE on a shared executor, and the budget is spent from
-    // THIS clock: an operation task still queued for a cooperative thread burns exactly the same
-    // 0.5s a genuinely slow `normalize` does, and `latency_ms` alone reads ~500 either way. #1946
-    // measured that dependence for the ordered siblings; the same one applies here. Stamp the
-    // instant the closure actually BEGINS so a timeout breadcrumb says which of the two it was —
-    // engine work, or a take that never got a thread — instead of leaving the next occurrence as
-    // undiagnosable as the last. `OSAllocatedUnfairLock` because the closure is `@Sendable`; the
-    // read below happens after `withDeadline` returns, back on this actor.
+    // `withDeadline` is a FIRST-CLAIM RACE on a shared executor, so a take still queued for a
+    // cooperative thread can burn the budget without the engine ever running, and `latency_ms`
+    // alone reads ~500 either way (#1946 measured that dependence for the ordered siblings).
+    // Record when the closure ENTERS, relative to this call's start, so a timeout breadcrumb
+    // carries at least that much instead of leaving the next occurrence as undiagnosable as the
+    // last. What it CANNOT carry: `withDeadline` starts its relative sleep when its own timer
+    // task is scheduled, not when this line runs, so the timer's decision instant is not
+    // observable from here and the fields below are read against the NOMINAL budget instead.
+    // `OSAllocatedUnfairLock` because the closure is `@Sendable`; the read happens after
+    // `withDeadline` returns, back on this actor.
     let engineStart = OSAllocatedUnfairLock<Double?>(initialState: nil)
     let start = CFAbsoluteTimeGetCurrent()
     let maybeConverted = await withDeadline(seconds: Self.deadlineSeconds) {
@@ -126,10 +128,10 @@ final class InverseTextNormalizationStep: TextProcessingStep {
     guard let converted = maybeConverted else {
       // Read AFTER `withDeadline` returned, so a closure the timer already beat can still enter
       // and stamp itself — `operationTask.cancel()` cannot stop a synchronous body from being
-      // scheduled. Compare the stamp against the BUDGET, not against `elapsedMs`: `elapsedMs` is
-      // the caller's own resume time and on a loaded machine runs well past the budget, so a
-      // closure that entered at 600 ms would clear a 800 ms `elapsedMs` and be reported as having
-      // been running when the timer won, which it was not.
+      // scheduled. Compare the stamp against the NOMINAL BUDGET, not against `elapsedMs`:
+      // `elapsedMs` is the caller's own resume time and on a loaded machine runs well past the
+      // budget, so a closure that entered at 600 ms would clear an 800 ms `elapsedMs` and be
+      // reported as having been running when the timer won, which it was not.
       let engineStartMs = engineStart.withLock { $0 }.map { ($0 - start) * 1000 }
       let queueWaitMs = engineStartMs.flatMap { $0 <= Self.deadlineSeconds * 1000 ? $0 : nil }
       // Deadline hit — the (pathological) normalize was abandoned; the user gets
@@ -142,13 +144,13 @@ final class InverseTextNormalizationStep: TextProcessingStep {
         extra: [
           "latency_ms": elapsedMs,
           "len_before": lenBefore,
-          // false = no closure entry was observed within the budget, so the deadline was spent
-          // QUEUED rather than normalizing and nothing about the engine is implicated. True
-          // carries the delay to closure ENTRY. Read the pair as "did the engine get a thread in
-          // time, and how long did it wait" — `latency_ms` is the caller's own resume time and
-          // overshoots the budget under load, so `latency_ms - queue_wait_ms` is NOT engine
-          // execution time. Timing the engine itself needs a stamp at the timer's decision, which
-          // is inside `withDeadline` and not available here.
+          // `engine_started` = an entry stamp was observed WITHIN THE NOMINAL BUDGET. `false`
+          // therefore covers both "never entered" and "entered late", and `queue_wait_ms` carries
+          // the entry delay only for a qualifying start, -1 otherwise. Read as evidence, not as a
+          // verdict: neither field establishes the state at the timer's own decision instant, nor
+          // rules a slow `normalize` in or out, and `latency_ms` includes the caller's resumption
+          // delay — so `latency_ms - queue_wait_ms` is NOT engine execution time. Timing the
+          // engine itself needs a stamp at that decision, inside `withDeadline`.
           "engine_started": queueWaitMs != nil,
           "queue_wait_ms": queueWaitMs ?? -1,
         ])

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -1179,21 +1179,41 @@ public struct InverseTextNormalizer: Sendable {
   // SCANNING utf-16 units to a token boundary and materializing only that, so the cost is the
   // length of the neighbouring tokens rather than the length of the rest of the take.
   //
-  // Both use `isWhitespace` — the Unicode White_Space property spelled out in `whitespaceSet` —
-  // which is the same boundary `splitWords` (`Character.isWhitespace`) splits on. That equality
-  // is what makes these drop-in: the caller keeps running the identical `splitWords` /
-  // `firstMatch` / `.first` / `.last` logic, just over a window instead of the whole tail.
-  // Surrogates are not whitespace under either rule, so a cut can never land inside a pair.
+  // The scan walks utf-16 units against `isWhitespace` (`whitespaceSet`, the Unicode White_Space
+  // property). THAT IS NOT THE SAME BOUNDARY `splitWords` USES, and assuming it was is what an
+  // earlier draft of these helpers got wrong: `splitWords` asks `Character.isWhitespace`, which
+  // classifies a whole GRAPHEME CLUSTER by its FIRST scalar. A combining mark after a space joins
+  // the space's cluster, so Swift calls the pair whitespace while a scalar scan calls the mark a
+  // token of its own. Measured: on `"it covers two \u{0301} square miles"` the whole tail splits
+  // to `["square", "miles"]` and a two-token scalar window yields only `["square"]`, so the
+  // cardinal pass stopped seeing the unit noun and left "two" spelled.
+  //
+  // So the scan PROPOSES and `splitWords` DISPOSES: each helper grows its window by scalar-token
+  // steps and hands the candidate back to `splitWords` itself, stopping only once `splitWords`
+  // reports enough complete tokens. Whatever the scan miscounts on the way, the tokens the caller
+  // actually reads are the ones the whole text would have given. Surrogates are not whitespace
+  // under either rule, so a cut can never land inside a pair.
+  //
+  // `neighbourScanCap` bounds the growth. Reaching it needs text that is mostly combining marks
+  // sitting against whitespace, which dictation does not produce, and the behaviour there is the
+  // OLD short-window behaviour: a guard that cannot see its neighbour declines to convert, so the
+  // cap fails SAFE (a number stays spelled) exactly like `runIsCleanlyPaired`'s walk ceiling.
+  //
+  // One shape stays linear in the take and cannot be helped here: text with no whitespace at all
+  // ("twenty/twenty/twenty/…") is ONE token, so the window is the rest of the take. Speech
+  // arrives with spaces; this is a property of the input, not of the window.
+  static let neighbourScanCap = 32
 
-  /// The text from `end` through the end of its SECOND whitespace-delimited token — the window
-  /// every "what follows this match" reader in this file stays inside.
+  /// The text from `end` through the end of its THIRD `splitWords` token — the window every
+  /// "what follows this match" reader in this file stays inside.
   ///
-  /// TWO tokens, because that is the deepest any caller looks: the cardinal pass reads
-  /// `toksAfter[1]` for a unit with a modifier ("two square miles") and for an age period
-  /// ("two years old"). Leading whitespace is preserved so an anchored `^\s+...` probe and a
-  /// `.first == "-"` glue test read exactly what they read on the full tail.
+  /// TWO tokens are what a caller reads: the cardinal pass reads `toksAfter[1]` for a unit with a
+  /// modifier ("two square miles") and for an age period ("two years old"). The window carries a
+  /// third so those two are each closed inside it; see the note above. Leading whitespace is
+  /// preserved so an anchored `^\s+...` probe and a `.first == "-"` glue test read exactly what
+  /// they read on the full tail.
   ///
-  /// Truncating at a token boundary cannot change an answer: a reader that wants token 1 or 2
+  /// Ending on a `splitWords` boundary cannot change an answer: a reader that wants token 1 or 2
   /// gets it whole, `count >= 2` is decided identically, and a `\b` closing an anchored probe
   /// inside token 1 sees the same following character (the boundary that ended the token) as it
   /// would in the full text. There is no character cap — a cap could cut a token in half and
@@ -1202,28 +1222,54 @@ public struct InverseTextNormalizer: Sendable {
     let n = ns.length
     guard end < n else { return "" }
     var i = end
-    for _ in 0..<2 {
+    var scanned = 0
+    while i < n, scanned < neighbourScanCap {
       while i < n, isWhitespace(ns.character(at: i)) { i += 1 }
       guard i < n else { break }
       while i < n, !isWhitespace(ns.character(at: i)) { i += 1 }
+      scanned += 1
+      // THREE, so the two the callers read are each closed by a whitespace run INSIDE the window.
+      // Stopping at two would leave token 2 ending on the window edge, and a cluster that Swift
+      // continues across that edge (a Prepend scalar before the space the scan stopped on) would
+      // hand the caller a token the whole text does not have.
+      guard scanned >= 3,
+        Self.splitWords(ns.substring(with: NSRange(location: end, length: i - end))).count >= 3
+      else { continue }
+      break
     }
     return ns.substring(with: NSRange(location: end, length: i - end))
   }
 
-  /// The last whitespace-delimited token before `start`, plus whether NOTHING but whitespace
-  /// precedes it — the two things a "what came before this match" reader in this file asks.
+  /// The last `splitWords` token before `start`, plus whether NOTHING but whitespace precedes it —
+  /// the two things a "what came before this match" reader in this file asks.
   ///
   /// `token` is `splitWords(everythingBefore).last ?? ""`, and `headIsBlank` is what
-  /// `everythingBefore` trimmed of trailing whitespace answers to `isEmpty`. When `headIsBlank`
-  /// is false the token is non-empty and its LAST character is the last character of that
-  /// trimmed head, which is the sentence-boundary sentinel the cardinal pass tests.
+  /// `everythingBefore` trimmed of trailing whitespace answers to `isEmpty` (the two agree:
+  /// trimming trailing whitespace empties a head exactly when it holds no token). When
+  /// `headIsBlank` is false the token is non-empty and its LAST character is the last character
+  /// of that trimmed head, which is the sentence-boundary sentinel the cardinal pass tests.
   static func lastTokenBefore(_ ns: NSString, _ start: Int) -> (token: String, headIsBlank: Bool) {
-    var p = start
-    while p > 0, isWhitespace(ns.character(at: p - 1)) { p -= 1 }
-    guard p > 0 else { return ("", true) }
-    var q = p
-    while q > 0, !isWhitespace(ns.character(at: q - 1)) { q -= 1 }
-    return (ns.substring(with: NSRange(location: q, length: p - q)), false)
+    var q = start
+    var scanned = 0
+    while q > 0, scanned < neighbourScanCap {
+      while q > 0, isWhitespace(ns.character(at: q - 1)) { q -= 1 }
+      guard q > 0 else { break }
+      while q > 0, !isWhitespace(ns.character(at: q - 1)) { q -= 1 }
+      scanned += 1
+      // TWO. The last token is already closed on its right by `start`, so one complete token in
+      // front of it is what puts its LEFT boundary inside the window.
+      guard scanned >= 2,
+        Self.splitWords(ns.substring(with: NSRange(location: q, length: start - q))).count >= 2
+      else { continue }
+      break
+    }
+    let head = ns.substring(with: NSRange(location: q, length: start - q))
+    // `splitWords(head).last` and "the head trimmed of trailing whitespace is empty" are the two
+    // questions the whole-head read answered, and asking `splitWords` for BOTH is what keeps the
+    // pair consistent: a non-empty token is returned only when `splitWords` found one, so
+    // `headIsBlank == false` always carries a token whose `.last` exists.
+    if let last = Self.splitWords(head).last, !last.isEmpty { return (last, false) }
+    return ("", true)
   }
 
   static func gluedRunIsOnlyPunctuation(_ ns: NSString, _ from: Int, _ to: Int) -> Bool {

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -405,7 +405,9 @@ public struct InverseTextNormalizer: Sendable {
     let trailAndPat = #"^\s+and\s+(?:"# + Self.numwordAlt + #"|\d)"#  // number-word OR digit endpoint
     t = reSub(betweenPat, t) { m in
       let end = m.result.range.location + m.result.range.length
-      if firstMatch(trailAndPat, Self.tailWindow(m.ns, end)) != nil { return nil }
+      // No readable neighbour = no conversion (see `neighbourScanCap`).
+      guard let after = Self.tailWindow(m.ns, end) else { return nil }
+      if firstMatch(trailAndPat, after) != nil { return nil }
       guard let r = rng(m.g("a") ?? "", m.g("b") ?? "") else { return nil }
       return " between \(r) "
     }
@@ -439,7 +441,8 @@ public struct InverseTextNormalizer: Sendable {
       // all-ones AND no unit noun after (so "one by one inch" stays a real dimension). "two by
       // two", "three by three", or any >=10 are dimensions and convert.
       let end = m.result.range.location + m.result.range.length
-      let nxtAfter = Self.clean(Self.splitWords(Self.tailWindow(m.ns, end)).first ?? "")
+      guard let afterBy = Self.tailWindow(m.ns, end) else { return nil }
+      let nxtAfter = Self.clean(Self.splitWords(afterBy).first ?? "")
       if Set(legs) == [1], !Self.unitNouns.contains(nxtAfter) { return nil }
       return " " + legs.map { comma($0) }.joined(separator: " by ") + " "
     }
@@ -467,7 +470,7 @@ public struct InverseTextNormalizer: Sendable {
       let tailAnd = String(repeating: " and", count: trailAnd)
       let start = m.result.range.location
       let end = start + m.result.range.length
-      let after = Self.tailWindow(m.ns, end)
+      guard let after = Self.tailWindow(m.ns, end) else { return nil }
       let toksAfter = Self.splitWords(after)
       let nxt = toksAfter.first ?? ""
       let nxtCap = nxt.first?.isUppercase ?? false
@@ -502,7 +505,7 @@ public struct InverseTextNormalizer: Sendable {
         if shout {
           capsConvert = true
         } else {
-          let prevW = Self.lastTokenBefore(m.ns, start).token
+          guard let prevW = Self.lastTokenBefore(m.ns, start)?.token else { return nil }
           if capsw(prevW) || capsw(nxt) { return nil }  // part of an all-caps Title -> leave
           capsConvert = true  // isolated caps number = emphasis -> convert
         }
@@ -511,7 +514,7 @@ public struct InverseTextNormalizer: Sendable {
         if noninitialCap { return nil }  // "One Million Moms"
         if firstCap && single && nxtCap { return nil }  // brand "Hundred Acre Wood","Forty Niners"
         if firstCap {
-          let before = Self.lastTokenBefore(m.ns, start)
+          guard let before = Self.lastTokenBefore(m.ns, start) else { return nil }
           let sentinel: Set<Character> = [".", "!", "?", "\n", "\"", "'", "(", "["]
           let sentenceInitial = before.headIsBlank || sentinel.contains(before.token.last!)
           if !sentenceInitial { return nil }  // capitalized mid-sentence, ambiguous -> spelled
@@ -1194,10 +1197,15 @@ public struct InverseTextNormalizer: Sendable {
   // actually reads are the ones the whole text would have given. Surrogates are not whitespace
   // under either rule, so a cut can never land inside a pair.
   //
-  // `neighbourScanCap` bounds the growth. Reaching it needs text that is mostly combining marks
-  // sitting against whitespace, which dictation does not produce, and the behaviour there is the
-  // OLD short-window behaviour: a guard that cannot see its neighbour declines to convert, so the
-  // cap fails SAFE (a number stays spelled) exactly like `runIsCleanlyPaired`'s walk ceiling.
+  // `neighbourScanCap` bounds the growth, and hitting it returns `nil` rather than a short window.
+  // A short window is NOT the safe answer, because these guards are mostly PROTECTIONS: the
+  // all-caps title guard declines when the previous token is all-caps, and the brand guard
+  // declines when the next token is capitalized. Hand either of them an empty neighbour and the
+  // protection simply does not fire, so a capped read CONVERTS what the whole text preserved —
+  // measured on a lead of 33 combining marks, where "NASA … TWELVE times" turned into "12" and
+  // "Twenty … Niners" into "20". `nil` means "I could not see the neighbour", every caller
+  // declines on it, and the number stays spelled, which is the direction `runIsCleanlyPaired`'s
+  // walk ceiling already fails in.
   //
   // One shape stays linear in the take and cannot be helped here: text with no whitespace at all
   // ("twenty/twenty/twenty/…") is ONE token, so the window is the rest of the take. Speech
@@ -1218,7 +1226,7 @@ public struct InverseTextNormalizer: Sendable {
   /// inside token 1 sees the same following character (the boundary that ended the token) as it
   /// would in the full text. There is no character cap — a cap could cut a token in half and
   /// change what `clean` compares against, and a token is short in real dictation.
-  static func tailWindow(_ ns: NSString, _ end: Int) -> String {
+  static func tailWindow(_ ns: NSString, _ end: Int) -> String? {
     let n = ns.length
     guard end < n else { return "" }
     var i = end
@@ -1237,7 +1245,12 @@ public struct InverseTextNormalizer: Sendable {
       else { continue }
       break
     }
-    return ns.substring(with: NSRange(location: end, length: i - end))
+    let window = ns.substring(with: NSRange(location: end, length: i - end))
+    // `i == n` means the scan ran out of TEXT, not out of budget: the window is the whole tail and
+    // is complete however few tokens it holds. Anything else that stopped short of three tokens
+    // stopped on the cap, and cannot answer what the caller is about to ask.
+    guard i == n || Self.splitWords(window).count >= 3 else { return nil }
+    return window
   }
 
   /// The last `splitWords` token before `start`, plus whether NOTHING but whitespace precedes it —
@@ -1248,7 +1261,7 @@ public struct InverseTextNormalizer: Sendable {
   /// trimming trailing whitespace empties a head exactly when it holds no token). When
   /// `headIsBlank` is false the token is non-empty and its LAST character is the last character
   /// of that trimmed head, which is the sentence-boundary sentinel the cardinal pass tests.
-  static func lastTokenBefore(_ ns: NSString, _ start: Int) -> (token: String, headIsBlank: Bool) {
+  static func lastTokenBefore(_ ns: NSString, _ start: Int) -> (token: String, headIsBlank: Bool)? {
     var q = start
     var scanned = 0
     while q > 0, scanned < neighbourScanCap {
@@ -1264,11 +1277,16 @@ public struct InverseTextNormalizer: Sendable {
       break
     }
     let head = ns.substring(with: NSRange(location: q, length: start - q))
+    let tokens = Self.splitWords(head)
+    // `q == 0` means the scan ran out of TEXT: the window IS the whole head. Otherwise a window
+    // holding fewer than two tokens stopped on the cap, and its last token may be cut by the
+    // window's own left edge rather than by real whitespace.
+    guard q == 0 || tokens.count >= 2 else { return nil }
     // `splitWords(head).last` and "the head trimmed of trailing whitespace is empty" are the two
     // questions the whole-head read answered, and asking `splitWords` for BOTH is what keeps the
     // pair consistent: a non-empty token is returned only when `splitWords` found one, so
     // `headIsBlank == false` always carries a token whose `.last` exists.
-    if let last = Self.splitWords(head).last, !last.isEmpty { return (last, false) }
+    if let last = tokens.last, !last.isEmpty { return (last, false) }
     return ("", true)
   }
 
@@ -1730,7 +1748,9 @@ public struct InverseTextNormalizer: Sendable {
     t = reSub(scalePat, t) { m in
       let sword = (m.g("s") ?? "").lowercased()
       // fraction guard: "a thousandth of a second" is 1/1000, not the 1,000th -> leave spelled.
-      let afterScale = Self.tailWindow(m.ns, m.result.range.location + m.result.range.length)
+      guard
+        let afterScale = Self.tailWindow(m.ns, m.result.range.location + m.result.range.length)
+      else { return nil }
       if firstMatch(#"^\s+of\b"#, afterScale) != nil { return nil }
       let n: Int
       if let lead = m.g("lead") {

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -405,7 +405,7 @@ public struct InverseTextNormalizer: Sendable {
     let trailAndPat = #"^\s+and\s+(?:"# + Self.numwordAlt + #"|\d)"#  // number-word OR digit endpoint
     t = reSub(betweenPat, t) { m in
       let end = m.result.range.location + m.result.range.length
-      if firstMatch(trailAndPat, m.ns.substring(from: end)) != nil { return nil }
+      if firstMatch(trailAndPat, Self.tailWindow(m.ns, end)) != nil { return nil }
       guard let r = rng(m.g("a") ?? "", m.g("b") ?? "") else { return nil }
       return " between \(r) "
     }
@@ -439,7 +439,7 @@ public struct InverseTextNormalizer: Sendable {
       // all-ones AND no unit noun after (so "one by one inch" stays a real dimension). "two by
       // two", "three by three", or any >=10 are dimensions and convert.
       let end = m.result.range.location + m.result.range.length
-      let nxtAfter = Self.clean(Self.splitWords(m.ns.substring(from: end)).first ?? "")
+      let nxtAfter = Self.clean(Self.splitWords(Self.tailWindow(m.ns, end)).first ?? "")
       if Set(legs) == [1], !Self.unitNouns.contains(nxtAfter) { return nil }
       return " " + legs.map { comma($0) }.joined(separator: " by ") + " "
     }
@@ -467,7 +467,7 @@ public struct InverseTextNormalizer: Sendable {
       let tailAnd = String(repeating: " and", count: trailAnd)
       let start = m.result.range.location
       let end = start + m.result.range.length
-      let after = m.ns.substring(from: end)
+      let after = Self.tailWindow(m.ns, end)
       let toksAfter = Self.splitWords(after)
       let nxt = toksAfter.first ?? ""
       let nxtCap = nxt.first?.isUppercase ?? false
@@ -502,7 +502,7 @@ public struct InverseTextNormalizer: Sendable {
         if shout {
           capsConvert = true
         } else {
-          let prevW = Self.splitWords(m.ns.substring(to: start)).last ?? ""
+          let prevW = Self.lastTokenBefore(m.ns, start).token
           if capsw(prevW) || capsw(nxt) { return nil }  // part of an all-caps Title -> leave
           capsConvert = true  // isolated caps number = emphasis -> convert
         }
@@ -511,10 +511,9 @@ public struct InverseTextNormalizer: Sendable {
         if noninitialCap { return nil }  // "One Million Moms"
         if firstCap && single && nxtCap { return nil }  // brand "Hundred Acre Wood","Forty Niners"
         if firstCap {
-          var before = m.ns.substring(to: start)
-          while let last = before.last, last.isWhitespace { before.removeLast() }
+          let before = Self.lastTokenBefore(m.ns, start)
           let sentinel: Set<Character> = [".", "!", "?", "\n", "\"", "'", "(", "["]
-          let sentenceInitial = before.isEmpty || sentinel.contains(before.last!)
+          let sentenceInitial = before.headIsBlank || sentinel.contains(before.token.last!)
           if !sentenceInitial { return nil }  // capitalized mid-sentence, ambiguous -> spelled
         }
       }
@@ -1169,6 +1168,64 @@ public struct InverseTextNormalizer: Sendable {
     return horizontalWhitespaceSet.contains(scalar)
   }
 
+  // MARK: - Bounded neighbour reads (Sentry `inverse_normalization_timeout`)
+  //
+  // A callback that asks "what follows this match" by taking `ns.substring(from: end)` copies
+  // — and `splitWords` then tokenizes — EVERY remaining character of the transcript. The
+  // cardinal pass fires once per number-word run, so that is O(text) work per match and
+  // O(text x matches) per call: quadratic in a long numeric dictation, which is how a pure-CPU
+  // regex chain that is milliseconds on a sentence reaches the step's 0.5s `withDeadline` and
+  // reports `inverse_normalization_timeout`. The two helpers below answer the same questions by
+  // SCANNING utf-16 units to a token boundary and materializing only that, so the cost is the
+  // length of the neighbouring tokens rather than the length of the rest of the take.
+  //
+  // Both use `isWhitespace` — the Unicode White_Space property spelled out in `whitespaceSet` —
+  // which is the same boundary `splitWords` (`Character.isWhitespace`) splits on. That equality
+  // is what makes these drop-in: the caller keeps running the identical `splitWords` /
+  // `firstMatch` / `.first` / `.last` logic, just over a window instead of the whole tail.
+  // Surrogates are not whitespace under either rule, so a cut can never land inside a pair.
+
+  /// The text from `end` through the end of its SECOND whitespace-delimited token — the window
+  /// every "what follows this match" reader in this file stays inside.
+  ///
+  /// TWO tokens, because that is the deepest any caller looks: the cardinal pass reads
+  /// `toksAfter[1]` for a unit with a modifier ("two square miles") and for an age period
+  /// ("two years old"). Leading whitespace is preserved so an anchored `^\s+...` probe and a
+  /// `.first == "-"` glue test read exactly what they read on the full tail.
+  ///
+  /// Truncating at a token boundary cannot change an answer: a reader that wants token 1 or 2
+  /// gets it whole, `count >= 2` is decided identically, and a `\b` closing an anchored probe
+  /// inside token 1 sees the same following character (the boundary that ended the token) as it
+  /// would in the full text. There is no character cap — a cap could cut a token in half and
+  /// change what `clean` compares against, and a token is short in real dictation.
+  static func tailWindow(_ ns: NSString, _ end: Int) -> String {
+    let n = ns.length
+    guard end < n else { return "" }
+    var i = end
+    for _ in 0..<2 {
+      while i < n, isWhitespace(ns.character(at: i)) { i += 1 }
+      guard i < n else { break }
+      while i < n, !isWhitespace(ns.character(at: i)) { i += 1 }
+    }
+    return ns.substring(with: NSRange(location: end, length: i - end))
+  }
+
+  /// The last whitespace-delimited token before `start`, plus whether NOTHING but whitespace
+  /// precedes it — the two things a "what came before this match" reader in this file asks.
+  ///
+  /// `token` is `splitWords(everythingBefore).last ?? ""`, and `headIsBlank` is what
+  /// `everythingBefore` trimmed of trailing whitespace answers to `isEmpty`. When `headIsBlank`
+  /// is false the token is non-empty and its LAST character is the last character of that
+  /// trimmed head, which is the sentence-boundary sentinel the cardinal pass tests.
+  static func lastTokenBefore(_ ns: NSString, _ start: Int) -> (token: String, headIsBlank: Bool) {
+    var p = start
+    while p > 0, isWhitespace(ns.character(at: p - 1)) { p -= 1 }
+    guard p > 0 else { return ("", true) }
+    var q = p
+    while q > 0, !isWhitespace(ns.character(at: q - 1)) { q -= 1 }
+    return (ns.substring(with: NSRange(location: q, length: p - q)), false)
+  }
+
   static func gluedRunIsOnlyPunctuation(_ ns: NSString, _ from: Int, _ to: Int) -> Bool {
     guard from < to else { return true }
     let glued = ns.substring(with: NSRange(location: from, length: to - from))
@@ -1627,7 +1684,7 @@ public struct InverseTextNormalizer: Sendable {
     t = reSub(scalePat, t) { m in
       let sword = (m.g("s") ?? "").lowercased()
       // fraction guard: "a thousandth of a second" is 1/1000, not the 1,000th -> leave spelled.
-      let afterScale = m.ns.substring(from: m.result.range.location + m.result.range.length)
+      let afterScale = Self.tailWindow(m.ns, m.result.range.location + m.result.range.length)
       if firstMatch(#"^\s+of\b"#, afterScale) != nil { return nil }
       let n: Int
       if let lead = m.g("lead") {

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
@@ -40,15 +40,11 @@ private let midSentenceLead = "Then he said that "
 /// 2. Every guard that reads a neighbour decides the same way with a long take around it as it
 ///    does alone — the case the old whole-tail read paid for and a too-small window breaks.
 ///
-/// Claim 2 is asserted as an INVARIANT (`long` extends `short`) rather than against baked
-/// output, so these tests pin the property under test and cannot drift into a second, weaker
-/// copy of the parity fixture. The handful of exact outputs at the end are the oracle's own
-/// rows, re-run with a long tail attached.
+/// Claim 1 is this suite, and it is a DRIFT GUARD: an unbounded window still produces the
+/// right text, just slowly, so nothing here is safety for the user. Claim 2 is the product
+/// outcome and lives in `InverseTextNormalizerLongTakeConversionTests` below.
+@Suite("ITN neighbour reads stay bounded (#2758)", .tags(.driftGuard))
 struct InverseTextNormalizerNeighbourWindowTests {
-
-  private static let itn = InverseTextNormalizer()
-
-  // MARK: - 1. The window is bounded
 
   /// The invariant the timeout fix rests on: text beyond the second token cannot make the
   /// window any bigger, so the per-match cost stops tracking the length of the take.
@@ -118,8 +114,21 @@ struct InverseTextNormalizerNeighbourWindowTests {
     let ns = "\(head)\(tail)" as NSString
     #expect(InverseTextNormalizer.tailWindow(ns, (head as NSString).length) == window)
   }
+}
 
-  // MARK: - 2. Every neighbour-reading guard decides the same way
+/// Bounding the neighbour reads changed nothing about what the ITN passes DECIDE: a take with
+/// numbers in it comes back formatted the same way whether it stands alone or sits inside a
+/// long dictation. When this fails the user is pasted a phone number, date, currency amount or
+/// measurement left in spoken form.
+///
+/// Claim 2 is asserted as an INVARIANT (`long` extends `short`) rather than against baked
+/// output, so these tests pin the property under test and cannot drift into a second, weaker
+/// copy of the parity fixture. The exact outputs in the last test are the oracle's own rows,
+/// re-run with a long tail attached.
+@Suite("ITN converts the same inside a long take (#2758)", .tags(.productOutcome))
+struct InverseTextNormalizerLongTakeConversionTests {
+
+  private static let itn = InverseTextNormalizer()
 
   /// One row per guard that reads across the match boundary. Each is normalized alone and
   /// again with `inertTail` appended; since the padding adds no match of its own, a correct
@@ -182,7 +191,7 @@ struct InverseTextNormalizerNeighbourWindowTests {
     #expect(long.hasSuffix(short))
   }
 
-  // MARK: - 3. The oracle's own rows, re-run with a long tail
+  // MARK: - The oracle's own rows, re-run with a long tail
 
   /// A prefix invariant proves the window did not change the decision; these pin what that
   /// decision IS, so a window failure cannot hide behind two identically-wrong outputs. Every

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
@@ -68,7 +68,7 @@ struct InverseTextNormalizerNeighbourWindowTests {
   func lastTokenBeforeIsBounded() {
     let lead = String(repeating: sentenceLead, count: 500) + "roughly"
     let ns = "\(lead) twenty miles" as NSString
-    let before = InverseTextNormalizer.lastTokenBefore(ns, (lead as NSString).length)
+    let before = try! #require(InverseTextNormalizer.lastTokenBefore(ns, (lead as NSString).length))
 
     #expect(before.token == "roughly")
     #expect(before.headIsBlank == false)
@@ -93,7 +93,7 @@ struct InverseTextNormalizerNeighbourWindowTests {
     ] as [(head: String, blank: Bool, token: String)])
   func lastTokenBeforeMatchesWholeHead(head: String, blank: Bool, token: String) {
     let ns = "\(head)twenty" as NSString
-    let got = InverseTextNormalizer.lastTokenBefore(ns, (head as NSString).length)
+    let got = try! #require(InverseTextNormalizer.lastTokenBefore(ns, (head as NSString).length))
     #expect(got.headIsBlank == blank)
     #expect(got.token == token)
   }
@@ -123,11 +123,15 @@ struct InverseTextNormalizerNeighbourWindowTests {
       " \u{1F1FA}\u{1F1F8} square miles",
       " e\u{0301}clair square miles",
       " \u{200D} square miles",
+      // U+0600 is Prepend: Swift joins it to the FOLLOWING character, so a scan that stops on the
+      // space after it would end its window inside a cluster.
+      " square miles\u{0600} out later",
+      " square \u{0600} miles out",
     ])
   func windowKeepsTheFirstTwoTokens(tail: String) {
     let head = "twenty"
     let ns = "\(head)\(tail)" as NSString
-    let window = InverseTextNormalizer.tailWindow(ns, (head as NSString).length)
+    let window = try! #require(InverseTextNormalizer.tailWindow(ns, (head as NSString).length))
     #expect(
       Array(InverseTextNormalizer.splitWords(window).prefix(2))
         == Array(InverseTextNormalizer.splitWords(tail).prefix(2)))
@@ -142,10 +146,11 @@ struct InverseTextNormalizerNeighbourWindowTests {
       "", "   ", "\n\n", "He said.", "He said. ", "He said.\n", "(", "a NASA ",
       "He said. \u{0301} ", "NASA \u{0301} ", "x\u{0301} ", " \u{0301}\u{0301} ",
       "He said.\u{00A0}", "one\r\ntwo ", "\u{0301}", "he said e\u{0301}clair ",
+      "NASA\u{0600} ", "he said\u{0600}NASA ",
     ])
   func headMatchesTheWholeHead(head: String) {
     let ns = "\(head)twenty" as NSString
-    let got = InverseTextNormalizer.lastTokenBefore(ns, (head as NSString).length)
+    let got = try! #require(InverseTextNormalizer.lastTokenBefore(ns, (head as NSString).length))
     var trimmed = head
     while let last = trimmed.last, last.isWhitespace { trimmed.removeLast() }
     #expect(got.headIsBlank == trimmed.isEmpty)
@@ -169,6 +174,36 @@ struct InverseTextNormalizerNeighbourWindowTests {
     let head = "twenty"
     let ns = "\(head)\(tail)" as NSString
     #expect(InverseTextNormalizer.tailWindow(ns, (head as NSString).length) == window)
+  }
+
+  /// The cap is a REFUSAL, and that is the half a short window cannot deliver. These guards are
+  /// protections — the all-caps title guard and the brand guard both DECLINE on what they see —
+  /// so an empty neighbour makes the protection silently not fire and converts what the whole
+  /// text preserved. Refusing instead is also the only assertion here that a whole-text
+  /// implementation could not pass, so it is what pins the read as bounded at all.
+  @Test("a neighbour the scan cannot reach is refused, not answered short")
+  func capRefusesRatherThanAnsweringShort() {
+    let gap = String(repeating: " \u{0301}", count: InverseTextNormalizer.neighbourScanCap + 1)
+    let head = "Twenty"
+    let tailNS = "\(head)\(gap) Niners arrived" as NSString
+    #expect(InverseTextNormalizer.tailWindow(tailNS, (head as NSString).length) == nil)
+
+    let lead = "NASA\(gap) "
+    let headNS = "\(lead)TWELVE times" as NSString
+    #expect(InverseTextNormalizer.lastTokenBefore(headNS, (lead as NSString).length) == nil)
+  }
+
+  /// And the refusal reaches the user as the SAFE outcome: the number the whole-text read
+  /// preserved is still preserved, rather than converted by a guard that saw nothing.
+  @Test(
+    "a number whose neighbour is out of reach stays spelled",
+    arguments: ["Twenty%@ Niners arrived", "NASA%@ TWELVE times"])
+  func capKeepsTheNumberSpelled(template: String) {
+    let gap = String(repeating: " \u{0301}", count: InverseTextNormalizer.neighbourScanCap + 1)
+    let input = template.replacingOccurrences(of: "%@", with: gap)
+    let got = InverseTextNormalizer().normalize(input, spokenPunctuation: false)
+    #expect(!got.contains("20"))
+    #expect(!got.contains("12"))
   }
 }
 

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
@@ -202,8 +202,9 @@ struct InverseTextNormalizerNeighbourWindowTests {
     let gap = String(repeating: " \u{0301}", count: InverseTextNormalizer.neighbourScanCap + 1)
     let input = template.replacingOccurrences(of: "%@", with: gap)
     let got = InverseTextNormalizer().normalize(input, spokenPunctuation: false)
-    #expect(!got.contains("20"))
-    #expect(!got.contains("12"))
+    // Whole-text equality, not just "no digits": a refusal that DELETED the number, or corrupted
+    // the text around it, would satisfy a negative check and is not what refusing means.
+    #expect(got == input)
   }
 }
 

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
@@ -48,16 +48,18 @@ struct InverseTextNormalizerNeighbourWindowTests {
 
   /// The invariant the timeout fix rests on: text beyond the second token cannot make the
   /// window any bigger, so the per-match cost stops tracking the length of the take.
-  @Test("tailWindow size is set by the next two tokens, not by the length of the take")
+  @Test("tailWindow size is set by the next few tokens, not by the length of the take")
   func tailWindowIsBounded() {
     let head = "we counted twenty"
     let short = "\(head) miles out"
     let long = "\(head) miles out\(inertTail)"
     let end = (head as NSString).length
 
+    // A tail with nothing past its own two tokens stops at the end of the text.
     #expect(InverseTextNormalizer.tailWindow(short as NSString, end) == " miles out")
-    #expect(InverseTextNormalizer.tailWindow(long as NSString, end) == " miles out")
-    // The tail the old read copied, and `splitWords` then tokenized, on every match.
+    // 15 characters of window against a take of more than fifteen THOUSAND — and the padding is
+    // what the old read copied, and `splitWords` then tokenized, on every single match.
+    #expect(InverseTextNormalizer.tailWindow(long as NSString, end) == " miles out plus")
     #expect((long as NSString).length > 15_000)
   }
 
@@ -96,6 +98,60 @@ struct InverseTextNormalizerNeighbourWindowTests {
     #expect(got.token == token)
   }
 
+  /// The equivalence the whole thing rests on, checked against the whole-text read it replaced
+  /// rather than against baked values.
+  ///
+  /// `splitWords` asks `Character.isWhitespace`, which classifies a whole GRAPHEME CLUSTER by its
+  /// FIRST scalar, so a combining mark sitting against a space is whitespace to it and a token to
+  /// a scalar scan. An earlier draft of `tailWindow` scanned scalars and stopped a token short on
+  /// exactly that input, which cost `"it covers two \u{0301} square miles"` its conversion.
+  @Test(
+    "the window's first two tokens are the whole tail's first two tokens",
+    arguments: [
+      "",
+      " ",
+      " miles",
+      " square miles out",
+      "-year-old boy now",
+      " of a second",
+      " and one hundred more",
+      " \u{0301} square miles",
+      " \u{0301}\u{0301} square miles out",
+      "\u{0301} square miles out",
+      "\r\n square miles out",
+      "\u{00A0}square\u{2028}miles out",
+      " \u{1F1FA}\u{1F1F8} square miles",
+      " e\u{0301}clair square miles",
+      " \u{200D} square miles",
+    ])
+  func windowKeepsTheFirstTwoTokens(tail: String) {
+    let head = "twenty"
+    let ns = "\(head)\(tail)" as NSString
+    let window = InverseTextNormalizer.tailWindow(ns, (head as NSString).length)
+    #expect(
+      Array(InverseTextNormalizer.splitWords(window).prefix(2))
+        == Array(InverseTextNormalizer.splitWords(tail).prefix(2)))
+    // The anchored `^\s+...` probes and the `.first == "-"` glue test read from the very start.
+    #expect(window.first == tail.first)
+  }
+
+  /// The head side of the same equivalence, against the same oracle.
+  @Test(
+    "lastTokenBefore reports the whole head's last token and its blankness",
+    arguments: [
+      "", "   ", "\n\n", "He said.", "He said. ", "He said.\n", "(", "a NASA ",
+      "He said. \u{0301} ", "NASA \u{0301} ", "x\u{0301} ", " \u{0301}\u{0301} ",
+      "He said.\u{00A0}", "one\r\ntwo ", "\u{0301}", "he said e\u{0301}clair ",
+    ])
+  func headMatchesTheWholeHead(head: String) {
+    let ns = "\(head)twenty" as NSString
+    let got = InverseTextNormalizer.lastTokenBefore(ns, (head as NSString).length)
+    var trimmed = head
+    while let last = trimmed.last, last.isWhitespace { trimmed.removeLast() }
+    #expect(got.headIsBlank == trimmed.isEmpty)
+    #expect(got.token == (InverseTextNormalizer.splitWords(head).last ?? ""))
+  }
+
   /// The leading gap is kept, because the anchored probes that read the window
   /// (`^\s+and\s+...`, `^\s+of\b`) and the `.first == "-"` glue test all start at `end`. A
   /// tail with fewer than two tokens degrades to exactly what the whole-tail read gave.
@@ -105,8 +161,8 @@ struct InverseTextNormalizerNeighbourWindowTests {
       ("", ""),
       (" ", " "),
       ("-year-old", "-year-old"),
-      (" of a second", " of a"),
-      (" and one hundred", " and one"),
+      (" of a second", " of a second"),
+      (" and one hundred", " and one hundred"),
       (" miles", " miles"),
     ] as [(tail: String, window: String)])
   func tailWindowShapes(tail: String, window: String) {
@@ -189,6 +245,16 @@ struct InverseTextNormalizerLongTakeConversionTests {
     let long = Self.itn.normalize(
       String(repeating: lead, count: 300) + input, spokenPunctuation: false)
     #expect(long.hasSuffix(short))
+  }
+
+  /// A combining mark between a number and the unit noun that anchors it is whitespace to
+  /// `splitWords`, so the unit is still the neighbour the AP rule reads and the number still
+  /// becomes a figure.
+  @Test("a combining mark beside a number does not cost it its conversion")
+  func combiningMarkKeepsTheConversion() {
+    let got = Self.itn.normalize("it covers two \u{0301} square miles", spokenPunctuation: false)
+    #expect(got.contains("2"))
+    #expect(!got.contains("two"))
   }
 
   // MARK: - The oracle's own rows, re-run with a long tail

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerNeighbourWindowTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// Inert padding: no number word, ordinal, unit noun, age period, month, or connector this
+/// file reacts to, and no `.!?` (so `applyPunct`'s sentence-capitalization pass cannot touch its
+/// first letter and change the text under the comparisons below). Appending it must extend a take
+/// without adding a single match of its own.
+private let inertTail = String(
+  repeating: " plus the discussion kept going quite a while longer afterwards", count: 300)
+
+/// Sentence-initial inert lead: ends on `. `, so a match placed after it is still
+/// sentence-initial however many times the unit repeats. Already capitalized, so `applyPunct`
+/// leaves every copy alone.
+private let sentenceLead = "This is prior context. "
+
+/// Mid-sentence inert lead: ends on an ordinary word, so a match placed after it is NOT
+/// sentence-initial. Also already capitalized, for the same reason.
+private let midSentenceLead = "Then he said that "
+
+/// The neighbour reads the ITN passes make around a match are BOUNDED, and bounding them
+/// changed nothing about what those passes decide.
+///
+/// Why this exists: the cardinal pass fires once per number-word run and used to answer
+/// "what follows this match" with `ns.substring(from: end)` — a copy, then a `splitWords`
+/// tokenization, of every remaining character of the take. That is O(text) per match and so
+/// O(text x matches) per call, quadratic in a long numeric dictation, which is how a chain
+/// that costs milliseconds on a sentence reaches `InverseTextNormalizationStep`'s 0.5s
+/// `withDeadline` and reports `inverse_normalization_timeout` (Sentry, v2.4.8, macOS 26.6.2).
+/// `tailWindow` / `lastTokenBefore` answer the same questions from the neighbouring TOKENS.
+///
+/// The parity fixture cannot cover this on its own: `parity.jsonl` rows are single sentences,
+/// so their tails are already short and a window that is too small would still pass every one
+/// of them. What needs proving here is the pair of claims parity does not reach:
+///
+/// 1. The window really is bounded — its size tracks the neighbouring tokens, NOT the rest of
+///    the take. That is the whole complexity claim, asserted structurally rather than with a
+///    wall clock (which would be flaky in CI and says nothing on a fast machine anyway).
+/// 2. Every guard that reads a neighbour decides the same way with a long take around it as it
+///    does alone — the case the old whole-tail read paid for and a too-small window breaks.
+///
+/// Claim 2 is asserted as an INVARIANT (`long` extends `short`) rather than against baked
+/// output, so these tests pin the property under test and cannot drift into a second, weaker
+/// copy of the parity fixture. The handful of exact outputs at the end are the oracle's own
+/// rows, re-run with a long tail attached.
+struct InverseTextNormalizerNeighbourWindowTests {
+
+  private static let itn = InverseTextNormalizer()
+
+  // MARK: - 1. The window is bounded
+
+  /// The invariant the timeout fix rests on: text beyond the second token cannot make the
+  /// window any bigger, so the per-match cost stops tracking the length of the take.
+  @Test("tailWindow size is set by the next two tokens, not by the length of the take")
+  func tailWindowIsBounded() {
+    let head = "we counted twenty"
+    let short = "\(head) miles out"
+    let long = "\(head) miles out\(inertTail)"
+    let end = (head as NSString).length
+
+    #expect(InverseTextNormalizer.tailWindow(short as NSString, end) == " miles out")
+    #expect(InverseTextNormalizer.tailWindow(long as NSString, end) == " miles out")
+    // The tail the old read copied, and `splitWords` then tokenized, on every match.
+    #expect((long as NSString).length > 15_000)
+  }
+
+  /// Same claim on the other side: text further back than the previous token is never read.
+  @Test("lastTokenBefore size is set by the previous token, not by the length of the take")
+  func lastTokenBeforeIsBounded() {
+    let lead = String(repeating: sentenceLead, count: 500) + "roughly"
+    let ns = "\(lead) twenty miles" as NSString
+    let before = InverseTextNormalizer.lastTokenBefore(ns, (lead as NSString).length)
+
+    #expect(before.token == "roughly")
+    #expect(before.headIsBlank == false)
+    #expect(ns.length > 10_000)
+  }
+
+  /// `lastTokenBefore` collapses the two questions the old whole-head read answered: `token`
+  /// is `splitWords(head).last ?? ""`, and `headIsBlank` is whether the head trimmed of
+  /// trailing whitespace is empty — so when it is not, `token.last` is that trimmed head's
+  /// last character, which is the sentence-boundary sentinel the cardinal pass tests.
+  @Test(
+    "lastTokenBefore reproduces the whole-head read",
+    arguments: [
+      ("", true, ""),
+      ("   ", true, ""),
+      ("\n\n", true, ""),
+      ("He said.", false, "said."),
+      ("He said. ", false, "said."),
+      ("He said.\n", false, "said."),
+      ("(", false, "("),
+      ("a NASA", false, "NASA"),
+    ] as [(head: String, blank: Bool, token: String)])
+  func lastTokenBeforeMatchesWholeHead(head: String, blank: Bool, token: String) {
+    let ns = "\(head)twenty" as NSString
+    let got = InverseTextNormalizer.lastTokenBefore(ns, (head as NSString).length)
+    #expect(got.headIsBlank == blank)
+    #expect(got.token == token)
+  }
+
+  /// The leading gap is kept, because the anchored probes that read the window
+  /// (`^\s+and\s+...`, `^\s+of\b`) and the `.first == "-"` glue test all start at `end`. A
+  /// tail with fewer than two tokens degrades to exactly what the whole-tail read gave.
+  @Test(
+    "tailWindow preserves the leading gap and handles a short tail",
+    arguments: [
+      ("", ""),
+      (" ", " "),
+      ("-year-old", "-year-old"),
+      (" of a second", " of a"),
+      (" and one hundred", " and one"),
+      (" miles", " miles"),
+    ] as [(tail: String, window: String)])
+  func tailWindowShapes(tail: String, window: String) {
+    let head = "twenty"
+    let ns = "\(head)\(tail)" as NSString
+    #expect(InverseTextNormalizer.tailWindow(ns, (head as NSString).length) == window)
+  }
+
+  // MARK: - 2. Every neighbour-reading guard decides the same way
+
+  /// One row per guard that reads across the match boundary. Each is normalized alone and
+  /// again with `inertTail` appended; since the padding adds no match of its own, a correct
+  /// window makes the long output the short one with the padding carried through verbatim.
+  ///
+  /// A window too small to reach the deciding neighbour flips exactly one of these and breaks
+  /// the prefix — which is the failure the old whole-tail read bought at O(text) per match.
+  @Test(
+    "a neighbour-reading guard decides the same buried in a long take as it does alone",
+    arguments: [
+      // AP unit-noun anchor: forces digits below the spell-out threshold (reads token 1).
+      "I walked two miles",
+      // unit with a modifier (reads token 2).
+      "it covers two square miles",
+      // age period (reads token 2).
+      "she is five years old",
+      // hyphenated age compound (anchored probe inside token 1).
+      "a five-year-old boy",
+      // unit inside a hyphenated compound (splits token 1 on "-").
+      "a five-foot-tall person",
+      // no anchor at all: AP spells it out, and the padding must not change that.
+      "I walked two blocks",
+      // capitalized mid-sentence is ambiguous and stays spelled (reads the previous token).
+      "the Forty Niners won",
+      // all-caps title guard, which reads the previous token (this take is not shout: the
+      // padding is lowercase either way, so the shout branch is not what is being compared).
+      "TWELVE ANGRY MEN screened tonight",
+      // "by" idiom guard (reads token 1 after the match) ...
+      "go one by one",
+      // ... and the same shape with a unit noun after it, which IS a dimension.
+      "a one by one inch tile",
+      // "between A and B" declines when a trailing "and <number>" means a truncated endpoint.
+      "between one hundred and five and one hundred and ten",
+      // scale-ordinal fraction guard (anchored "of" probe) ...
+      "a thousandth of a second",
+      // ... and without the "of", the ordinal.
+      "the thousandth visitor",
+    ])
+  func guardDecidesTheSameWithALongTail(input: String) {
+    let alone = Self.itn.normalize(input, spokenPunctuation: false)
+    let buried = Self.itn.normalize(input + inertTail, spokenPunctuation: false)
+    #expect(buried == alone + inertTail)
+  }
+
+  /// The head side of the same claim. Repeating an inert lead moves the match further from the
+  /// start of the take without changing the token immediately before it, so every guard that
+  /// reads backwards must reach the same verdict and leave the same suffix.
+  @Test(
+    "a neighbour-reading guard decides the same after a long lead as after a short one",
+    arguments: [
+      "Twenty people came",  // sentence-initial capital vs capitalized mid-sentence
+      "TWELVE ANGRY MEN screened tonight",  // all-caps title guard reads the previous token
+      "I said TWELVE times",  // isolated all-caps number, same guard, other verdict
+      "two miles per hour",
+    ], [sentenceLead, midSentenceLead])
+  func guardDecidesTheSameAfterALongLead(input: String, lead: String) {
+    let short = Self.itn.normalize(lead + input, spokenPunctuation: false)
+    let long = Self.itn.normalize(
+      String(repeating: lead, count: 300) + input, spokenPunctuation: false)
+    #expect(long.hasSuffix(short))
+  }
+
+  // MARK: - 3. The oracle's own rows, re-run with a long tail
+
+  /// A prefix invariant proves the window did not change the decision; these pin what that
+  /// decision IS, so a window failure cannot hide behind two identically-wrong outputs. Every
+  /// pair here is a row of `parity.jsonl` (the Python oracle's baked output).
+  @Test(
+    "oracle rows still convert correctly with a long tail attached",
+    arguments: [
+      ("two miles per hour", "2 miles per hour"),
+      ("she is five years old", "she is 5 years old"),
+      ("two square miles", "2 square miles"),
+      ("a five-year-old boy", "a 5-year-old boy"),
+      ("a five-foot-tall person", "a 5-foot-tall person"),
+      ("the Forty Niners won", "the Forty Niners won"),
+      ("go one by one", "go one by one"),
+      ("a thousandth of a second", "a thousandth of a second"),
+      (
+        "between one hundred and five and one hundred and ten",
+        "between one hundred and five and one hundred and ten"
+      ),
+    ] as [(input: String, expected: String)])
+  func oracleRowsWithALongTail(input: String, expected: String) {
+    #expect(Self.itn.normalize(input, spokenPunctuation: true) == expected)
+    #expect(
+      Self.itn.normalize(input + inertTail, spokenPunctuation: true)
+        == expected + inertTail)
+  }
+}


### PR DESCRIPTION
Fixes #2758.

## Summary

The ITN limb's 0.5s `withDeadline` fired once in production (Sentry `inverse_normalization_timeout`,
v2.4.8, macOS 26.6.2), so that take was pasted with its numbers unformatted — every number, date, phone
number, currency amount and time left in spoken form, and the deterministic floor that protects a
polish-disabled take gone with them.

The cause is a whole-text neighbour read. Callbacks answered "what is next to this match" with
`m.ns.substring(from: end)` / `m.ns.substring(to: start)` and then ran `splitWords` over the result — a
copy AND a tokenization of every remaining character of the take, to read at most two tokens. The cardinal
pass fires once per number-word run, so that is O(text) per match and O(text x matches) per call.

**On the field data the curve is LINEAR, not quadratic, and the fix is still the right one.**
`dictation.completed` carries the ITN fields; over 30 days of production, 98,909 takes across 827 people,
`itn_latency_ms` doubles per doubling of `itn_len_before` — because `matches` counts spoken-number runs
and ordinary dictation is not number-dense. The synthetic table below is number-dense by construction, so
it shows the code's true complexity and NOT the shape users produce. What justifies shipping is the margin
at the top end: of the 23 takes at or above 16 KB in a month, p95 ITN latency is 346.7 ms against a 500 ms
budget on a machine faster than the slowest supported Mac, and the failure is total rather than degraded
when it lands. Full analysis in #2758.

Characters copied out of the take plus tokens allocated by `splitWords`, over the cardinal matches of a
generated numeric dictation — the code's complexity, not the fleet's:

| take | matches | chars copied | tokens allocated |
|---|---|---|---|
| 6 KB | 161 | 499,828 | 91,442 |
| 25 KB | 650 | 8,056,825 | 1,475,925 |
| 100 KB | 2,600 | 129,142,300 | 23,648,700 |

## Changes

- **`InverseTextNormalizer.swift`** — two bounded helpers, `tailWindow` and `lastTokenBefore`, that answer
  the same questions from the NEIGHBOURING TOKENS. Cost becomes the length of those tokens rather than the
  length of the rest of the take.
  - **The scan proposes and `splitWords` disposes.** A utf-16 scan against the Unicode White_Space property
    is NOT the boundary `splitWords` uses: `splitWords` asks `Character.isWhitespace`, which classifies a
    whole grapheme CLUSTER by its FIRST scalar, so a combining mark against a space joins the space's
    cluster and is whitespace to Swift while a scalar scan calls it a token. Measured: on
    `"it covers two \u{0301} square miles"` the whole tail splits to `["square", "miles"]` and a two-token
    scalar window yields only `["square"]`, so the cardinal pass stops seeing the unit noun and leaves
    "two" spelled. Each helper therefore grows its window by scalar-token steps and hands the candidate
    back to `splitWords` itself, stopping once `splitWords` reports enough COMPLETE tokens — three for the
    tail (so the two a caller reads are each closed by a whitespace run inside the window, which also
    covers a Prepend scalar continuing a cluster across the window edge), two for the head (its last token
    is already closed on the right by the match).
  - Growth is bounded by `neighbourScanCap`, and hitting it returns `nil` rather than a short window.
    **A short window is not the safe answer**, because these guards are mostly PROTECTIONS: the all-caps
    title guard declines when the previous token is all-caps, the brand guard declines when the next token
    is capitalized. Hand either an empty neighbour and the protection simply does not fire, so a capped
    read CONVERTS what the whole text preserved — reproduced on a 33-mark gap, where "NASA … TWELVE times"
    became "12" and "Twenty … Niners" became "20". `nil` means "I could not see the neighbour"; **all six
    call sites decline on it** and the number stays spelled, which is the direction
    `runIsCleanlyPaired`'s walk ceiling already fails in.
  - The cap bounds token STEPS, not characters: one step can still cross a long token or a long whitespace
    run. The claim is bounded token-step growth, not a fixed character or time bound.
  - Applied at the six sites that read the whole head or tail. The two remaining whole-head reads
    (`isBareURLUtterance`, `normalizeGarbledHTTPSPrefix`) genuinely ask about the entire lead and fire only
    on rare URL matches — left alone. The URL passes at lines 819-881 already use fixed-length windows.
  - **Scope, stated:** this removes the neighbour-read term, not every length term. `normalize` still
    restores protected spans with one whole-string pass per span, and `SnippetExpander` / `EmojiRestorer`
    have the same shape. Those fire on rare matches where the cardinal pass fires once per number-word
    run, so they are filed as **#2759** rather than widened into this change. One further limit is
    documented in the helper: a take with no whitespace at all ("twenty/twenty/twenty/...") is one token,
    so the window is the rest of it. Speech arrives with spaces; that is a property of the input.
- **`InverseTextNormalizationStep.swift`** — stamp the instant the deadline's operation closure actually
  starts. `withDeadline` is a first-claim race on a shared executor and its budget is spent from the
  caller's clock, so a take still queued for a cooperative thread burns the same 0.5s a slow `normalize`
  does, and `latency_ms` reads ~500 either way (#1946 measured that dependence for the ordered siblings).
  The breadcrumb now carries `engine_started` and `queue_wait_ms`, so the next occurrence says which of the
  two it was. **A coherence guard sits on the pair:** `operationTask.cancel()` cannot stop a synchronous
  body from being scheduled, so a closure the timer already beat can still enter and stamp itself. The
  stamp is compared against the BUDGET, not against `latency_ms` — `latency_ms` is the caller's own resume
  time and overshoots the budget under load, so a closure entering at 600 ms would clear an 800 ms
  `latency_ms` and be reported as having been running when the timer won, which it was not.
  `deadlineSeconds` is named once and feeds the `withDeadline` call, the `TimeoutError` and this
  comparison, so the three cannot drift. **`latency_ms - queue_wait_ms` is NOT engine execution time** and
  the comment no longer says it is; timing the engine needs a stamp at the timer's own decision, which is
  inside `withDeadline`. **The fingerprint is untouched** —
  `handledErrorFingerprint` is built from category, error descriptor, optional detail and environment, and
  `extra` never enters it — so this stays the same Sentry issue.
- **`InverseTextNormalizerNeighbourWindowTests.swift`** — new file, two suites; see below.

## Why the existing tests do not cover this

`parity.jsonl` + `parity_holdout.jsonl` (6,120 oracle rows) are the behavior gate and stay green, but their
rows are single sentences: their tails are already short, so a window too small to reach the deciding
neighbour would pass every one of them. Two suites close that gap, split on what they actually protect:

**`InverseTextNormalizerNeighbourWindowTests` (`.driftGuard`)** — an unbounded window still produces the
right text, only slower, so nothing here is safety for the user.
1. The window is bounded, asserted structurally (window size tracks the neighbouring tokens, not the take),
   not on a wall clock, which would be flaky in CI and says nothing on a fast machine.
2. Both helpers are pinned against the WHOLE-TEXT read they replaced rather than against baked values,
   over combining marks, CRLF, NBSP, U+2028, a regional-indicator pair, ZWJ, a precomposed-versus-
   decomposed accent, and a Prepend scalar (U+0600, which Swift joins to the FOLLOWING character). That is
   the pair of tests that catches the segmentation defect above.
3. Past the cap both helpers return `nil`, and the number comes back still spelled. That `nil` assertion
   is the only one in the file a whole-text implementation could not also pass, so it is what pins the
   read as bounded at all.

**`InverseTextNormalizerLongTakeConversionTests` (`.productOutcome`)** — when this fails the user is pasted
a phone number, date, currency amount or measurement left in spoken form.
1. Every neighbour-reading guard decides the same way buried in a long take as it does alone: each is
   normalized alone and again with inert padding, asserting the long output extends the short one. Stated
   as an invariant rather than against baked output, so the suite pins the property under test instead of
   becoming a second, weaker copy of the parity fixture.
2. A handful of `parity.jsonl` rows are re-run with a long tail attached, so a window failure cannot hide
   behind two identically-wrong outputs.

Separately, the 8 tail reads and 3 head reads were modelled against their whole-text originals and fuzzed
over 300,000 randomized strings drawn from the punctuation, hyphen-compound, non-BMP and unusual-whitespace
shapes these guards see. **That fuzz did not include a combining mark adjacent to whitespace**, which is
the shape that broke, so it is reported here as the coverage it was rather than as a proof of equivalence.

## Verification

Run on this Mac (M4 Pro, macOS 26.6.2), Debug lane, `scripts/xcode-test.sh`:

- Full suite: **7457 tests in 665 suites, PASS**, including `InverseTextNormalizerParityTests` (6,120
  oracle rows) and both new suites.
- `TestInventoryFreezeTests` green: both new suites declare a class tag.

**Live UAT** on the dev build (`scripts/build-dev-app.sh` — build, strict signature verify, launch, no
crash). Ambient control first: a silent 6.67 s probe logged `No speech detected`, so the room was quiet.
The take:

```
CORRECTION_DEBUG [Inverse Text Normalization] IN:  Miles to the side that covers two square miles near two zero three nine five four eight eight seven nine.
CORRECTION_DEBUG [Inverse Text Normalization] OUT: Miles to the side that covers 2 square miles near 203-954-8879.
```

`two square miles` → `2 square miles` is the TOKEN-2 read — the cardinal pass reads `toksAfter[1]`
("miles") to decide a unit-with-modifier, and that read now comes from `tailWindow`. It is one of the six
changed sites. The spoken phone number converting is the issue's headline example. `LLM Polish` reported
`no change`, so this is ITN's own output reaching the user. The recognizer dropped the sentence's opening,
which is the recognizer and not the path under test; the verdict is the log block, because the harness's
`Transcription:` field prints RAW ASR and a token ITN itself produces can never satisfy its content check
(`RULE: uat-verdicts-from-app-log`). Artifacts in `.validation/runs/20260909-184012-6390eace/`.

Codex review (`gpt-6-astra`), five rounds, ending in an explicit **ALL-CLEAR**. Round 1 found the segmentation defect and the breadcrumb
ordering defect. Round 2 found that the first repair's scan cap answered SHORT where it had to refuse, and
compiled both reproductions; the fix for that enumerates the class — every consumer of either helper
guards on `nil` — rather than patching the two reported cases. Round 3 is the confirming re-run. The
Round 4 found one comment sentence asserting something the code cannot establish (the timer's decision
instant is not observable from the step), and round 5 confirmed clean. The pre-existing quadratics in
`InverseTextNormalizer`'s protected-span restoration, `SnippetExpander` and `EmojiRestorer` are filed as
#2759.

## Pre-Merge Checklist

### Build Verification
- [x] Logic tests pass locally (`scripts/xcode-test.sh`) — `InverseTextNormalizerParityTests` and both new
      suites included
- [x] Dev build passes locally (`scripts/build-dev-app.sh`, Xcode/Tuist engine)
- [x] CI `build-check` status is green

### Behavioral Testing (Local UAT)
- [x] App rebuilt and relaunched
- [x] Smoke test of the core dictation flow (record -> transcribe -> paste) on a numeric take, with a
      silent ambient control run first

### Code Quality
- [x] Commits follow conventional commit format (`type(scope): message`)
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed from FluidAudio/WhisperKit/AVFoundation

### Polish Eval
Not applicable — no change under `Sources/EnviousWisprLLM/`, `CustomWordsManager.swift`, or `scripts/eval/`.

### Release Housekeeping
Not applicable — not targeting a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
