### PR TITLE
feat(pipeline): transcribe a file you already have (#2648)

### DIFF
--- a/Sources/EnviousWisprASR/AudioFileDecoder.swift
+++ b/Sources/EnviousWisprASR/AudioFileDecoder.swift
@@ -28,6 +28,40 @@ import Foundation
 /// length" is published.
 public enum AudioFileDecoder {
 
+  /// A decoded file, plus the facts the Upload step shows about it.
+  ///
+  /// The metadata is read from the SAME asset the samples came from, in the same
+  /// pass, so the line under the file name cannot describe a different file from
+  /// the one about to be transcribed.
+  public struct Decoded: Sendable {
+    public let samples: [Float]
+    /// Length of the source recording, for "1 hr 12 min".
+    public let seconds: Double
+    /// Size on disk, for "68.4 MB".
+    public let byteCount: Int64
+    /// The source codec as macOS reports it, for "AAC".
+    public let codec: String
+    /// The source sample rate, for "44.1 kHz".
+    public let sampleRate: Double
+    /// The source channel count, for "mono" / "stereo".
+    public let channelCount: Int
+
+    /// `public` so a test can build one. The decoder is the only production
+    /// producer; a fixture that had to run a real file through it could not
+    /// exercise the Upload screen's own states.
+    public init(
+      samples: [Float], seconds: Double, byteCount: Int64, codec: String, sampleRate: Double,
+      channelCount: Int
+    ) {
+      self.samples = samples
+      self.seconds = seconds
+      self.byteCount = byteCount
+      self.codec = codec
+      self.sampleRate = sampleRate
+      self.channelCount = channelCount
+    }
+  }
+
   /// Why a file was refused, in the terms a sentence can be written from. Every
   /// case is something the user can act on or at least understand; none of them
   /// is a fallback.
@@ -66,7 +100,7 @@ public enum AudioFileDecoder {
   /// this decoder and to any other. We transcribe what the file contains. A cut
   /// that destroys the header is refused, because the file will not open at all;
   /// a cut that only removes audio is not, because there is nothing to detect.
-  public static func decode(url: URL) async throws -> [Float] {
+  public static func decode(url: URL) async throws -> Decoded {
     let asset = AVURLAsset(url: url)
 
     let tracks: [AVAssetTrack]
@@ -127,7 +161,46 @@ public enum AudioFileDecoder {
     }
 
     guard !samples.isEmpty else { throw Rejection.noAudio }
-    return samples
+
+    // Every field below describes the file for the screen; none of it is used
+    // to transcribe. So each one degrades to a true-but-vague value rather than
+    // failing the import: a track that reports no format description still gets
+    // transcribed, it just describes itself as "audio".
+    //
+    // `formatDescriptions` is typed `[Any]`, so the cast is unavoidable, and it
+    // is `as!` on purpose: the conditional form does not compile here, because
+    // Swift rejects `as?` to a CoreFoundation type as a downcast that ALWAYS
+    // SUCCEEDS ("conditional downcast to CoreFoundation type
+    // 'CMAudioFormatDescription' will always succeed"). The compiler is
+    // asserting the cast cannot fail; a defensive `as?` would be dead code the
+    // build refuses.
+    let format = tracks.first?.formatDescriptions.first as! CMAudioFormatDescription?
+    let basic = format.flatMap(CMAudioFormatDescriptionGetStreamBasicDescription)
+    let byteCount = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64
+    return Decoded(
+      samples: samples,
+      seconds: Double(samples.count) / AudioConstants.sampleRate,
+      byteCount: byteCount ?? 0,
+      codec: format.map(Self.codecName(for:)) ?? "audio",
+      sampleRate: basic?.pointee.mSampleRate ?? AudioConstants.sampleRate,
+      channelCount: Int(basic?.pointee.mChannelsPerFrame ?? 1))
+  }
+
+  /// The source codec's four-character type, rendered the way a person names it.
+  ///
+  /// A short table rather than a general decoder: these are the formats the
+  /// Upload step advertises, and an unknown one falls back to a word that is
+  /// true of every file that reaches here rather than to a code nobody reads.
+  private static func codecName(for description: CMAudioFormatDescription) -> String {
+    switch CMFormatDescriptionGetMediaSubType(description) {
+    case kAudioFormatMPEG4AAC, kAudioFormatMPEG4AAC_HE, kAudioFormatMPEG4AAC_HE_V2: return "AAC"
+    case kAudioFormatMPEGLayer3: return "MP3"
+    case kAudioFormatLinearPCM: return "PCM"
+    case kAudioFormatAppleLossless: return "ALAC"
+    case kAudioFormatFLAC: return "FLAC"
+    case kAudioFormatOpus: return "Opus"
+    default: return "audio"
+    }
   }
 
   /// Copies one sample buffer's audio into `samples`.

--- a/Sources/EnviousWisprASR/AudioFileDecoder.swift
+++ b/Sources/EnviousWisprASR/AudioFileDecoder.swift
@@ -121,11 +121,25 @@ public enum AudioFileDecoder {
       throw Rejection.unreadable
     }
 
+    // **ONE track, not all of them.** `AVAssetReaderAudioMixOutput` MIXES every
+    // track it is given into the single mono stream. A film or a recorded call
+    // routinely carries several audio programs — an alternate language, a
+    // commentary, a descriptive-audio track — and mixing them hands the engine
+    // two people talking over each other in different languages, which is not
+    // something a transcript can recover from. The first track is what every
+    // player treats as the main program, and it is what the user hears when they
+    // open the file. Found by cloud review.
+    //
+    // A user who wants a different track has no way to say so yet, and that is a
+    // real limitation rather than a hidden one: the alternative on offer was
+    // mixing all of them, which is worse in every case including this one.
+    let chosenTrack = tracks.prefix(1)
+
     // The conversion is the READER's job, not a second pass of ours: these
     // settings make every source format arrive already downmixed to mono and
     // resampled to the rate the engines take.
     let output = AVAssetReaderAudioMixOutput(
-      audioTracks: tracks,
+      audioTracks: Array(chosenTrack),
       audioSettings: [
         AVFormatIDKey: kAudioFormatLinearPCM,
         AVSampleRateKey: AudioConstants.sampleRate,

--- a/Sources/EnviousWisprASR/AudioFileDecoder.swift
+++ b/Sources/EnviousWisprASR/AudioFileDecoder.swift
@@ -133,7 +133,15 @@ public enum AudioFileDecoder {
     // A user who wants a different track has no way to say so yet, and that is a
     // real limitation rather than a hidden one: the alternative on offer was
     // mixing all of them, which is worse in every case including this one.
-    let chosenTrack = tracks.prefix(1)
+    // **Enabled first, then first.** Track ORDER is not the asset's playback
+    // selection: a movie can carry a disabled commentary, descriptive-audio or
+    // alternate-language track ahead of the main program, and `prefix(1)` would
+    // hand the engine the commentary. `isEnabled` is the flag a player reads to
+    // decide what you hear on opening the file. Falling back to the first track
+    // keeps a file whose tracks are all marked disabled working rather than
+    // refusing it. Found by cloud review, one round after the mixing finding
+    // this replaced.
+    let chosenTrack = [tracks.first(where: \.isEnabled) ?? tracks[0]]
 
     // The conversion is the READER's job, not a second pass of ours: these
     // settings make every source format arrive already downmixed to mono and

--- a/Sources/EnviousWisprASR/AudioFileDecoder.swift
+++ b/Sources/EnviousWisprASR/AudioFileDecoder.swift
@@ -1,0 +1,157 @@
+import AVFoundation
+import EnviousWisprCore
+import Foundation
+
+/// #2648 — turns a file the user picked into the samples the ASR engines already
+/// take: 16 kHz, mono, `Float32`.
+///
+/// **The one genuinely new thing this feature needs is an audio input that is
+/// not the microphone.** Everything downstream of ASR already exists. A file has
+/// failure modes a live microphone does not — an unsupported codec, a corrupt
+/// container, a video with no audio track, a zero-byte file — and the founder's
+/// audio priority order puts a plain honest sentence on each of them rather than
+/// a fallback.
+///
+/// **`AVAssetReader`, not `AVAudioFile`.** `BenchmarkSuite.loadAudioFile` is the
+/// existing decode in this repo and it is the wrong shape here for two reasons.
+/// It reads the WHOLE file into memory at the SOURCE format before converting,
+/// which for a 3-hour 48 kHz stereo recording is gigabytes; and `AVAudioFile`
+/// cannot open a video container at all, while "any audio or video file macOS
+/// can decode" is the feature's stated scope. `AVAssetReader` handles both, and
+/// its output settings do the downmix and resample as it goes, so the file is
+/// read once and converted in the same pass.
+///
+/// **What it still holds in memory is the RESULT**, at 16 kHz mono float: about
+/// 230 MB per hour of audio, so roughly 690 MB for the three-hour case named as a
+/// ship criterion on #2648. That number is measured arithmetic, not a measured
+/// run; the three-hour run with peak memory recorded is still owed before "any
+/// length" is published.
+public enum AudioFileDecoder {
+
+  /// Why a file was refused, in the terms a sentence can be written from. Every
+  /// case is something the user can act on or at least understand; none of them
+  /// is a fallback.
+  public enum Rejection: Error, Equatable, Sendable {
+    /// Nothing at that path, or the file cannot be opened at all.
+    case unreadable
+    /// The file opened and carries no audio: a Keynote deck, a video-only clip,
+    /// an image. The one case a person is most likely to hit by mistake.
+    case noAudioTrack
+    /// The file has an audio track that decodes to nothing — a zero-length
+    /// recording, or a truncated file whose audio never starts.
+    case noAudio
+    /// The decoder started and then failed. Carries the underlying reason for
+    /// the log, never for the user.
+    case decodeFailed(String)
+  }
+
+  /// Decodes `url` to 16 kHz mono `Float32`, in one pass.
+  ///
+  /// Cancellation is cooperative and checked once per read: a user who presses
+  /// Stop during a long decode stops paying for it, and the partial result is
+  /// discarded rather than returned, because half a recording transcribed as if
+  /// it were the whole one is worse than no result.
+  ///
+  /// **A TRUNCATED FILE IS NOT DETECTABLE HERE, and a guard for it was built and
+  /// then removed.** The intuition was that a cut file still declares its
+  /// original length, so declared duration and decoded samples would disagree.
+  /// Measured on a 3-second 16 kHz WAV cut to a third of its bytes:
+  /// `AVAsset.load(.duration)` returned **0.957 s** and the decode returned
+  /// **15,317 samples**, which is 0.957 s. AVFoundation derives the duration
+  /// from the bytes that are present, so the two agree by construction and no
+  /// threshold between them can ever fire.
+  ///
+  /// What that means for the user is worth stating plainly rather than guarding:
+  /// **a truncated recording is indistinguishable from a shorter recording**, to
+  /// this decoder and to any other. We transcribe what the file contains. A cut
+  /// that destroys the header is refused, because the file will not open at all;
+  /// a cut that only removes audio is not, because there is nothing to detect.
+  public static func decode(url: URL) async throws -> [Float] {
+    let asset = AVURLAsset(url: url)
+
+    let tracks: [AVAssetTrack]
+    do {
+      tracks = try await asset.loadTracks(withMediaType: .audio)
+    } catch {
+      // A missing file, an unreadable one and an unsupported container all
+      // arrive here. They are one sentence to the user either way: we could not
+      // read this file.
+      throw Rejection.unreadable
+    }
+    guard !tracks.isEmpty else { throw Rejection.noAudioTrack }
+
+    let reader: AVAssetReader
+    do {
+      reader = try AVAssetReader(asset: asset)
+    } catch {
+      throw Rejection.unreadable
+    }
+
+    // The conversion is the READER's job, not a second pass of ours: these
+    // settings make every source format arrive already downmixed to mono and
+    // resampled to the rate the engines take.
+    let output = AVAssetReaderAudioMixOutput(
+      audioTracks: tracks,
+      audioSettings: [
+        AVFormatIDKey: kAudioFormatLinearPCM,
+        AVSampleRateKey: AudioConstants.sampleRate,
+        AVNumberOfChannelsKey: 1,
+        AVLinearPCMBitDepthKey: 32,
+        AVLinearPCMIsFloatKey: true,
+        AVLinearPCMIsBigEndianKey: false,
+        AVLinearPCMIsNonInterleaved: false,
+      ])
+    guard reader.canAdd(output) else { throw Rejection.decodeFailed("reader_rejected_output") }
+    reader.add(output)
+    guard reader.startReading() else {
+      throw Rejection.decodeFailed(reader.error.map(String.init(describing:)) ?? "start_failed")
+    }
+
+    var samples: [Float] = []
+    while let buffer = output.copyNextSampleBuffer() {
+      try Task.checkCancellation()
+      appendSamples(from: buffer, into: &samples)
+      CMSampleBufferInvalidate(buffer)
+    }
+
+    switch reader.status {
+    case .completed:
+      break
+    case .failed, .cancelled, .reading, .unknown:
+      // A truncated file ends here rather than at `.completed`. Refuse rather
+      // than return what was read: a partial transcript presented as a whole one
+      // is the failure this feature must not have.
+      throw Rejection.decodeFailed(reader.error.map(String.init(describing:)) ?? "read_incomplete")
+    @unknown default:
+      throw Rejection.decodeFailed("unknown_reader_status")
+    }
+
+    guard !samples.isEmpty else { throw Rejection.noAudio }
+    return samples
+  }
+
+  /// Copies one sample buffer's audio into `samples`.
+  ///
+  /// The settings above pin the format to non-interleaved mono `Float32`, so
+  /// there is exactly one channel to read and no per-sample conversion to do
+  /// here. A buffer with no data block is skipped rather than treated as an
+  /// error: it is how a decoder reports a gap, not a failure.
+  private static func appendSamples(from buffer: CMSampleBuffer, into samples: inout [Float]) {
+    guard let blockBuffer = CMSampleBufferGetDataBuffer(buffer) else { return }
+    var lengthAtOffset = 0
+    var totalLength = 0
+    var dataPointer: UnsafeMutablePointer<CChar>?
+    guard
+      CMBlockBufferGetDataPointer(
+        blockBuffer, atOffset: 0, lengthAtOffsetOut: &lengthAtOffset,
+        totalLengthOut: &totalLength, dataPointerOut: &dataPointer) == noErr,
+      let dataPointer
+    else { return }
+
+    let count = totalLength / MemoryLayout<Float>.size
+    guard count > 0 else { return }
+    dataPointer.withMemoryRebound(to: Float.self, capacity: count) { floats in
+      samples.append(contentsOf: UnsafeBufferPointer(start: floats, count: count))
+    }
+  }
+}

--- a/Sources/EnviousWisprASR/AudioFileDecoder.swift
+++ b/Sources/EnviousWisprASR/AudioFileDecoder.swift
@@ -196,7 +196,13 @@ public enum AudioFileDecoder {
     // 'CMAudioFormatDescription' will always succeed"). The compiler is
     // asserting the cast cannot fail; a defensive `as?` would be dead code the
     // build refuses.
-    let format = tracks.first?.formatDescriptions.first as! CMAudioFormatDescription?
+    // **The track we DECODED, not the first one.** Choosing an enabled track
+    // above and then describing `tracks.first` here left the Upload screen
+    // reporting the codec, sample rate and channel count of the disabled
+    // commentary it had just declined to transcribe. Twenty lines apart, in one
+    // function, and found by cloud review rather than by me — which is the twin
+    // question in its purest form.
+    let format = chosenTrack.first?.formatDescriptions.first as! CMAudioFormatDescription?
     let basic = format.flatMap(CMAudioFormatDescriptionGetStreamBasicDescription)
     let byteCount = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64
     return Decoded(

--- a/Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift
+++ b/Sources/EnviousWisprAppKit/App/ActiveEngineOperation.swift
@@ -13,8 +13,11 @@ import EnviousWisprCore
 /// where the gate cannot reach it, and mapping a model whose bytes may still be
 /// moving is exactly what that gate prevents.
 ///
-/// Its two callers are the ones that never went through the normal dictation
-/// doors: crash recovery and the Diagnostics benchmark. Streaming deliberately
+/// Its callers are the ones that never went through the normal dictation doors:
+/// crash recovery, the Diagnostics benchmark, and since #2648 file import, whose
+/// Transcription step lets the user pick All Languages for one recording — a
+/// direct `ASRManager.transcribe` there throws `ASRManagerNotOwnedError`, since
+/// WhisperKit does not live in the manager. Streaming deliberately
 /// stays on the manager — WhisperKit does not stream through it, and the manager
 /// answers `activeBackendSupportsStreaming` false for a backend it does not own.
 @MainActor

--- a/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
@@ -2,6 +2,7 @@
 import EnviousWisprASR
 import EnviousWisprAudio
 import EnviousWisprCore
+import EnviousWisprPipeline
 import Foundation
 
 /// Measures ASR transcription performance across different audio durations.
@@ -46,7 +47,23 @@ final class BenchmarkSuite {
   /// closure triplet.
   let engineMutationScope: EngineMutationScope
 
-  init(engineMutationScope: EngineMutationScope) {
+  /// #2648 — the shared workload lease, so a benchmark cannot run on top of a
+  /// file import.
+  ///
+  /// **`EngineMutationScope` is not this question.** It serialises MUTATIONS —
+  /// loads, unloads, removals — and admits several at once by design; a
+  /// benchmark holding it still calls `ActiveEngineOperation.transcribe` on the
+  /// one inference slot a running import is using, so both decode at once and
+  /// both get slower while the import's progress stops meaning anything. Found
+  /// by cloud review. Two authorities, two questions, and the benchmark was
+  /// asking the wrong one.
+  ///
+  /// Defaults to a free lease so every existing construction and every test is
+  /// unchanged.
+  private let engineLease: EngineLease
+
+  init(engineMutationScope: EngineMutationScope, engineLease: EngineLease = EngineLease()) {
+    self.engineLease = engineLease
     self.engineMutationScope = engineMutationScope
   }
 
@@ -65,9 +82,28 @@ final class BenchmarkSuite {
     }
   }
 
+  /// Takes the shared workload claim, or reports why not and returns nil.
+  private func claimTheEngine(site: String) -> EngineLease.Token? {
+    switch engineLease.admit(.dictation) {
+    case .granted(let token):
+      return token
+    case .refused(let holder):
+      lastFailure =
+        holder == .fileImport
+        ? "A file is being transcribed. Try again when it finishes."
+        : "The engine is busy. Try again in a moment."
+      return nil
+    }
+  }
+
   /// Run ASR benchmarks with the given ASR manager.
   func run(using asrManager: any ASRManagerInterface, activeEngine: ActiveEngineOperation) async {
     guard !isRunning else { return }
+    // Refused rather than queued: a benchmark that waited would report a number
+    // measured against a machine busy doing something else, which is worse than
+    // no number.
+    guard let admission = claimTheEngine(site: "benchmark") else { return }
+    defer { engineLease.release(admission) }
     isRunning = true
     results = []
     lastFailure = nil

--- a/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
+++ b/Sources/EnviousWisprAppKit/App/BenchmarkSuite.swift
@@ -82,28 +82,42 @@ final class BenchmarkSuite {
     }
   }
 
-  /// Takes the shared workload claim, or reports why not and returns nil.
-  private func claimTheEngine(site: String) -> EngineLease.Token? {
+  /// Runs `body` holding the shared workload claim, or reports why not.
+  ///
+  /// **Every benchmark entry point goes through this.** The first version
+  /// claimed inside one of the two and left the other — `runPipelineBenchmark`,
+  /// two methods away — still decoding on top of a running import. A helper
+  /// makes the next entry point's author write one line instead of remembering a
+  /// rule.
+  ///
+  /// Refused rather than queued: a benchmark that waited would report a number
+  /// measured against a machine busy doing something else, which is worse than
+  /// no number.
+  private func withEngineClaim(_ body: () async -> Void) async {
+    let token: EngineLease.Token
     switch engineLease.admit(.dictation) {
-    case .granted(let token):
-      return token
+    case .granted(let granted):
+      token = granted
     case .refused(let holder):
       lastFailure =
         holder == .fileImport
         ? "A file is being transcribed. Try again when it finishes."
         : "The engine is busy. Try again in a moment."
-      return nil
+      return
     }
+    defer { engineLease.release(token) }
+    await body()
   }
 
   /// Run ASR benchmarks with the given ASR manager.
   func run(using asrManager: any ASRManagerInterface, activeEngine: ActiveEngineOperation) async {
     guard !isRunning else { return }
-    // Refused rather than queued: a benchmark that waited would report a number
-    // measured against a machine busy doing something else, which is worse than
-    // no number.
-    guard let admission = claimTheEngine(site: "benchmark") else { return }
-    defer { engineLease.release(admission) }
+    await withEngineClaim { await runBatch(using: asrManager, activeEngine: activeEngine) }
+  }
+
+  private func runBatch(
+    using asrManager: any ASRManagerInterface, activeEngine: ActiveEngineOperation
+  ) async {
     isRunning = true
     results = []
     lastFailure = nil
@@ -142,6 +156,14 @@ final class BenchmarkSuite {
     using asrManager: any ASRManagerInterface, activeEngine: ActiveEngineOperation
   ) async {
     guard !isRunning else { return }
+    await withEngineClaim {
+      await runPipeline(using: asrManager, activeEngine: activeEngine)
+    }
+  }
+
+  private func runPipeline(
+    using asrManager: any ASRManagerInterface, activeEngine: ActiveEngineOperation
+  ) async {
     isRunning = true
     pipelineResult = nil
     // Both entry points clear it. Clearing in `run` alone left a successful

--- a/Sources/EnviousWisprAppKit/App/DiagnosticsCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DiagnosticsCoordinator.swift
@@ -18,4 +18,15 @@ final class DiagnosticsCoordinator {
   init(engineMutationScope: EngineMutationScope) {
     benchmark = BenchmarkSuite(engineMutationScope: engineMutationScope)
   }
+
+  /// #2648 — takes an ALREADY-BUILT suite, so the shared workload lease reaches
+  /// the benchmark without this home learning what a lease is.
+  ///
+  /// The import ceiling refused the obvious version, and correctly: this type
+  /// exists to own the benchmark surface, and threading a pipeline type through
+  /// it to reach the suite is the coupling that cap is there to prevent. The
+  /// composition root holds both already.
+  init(benchmark: BenchmarkSuite) {
+    self.benchmark = benchmark
+  }
 }

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -176,6 +176,18 @@ enum DictationNarrator {
       case (.otherInterruption, false):
         return "Recording interrupted. Text may be cut short."
       }
+    // #2648. Says what the user has to act on: nothing was recorded, and when
+    // to try again. The mechanism is a single inference slot they have never
+    // heard of, so the words name the JOB that is using it instead.
+    case .sharedEngineBusy(let holder):
+      switch holder {
+      case .fileImport:
+        return "A file is being transcribed. Try again when it finishes."
+      case .crashRecovery:
+        return "Finishing an earlier recording. Try again in a moment."
+      case .dictation:
+        return "Already recording."
+      }
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -179,12 +179,21 @@ enum DictationNarrator {
     // #2648. Says what the user has to act on: nothing was recorded, and when
     // to try again. The mechanism is a single inference slot they have never
     // heard of, so the words name the JOB that is using it instead.
+    //
+    // **Length is a constraint, not a preference.** This renders in the 280x44
+    // single-line notification pill (`PillCatalog.swift:210-216`), which
+    // TRUNCATES rather than wrapping. Live UAT on 2026-09-09 showed the first
+    // draft on screen as "A file is being transcribed. Try ag..." — the half
+    // telling the user what to do was the half that got cut. The shipped
+    // neighbours in this same pill top out around 46 characters
+    // ("Microphone disconnected. Text may be cut short."), so these stay under
+    // that. `DictationNarratorTests` holds the ceiling.
     case .sharedEngineBusy(let holder):
       switch holder {
       case .fileImport:
-        return "A file is being transcribed. Try again when it finishes."
+        return "A file is being transcribed. Try again soon."
       case .crashRecovery:
-        return "Finishing an earlier recording. Try again in a moment."
+        return "Finishing an earlier take. Try again soon."
       case .dictation:
         return "Already recording."
       }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -41,6 +41,17 @@ final class DictationLifecycleCoordinator {
   let languageSuggestionPresenter: LanguageSuggestionPresenter?  // 10
   let recordingLockedAccess: RecordingLockedAccess  // 11
 
+  /// #2648 — hands the shared-resource claim back when a session reaches a
+  /// terminal state.
+  ///
+  /// A bare closure, not a package: it is ONE capability, matching how
+  /// `RecordingStarter` stores `beginMinting` / `endMinting`. It is also not a
+  /// collaborator by the ceiling parser's definition, so this home's
+  /// collaborator cap is unchanged at 12 — said out loud rather than left for a
+  /// reader to notice, because the method cap in the same suite DID have to be
+  /// raised for `acceptEngineToken` below.
+  let releaseEngineClaim: @MainActor (EngineLease.Token) -> Void
+
   /// Bidirectional accessor for the hands-free `isRecordingLocked` flag (rehomed
   /// onto `LiveRecordingState` in PR-C.3 of #763). The state-change closure both
   /// READS the lock state (to pass into
@@ -71,6 +82,23 @@ final class DictationLifecycleCoordinator {
   /// #1342: exact-once start/stop sound cue, tracked per backend. `var`, not
   /// `let` — excluded from the collaborator ceiling by design.
   private var recordingSoundCue = RecordingSoundCue()
+
+  /// #2648 — the running session's claim on the shared ASR-and-polish resource,
+  /// handed over by `RecordingStarter` at the moment the session was minted,
+  /// **paired with the backend that minted it**.
+  ///
+  /// It lives here rather than on the start path because both start methods
+  /// RETURN while the recording is still running
+  /// (`RecordingStarter.swift:437-497`, `:610-626`), so a release on the way out
+  /// of `start()` would admit a file import into the middle of a live dictation.
+  /// Owned mutable state, so it is excluded from the collaborator ceiling.
+  ///
+  /// **The backend is stored because both handlers below read the same slot.**
+  /// Without it, a terminal transition published by the backend that is NOT
+  /// running this session releases the running session's claim, and the release
+  /// looks entirely correct at the site that performs it. Found by cloud review
+  /// of this chunk.
+  private var liveEngineToken: (token: EngineLease.Token, backend: LastCapturingBackend)?
 
   /// Cancellable Task for the deferred polish-failed warning overlay. Cancelled
   /// on every new recording start. Shared across both backends because the
@@ -156,7 +184,8 @@ final class DictationLifecycleCoordinator {
     settings: SettingsManager,
     lastRecordingResult: LastRecordingResult,
     languageSuggestionPresenter: LanguageSuggestionPresenter?,
-    recordingLockedAccess: RecordingLockedAccess
+    recordingLockedAccess: RecordingLockedAccess,
+    releaseEngineClaim: @escaping @MainActor (EngineLease.Token) -> Void
   ) {
     self.application = application
     self.kernelDriver = kernelDriver
@@ -170,6 +199,7 @@ final class DictationLifecycleCoordinator {
     self.lastRecordingResult = lastRecordingResult
     self.languageSuggestionPresenter = languageSuggestionPresenter
     self.recordingLockedAccess = recordingLockedAccess
+    self.releaseEngineClaim = releaseEngineClaim
   }
 
   /// Wire the two pipelines' `onStateChange` callbacks. Called once by the
@@ -194,6 +224,21 @@ final class DictationLifecycleCoordinator {
     }
     whisperKitKernelDriver.onSessionEndedWithoutSave = { [weak self] id, ending in
       self?.onRecordingEndedWithoutDurableSave(id, ending)
+    }
+    // #2648: the shared-resource claim comes back on the kernel's ACCEPTED
+    // terminal, not on the published state.
+    //
+    // The published state was the first design and it was wrong in a way that is
+    // reachable today, without file import: an error pinned during finalization
+    // publishes a terminal while the kernel is still finalizing, and crash
+    // recovery — which competes for this same claim — takes it and starts a
+    // replay while the first take is still in the polish server. Found by cloud
+    // review, which also supplied the sequence.
+    kernelDriver.onSessionTerminalAccepted = { [weak self] _ in
+      self?.releaseEngineClaimIfHeld(mintedBy: .parakeet)
+    }
+    whisperKitKernelDriver.onSessionTerminalAccepted = { [weak self] _ in
+      self?.releaseEngineClaimIfHeld(mintedBy: .whisperKit)
     }
     // #930: the overlay-only sub-status channel. A `.transcribing` →
     // `.polishing` flip mid-`.finalizing` does NOT change the public
@@ -496,6 +541,39 @@ final class DictationLifecycleCoordinator {
   /// stale warning from the previous session cannot race the new dictation's
   /// visual feedback. PR10 will inline this when start/stop/cancel migrate
   /// into the recording-state homes; this method retires with it.
+  /// #2648 — takes ownership of this session's claim on the shared resource,
+  /// naming the backend that minted it.
+  ///
+  /// Called once per minted session, by whichever start route minted it. A
+  /// second call before the first session ends would mean two live sessions,
+  /// which the claim itself makes impossible; if it ever happened, the earlier
+  /// token would be dropped rather than released, so it is released here first.
+  func acceptEngineToken(_ token: EngineLease.Token, mintedBy backend: LastCapturingBackend) {
+    if let liveEngineToken { releaseEngineClaim(liveEngineToken.token) }
+    liveEngineToken = (token, backend)
+  }
+
+  /// Hands the claim back on the kernel's ACCEPTED terminal, **and only for the
+  /// backend that minted it**.
+  ///
+  /// Driven from `onSessionTerminalAccepted` for both backends, which fires
+  /// exactly once per take from `finishTerminal`'s own `defer` — after the
+  /// guards, unreachable from a stale or losing terminal, and independent of the
+  /// published state that an external reason can pin early.
+  ///
+  /// The backend check is what keeps two call sites from being worse than one:
+  /// the idle engine reaches terminals too, and an unmatched release hands the
+  /// shared resource away while the running session is still using it.
+  ///
+  /// A repeated or unrelated completion does nothing: the claim is cleared
+  /// before it is handed back, and a token that is not the live one cannot
+  /// release it (`EngineLease.release`).
+  private func releaseEngineClaimIfHeld(mintedBy backend: LastCapturingBackend) {
+    guard let held = liveEngineToken, held.backend == backend else { return }
+    liveEngineToken = nil
+    releaseEngineClaim(held.token)
+  }
+
   func cancelPendingWarning() {
     postCompletionWarningTask?.cancel()
   }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationRuntime.swift
@@ -55,6 +55,11 @@ final class DictationRuntime {
     dictationLifecycleCoordinator: DictationLifecycleCoordinator,
     recoveryCoordinator: RecoveryCoordinator,
     recordingLockedAccess: DictationLifecycleCoordinator.RecordingLockedAccess,
+    // #2648 — passed straight through to `RecordingStarter`, never stored here.
+    // This type owns no arbitration decision; it forwards the one seam the start
+    // path needs so the composition root stays the only place that knows the
+    // shared claim exists.
+    engineAdmission: EngineAdmissionAccess,
     resolveActiveCaptureBackend: @escaping @MainActor () -> DictationLifecycleCoordinator
       .LastCapturingBackend?,
     resolveActiveTelemetryTarget: @escaping @MainActor () -> (any HeartPathTelemetryTarget)?,
@@ -127,6 +132,7 @@ final class DictationRuntime {
       // bare closures, so the starter stays off its collaborator cap and the
       // kernel never sees the coordinator.
       recovery: RecoveryWiring.access(binding: recoveryCoordinator),
+      engineAdmission: engineAdmission,
       // #1171: drive the selected engine to ready before recording, gate a press
       // during an in-flight switch, and hold the start-window state-gate so the
       // coordinator can't switch the engine out mid-startup.

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingStarter.swift
@@ -93,6 +93,20 @@ final class RecordingStarter {
 
   let recovery: RecoveryAccess
 
+  /// #2648 — the shared ASR-and-polish resource, claimed for THIS dictation.
+  ///
+  /// One slot, and the holder is bound at wiring time, so the start path cannot
+  /// claim the resource as anything but a dictation. The starter never sees
+  /// `EngineLease`; `EngineAdmissionAccess` is the same wrapper shape
+  /// `RecoveryEngineClaim` uses over `EngineRecoveryGate`.
+  ///
+  /// This is the eighth `let` collaborator, and the ceiling suite was raised
+  /// from 7 to 8 in the same change. The alternatives were worse: the existing
+  /// `RecoveryAccess` package is recovery's domain, and choosing a bare closure
+  /// purely because the closure bin has room would be picking a shape to satisfy
+  /// a counter rather than to describe the dependency.
+  let engineAdmission: EngineAdmissionAccess
+
   /// #1171 — drives the SELECTED engine to ready (the coordinator owns the
   /// single-flight switch + warm) and returns the outcome (ready / notInstalled /
   /// notReady). Bound to `EngineCoordinator.ensureSelectedReadyForPress`; default
@@ -187,6 +201,30 @@ final class RecordingStarter {
     TelemetryService.shared.recoveryPressBlocked(asrBackend: backend.rawValue)
   }
 
+  /// #2648 — the session-claim hand-off found no lifecycle coordinator.
+  ///
+  /// A fault worth seeing rather than a case to handle quietly: the same shape
+  /// (and the same error type) `HotkeyController` uses for its own nil
+  /// collaborators, so both land in one Sentry group.
+  private static func reportNilCollaborator(callback: String) {
+    SentryBreadcrumb.captureError(
+      HotkeyController.NilCollaboratorError(callback: callback),
+      category: .pipelineDispatchFailed, stage: "recording",
+      extra: ["callback": callback])
+  }
+
+  /// #2648 — every shared-resource refusal read site funnels through here.
+  ///
+  /// **Ordering is load-bearing and it is checked AFTER the recovery gate, not
+  /// before.** Crash recovery holds the same claim while it replays, so a
+  /// lease-first ladder would answer a recovery press with this generic pill
+  /// instead of the recovery notice, which carries a Discard button and is the
+  /// only way out of a stuck replay. Recovery refuses first; whatever reaches
+  /// here is a different workload.
+  private func handleSharedEngineBusyPressRefused(holder: EngineLease.Holder) {
+    recordingOverlay.present(.warning(reason: .sharedEngineBusy(holder: holder)))
+  }
+
   /// Called immediately before a press commits to minting an active kernel
   /// session (every gate, including the recovery one, has already passed).
   /// Consumes any pending blocked-press info and emits the pairing
@@ -218,6 +256,7 @@ final class RecordingStarter {
     dictationLifecycleCoordinator: DictationLifecycleCoordinator?,
     accessibilityRefresh: (@MainActor () -> Void)? = nil,
     recovery: RecoveryAccess,
+    engineAdmission: EngineAdmissionAccess,
     ensureSelectedReadyForPress: @escaping @MainActor () async -> EngineCoordinator.PressReadiness =
       {
         .notReady
@@ -227,6 +266,7 @@ final class RecordingStarter {
     endMinting: @escaping @MainActor () -> Void = {}
   ) {
     self.recovery = recovery
+    self.engineAdmission = engineAdmission
     self.ensureSelectedReadyForPress = ensureSelectedReadyForPress
     self.isEngineSwitching = isEngineSwitching
     self.beginMinting = beginMinting
@@ -281,6 +321,27 @@ final class RecordingStarter {
     if recovery.isRecovering() {
       handleRecoveryPressRefused(backend: backend)
       return .noRecording
+    }
+    // #2648 — the shared ASR-and-polish resource. Claimed HERE, before any
+    // engine work: a refusal must reach the user as a pill at press time, not
+    // after a pre-warm they cannot see the point of. Recovery is refused one
+    // gate above, so a claim that fails here belongs to another workload.
+    let engineToken: EngineLease.Token
+    switch engineAdmission.claim() {
+    case .granted(let token):
+      engineToken = token
+    case .refused(let holder):
+      handleSharedEngineBusyPressRefused(holder: holder)
+      return .noRecording
+    }
+    // Handed to `DictationLifecycleCoordinator` at the moment a session is
+    // minted, and released here on every path that mints nothing. `defer` reads
+    // this variable's FINAL value, so the single assignment at the hand-off
+    // covers every early return between here and there, however many get added
+    // later — which is why the release is not repeated at each one.
+    var unmintedEngineToken: EngineLease.Token? = engineToken
+    defer {
+      if let unmintedEngineToken { engineAdmission.release(unmintedEngineToken) }
     }
     // #1171 — start-of-recording safety: never record on an engine other than the
     // one the user selected (a switch deferred while busy/recovering may not have
@@ -425,6 +486,24 @@ final class RecordingStarter {
       // (held since before preWarm) guarantees the coordinator did NOT switch the
       // active engine across these awaits, so `active` is still the user's choice.
       try await active.handle(event: .toggleRecording(config))
+      // The session is minted, so the claim now belongs to the session rather
+      // than to this call. Both start methods RETURN while the recording is
+      // still running, so releasing on the way out would admit an import into
+      // the middle of a live dictation; the lifecycle coordinator releases it on
+      // the session's single terminal path, after ASR and polish.
+      //
+      // A nil coordinator is a FAULT, not a quiet case: nothing would ever
+      // drive this session to a terminal, so nothing would hand the claim back
+      // and every later press would be refused for a dictation that had already
+      // ended. Leaving the token in `unmintedEngineToken` makes the `defer`
+      // release it on the way out, which costs this session's exclusivity and
+      // keeps the record button working — the right way round for a limb.
+      if let coordinator = dictationLifecycleCoordinator {
+        coordinator.acceptEngineToken(engineToken, mintedBy: isWhisperKit ? .whisperKit : .parakeet)
+        unmintedEngineToken = nil
+      } else {
+        Self.reportNilCollaborator(callback: "acceptEngineToken")
+      }
     } catch {
       heartControlRecovery.recover(
         error: error, op: "toggle-from-prewarm",
@@ -512,6 +591,14 @@ final class RecordingStarter {
     let active: KernelDictationDriver = isWK ? whisperKitKernelDriver : kernelDriver
     let isStartingFromIdle =
       !(isWK ? whisperKitKernelDriver.state.isActive : kernelDriver.state.isActive)
+    // #2648 — held from the claim below until either the mint hands it to the
+    // lifecycle coordinator or this call ends without minting. Declared out here
+    // because the claim happens inside the start-only gate block and the release
+    // has to cover every exit after it.
+    var claimedEngineToken: EngineLease.Token?
+    defer {
+      if let claimedEngineToken { engineAdmission.release(claimedEngineToken) }
+    }
     if isStartingFromIdle {
       // #1063 PR2 — recovery hold, same as the PTT path. A toggle that would START
       // while recovery holds the engine mints no session: show the pill and bail.
@@ -519,6 +606,17 @@ final class RecordingStarter {
       // `isStartingFromIdle`).
       if recovery.isRecovering() {
         handleRecoveryPressRefused(backend: backend)
+        return
+      }
+      // #2648 — the shared-resource claim, same as the PTT path and in the same
+      // position: after recovery, before any engine work. A STOP toggle never
+      // reaches here (guarded by `isStartingFromIdle`), so stopping a recording
+      // is never refused.
+      switch engineAdmission.claim() {
+      case .granted(let token):
+        claimedEngineToken = token
+      case .refused(let holder):
+        handleSharedEngineBusyPressRefused(holder: holder)
         return
       }
       // #1171 — start-of-recording safety, same as the PTT path: never record on
@@ -592,6 +690,19 @@ final class RecordingStarter {
         // NOT switch the active engine, so `active` is still the user's choice.
       }
       try await active.handle(event: .toggleRecording(config))
+      // Minted, so the claim belongs to the session now — same hand-off as the
+      // PTT path, for the same reason: this method returns while the recording
+      // is still running.
+      // Same hand-off, same nil-coordinator fault handling as the PTT path: the
+      // claim is only cleared here when somebody real took ownership of it.
+      if let token = claimedEngineToken {
+        if let coordinator = dictationLifecycleCoordinator {
+          coordinator.acceptEngineToken(token, mintedBy: isWK ? .whisperKit : .parakeet)
+          claimedEngineToken = nil
+        } else {
+          Self.reportNilCollaborator(callback: "acceptEngineToken")
+        }
+      }
       // GitHub cloud review, PR #1732: consume the pending blocked-press info
       // (and emit `recovery.press_unblocked`) only after `handle(event:)`
       // returned WITHOUT throwing AND the pipeline is genuinely active — a

--- a/Sources/EnviousWisprAppKit/App/EngineAdmissionAccess.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineAdmissionAccess.swift
@@ -1,0 +1,43 @@
+import EnviousWisprPipeline
+
+/// #2648 — the narrow seam onto `EngineLease`, so nothing that COMPETES for the
+/// shared ASR-and-polish resource has to know the authority that arbitrates it.
+///
+/// The same shape and the same reason as `RecoveryEngineClaim` wrapping
+/// `EngineRecoveryGate`: the composition root owns the one lease and hands each
+/// participant a pair of closures bound to it.
+///
+/// **The holder is bound at wiring time, not passed at the call site.** A start
+/// path that could name its own holder could claim the resource AS the file
+/// import, and nothing in the type system would notice. Each participant gets an
+/// instance that can only ever claim as itself.
+@MainActor
+struct EngineAdmissionAccess {
+  /// Claims the shared resource for THIS participant. A refusal carries the
+  /// current holder with it, in one answer, so a caller never has to ask a
+  /// second question and invent a fallback when it comes back empty.
+  let claim: @MainActor () -> EngineLease.Admission
+
+  /// Hands the claim back. Only the matching token releases, so a late call from
+  /// an abandoned attempt cannot evict a live one.
+  let release: @MainActor (EngineLease.Token) -> Void
+
+  /// Binds a participant to the one live lease.
+  static func live(lease: EngineLease, as holder: EngineLease.Holder) -> Self {
+    Self(
+      claim: { lease.admit(holder) },
+      release: { lease.release($0) })
+  }
+
+  /// Same structural mitigation as `RecoveryEngineClaim.alwaysAllowedForTesting`
+  /// and `EngineMutationScope.alwaysAllowedForTesting` — zero production
+  /// references, enforced by the same freeze test
+  /// (`EngineMutationInventoryFreezeTests`, test 5).
+  ///
+  /// A test that is not exercising admission gets a claim that always succeeds.
+  /// A test that IS exercising it builds a real `EngineLease` and calls
+  /// `live(lease:as:)`, which is what the record-trigger audit does.
+  internal static let alwaysAllowedForTesting = Self(
+    claim: { EngineLease().admit(.dictation) },
+    release: { _ in })
+}

--- a/Sources/EnviousWisprAppKit/App/EngineAdmissionAccess.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineAdmissionAccess.swift
@@ -22,11 +22,22 @@ struct EngineAdmissionAccess {
   /// an abandoned attempt cannot evict a live one.
   let release: @MainActor (EngineLease.Token) -> Void
 
+  /// Who holds the resource right now, WITHOUT taking it.
+  ///
+  /// **A peek, for refusing early.** File import has to warm the engine the user
+  /// picked before it can claim, and that takes seconds; asking the user to
+  /// watch "Getting the engine ready" and only then telling them a dictation is
+  /// running is a worse answer than telling them at the press. `claim()` is
+  /// still what decides — this only refuses sooner in the case that is already
+  /// certain.
+  let currentHolder: @MainActor () -> EngineLease.Holder?
+
   /// Binds a participant to the one live lease.
   static func live(lease: EngineLease, as holder: EngineLease.Holder) -> Self {
     Self(
       claim: { lease.admit(holder) },
-      release: { lease.release($0) })
+      release: { lease.release($0) },
+      currentHolder: { lease.currentHolder })
   }
 
   /// Same structural mitigation as `RecoveryEngineClaim.alwaysAllowedForTesting`
@@ -39,5 +50,6 @@ struct EngineAdmissionAccess {
   /// `live(lease:as:)`, which is what the record-trigger audit does.
   internal static let alwaysAllowedForTesting = Self(
     claim: { EngineLease().admit(.dictation) },
-    release: { _ in })
+    release: { _ in },
+    currentHolder: { nil })
 }

--- a/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/EngineCoordinator.swift
@@ -64,6 +64,18 @@ final class EngineCoordinator {
     let isEngineActive: @MainActor (ASRBackendType) -> Bool
     /// Whether crash recovery is replaying on the shared engine.
     let isRecovering: @MainActor () -> Bool
+
+    /// #2648 — whether a file import is using the shared engine right now.
+    ///
+    /// A THIRD workload joined the set gate 5 and gate 6 were written for, and
+    /// neither could see it: with both dictation drivers idle and recovery
+    /// false, a switch proceeded and `asrManager.switchBackend` unloaded the
+    /// backend the import's own `transcribe` call was executing on. A 40-minute
+    /// file would fail after decoding. Found by cloud review.
+    ///
+    /// Defaults to "not running" so every existing construction keeps today's
+    /// behaviour rather than silently gaining a new deferral.
+    var isFileImportRunning: @MainActor () -> Bool = { false }
     /// Whether the given engine's model is on disk (gates a load attempt).
     let isInstalled: @MainActor (ASRBackendType) -> Bool
     /// A telemetry label for the given engine's pipeline state.
@@ -344,6 +356,16 @@ final class EngineCoordinator {
     // 6. Crash recovery is replaying on the shared engine — defer to completion.
     if deps.isRecovering() {
       markBlocked(.recovery)
+      return
+    }
+
+    // 6b. #2648 — a file import is using the shared engine. Same reason as gate
+    // 5 and gate 6: switching now unloads the engine underneath work that is
+    // already running. The import releases its claim on every exit, and the
+    // release re-pokes this coordinator, so a switch deferred here applies as
+    // soon as the run ends rather than waiting for another trigger.
+    if deps.isFileImportRunning() {
+      markBlocked(.pipelineActive)
       return
     }
 

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -173,6 +173,15 @@ final class FileImportCoordinator {
 
   func noteSaveSucceeded(fileName: String) { saveMessage = "Saved to \(fileName)." }
 
+  /// Forgets the last save outcome. Called wherever the document is replaced or
+  /// regenerated, because a stale "Saved to Meeting.txt" over words that have
+  /// never been saved is the exact belief that makes a user press New
+  /// transcription and lose them. Found by Codex.
+  private func forgetSaveOutcome() {
+    saveMessage = nil
+    saveFailureDetail = nil
+  }
+
   func noteSaveFailed(_ error: any Error) {
     saveMessage = "That file couldn't be saved. Your words are still here. Try another place."
     saveFailureDetail = String(describing: error)
@@ -362,6 +371,7 @@ final class FileImportCoordinator {
     let generationAtStart = generation
     file = nil
     step = .upload
+    forgetSaveOutcome()
     state = .reading(fileName: name)
     Task { [weak self] in
       guard let self else { return }
@@ -392,7 +402,14 @@ final class FileImportCoordinator {
   private func showRejection(_ reason: FileImportRejection) {
     state = .rejected(reason)
     phase = ""
-    step = .upload
+    // **Where a refusal is READ, and it depends on what the user would lose.**
+    // With no document, Upload is the step that renders a refusal AND offers the
+    // way out of it: another file. With one, Upload offers only the thing that
+    // DESTROYS it — refusing "Clean it again" because a dictation is running
+    // sent the user to a screen from which their finished transcript could not
+    // be copied, saved or retried. Done renders the same refusal beside the
+    // words. Found by Codex.
+    step = hasDocument ? .done : .upload
   }
 
   /// Moves forward through the wizard. Refused once a run is in flight: the
@@ -413,15 +430,21 @@ final class FileImportCoordinator {
     }
   }
 
-  /// Goes back one step. Only ever available while nothing has run.
+  /// Whether there is a document to go back TO. The single fact three of the
+  /// rules below turn on.
+  var hasDocument: Bool { !rawTranscript.isEmpty }
+
+  /// Whether Back is offered right now, so the button is absent rather than
+  /// present and inert.
+  var canGoBack: Bool {
+    guard let previous = Step(rawValue: step.rawValue - 1) else { return false }
+    return canGo(to: previous)
+  }
+
+  /// Goes back one step, if that step is one the user may be on.
   func goBack() {
-    guard !isRunning else { return }
-    switch step {
-    case .upload, .working, .done: break
-    case .transcription: step = .upload
-    case .polish: step = .transcription
-    case .review: step = .polish
-    }
+    guard let previous = Step(rawValue: step.rawValue - 1), canGo(to: previous) else { return }
+    step = previous
   }
 
   /// Takes the user back to the Polish step with the finished document intact.
@@ -436,34 +459,40 @@ final class FileImportCoordinator {
     step = .polish
   }
 
-  /// Whether the step bar may take the user to `target` RIGHT NOW.
+  /// **The ONE answer to "may the user be on this step right now".**
   ///
-  /// **One function, read by both the bar and the jump**, so a step cannot be
-  /// clickable and refuse, or be refused and look clickable. "Earlier than the
-  /// current step" was the whole rule and it let a finished run navigate to
-  /// Working — an inactive progress bar with a Stop button that does nothing and
-  /// no way back to the document — and to Upload, where Continue is refused
-  /// because the state is finished rather than ready. Found by Codex.
-  func canJump(to target: Step) -> Bool {
+  /// Read by the step bar's `disabled`, by `jump(to:)`, by `goBack()` and by
+  /// where a refusal lands. Three separate movers each had their own rule and
+  /// each let the user reach a screen the finished document could not be
+  /// reached from: the bar offered Working after a run, Back walked from Polish
+  /// to Upload where Continue is refused because the state is finished, and a
+  /// refusal sent the user to Upload whose only offer is choosing another file,
+  /// which clears the document. Three findings, three rounds, one cause — so
+  /// this is the rule, and nothing moves `step` without asking it.
+  ///
+  /// **The test that decides every case: can the user get back to their words?**
+  func canGo(to target: Step) -> Bool {
     guard !isRunning, target != step else { return false }
     switch target {
-    // Never: it shows a run in progress, and after one there is none.
+    // Never by navigation: it shows a run in progress, and after one there is
+    // none. `start()` and `rePolish()` are the only ways in.
     case .working: return false
-    // Only ever forward INTO, by finishing a run.
-    case .done: return false
-    // Choosing another file is `startOver()`'s job, reached from Done's own
-    // button, because it also has to clear the document.
-    case .upload: return rawTranscript.isEmpty && step.rawValue > Step.upload.rawValue
-    // The two choice steps stay reachable after a run: picking a different
-    // polisher and cleaning the same words again is a supported thing to do.
+    // **The way back to the document, and the reason the others can be strict.**
+    case .done: return hasDocument
+    // Choosing another file is `startOver()`'s job, because it also has to clear
+    // the document. Offering Upload with a document present is what stranded it.
+    case .upload: return !hasDocument
+    // With a document the choice steps go both ways: picking a different
+    // polisher and returning to the words is a supported thing to do. Without
+    // one, the wizard runs forwards and the bar only goes back.
     case .transcription, .polish, .review:
-      return file != nil && target.rawValue < step.rawValue
+      return file != nil && (hasDocument || target.rawValue < step.rawValue)
     }
   }
 
-  /// Takes the user to `target` if `canJump(to:)` allows it.
+  /// Takes the user to `target` if `canGo(to:)` allows it.
   func jump(to target: Step) {
-    guard canJump(to: target) else { return }
+    guard canGo(to: target) else { return }
     step = target
   }
 
@@ -476,6 +505,7 @@ final class FileImportCoordinator {
     rawTranscript = ""
     decodedSamples = []
     runConfiguration = nil
+    forgetSaveOutcome()
     state = .idle
     step = .upload
   }
@@ -573,6 +603,8 @@ final class FileImportCoordinator {
     generation += 1
     let generationAtStart = generation
     parts = []
+    // The saved words are about to be replaced by different ones.
+    forgetSaveOutcome()
     step = .working
     phase = "Cleaning it up"
 

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -284,8 +284,30 @@ final class FileImportCoordinator {
   // MARK: - Collaborators
 
   private let decode: @Sendable (URL) async throws -> AudioFileDecoder.Decoded
-  private let transcribe: @MainActor ([Float]) async throws -> String
+  /// Returns the words AND the language the engine reported, because the
+  /// cleanup chain's language ladder prefers the engine's own answer over
+  /// identifying one from the text. Reducing this to a bare `String` discarded
+  /// the better source at the only place it existed.
+  private let transcribe: @MainActor ([Float]) async throws -> (
+    text: String, language: String?
+  )
   private let engineAdmission: EngineAdmissionAccess
+
+  /// Stops both engines' pending model-unload timers, and puts the user's
+  /// setting back. **Called as a PAIR, by one `defer`.**
+  ///
+  /// The first version disarmed them in `ensureEngineReady` and re-armed them in
+  /// `onEngineReleased`, which only runs once a lease token has been acquired.
+  /// Every exit before that — the engine not installed, a warm that did not
+  /// take, a Stop landing during the readiness drive, a refusal because
+  /// something else holds the claim — left both timers disarmed for the rest of
+  /// the session, so the user's model-unload setting silently stopped applying.
+  ///
+  /// **Two rounds of cloud review found two different halves of this same
+  /// bracket left undone**, so it is now one `defer` in one place rather than a
+  /// pair of calls that have to be kept in step by remembering.
+  private let disarmEngineTimers: @MainActor () -> Void
+  private let rearmEngineTimers: @MainActor () -> Void
 
   /// Drives the SELECTED speech engine to active-and-warm, and says what
   /// happened. The composition root points this at
@@ -370,7 +392,8 @@ final class FileImportCoordinator {
   /// that Stop changes the screen at once while the claim waits for the work to
   /// exit — cannot be tested at all unless a test can make a part take as long
   /// as it likes.
-  private let processPart: @MainActor (String) async throws -> FileImportRunner.PartOutcome
+  private let processPart:
+    @MainActor (String, String?) async throws -> FileImportRunner.PartOutcome
 
   /// **Generation protects STATE. Terminal completion protects the RESOURCE.**
   /// Neither substitutes for the other, and this coordinator needs both: Stop
@@ -382,18 +405,25 @@ final class FileImportCoordinator {
 
   init(
     decode: @escaping @Sendable (URL) async throws -> AudioFileDecoder.Decoded,
-    transcribe: @escaping @MainActor ([Float]) async throws -> String,
+    transcribe: @escaping @MainActor ([Float]) async throws -> (
+      text: String, language: String?
+    ),
     engineAdmission: EngineAdmissionAccess,
     polishOllamaLocalityNow: @escaping @MainActor () -> Bool? = { false },
     refreshOllamaFacts: @escaping @MainActor () async -> Void = {},
+    disarmEngineTimers: @escaping @MainActor () -> Void = {},
+    rearmEngineTimers: @escaping @MainActor () -> Void = {},
     ensureEngineReady: @escaping @MainActor () async -> EngineReadiness = { .ready },
     onEngineReleased: @escaping @MainActor () -> Void = {},
     beginRun: @escaping @MainActor () -> RunConfiguration,
-    processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome
+    processPart:
+      @escaping @MainActor (String, String?) async throws -> FileImportRunner.PartOutcome
   ) {
     self.polishOllamaLocalityNow = polishOllamaLocalityNow
     self.refreshOllamaFacts = refreshOllamaFacts
     self.ensureEngineReady = ensureEngineReady
+    self.disarmEngineTimers = disarmEngineTimers
+    self.rearmEngineTimers = rearmEngineTimers
     self.onEngineReleased = onEngineReleased
     self.decode = decode
     self.transcribe = transcribe
@@ -672,6 +702,11 @@ final class FileImportCoordinator {
   /// The in-flight read, so replacing or clearing the file can stop it.
   private var decodeTask: Task<Void, Never>?
 
+  /// What the engine said this recording's language was, kept so a re-polish
+  /// uses the same evidence the first run did rather than falling back to
+  /// guessing from the text.
+  private var engineReportedLanguage: String?
+
   /// Runs the import. Claims the shared engine first: a refusal here is a
   /// refusal to start, not a queue.
   func start() {
@@ -693,6 +728,11 @@ final class FileImportCoordinator {
 
     runTask = Task { [weak self] in
       guard let self else { return }
+
+      // **The whole run, inside one bracket.** Nothing below can exit without
+      // the user's model-unload setting being put back.
+      disarmEngineTimers()
+      defer { rearmEngineTimers() }
 
       // 1. The engine the user picked, actually active and actually warm.
       let readiness = await ensureEngineReady()
@@ -801,7 +841,8 @@ final class FileImportCoordinator {
 
   private func run(generationAtStart: Int) async {
     do {
-      let transcript = try await transcribe(decodedSamples)
+      let (transcript, language) = try await transcribe(decodedSamples)
+      engineReportedLanguage = language
       // **The generation guard comes FIRST, before any shared write.** A slow
       // transcription that returns after the user stopped and chose another file
       // belongs to a run nobody is watching; clearing `decodedSamples` on the way
@@ -869,7 +910,7 @@ final class FileImportCoordinator {
     for (index, piece) in pieces.enumerated() {
       if Task.isCancelled || generationAtStart != generation { return }
       do {
-        let outcome = try await processPart(piece)
+        let outcome = try await processPart(piece, engineReportedLanguage)
         // Re-read AFTER the await: a Stop during this part must not write into
         // a run the user has already ended.
         guard generationAtStart == generation else { return }

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -422,7 +422,16 @@ final class FileImportCoordinator {
     step = .upload
     forgetSaveOutcome()
     state = .reading(fileName: name)
-    Task { [weak self] in
+    // **Cancelled, not merely ignored.** The generation check discards a stale
+    // result AFTER the work is done, which is the right answer to "whose file is
+    // this" and no answer at all to "should this still be running". A three-hour
+    // recording decodes to about 690 MB of samples; picking a second file while
+    // the first is reading left both decodes running and both arrays growing,
+    // for a result one of them was always going to throw away. `AudioFileDecoder`
+    // already checks cancellation inside its read loop, so this stops it in the
+    // middle rather than at the end. Found by Codex.
+    decodeTask?.cancel()
+    decodeTask = Task { [weak self] in
       guard let self else { return }
       do {
         let decoded = try await decode(url)
@@ -433,6 +442,8 @@ final class FileImportCoordinator {
           channelCount: decoded.channelCount)
         state = .ready(fileName: name, seconds: decoded.seconds)
         decodedSamples = decoded.samples
+      } catch is CancellationError {
+        // Superseded by another file. The newer decode owns the screen.
       } catch {
         guard generationAtStart == generation else { return }
         showRejection(Self.rejection(for: error))
@@ -628,6 +639,8 @@ final class FileImportCoordinator {
   /// Clears everything and returns to an empty Upload step.
   func startOver() {
     guard !isRunning else { return }
+    decodeTask?.cancel()
+    decodeTask = nil
     generation += 1
     file = nil
     parts = []
@@ -642,6 +655,9 @@ final class FileImportCoordinator {
   /// The decoded audio, held between `choose` and `start` so pressing Start does
   /// not read the file a second time.
   private var decodedSamples: [Float] = []
+
+  /// The in-flight read, so replacing or clearing the file can stop it.
+  private var decodeTask: Task<Void, Never>?
 
   /// Runs the import. Claims the shared engine first: a refusal here is a
   /// refusal to start, not a queue.

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -217,9 +217,18 @@ final class FileImportCoordinator {
   /// The bundled local polisher a RUNNING import has pinned, or nil. Read by the
   /// settings sync so a provider switch defers tearing down the server this run
   /// is using, exactly as it already defers for a live dictation.
+  ///
+  /// **Held separately from `runConfiguration`, which is document metadata and
+  /// is RESETTABLE.** Stop returns while the cancelled work still holds the
+  /// engine; pressing New transcription in that window cleared the configuration
+  /// and with it the pin, so a provider change could tear down a server the work
+  /// was still inside. The pin now lives and dies with the physical hold. Found
+  /// by Codex.
   var pinnedLocalPolishProvider: LLMProvider? {
-    isEngineHeld ? runConfiguration?.localPolishProvider : nil
+    isEngineHeld ? heldLocalPolishProvider : nil
   }
+
+  private var heldLocalPolishProvider: LLMProvider?
 
   /// The document as one piece of text, for copy and save.
   /// The document as one piece of text, for Copy and Save.
@@ -310,6 +319,11 @@ final class FileImportCoordinator {
     /// The BUNDLED local polisher this run froze, if any, so the settings sync
     /// can defer tearing its server down until the run releases its claim.
     let localPolishProvider: LLMProvider?
+    /// The polisher this run was configured with, for the line crediting the
+    /// document. Reading LIVE settings there credited whatever was selected
+    /// NOW: finishing with EG-1, pressing Change, picking Claude and returning
+    /// to Done labelled unchanged EG-1 output as Claude's. Found by Codex.
+    let polishProvider: LLMProvider
   }
 
   /// Freezes the configuration this run uses and returns it. Called once per
@@ -409,7 +423,7 @@ final class FileImportCoordinator {
     // sent the user to a screen from which their finished transcript could not
     // be copied, saved or retried. Done renders the same refusal beside the
     // words. Found by Codex.
-    step = hasDocument ? .done : .upload
+    jump(to: hasDocument ? .done : .upload)
   }
 
   /// Moves forward through the wizard. Refused once a run is in flight: the
@@ -418,10 +432,9 @@ final class FileImportCoordinator {
   func advance() {
     guard !isRunning else { return }
     switch step {
-    case .upload:
-      if case .ready = state { step = .transcription }
-    case .transcription: step = .polish
-    case .polish: step = .review
+    case .upload: jump(to: .transcription, advancing: true)
+    case .transcription: jump(to: .polish, advancing: true)
+    case .polish: jump(to: .review, advancing: true)
     // With a transcript already in hand, Start means POLISH AGAIN: the audio
     // has been read and transcribed, and re-doing either would be slower and
     // would produce the same words.
@@ -443,8 +456,8 @@ final class FileImportCoordinator {
 
   /// Goes back one step, if that step is one the user may be on.
   func goBack() {
-    guard let previous = Step(rawValue: step.rawValue - 1), canGo(to: previous) else { return }
-    step = previous
+    guard let previous = Step(rawValue: step.rawValue - 1) else { return }
+    jump(to: previous)
   }
 
   /// Takes the user back to the Polish step with the finished document intact.
@@ -455,8 +468,8 @@ final class FileImportCoordinator {
   /// so picking a different polisher and pressing Start again costs no re-read
   /// and no second transcription. Found by Codex.
   func choosePolisherAgain() {
-    guard !isRunning, !rawTranscript.isEmpty else { return }
-    step = .polish
+    guard hasDocument else { return }
+    jump(to: .polish)
   }
 
   /// **The ONE answer to "may the user be on this step right now".**
@@ -471,7 +484,13 @@ final class FileImportCoordinator {
   /// this is the rule, and nothing moves `step` without asking it.
   ///
   /// **The test that decides every case: can the user get back to their words?**
-  func canGo(to target: Step) -> Bool {
+  /// - Parameter advancing: true only for Continue, which is the one mover that
+  ///   goes FORWARD through a wizard the user has not finished. Without it this
+  ///   predicate answered a narrower question than its name — backward step-bar
+  ///   navigation — and `advance()` had to bypass it to work at all, which is
+  ///   how a "single authority" ended up with five writers around it. Codex
+  ///   round 4 enumerated them from the code and found the claim false.
+  func canGo(to target: Step, advancing: Bool = false) -> Bool {
     guard !isRunning, target != step else { return false }
     switch target {
     // Never by navigation: it shows a run in progress, and after one there is
@@ -484,15 +503,27 @@ final class FileImportCoordinator {
     case .upload: return !hasDocument
     // With a document the choice steps go both ways: picking a different
     // polisher and returning to the words is a supported thing to do. Without
-    // one, the wizard runs forwards and the bar only goes back.
+    // one, the bar only goes back and Continue is the only way forward — one
+    // step at a time, and only once a file has actually been read.
     case .transcription, .polish, .review:
-      return file != nil && (hasDocument || target.rawValue < step.rawValue)
+      guard file != nil else { return false }
+      if hasDocument || target.rawValue < step.rawValue { return true }
+      guard advancing, case .ready = state else { return false }
+      return target.rawValue == step.rawValue + 1
     }
   }
 
-  /// Takes the user to `target` if `canGo(to:)` allows it.
-  func jump(to target: Step) {
-    guard canGo(to: target) else { return }
+  /// Takes the user to `target` if `canGo(to:advancing:)` allows it. **The only
+  /// navigation writer.** Three writers remain outside it and are exceptions by
+  /// construction, not by oversight:
+  ///
+  /// - `choose(url:)` and `startOver()` RESET to Upload while clearing what made
+  ///   Upload unreachable, so asking a predicate about the state they are in the
+  ///   middle of replacing would answer about the old one.
+  /// - `start()`, `stop()`, `rePolish()` and `polishAll` move the user because
+  ///   the WORK moved. They are not navigation and must not be refusable.
+  func jump(to target: Step, advancing: Bool = false) {
+    guard canGo(to: target, advancing: advancing) else { return }
     step = target
   }
 
@@ -561,6 +592,8 @@ final class FileImportCoordinator {
         finishEngineHold()
       }
       runConfiguration = beginRun()
+      // Pinned from the SAME freeze, so the pin cannot outlive or predate it.
+      heldLocalPolishProvider = runConfiguration?.localPolishProvider
       phase = "Writing down what was said"
 
       await run(generationAtStart: generationAtStart)
@@ -599,6 +632,8 @@ final class FileImportCoordinator {
     }
 
     runConfiguration = beginRun()
+    // Pinned from the SAME freeze, so the pin cannot outlive or predate it.
+    heldLocalPolishProvider = runConfiguration?.localPolishProvider
 
     generation += 1
     let generationAtStart = generation
@@ -661,6 +696,7 @@ final class FileImportCoordinator {
   /// the same paths. Found by Codex.
   private func finishEngineHold() {
     isEngineHeld = false
+    heldLocalPolishProvider = nil
     onEngineReleased()
   }
 

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -315,11 +315,22 @@ final class FileImportCoordinator {
   /// shared engine. The composition root points it at the existing retry paths.
   let onEngineReleased: @MainActor () -> Void
 
-  /// Whether the polish model selected RIGHT NOW is an Ollama model the daemon
-  /// proxies to its own servers. Read live before a run for the page's privacy
-  /// line, and frozen into `RunConfiguration` at Start so a finished document is
-  /// never re-described by a later catalog refresh.
-  let polishIsRemoteOllamaNow: @MainActor () -> Bool
+  /// Where an Ollama polish would send the text, for the model selected NOW.
+  ///
+  /// **Three answers, and the third one is the point.** `true` proxied to
+  /// Ollama's servers, `false` running on this Mac, `nil` the daemon has not
+  /// been asked yet — which is the ordinary state after a relaunch, because the
+  /// catalog is populated by the AI Polish page and a user who opens Transcribe
+  /// a File directly has never been there. Collapsing `nil` into `false` made
+  /// the page promise the transcript stays on this Mac while sending it to
+  /// Ollama's servers. Found by Codex. A privacy promise may only be made from
+  /// a KNOWN answer.
+  let polishOllamaLocalityNow: @MainActor () -> Bool?
+
+  /// Asks the daemon, so the answer above stops being `nil`. Called when the
+  /// Polish step appears rather than at launch: it is one local request, and
+  /// only this screen needs it.
+  let refreshOllamaFacts: @MainActor () async -> Void
 
   /// What one run is pinned to, captured at Start.
   ///
@@ -341,8 +352,10 @@ final class FileImportCoordinator {
     let polishProvider: LLMProvider
     /// The LOCAL Ollama model this run froze, if any, so the eviction rule can
     /// leave its weights alone while the run is using them. Nil for every other
-    /// provider and for a model Ollama proxies to its own servers, which has no
-    /// weights on this Mac to protect.
+    /// provider, for a model Ollama proxies to its own servers (no weights here
+    /// to protect), and for one whose location is unknown — an unknown model is
+    /// evicted by the existing rule on purpose, and pinning it would defer an
+    /// eviction on a guess.
     let ollamaModel: String?
   }
 
@@ -371,13 +384,15 @@ final class FileImportCoordinator {
     decode: @escaping @Sendable (URL) async throws -> AudioFileDecoder.Decoded,
     transcribe: @escaping @MainActor ([Float]) async throws -> String,
     engineAdmission: EngineAdmissionAccess,
-    polishIsRemoteOllamaNow: @escaping @MainActor () -> Bool = { false },
+    polishOllamaLocalityNow: @escaping @MainActor () -> Bool? = { false },
+    refreshOllamaFacts: @escaping @MainActor () async -> Void = {},
     ensureEngineReady: @escaping @MainActor () async -> EngineReadiness = { .ready },
     onEngineReleased: @escaping @MainActor () -> Void = {},
     beginRun: @escaping @MainActor () -> RunConfiguration,
     processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome
   ) {
-    self.polishIsRemoteOllamaNow = polishIsRemoteOllamaNow
+    self.polishOllamaLocalityNow = polishOllamaLocalityNow
+    self.refreshOllamaFacts = refreshOllamaFacts
     self.ensureEngineReady = ensureEngineReady
     self.onEngineReleased = onEngineReleased
     self.decode = decode
@@ -433,6 +448,36 @@ final class FileImportCoordinator {
   /// at Start leaves them on Review with an inert button. Both go back to Upload,
   /// which is the one step that renders a refusal AND offers the way out of it —
   /// choosing another file. Found by Codex.
+  /// Whether this refusal is about the ENGINE rather than the file.
+  ///
+  /// **The difference decides what the user has to redo.** A file we could not
+  /// read needs a different file. A busy engine, a missing model or a warm-up
+  /// that did not take needs nothing redone at all — the audio is decoded and in
+  /// memory, and the message says "try again". It did not mean it: the only
+  /// route back was choosing the file again and paying the read a second time,
+  /// which on a long recording is the slowest part. Found by Codex.
+  static func isAboutTheEngine(_ reason: FileImportRejection) -> Bool {
+    switch reason {
+    case .engineBusy, .engineNotInstalled, .engineNotReady: return true
+    case .cannotRead, .noAudio, .noSpeechFound, .failed: return false
+    }
+  }
+
+  /// Whether Try again is offered: an engine refusal, with the audio still here.
+  var canRetry: Bool {
+    guard case .rejected(let reason) = state else { return false }
+    return Self.isAboutTheEngine(reason) && !decodedSamples.isEmpty && file != nil
+  }
+
+  /// Puts the already-decoded file back in hand and starts it again.
+  func retry() {
+    guard canRetry, let file else { return }
+    // Back to the state `start()` requires. The user is already standing on
+    // Review, where the refusal placed them and where Try again is.
+    state = .ready(fileName: file.name, seconds: file.seconds)
+    start()
+  }
+
   private func showRejection(_ reason: FileImportRejection) {
     state = .rejected(reason)
     phase = ""
@@ -443,7 +488,22 @@ final class FileImportCoordinator {
     // sent the user to a screen from which their finished transcript could not
     // be copied, saved or retried. Done renders the same refusal beside the
     // words. Found by Codex.
-    jump(to: hasDocument ? .done : .upload)
+    //
+    // An ENGINE refusal with the audio still in hand stays on Review, where Try
+    // again is, because nothing about the file needs redoing.
+    step =
+      if hasDocument {
+        // Done renders the refusal above the words it did not touch. Upload
+        // would offer only the thing that destroys them.
+        .done
+      } else if canRetry {
+        // Already read, nothing to redo: stay where Try again is.
+        .review
+      } else {
+        // The one step that renders a refusal AND offers the way out: a
+        // different file.
+        .upload
+      }
   }
 
   /// Moves forward through the wizard. Refused once a run is in flight: the
@@ -466,6 +526,19 @@ final class FileImportCoordinator {
   /// Whether there is a document to go back TO. The single fact three of the
   /// rules below turn on.
   var hasDocument: Bool { !rawTranscript.isEmpty }
+
+  /// Whether the Done screen is showing the ORIGINAL words instead of the
+  /// cleaned ones.
+  ///
+  /// **The page promises "Original kept" and "Your untouched words are kept
+  /// beside this one", and nothing showed them.** Once the first cleaned passage
+  /// landed, the raw transcript was in memory and unreachable — no view rendered
+  /// it, and Copy and Save exported only the cleaned passages. A promise with no
+  /// way to check it is a promise the product does not keep. Found by Codex.
+  var isShowingOriginal = false
+
+  /// What Copy and Save hand over, which is always what the screen is showing.
+  var exportText: String { isShowingOriginal ? rawTranscript : documentText }
 
   /// Whether Back is offered right now, so the button is absent rather than
   /// present and inert.
@@ -542,6 +615,11 @@ final class FileImportCoordinator {
   ///   middle of replacing would answer about the old one.
   /// - `start()`, `stop()`, `rePolish()` and `polishAll` move the user because
   ///   the WORK moved. They are not navigation and must not be refusable.
+  /// - `showRejection(_:)` PLACES the user where a refusal can be read and acted
+  ///   on. That destination is chosen by what they would LOSE, not by where they
+  ///   asked to go, and on a refusal raised from Review it is Review itself —
+  ///   which `canGo` refuses by construction, since it never returns true for
+  ///   the step you are already on.
   func jump(to target: Step, advancing: Bool = false) {
     guard canGo(to: target, advancing: advancing) else { return }
     step = target

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1,0 +1,288 @@
+import EnviousWisprASR
+import EnviousWisprCore
+import EnviousWisprPipeline
+import Foundation
+import Observation
+
+/// #2648 — the state machine behind Transcribe a File.
+///
+/// **A coordinator rather than a view model, because the job outlives the view.**
+/// The founder's requirement is that leaving the page and coming back returns to
+/// the same state, and that the sidebar shows a dot while a run is going.
+/// A view that owned the state could do neither. `TranscriptCoordinator` is the
+/// precedent for a `@MainActor @Observable` coordinator the composition root
+/// holds and injects into the environment.
+///
+/// **Five states, one direction, no re-entry**, plus two terminal side branches:
+/// `rejected` from reading, and `stopped` from anywhere after transcribing.
+/// `stopped` keeps whatever was produced, because a user who stops a 40-minute
+/// import after 30 minutes should not lose the 30.
+@MainActor
+@Observable
+final class FileImportCoordinator {
+
+  // MARK: - What the screen is showing
+
+  enum State: Equatable {
+    case idle
+    case reading(fileName: String)
+    case ready(fileName: String, seconds: Double)
+    case transcribing(fileName: String)
+    /// `done` parts of `total` have finished. The user never sees these numbers
+    /// as "chunks" — the founder's call is that the chunking is never
+    /// user-facing — but the progress they drive is.
+    case polishing(done: Int, total: Int)
+    case finished
+    case rejected(FileImportRejection)
+    case stopped
+  }
+
+  /// Why a file never started. Each one is a sentence a person can act on.
+  enum FileImportRejection: Equatable, Sendable {
+    case cannotRead
+    case noAudio
+    case noSpeechFound
+    case engineBusy(SharedEngineHolder)
+    case failed(String)
+  }
+
+  /// One part of the document, as the reader sees it.
+  struct Part: Equatable, Identifiable, Sendable {
+    let id: Int
+    /// The words as they stand now: polished if polish landed, deterministic
+    /// otherwise.
+    var text: String
+    /// True when this part is showing unpolished text. Marked in the document
+    /// rather than hidden: thirteen good parts and one raw part is a good
+    /// outcome, and hiding the raw one is the failure.
+    var isUnpolished: Bool
+  }
+
+  private(set) var state: State = .idle
+  private(set) var parts: [Part] = []
+
+  /// The whole raw transcript, kept so a re-polish never re-reads the file.
+  private(set) var rawTranscript: String = ""
+
+  /// The document as one piece of text, for copy and save.
+  var documentText: String { parts.map(\.text).joined(separator: "\n\n") }
+
+  /// Whether a run is in flight, for the sidebar dot.
+  var isRunning: Bool {
+    switch state {
+    case .transcribing, .polishing: return true
+    case .idle, .reading, .ready, .finished, .rejected, .stopped: return false
+    }
+  }
+
+  // MARK: - Collaborators
+
+  private let decode: @Sendable (URL) async throws -> [Float]
+  private let transcribe: @MainActor ([Float]) async throws -> String
+  private let engineAdmission: EngineAdmissionAccess
+
+  /// Freezes the configuration this run uses. Called once per run, before the
+  /// first part — the founder's "one import, one configuration" call, so a
+  /// settings change halfway through cannot produce a document polished two
+  /// different ways.
+  private let beginRun: @MainActor () -> Void
+
+  /// Runs one part. A closure rather than the concrete `FileImportRunner` for
+  /// one reason and it is not style: the property this type exists to hold —
+  /// that Stop changes the screen at once while the claim waits for the work to
+  /// exit — cannot be tested at all unless a test can make a part take as long
+  /// as it likes.
+  private let processPart: @MainActor (String) async throws -> FileImportRunner.PartOutcome
+
+  /// **Generation protects STATE. Terminal completion protects the RESOURCE.**
+  /// Neither substitutes for the other, and this coordinator needs both: Stop
+  /// changes what the user sees at once and bumps this, so a late part cannot
+  /// write into a run the user has already ended — while the claim is released
+  /// only from the run task's own `defer`, after the physical work has exited.
+  private var generation = 0
+  private var runTask: Task<Void, Never>?
+
+  init(
+    decode: @escaping @Sendable (URL) async throws -> [Float],
+    transcribe: @escaping @MainActor ([Float]) async throws -> String,
+    engineAdmission: EngineAdmissionAccess,
+    beginRun: @escaping @MainActor () -> Void,
+    processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome
+  ) {
+    self.decode = decode
+    self.transcribe = transcribe
+    self.engineAdmission = engineAdmission
+    self.beginRun = beginRun
+    self.processPart = processPart
+  }
+
+  // MARK: - The user's four actions
+
+  /// The user picked a file. Reads it far enough to say whether it can be
+  /// transcribed at all, before anything touches an engine.
+  func choose(url: URL) {
+    guard !isRunning else { return }
+    parts = []
+    rawTranscript = ""
+    decodedSamples = []
+    let name = url.lastPathComponent
+    // Bumped HERE too, not only when a run starts. Picking a second file while
+    // the first is still decoding is an ordinary thing to do, and without this
+    // both decodes carry the same generation, so whichever finishes last wins —
+    // which can be the file the user already replaced.
+    generation += 1
+    let generationAtStart = generation
+    state = .reading(fileName: name)
+    Task { [weak self] in
+      guard let self else { return }
+      do {
+        let samples = try await decode(url)
+        guard generationAtStart == generation else { return }
+        state = .ready(
+          fileName: name, seconds: Double(samples.count) / AudioConstants.sampleRate)
+        decodedSamples = samples
+      } catch {
+        guard generationAtStart == generation else { return }
+        state = .rejected(Self.rejection(for: error))
+      }
+    }
+  }
+
+  /// The decoded audio, held between `choose` and `start` so pressing Start does
+  /// not read the file a second time.
+  private var decodedSamples: [Float] = []
+
+  /// Runs the import. Claims the shared engine first: a refusal here is a
+  /// refusal to start, not a queue.
+  func start() {
+    guard case .ready(let name, _) = state else { return }
+
+    let token: EngineLease.Token
+    switch engineAdmission.claim() {
+    case .granted(let granted):
+      token = granted
+    case .refused(let holder):
+      state = .rejected(.engineBusy(holder))
+      return
+    }
+
+    beginRun()
+
+    generation += 1
+    let generationAtStart = generation
+    state = .transcribing(fileName: name)
+
+    runTask = Task { [weak self] in
+      // **The claim goes back only here**, after the physical work has exited.
+      // Releasing where Stop is DECIDED would let a dictation in while a
+      // cancelled part was still inside the one-slot polish server.
+      defer { self?.engineAdmission.release(token) }
+      await self?.run(generationAtStart: generationAtStart)
+    }
+  }
+
+  /// Stop changes what the user sees at once and keeps whatever is finished.
+  /// The claim is not released here — see `start`.
+  func stop() {
+    guard isRunning else { return }
+    generation += 1
+    state = .stopped
+    runTask?.cancel()
+  }
+
+  /// Re-runs the cleanup under the current settings, from the transcript already
+  /// in memory. **The file is never read again**, which is the whole point of
+  /// keeping the raw transcript.
+  func rePolish() {
+    guard !rawTranscript.isEmpty, !isRunning else { return }
+
+    let token: EngineLease.Token
+    switch engineAdmission.claim() {
+    case .granted(let granted):
+      token = granted
+    case .refused(let holder):
+      state = .rejected(.engineBusy(holder))
+      return
+    }
+
+    beginRun()
+
+    generation += 1
+    let generationAtStart = generation
+    parts = []
+
+    runTask = Task { [weak self] in
+      defer { self?.engineAdmission.release(token) }
+      guard let self else { return }
+      await polishAll(
+        TranscriptSplitter.split(rawTranscript), generationAtStart: generationAtStart)
+    }
+  }
+
+  // MARK: - The run
+
+  private func run(generationAtStart: Int) async {
+    do {
+      let transcript = try await transcribe(decodedSamples)
+      guard generationAtStart == generation else { return }
+      guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        state = .rejected(.noSpeechFound)
+        return
+      }
+      rawTranscript = transcript
+      await polishAll(TranscriptSplitter.split(transcript), generationAtStart: generationAtStart)
+    } catch is CancellationError {
+      // Stop already set the visible state; there is nothing to say.
+    } catch {
+      guard generationAtStart == generation else { return }
+      state = .rejected(Self.rejection(for: error))
+    }
+  }
+
+  /// Runs every part, one at a time, publishing each as it lands.
+  ///
+  /// One at a time is not a simplification: the polish server has a single
+  /// inference slot, so parts in parallel would queue inside it and the progress
+  /// the user sees would stop meaning anything.
+  private func polishAll(_ pieces: [String], generationAtStart: Int) async {
+    guard !pieces.isEmpty else {
+      state = .finished
+      return
+    }
+    state = .polishing(done: 0, total: pieces.count)
+
+    for (index, piece) in pieces.enumerated() {
+      if Task.isCancelled || generationAtStart != generation { return }
+      do {
+        let outcome = try await processPart(piece)
+        // Re-read AFTER the await: a Stop during this part must not write into
+        // a run the user has already ended.
+        guard generationAtStart == generation else { return }
+        parts.append(
+          Part(id: index, text: outcome.displayText, isUnpolished: outcome.isUnpolished))
+      } catch is CancellationError {
+        return
+      } catch {
+        guard generationAtStart == generation else { return }
+        // A part that could not run at all still appears, carrying its raw
+        // words. A gap in the document would be the silent failure.
+        parts.append(Part(id: index, text: piece, isUnpolished: true))
+      }
+      guard generationAtStart == generation else { return }
+      state = .polishing(done: index + 1, total: pieces.count)
+    }
+    guard generationAtStart == generation else { return }
+    state = .finished
+  }
+
+  private static func rejection(for error: any Error) -> FileImportRejection {
+    switch error {
+    case AudioFileDecoder.Rejection.unreadable:
+      return .cannotRead
+    case AudioFileDecoder.Rejection.noAudioTrack, AudioFileDecoder.Rejection.noAudio:
+      return .noAudio
+    default:
+      return .failed(String(describing: error))
+    }
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -774,12 +774,21 @@ final class FileImportCoordinator {
       }
       // The timer above could have fired while we were claiming. Cheap to ask,
       // and the alternative is transcribing on an engine that just unloaded.
+      //
+      // **Both awaits are suspension points a Stop can land in**, and this one
+      // was added by the previous fix — for WhisperKit, readiness hops to the
+      // backend actor, so the window is real rather than theoretical. Neither
+      // await throws on cancellation, so without the guard a stopped run carried
+      // on and transcribed. Found by cloud review.
       if await engineIsLoaded() == false {
+        guard generationAtStart == generation else { return }
         guard await ensureEngineReady() == .ready else {
+          guard generationAtStart == generation else { return }
           showRejection(.engineNotReady)
           return
         }
       }
+      guard generationAtStart == generation else { return }
 
       runConfiguration = beginRun()
       // Pinned from the SAME freeze, so the pin cannot outlive or predate it.

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -21,6 +21,92 @@ import Observation
 @Observable
 final class FileImportCoordinator {
 
+  // MARK: - Where the user is in the flow
+
+  /// The six steps of the approved design, in order.
+  ///
+  /// **A wizard rather than one card**, because the user chooses BOTH engines
+  /// per import before anything runs, and the design gives each choice its own
+  /// screen with the specs needed to make it. The step bar is always visible and
+  /// a completed step can be gone back to while nothing has run.
+  enum Step: Int, CaseIterable, Equatable {
+    case upload = 1
+    case transcription
+    case polish
+    case review
+    case working
+    case done
+
+    var title: String {
+      switch self {
+      case .upload: return "Upload"
+      case .transcription: return "Transcription"
+      case .polish: return "Polish"
+      case .review: return "Review"
+      case .working: return "Working"
+      case .done: return "Done"
+      }
+    }
+  }
+
+  private(set) var step: Step = .upload
+
+  /// The engines THIS import will use. Seeded from the user's current settings
+  /// so the common case is one Continue away, and changed here without writing
+  /// back: a choice made for one file is not a change to how dictation works.
+  var chosenBackend: ASRBackendType = .parakeet
+  var chosenPolish: LLMProvider = .none
+
+  /// The file the user picked, described. Everything the Upload and Review steps
+  /// show about it comes from here rather than from a second read.
+  private(set) var file: ChosenFile?
+
+  struct ChosenFile: Equatable, Sendable {
+    let name: String
+    let seconds: Double
+    let byteCount: Int64
+    let codec: String
+    let sampleRate: Double
+    let channelCount: Int
+
+    /// "1 hr 12 min · 68.4 MB · AAC · 44.1 kHz · mono"
+    var detailLine: String {
+      [
+        FileImportCoordinator.durationText(seconds),
+        ByteCountFormatter.string(fromByteCount: byteCount, countStyle: .file),
+        codec,
+        String(format: "%.1f kHz", sampleRate / 1000),
+        channelCount == 1 ? "mono" : (channelCount == 2 ? "stereo" : "\(channelCount) channels"),
+      ].joined(separator: " · ")
+    }
+  }
+
+  /// "1 hr 12 min", "3 min", "48 sec".
+  ///
+  /// `nonisolated` because `ChosenFile.detailLine` is a plain value computation
+  /// that has no business hopping to the main actor to format a number.
+  nonisolated static func durationText(_ seconds: Double) -> String {
+    let total = Int(seconds.rounded())
+    if total < 60 { return "\(total) sec" }
+    let minutes = total / 60
+    if minutes < 60 { return "\(minutes) min" }
+    return "\(minutes / 60) hr \(minutes % 60) min"
+  }
+
+  /// How long the run is expected to take, for "Ready in about 3 minutes".
+  ///
+  /// Measured shape rather than a guess: the fast engine transcribes about an
+  /// hour of audio in seven seconds, and the polish is what actually costs time
+  /// — roughly twelve seconds per 500-word part.
+  var estimateText: String {
+    guard let file else { return "" }
+    // Rounded UP: 1,100 words is three parts, not two, and an estimate that
+    // truncates gets shorter exactly as the file gets longer.
+    let parts = max(1, Int(((file.seconds / 60.0 * 150.0) / 500.0).rounded(.up)))
+    let minutes = max(1, Int((Double(parts) * 12.0 / 60.0).rounded()))
+    return minutes == 1 ? "about a minute" : "about \(minutes) minutes"
+  }
+
   // MARK: - What the screen is showing
 
   enum State: Equatable {
@@ -61,8 +147,35 @@ final class FileImportCoordinator {
   private(set) var state: State = .idle
   private(set) var parts: [Part] = []
 
+  /// What the Working step's phase label says. The words describe the JOB, never
+  /// the mechanism: the user is never told about parts or chunks.
+  private(set) var phase: String = ""
+
+  /// How many words the transcript holds, shown live beside the progress bar.
+  var wordCount: Int { TranscriptSplitter.wordCount(in: rawTranscript) }
+
+  /// 0...1 for the progress bar.
+  var progress: Double {
+    if case .polishing(let done, let total) = state, total > 0 {
+      return Double(done) / Double(total)
+    }
+    if case .finished = state { return 1 }
+    return 0
+  }
+
   /// The whole raw transcript, kept so a re-polish never re-reads the file.
   private(set) var rawTranscript: String = ""
+
+  /// The configuration the CURRENT document was produced under, held until a new
+  /// run starts. `nil` before the first run.
+  private(set) var runConfiguration: RunConfiguration?
+
+  /// The bundled local polisher a RUNNING import has pinned, or nil. Read by the
+  /// settings sync so a provider switch defers tearing down the server this run
+  /// is using, exactly as it already defers for a live dictation.
+  var pinnedLocalPolishProvider: LLMProvider? {
+    isRunning ? runConfiguration?.localPolishProvider : nil
+  }
 
   /// The document as one piece of text, for copy and save.
   var documentText: String { parts.map(\.text).joined(separator: "\n\n") }
@@ -77,15 +190,30 @@ final class FileImportCoordinator {
 
   // MARK: - Collaborators
 
-  private let decode: @Sendable (URL) async throws -> [Float]
+  private let decode: @Sendable (URL) async throws -> AudioFileDecoder.Decoded
   private let transcribe: @MainActor ([Float]) async throws -> String
   private let engineAdmission: EngineAdmissionAccess
 
-  /// Freezes the configuration this run uses. Called once per run, before the
-  /// first part — the founder's "one import, one configuration" call, so a
-  /// settings change halfway through cannot produce a document polished two
-  /// different ways.
-  private let beginRun: @MainActor () -> Void
+  /// What one run is pinned to, captured at Start.
+  ///
+  /// **Everything that must not drift mid-run reads THIS, never live settings.**
+  /// Cloud review found two places that read the live value instead: the page's
+  /// privacy line, which would retrospectively claim "nothing is uploaded" over
+  /// a cloud-polished document, and the local-engine reconciliation, which would
+  /// tear down the very server this run is using.
+  struct RunConfiguration: Equatable, Sendable {
+    /// Whether the polisher this run froze sends text off the machine.
+    let polishIsCloud: Bool
+    /// The BUNDLED local polisher this run froze, if any, so the settings sync
+    /// can defer tearing its server down until the run releases its claim.
+    let localPolishProvider: LLMProvider?
+  }
+
+  /// Freezes the configuration this run uses and returns it. Called once per
+  /// run, before the first part — the founder's "one import, one configuration"
+  /// call, so a settings change halfway through cannot produce a document
+  /// polished two different ways.
+  private let beginRun: @MainActor () -> RunConfiguration
 
   /// Runs one part. A closure rather than the concrete `FileImportRunner` for
   /// one reason and it is not style: the property this type exists to hold —
@@ -103,10 +231,10 @@ final class FileImportCoordinator {
   private var runTask: Task<Void, Never>?
 
   init(
-    decode: @escaping @Sendable (URL) async throws -> [Float],
+    decode: @escaping @Sendable (URL) async throws -> AudioFileDecoder.Decoded,
     transcribe: @escaping @MainActor ([Float]) async throws -> String,
     engineAdmission: EngineAdmissionAccess,
-    beginRun: @escaping @MainActor () -> Void,
+    beginRun: @escaping @MainActor () -> RunConfiguration,
     processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome
   ) {
     self.decode = decode
@@ -132,20 +260,70 @@ final class FileImportCoordinator {
     // which can be the file the user already replaced.
     generation += 1
     let generationAtStart = generation
+    file = nil
+    step = .upload
     state = .reading(fileName: name)
     Task { [weak self] in
       guard let self else { return }
       do {
-        let samples = try await decode(url)
+        let decoded = try await decode(url)
         guard generationAtStart == generation else { return }
-        state = .ready(
-          fileName: name, seconds: Double(samples.count) / AudioConstants.sampleRate)
-        decodedSamples = samples
+        file = ChosenFile(
+          name: name, seconds: decoded.seconds, byteCount: decoded.byteCount,
+          codec: decoded.codec, sampleRate: decoded.sampleRate,
+          channelCount: decoded.channelCount)
+        state = .ready(fileName: name, seconds: decoded.seconds)
+        decodedSamples = decoded.samples
       } catch {
         guard generationAtStart == generation else { return }
         state = .rejected(Self.rejection(for: error))
       }
     }
+  }
+
+  /// Moves forward through the wizard. Refused once a run is in flight: the
+  /// choices are frozen for the run, so a step that could still change them
+  /// would be lying about what is about to happen.
+  func advance() {
+    guard !isRunning else { return }
+    switch step {
+    case .upload:
+      if case .ready = state { step = .transcription }
+    case .transcription: step = .polish
+    case .polish: step = .review
+    case .review: start()
+    case .working, .done: break
+    }
+  }
+
+  /// Goes back one step. Only ever available while nothing has run.
+  func goBack() {
+    guard !isRunning else { return }
+    switch step {
+    case .upload, .working, .done: break
+    case .transcription: step = .upload
+    case .polish: step = .transcription
+    case .review: step = .polish
+    }
+  }
+
+  /// Jumps to a completed step from the step bar. Same rule: only before a run.
+  func jump(to target: Step) {
+    guard !isRunning, target.rawValue < step.rawValue else { return }
+    step = target
+  }
+
+  /// Clears everything and returns to an empty Upload step.
+  func startOver() {
+    guard !isRunning else { return }
+    generation += 1
+    file = nil
+    parts = []
+    rawTranscript = ""
+    decodedSamples = []
+    runConfiguration = nil
+    state = .idle
+    step = .upload
   }
 
   /// The decoded audio, held between `choose` and `start` so pressing Start does
@@ -166,10 +344,12 @@ final class FileImportCoordinator {
       return
     }
 
-    beginRun()
+    runConfiguration = beginRun()
 
     generation += 1
     let generationAtStart = generation
+    step = .working
+    phase = "Writing down what was said"
     state = .transcribing(fileName: name)
 
     runTask = Task { [weak self] in
@@ -187,6 +367,13 @@ final class FileImportCoordinator {
     guard isRunning else { return }
     generation += 1
     state = .stopped
+    // **The step moves with the state.** Stopping is an ENDING, so the user
+    // lands on Done holding whatever finished, with Copy, Save and New
+    // transcription in reach. Leaving `step` on `.working` stranded them on a
+    // progress bar that would never move again, beside a Stop button that had
+    // already been pressed.
+    step = .done
+    phase = ""
     runTask?.cancel()
   }
 
@@ -205,11 +392,13 @@ final class FileImportCoordinator {
       return
     }
 
-    beginRun()
+    runConfiguration = beginRun()
 
     generation += 1
     let generationAtStart = generation
     parts = []
+    step = .working
+    phase = "Cleaning it up"
 
     runTask = Task { [weak self] in
       defer { self?.engineAdmission.release(token) }
@@ -224,16 +413,25 @@ final class FileImportCoordinator {
   private func run(generationAtStart: Int) async {
     do {
       let transcript = try await transcribe(decodedSamples)
+      // **Released as soon as the engine is done with it, on every exit.** At 16
+      // kHz mono float this is ~230 MB per hour of audio, and re-polish needs
+      // only `rawTranscript` — holding it for the rest of the app's life would
+      // cost the user hundreds of megabytes for a document they have already
+      // read. Found by cloud review.
+      decodedSamples = []
       guard generationAtStart == generation else { return }
       guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
         state = .rejected(.noSpeechFound)
         return
       }
       rawTranscript = transcript
+      phase = "Dividing it up to clean"
       await polishAll(TranscriptSplitter.split(transcript), generationAtStart: generationAtStart)
     } catch is CancellationError {
+      decodedSamples = []
       // Stop already set the visible state; there is nothing to say.
     } catch {
+      decodedSamples = []
       guard generationAtStart == generation else { return }
       state = .rejected(Self.rejection(for: error))
     }
@@ -247,8 +445,10 @@ final class FileImportCoordinator {
   private func polishAll(_ pieces: [String], generationAtStart: Int) async {
     guard !pieces.isEmpty else {
       state = .finished
+      step = .done
       return
     }
+    phase = "Cleaning it up"
     state = .polishing(done: 0, total: pieces.count)
 
     for (index, piece) in pieces.enumerated() {
@@ -272,7 +472,9 @@ final class FileImportCoordinator {
       state = .polishing(done: index + 1, total: pieces.count)
     }
     guard generationAtStart == generation else { return }
+    phase = ""
     state = .finished
+    step = .done
   }
 
   private static func rejection(for error: any Error) -> FileImportRejection {

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -26,9 +26,11 @@ final class FileImportCoordinator {
   /// The six steps of the approved design, in order.
   ///
   /// **A wizard rather than one card**, because the user chooses BOTH engines
-  /// per import before anything runs, and the design gives each choice its own
-  /// screen with the specs needed to make it. The step bar is always visible and
-  /// a completed step can be gone back to while nothing has run.
+  /// before anything runs, and the design gives each choice its own screen with
+  /// the specs needed to make it. The step bar is always visible and a completed
+  /// step can be gone back to while nothing has run. The choices are the app's
+  /// own settings, written through the same doors the Speech Engine and AI
+  /// Polish pages use — see the note below `estimateText`.
   enum Step: Int, CaseIterable, Equatable {
     case upload = 1
     case transcription
@@ -51,11 +53,20 @@ final class FileImportCoordinator {
 
   private(set) var step: Step = .upload
 
-  /// The engines THIS import will use. Seeded from the user's current settings
-  /// so the common case is one Continue away, and changed here without writing
-  /// back: a choice made for one file is not a change to how dictation works.
-  var chosenBackend: ASRBackendType = .parakeet
-  var chosenPolish: LLMProvider = .none
+  // The engines this import uses are NOT held here. The Transcription and
+  // Polish steps read and write `SettingsManager` directly, the same way the
+  // Speech Engine and AI Polish pages do, because those settings already have
+  // owners that make a choice REAL: `EngineCoordinator` switches the speech
+  // engine and loads its model, `PipelineSettingsSync` starts and stops the
+  // polish runtimes, and `SettingsManager` canonicalizes `llmModel` when the
+  // provider changes. Gate 2 approved reusing them ("ASR engines |
+  // EngineCoordinator, settings.selectedBackend | Reuse").
+  //
+  // A per-import copy was tried and did none of that: picking All Languages
+  // left Parakeet transcribing, and picking a polisher the app was not already
+  // using sent the previous provider's model id to the new provider and never
+  // started its server. Three defects, one cause, and the cause was holding a
+  // second copy of a setting whose effects live elsewhere. Found by Codex.
 
   /// The file the user picked, described. Everything the Upload and Review steps
   /// show about it comes from here rather than from a second read.
@@ -174,13 +185,17 @@ final class FileImportCoordinator {
   /// settings sync so a provider switch defers tearing down the server this run
   /// is using, exactly as it already defers for a live dictation.
   var pinnedLocalPolishProvider: LLMProvider? {
-    isRunning ? runConfiguration?.localPolishProvider : nil
+    isEngineHeld ? runConfiguration?.localPolishProvider : nil
   }
 
   /// The document as one piece of text, for copy and save.
   var documentText: String { parts.map(\.text).joined(separator: "\n\n") }
 
-  /// Whether a run is in flight, for the sidebar dot.
+  /// Whether a run is in flight AS THE SCREEN SEES IT. Drives the sidebar dot,
+  /// the Stop button and whether the wizard's steps are navigable.
+  ///
+  /// **Not a resource question.** Stop flips this the instant it is pressed,
+  /// deliberately, while the cancelled work is still inside the engine.
   var isRunning: Bool {
     switch state {
     case .transcribing, .polishing: return true
@@ -188,11 +203,32 @@ final class FileImportCoordinator {
     }
   }
 
+  /// Whether the run task still PHYSICALLY holds the shared engine.
+  ///
+  /// **Separate from `isRunning` because Stop separates them**, and every guard
+  /// that protects a resource must read this one. `isRunning` goes false at the
+  /// press; the claim is held until the cancelled transcription or polish call
+  /// actually returns, because a Core ML decode cannot be stopped cooperatively.
+  /// In that window a settings change reading `isRunning` would unload the ASR
+  /// backend, or tear down the polish server, out from under work still using
+  /// it. Found by Codex.
+  private(set) var isEngineHeld = false
+
   // MARK: - Collaborators
 
   private let decode: @Sendable (URL) async throws -> AudioFileDecoder.Decoded
   private let transcribe: @MainActor ([Float]) async throws -> String
   private let engineAdmission: EngineAdmissionAccess
+
+  /// Called once, on the main actor, after a run has physically released the
+  /// shared engine. The composition root points it at the existing retry paths.
+  let onEngineReleased: @MainActor () -> Void
+
+  /// Whether the polish model selected RIGHT NOW is an Ollama model the daemon
+  /// proxies to its own servers. Read live before a run for the page's privacy
+  /// line, and frozen into `RunConfiguration` at Start so a finished document is
+  /// never re-described by a later catalog refresh.
+  let polishIsRemoteOllamaNow: @MainActor () -> Bool
 
   /// What one run is pinned to, captured at Start.
   ///
@@ -234,9 +270,13 @@ final class FileImportCoordinator {
     decode: @escaping @Sendable (URL) async throws -> AudioFileDecoder.Decoded,
     transcribe: @escaping @MainActor ([Float]) async throws -> String,
     engineAdmission: EngineAdmissionAccess,
+    polishIsRemoteOllamaNow: @escaping @MainActor () -> Bool = { false },
+    onEngineReleased: @escaping @MainActor () -> Void = {},
     beginRun: @escaping @MainActor () -> RunConfiguration,
     processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome
   ) {
+    self.polishIsRemoteOllamaNow = polishIsRemoteOllamaNow
+    self.onEngineReleased = onEngineReleased
     self.decode = decode
     self.transcribe = transcribe
     self.engineAdmission = engineAdmission
@@ -276,9 +316,23 @@ final class FileImportCoordinator {
         decodedSamples = decoded.samples
       } catch {
         guard generationAtStart == generation else { return }
-        state = .rejected(Self.rejection(for: error))
+        showRejection(Self.rejection(for: error))
       }
     }
+  }
+
+  /// Where a refusal is READ, which is not always where it was produced.
+  ///
+  /// A rejection raised during a run leaves the user on Working, where nothing
+  /// renders it: a progress bar that will never move again, beside a Stop button
+  /// that does nothing because `isRunning` is already false. A rejection raised
+  /// at Start leaves them on Review with an inert button. Both go back to Upload,
+  /// which is the one step that renders a refusal AND offers the way out of it —
+  /// choosing another file. Found by Codex.
+  private func showRejection(_ reason: FileImportRejection) {
+    state = .rejected(reason)
+    phase = ""
+    step = .upload
   }
 
   /// Moves forward through the wizard. Refused once a run is in flight: the
@@ -291,7 +345,10 @@ final class FileImportCoordinator {
       if case .ready = state { step = .transcription }
     case .transcription: step = .polish
     case .polish: step = .review
-    case .review: start()
+    // With a transcript already in hand, Start means POLISH AGAIN: the audio
+    // has been read and transcribed, and re-doing either would be slower and
+    // would produce the same words.
+    case .review: rawTranscript.isEmpty ? start() : rePolish()
     case .working, .done: break
     }
   }
@@ -305,6 +362,18 @@ final class FileImportCoordinator {
     case .polish: step = .transcription
     case .review: step = .polish
     }
+  }
+
+  /// Takes the user back to the Polish step with the finished document intact.
+  ///
+  /// **Change is a request to choose, not a request to re-run.** It used to
+  /// clear every finished passage and immediately re-run the SAME polisher,
+  /// which threw the document away to reproduce it. The raw transcript is kept,
+  /// so picking a different polisher and pressing Start again costs no re-read
+  /// and no second transcription. Found by Codex.
+  func choosePolisherAgain() {
+    guard !isRunning, !rawTranscript.isEmpty else { return }
+    step = .polish
   }
 
   /// Jumps to a completed step from the step bar. Same rule: only before a run.
@@ -340,7 +409,7 @@ final class FileImportCoordinator {
     case .granted(let granted):
       token = granted
     case .refused(let holder):
-      state = .rejected(.engineBusy(holder))
+      showRejection(.engineBusy(holder))
       return
     }
 
@@ -352,11 +421,15 @@ final class FileImportCoordinator {
     phase = "Writing down what was said"
     state = .transcribing(fileName: name)
 
+    isEngineHeld = true
     runTask = Task { [weak self] in
       // **The claim goes back only here**, after the physical work has exited.
       // Releasing where Stop is DECIDED would let a dictation in while a
       // cancelled part was still inside the one-slot polish server.
-      defer { self?.engineAdmission.release(token) }
+      defer {
+        self?.engineAdmission.release(token)
+        self?.finishEngineHold()
+      }
       await self?.run(generationAtStart: generationAtStart)
     }
   }
@@ -388,7 +461,7 @@ final class FileImportCoordinator {
     case .granted(let granted):
       token = granted
     case .refused(let holder):
-      state = .rejected(.engineBusy(holder))
+      showRejection(.engineBusy(holder))
       return
     }
 
@@ -400,8 +473,12 @@ final class FileImportCoordinator {
     step = .working
     phase = "Cleaning it up"
 
+    isEngineHeld = true
     runTask = Task { [weak self] in
-      defer { self?.engineAdmission.release(token) }
+      defer {
+        self?.engineAdmission.release(token)
+        self?.finishEngineHold()
+      }
       guard let self else { return }
       await polishAll(
         TranscriptSplitter.split(rawTranscript), generationAtStart: generationAtStart)
@@ -413,29 +490,53 @@ final class FileImportCoordinator {
   private func run(generationAtStart: Int) async {
     do {
       let transcript = try await transcribe(decodedSamples)
-      // **Released as soon as the engine is done with it, on every exit.** At 16
-      // kHz mono float this is ~230 MB per hour of audio, and re-polish needs
-      // only `rawTranscript` — holding it for the rest of the app's life would
-      // cost the user hundreds of megabytes for a document they have already
-      // read. Found by cloud review.
-      decodedSamples = []
+      // **The generation guard comes FIRST, before any shared write.** A slow
+      // transcription that returns after the user stopped and chose another file
+      // belongs to a run nobody is watching; clearing `decodedSamples` on the way
+      // out erased the NEW file's audio while its Ready screen stayed up, and the
+      // next Start then transcribed an empty buffer. Found by Codex.
       guard generationAtStart == generation else { return }
+      releaseDecodedAudio()
       guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-        state = .rejected(.noSpeechFound)
+        showRejection(.noSpeechFound)
         return
       }
       rawTranscript = transcript
       phase = "Dividing it up to clean"
       await polishAll(TranscriptSplitter.split(transcript), generationAtStart: generationAtStart)
     } catch is CancellationError {
-      decodedSamples = []
+      guard generationAtStart == generation else { return }
+      releaseDecodedAudio()
       // Stop already set the visible state; there is nothing to say.
     } catch {
-      decodedSamples = []
       guard generationAtStart == generation else { return }
-      state = .rejected(Self.rejection(for: error))
+      releaseDecodedAudio()
+      showRejection(Self.rejection(for: error))
     }
   }
+
+  /// Ends the physical hold and wakes whatever deferred itself because of it.
+  ///
+  /// **A deferral needs a wake-up or it is just a stall.** `EngineCoordinator`
+  /// defers a speech-engine switch while an import runs, `PipelineSettingsSync`
+  /// defers tearing down a polish runtime this run pinned, and crash recovery
+  /// defers a replay. All three were written to be retried when the blocker
+  /// clears, and nothing was telling them it had. A settings change made during
+  /// a long import then sat pending until some unrelated event happened to poke
+  /// the same paths. Found by Codex.
+  private func finishEngineHold() {
+    isEngineHeld = false
+    onEngineReleased()
+  }
+
+  /// Drops the decoded audio once the engine is done with it.
+  ///
+  /// At 16 kHz mono float this is ~230 MB per hour of recording, and a re-polish
+  /// needs only `rawTranscript`, so holding it for the life of the app would cost
+  /// the user hundreds of megabytes for a document they have already read. Found
+  /// by cloud review. Only ever called after the generation guard, so it can
+  /// never drop audio belonging to a NEWER selection.
+  private func releaseDecodedAudio() { decodedSamples = [] }
 
   /// Runs every part, one at a time, publishing each as it lands.
   ///

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -228,7 +228,22 @@ final class FileImportCoordinator {
     isEngineHeld ? heldLocalPolishProvider : nil
   }
 
+  /// The Ollama model a RUNNING import has frozen, or nil.
+  ///
+  /// **A different pin from the one above, because it protects a different
+  /// thing.** `pinnedLocalPolishProvider` stops a bundled server being torn
+  /// down; this stops `reconcileOllamaEviction` unloading the WEIGHTS of the
+  /// model this run's remaining passages are about to use. That rule's pin check
+  /// reads the two dictation drivers' session configs, and an import has no
+  /// session config, so its model was unprotected: changing provider mid-import
+  /// evicted it, and every later passage paid a reload it could exceed its
+  /// polish deadline waiting for, returning raw text. Found by Codex.
+  var pinnedOllamaModel: String? {
+    isEngineHeld ? heldOllamaModel : nil
+  }
+
   private var heldLocalPolishProvider: LLMProvider?
+  private var heldOllamaModel: String?
 
   /// The document as one piece of text, for copy and save.
   /// The document as one piece of text, for Copy and Save.
@@ -324,6 +339,11 @@ final class FileImportCoordinator {
     /// NOW: finishing with EG-1, pressing Change, picking Claude and returning
     /// to Done labelled unchanged EG-1 output as Claude's. Found by Codex.
     let polishProvider: LLMProvider
+    /// The LOCAL Ollama model this run froze, if any, so the eviction rule can
+    /// leave its weights alone while the run is using them. Nil for every other
+    /// provider and for a model Ollama proxies to its own servers, which has no
+    /// weights on this Mac to protect.
+    let ollamaModel: String?
   }
 
   /// Freezes the configuration this run uses and returns it. Called once per
@@ -594,6 +614,7 @@ final class FileImportCoordinator {
       runConfiguration = beginRun()
       // Pinned from the SAME freeze, so the pin cannot outlive or predate it.
       heldLocalPolishProvider = runConfiguration?.localPolishProvider
+      heldOllamaModel = runConfiguration?.ollamaModel
       phase = "Writing down what was said"
 
       await run(generationAtStart: generationAtStart)
@@ -634,6 +655,7 @@ final class FileImportCoordinator {
     runConfiguration = beginRun()
     // Pinned from the SAME freeze, so the pin cannot outlive or predate it.
     heldLocalPolishProvider = runConfiguration?.localPolishProvider
+    heldOllamaModel = runConfiguration?.ollamaModel
 
     generation += 1
     let generationAtStart = generation
@@ -697,6 +719,7 @@ final class FileImportCoordinator {
   private func finishEngineHold() {
     isEngineHeld = false
     heldLocalPolishProvider = nil
+    heldOllamaModel = nil
     onEngineReleased()
   }
 

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -325,6 +325,10 @@ final class FileImportCoordinator {
   /// for a run that is itself waiting for the switch.
   private let ensureEngineReady: @MainActor () async -> EngineReadiness
 
+  /// Whether the selected engine still has a model resident. Asked once, after
+  /// the claim, because the unload timer is only disarmed from that point on.
+  private let engineIsLoaded: @MainActor () async -> Bool
+
   /// Mirrors `EngineCoordinator.PressReadiness` without importing it, so this
   /// type keeps knowing nothing about who owns engine switching.
   enum EngineReadiness: Sendable, Equatable {
@@ -411,6 +415,7 @@ final class FileImportCoordinator {
     engineAdmission: EngineAdmissionAccess,
     polishOllamaLocalityNow: @escaping @MainActor () -> Bool? = { false },
     refreshOllamaFacts: @escaping @MainActor () async -> Void = {},
+    engineIsLoaded: @escaping @MainActor () async -> Bool = { true },
     disarmEngineTimers: @escaping @MainActor () -> Void = {},
     rearmEngineTimers: @escaping @MainActor () -> Void = {},
     ensureEngineReady: @escaping @MainActor () async -> EngineReadiness = { .ready },
@@ -422,6 +427,7 @@ final class FileImportCoordinator {
     self.polishOllamaLocalityNow = polishOllamaLocalityNow
     self.refreshOllamaFacts = refreshOllamaFacts
     self.ensureEngineReady = ensureEngineReady
+    self.engineIsLoaded = engineIsLoaded
     self.disarmEngineTimers = disarmEngineTimers
     self.rearmEngineTimers = rearmEngineTimers
     self.onEngineReleased = onEngineReleased
@@ -729,11 +735,6 @@ final class FileImportCoordinator {
     runTask = Task { [weak self] in
       guard let self else { return }
 
-      // **The whole run, inside one bracket.** Nothing below can exit without
-      // the user's model-unload setting being put back.
-      disarmEngineTimers()
-      defer { rearmEngineTimers() }
-
       // 1. The engine the user picked, actually active and actually warm.
       let readiness = await ensureEngineReady()
       guard generationAtStart == generation else { return }
@@ -751,13 +752,35 @@ final class FileImportCoordinator {
       case .refused(let holder): showRejection(.engineBusy(holder)); return
       }
       isEngineHeld = true
+      // **The unload-timer bracket lives INSIDE the claim, and that placement is
+      // the fix.** Put around the whole task it also fired on the paths where
+      // this run never got the claim — and `ensureEngineReady()` suspends, so
+      // another workload can take the lease while it is running. The `defer`
+      // then re-armed the timers under SOMEBODY ELSE'S run, which is the same
+      // unload it exists to prevent, aimed at a different victim. Found by cloud
+      // review, one round after the leak it was fixing.
+      //
+      // Nothing is lost by disarming later: a timer that fires between the
+      // readiness drive and here unloads a model the readiness postcondition has
+      // already confirmed, and the re-check below reloads it.
+      disarmEngineTimers()
       // **The claim goes back only here**, after the physical work has exited.
       // Releasing where Stop is DECIDED would let a dictation in while a
       // cancelled part was still inside the one-slot polish server.
       defer {
+        rearmEngineTimers()
         engineAdmission.release(token)
         finishEngineHold()
       }
+      // The timer above could have fired while we were claiming. Cheap to ask,
+      // and the alternative is transcribing on an engine that just unloaded.
+      if await engineIsLoaded() == false {
+        guard await ensureEngineReady() == .ready else {
+          showRejection(.engineNotReady)
+          return
+        }
+      }
+
       runConfiguration = beginRun()
       // Pinned from the SAME freeze, so the pin cannot outlive or predate it.
       heldLocalPolishProvider = runConfiguration?.localPolishProvider

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -474,6 +474,14 @@ final class FileImportCoordinator {
     }
   }
 
+  /// Whether there is audio in hand to run, however the screen got here: a file
+  /// that decoded cleanly, or one whose run was refused for a reason about the
+  /// ENGINE rather than the file.
+  var isReadyToRun: Bool {
+    if case .ready = state { return true }
+    return canRetry
+  }
+
   /// Whether Try again is offered: an engine refusal, with the audio still here.
   var canRetry: Bool {
     guard case .rejected(let reason) = state else { return false }
@@ -612,7 +620,12 @@ final class FileImportCoordinator {
     case .transcription, .polish, .review:
       guard file != nil else { return false }
       if hasDocument || target.rawValue < step.rawValue { return true }
-      guard advancing, case .ready = state else { return false }
+      // **A retryable file goes forward exactly like a ready one.** Refused for
+      // a busy engine, the user goes Back to pick a different one — and could
+      // not come forward again, because this asked for `.ready` and a refusal
+      // leaves `.rejected`. The audio is decoded and in hand either way, which
+      // is the only thing "forward" depends on. Found by Codex.
+      guard advancing, isReadyToRun else { return false }
       return target.rawValue == step.rawValue + 1
     }
   }

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -140,6 +140,10 @@ final class FileImportCoordinator {
     case noAudio
     case noSpeechFound
     case engineBusy(SharedEngineHolder)
+    /// The engine chosen on the Transcription step is not downloaded.
+    case engineNotInstalled
+    /// It is installed but did not come up. The next Start retries.
+    case engineNotReady
     case failed(String)
   }
 
@@ -157,6 +161,26 @@ final class FileImportCoordinator {
 
   private(set) var state: State = .idle
   private(set) var parts: [Part] = []
+
+  /// A sentence about the last Save, or nil. Shown on Done, beside the buttons.
+  ///
+  /// **A failed save has to be LOUD**, because the next thing the user does is
+  /// press New transcription, which clears the only copy of the document. A
+  /// discarded write error — a full disk, a removed volume, a folder they cannot
+  /// write to — meant they threw the words away believing they were on disk.
+  /// Found by Codex.
+  private(set) var saveMessage: String?
+
+  func noteSaveSucceeded(fileName: String) { saveMessage = "Saved to \(fileName)." }
+
+  func noteSaveFailed(_ error: any Error) {
+    saveMessage = "That file couldn't be saved. Your words are still here. Try another place."
+    saveFailureDetail = String(describing: error)
+  }
+
+  /// The underlying failure, for the log. Never shown: the sentence above is
+  /// what the user reads.
+  private(set) var saveFailureDetail: String?
 
   /// What the Working step's phase label says. The words describe the JOB, never
   /// the mechanism: the user is never told about parts or chunks.
@@ -189,7 +213,17 @@ final class FileImportCoordinator {
   }
 
   /// The document as one piece of text, for copy and save.
-  var documentText: String { parts.map(\.text).joined(separator: "\n\n") }
+  /// The document as one piece of text, for Copy and Save.
+  ///
+  /// **Falls back to the raw transcript, because the screen does.** Stopping
+  /// during the FIRST passage leaves no finished parts and a full transcript,
+  /// and Done renders those raw words — while Copy put nothing on the clipboard
+  /// and Save wrote an empty file over the only copy the user had. Found by
+  /// Codex. Reading the same value the page renders is what makes the two unable
+  /// to disagree.
+  var documentText: String {
+    parts.isEmpty ? rawTranscript : parts.map(\.text).joined(separator: "\n\n")
+  }
 
   /// Whether a run is in flight AS THE SCREEN SEES IT. Drives the sidebar dot,
   /// the Stop button and whether the wizard's steps are navigable.
@@ -219,6 +253,30 @@ final class FileImportCoordinator {
   private let decode: @Sendable (URL) async throws -> AudioFileDecoder.Decoded
   private let transcribe: @MainActor ([Float]) async throws -> String
   private let engineAdmission: EngineAdmissionAccess
+
+  /// Drives the SELECTED speech engine to active-and-warm, and says what
+  /// happened. The composition root points this at
+  /// `EngineCoordinator.ensureSelectedReadyForPress()`, the same authority a
+  /// record press uses.
+  ///
+  /// **A run must not begin until this says ready.** Choosing All Languages
+  /// while its model is not downloaded leaves the coordinator's active engine
+  /// unchanged, so the import happily transcribed with the fast English engine
+  /// while Review promised the other one. A switch still in flight produced the
+  /// same mismatch. Found by Codex.
+  ///
+  /// Runs BEFORE the claim, deliberately: gate 6b defers an engine switch while
+  /// an import holds the engine, so claiming first would make the switch wait
+  /// for a run that is itself waiting for the switch.
+  private let ensureEngineReady: @MainActor () async -> EngineReadiness
+
+  /// Mirrors `EngineCoordinator.PressReadiness` without importing it, so this
+  /// type keeps knowing nothing about who owns engine switching.
+  enum EngineReadiness: Sendable, Equatable {
+    case ready
+    case notInstalled
+    case notReady
+  }
 
   /// Called once, on the main actor, after a run has physically released the
   /// shared engine. The composition root points it at the existing retry paths.
@@ -271,11 +329,13 @@ final class FileImportCoordinator {
     transcribe: @escaping @MainActor ([Float]) async throws -> String,
     engineAdmission: EngineAdmissionAccess,
     polishIsRemoteOllamaNow: @escaping @MainActor () -> Bool = { false },
+    ensureEngineReady: @escaping @MainActor () async -> EngineReadiness = { .ready },
     onEngineReleased: @escaping @MainActor () -> Void = {},
     beginRun: @escaping @MainActor () -> RunConfiguration,
     processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome
   ) {
     self.polishIsRemoteOllamaNow = polishIsRemoteOllamaNow
+    self.ensureEngineReady = ensureEngineReady
     self.onEngineReleased = onEngineReleased
     self.decode = decode
     self.transcribe = transcribe
@@ -376,9 +436,34 @@ final class FileImportCoordinator {
     step = .polish
   }
 
-  /// Jumps to a completed step from the step bar. Same rule: only before a run.
+  /// Whether the step bar may take the user to `target` RIGHT NOW.
+  ///
+  /// **One function, read by both the bar and the jump**, so a step cannot be
+  /// clickable and refuse, or be refused and look clickable. "Earlier than the
+  /// current step" was the whole rule and it let a finished run navigate to
+  /// Working — an inactive progress bar with a Stop button that does nothing and
+  /// no way back to the document — and to Upload, where Continue is refused
+  /// because the state is finished rather than ready. Found by Codex.
+  func canJump(to target: Step) -> Bool {
+    guard !isRunning, target != step else { return false }
+    switch target {
+    // Never: it shows a run in progress, and after one there is none.
+    case .working: return false
+    // Only ever forward INTO, by finishing a run.
+    case .done: return false
+    // Choosing another file is `startOver()`'s job, reached from Done's own
+    // button, because it also has to clear the document.
+    case .upload: return rawTranscript.isEmpty && step.rawValue > Step.upload.rawValue
+    // The two choice steps stay reachable after a run: picking a different
+    // polisher and cleaning the same words again is a supported thing to do.
+    case .transcription, .polish, .review:
+      return file != nil && target.rawValue < step.rawValue
+    }
+  }
+
+  /// Takes the user to `target` if `canJump(to:)` allows it.
   func jump(to target: Step) {
-    guard !isRunning, target.rawValue < step.rawValue else { return }
+    guard canJump(to: target) else { return }
     step = target
   }
 
@@ -404,33 +489,51 @@ final class FileImportCoordinator {
   func start() {
     guard case .ready(let name, _) = state else { return }
 
-    let token: EngineLease.Token
-    switch engineAdmission.claim() {
-    case .granted(let granted):
-      token = granted
-    case .refused(let holder):
+    // Refused at the press, not after the warm-up. See `currentHolder`.
+    if let holder = engineAdmission.currentHolder() {
       showRejection(.engineBusy(holder))
       return
     }
 
-    runConfiguration = beginRun()
-
     generation += 1
     let generationAtStart = generation
     step = .working
-    phase = "Writing down what was said"
+    // The engine may need switching or warming, which takes long enough to be
+    // worth naming rather than showing a bar at 0% with no explanation.
+    phase = "Getting the engine ready"
     state = .transcribing(fileName: name)
 
-    isEngineHeld = true
     runTask = Task { [weak self] in
+      guard let self else { return }
+
+      // 1. The engine the user picked, actually active and actually warm.
+      let readiness = await ensureEngineReady()
+      guard generationAtStart == generation else { return }
+      switch readiness {
+      case .notInstalled: showRejection(.engineNotInstalled); return
+      case .notReady: showRejection(.engineNotReady); return
+      case .ready: break
+      }
+
+      // 2. Only now claim, and only now freeze: the snapshot records the engine
+      // that is running, which step 1 has just made true.
+      let token: EngineLease.Token
+      switch engineAdmission.claim() {
+      case .granted(let granted): token = granted
+      case .refused(let holder): showRejection(.engineBusy(holder)); return
+      }
+      isEngineHeld = true
       // **The claim goes back only here**, after the physical work has exited.
       // Releasing where Stop is DECIDED would let a dictation in while a
       // cancelled part was still inside the one-slot polish server.
       defer {
-        self?.engineAdmission.release(token)
-        self?.finishEngineHold()
+        engineAdmission.release(token)
+        finishEngineHold()
       }
-      await self?.run(generationAtStart: generationAtStart)
+      runConfiguration = beginRun()
+      phase = "Writing down what was said"
+
+      await run(generationAtStart: generationAtStart)
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -741,6 +741,19 @@ final class FileImportCoordinator {
     // already been pressed.
     step = .done
     phase = ""
+    // **Released HERE, because the run task can no longer do it.** Every
+    // `releaseDecodedAudio()` sits behind the generation guard — deliberately,
+    // so a late task cannot erase a file the user has since chosen — and `stop()`
+    // bumps the generation, so after a Stop both the late-success and the
+    // cancellation path return at that guard and the samples stayed resident for
+    // the life of the app. Hundreds of megabytes on the multi-hour recordings
+    // this feature advertises. Found by cloud review; introduced by the fix that
+    // moved the guard in front of the release.
+    //
+    // Safe because Stop is terminal for this audio: `start()` requires `.ready`
+    // and Stop leaves `.stopped`, `canRetry` requires a rejection about the
+    // ENGINE, and a re-polish reads `rawTranscript`. Nothing left can want it.
+    releaseDecodedAudio()
     runTask?.cancel()
   }
 

--- a/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
@@ -16,14 +16,13 @@ import EnviousWisprServices
 /// be a second thing to keep in step every time a limb gains a setting.
 @MainActor
 enum FileImportSettingsFreeze {
-  /// `backend` and `polish` come from the WIZARD, not from settings: the user
-  /// chose them for this file on their own screens, and a run that ignored them
-  /// would make those screens decorative.
-  static func snapshot(
-    settings: SettingsManager, backend: ASRBackendType, polish: LLMProvider
-  ) -> RecordingSettingsSnapshot {
+  /// Reads settings and nothing else. The wizard's Transcription and Polish
+  /// steps WRITE these settings when the user picks, so by the time Start is
+  /// pressed the user's choice IS the setting — there is no second copy to
+  /// prefer, and no way for the two to disagree.
+  static func snapshot(settings: SettingsManager) -> RecordingSettingsSnapshot {
     RecordingSettingsSnapshot(
-      backendType: backend,
+      backendType: settings.selectedBackend,
       backendSupportsLanguageDetection: false,
       languageMode: settings.languageMode,
       wordCorrectionEnabled: settings.wordCorrectionEnabled,
@@ -31,7 +30,7 @@ enum FileImportSettingsFreeze {
       emojiFormatterEnabled: settings.emojiFormatterEnabled,
       spokenPunctuationEnabled: settings.spokenPunctuationEnabled,
       customWordsVersion: nil,
-      llmProvider: polish.rawValue,
+      llmProvider: settings.llmProvider.rawValue,
       llmModel: settings.llmModel,
       s1Control: settings.s1Control)
   }
@@ -43,12 +42,17 @@ enum FileImportSettingsFreeze {
   /// Derived from the same snapshot the runner froze, so the page's privacy
   /// line and the engine reconciliation cannot disagree with what the parts are
   /// actually polished by.
-  static func configuration(for snapshot: RecordingSettingsSnapshot)
-    -> FileImportCoordinator.RunConfiguration
-  {
+  /// - Parameter ollamaModelIsRemote: whether THIS run's Ollama model is one the
+  ///   daemon proxies to its own servers. Passed in rather than looked up here
+  ///   so the value is taken once, at Start, and cannot change under a document
+  ///   that has already been polished.
+  static func configuration(
+    for snapshot: RecordingSettingsSnapshot, ollamaModelIsRemote: Bool
+  ) -> FileImportCoordinator.RunConfiguration {
     let provider = LLMProvider(rawValue: snapshot.llmProvider) ?? .none
     return FileImportCoordinator.RunConfiguration(
-      polishIsCloud: TranscribeFileView.isCloud(provider),
+      polishIsCloud: TranscribeFileView.isCloud(
+        provider, ollamaModelIsRemote: ollamaModelIsRemote),
       // Only the BUNDLED servers are pinnable: Ollama is the user's own process
       // and the cloud providers have nothing on this Mac to tear down.
       localPolishProvider: (provider == .egOne || provider == .s1Mini) ? provider : nil)

--- a/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
@@ -1,0 +1,32 @@
+import EnviousWisprCore
+import EnviousWisprPipeline
+import EnviousWisprServices
+
+/// #2648 — the user's current settings, frozen for one import.
+///
+/// **One import, one configuration** (founder, 2026-09-04). A user who changes
+/// their polisher halfway through a 40-minute file must not get a document
+/// polished two different ways, so the run takes a copy at Start and every part
+/// reads that copy.
+///
+/// Reuses `RecordingSettingsSnapshot` rather than declaring a parallel type. It
+/// is already the single authority for "the settings a text-processing run
+/// needs", it is what the crash-recovery replay reads, and a second type would
+/// be a second thing to keep in step every time a limb gains a setting.
+@MainActor
+enum FileImportSettingsFreeze {
+  static func snapshot(settings: SettingsManager) -> RecordingSettingsSnapshot {
+    RecordingSettingsSnapshot(
+      backendType: settings.selectedBackend,
+      backendSupportsLanguageDetection: false,
+      languageMode: settings.languageMode,
+      wordCorrectionEnabled: settings.wordCorrectionEnabled,
+      fillerRemovalEnabled: settings.fillerRemovalEnabled,
+      emojiFormatterEnabled: settings.emojiFormatterEnabled,
+      spokenPunctuationEnabled: settings.spokenPunctuationEnabled,
+      customWordsVersion: nil,
+      llmProvider: settings.llmProvider.rawValue,
+      llmModel: settings.llmModel,
+      s1Control: settings.s1Control)
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
@@ -1,3 +1,4 @@
+import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprPipeline
 import EnviousWisprServices
@@ -15,9 +16,14 @@ import EnviousWisprServices
 /// be a second thing to keep in step every time a limb gains a setting.
 @MainActor
 enum FileImportSettingsFreeze {
-  static func snapshot(settings: SettingsManager) -> RecordingSettingsSnapshot {
+  /// `backend` and `polish` come from the WIZARD, not from settings: the user
+  /// chose them for this file on their own screens, and a run that ignored them
+  /// would make those screens decorative.
+  static func snapshot(
+    settings: SettingsManager, backend: ASRBackendType, polish: LLMProvider
+  ) -> RecordingSettingsSnapshot {
     RecordingSettingsSnapshot(
-      backendType: settings.selectedBackend,
+      backendType: backend,
       backendSupportsLanguageDetection: false,
       languageMode: settings.languageMode,
       wordCorrectionEnabled: settings.wordCorrectionEnabled,
@@ -25,8 +31,26 @@ enum FileImportSettingsFreeze {
       emojiFormatterEnabled: settings.emojiFormatterEnabled,
       spokenPunctuationEnabled: settings.spokenPunctuationEnabled,
       customWordsVersion: nil,
-      llmProvider: settings.llmProvider.rawValue,
+      llmProvider: polish.rawValue,
       llmModel: settings.llmModel,
       s1Control: settings.s1Control)
+  }
+
+  /// What the rest of the app must read INSTEAD of live settings once a run has
+  /// started: where this run's text goes, and which bundled local server it
+  /// depends on.
+  ///
+  /// Derived from the same snapshot the runner froze, so the page's privacy
+  /// line and the engine reconciliation cannot disagree with what the parts are
+  /// actually polished by.
+  static func configuration(for snapshot: RecordingSettingsSnapshot)
+    -> FileImportCoordinator.RunConfiguration
+  {
+    let provider = LLMProvider(rawValue: snapshot.llmProvider) ?? .none
+    return FileImportCoordinator.RunConfiguration(
+      polishIsCloud: TranscribeFileView.isCloud(provider),
+      // Only the BUNDLED servers are pinnable: Ollama is the user's own process
+      // and the cloud providers have nothing on this Mac to tear down.
+      localPolishProvider: (provider == .egOne || provider == .s1Mini) ? provider : nil)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
@@ -28,7 +28,11 @@ enum FileImportSettingsFreeze {
   static func snapshot(settings: SettingsManager) -> RecordingSettingsSnapshot {
     RecordingSettingsSnapshot(
       backendType: settings.selectedBackend,
-      backendSupportsLanguageDetection: false,
+      // **Asked, not assumed.** Hardcoding false told the resolver to ignore
+      // whatever WhisperKit reported, so an automatic-language import fell back
+      // to identifying the language from the ASR text — the weakest source in
+      // the ladder, on the text least safe to guess from. Found by cloud review.
+      backendSupportsLanguageDetection: settings.selectedBackend == .whisperKit,
       languageMode: settings.languageMode,
       wordCorrectionEnabled: settings.wordCorrectionEnabled,
       fillerRemovalEnabled: settings.fillerRemovalEnabled,

--- a/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
@@ -48,11 +48,13 @@ enum FileImportSettingsFreeze {
   /// line and the engine reconciliation cannot disagree with what the parts are
   /// actually polished by.
   /// - Parameter ollamaModelIsRemote: whether THIS run's Ollama model is one the
-  ///   daemon proxies to its own servers. Passed in rather than looked up here
-  ///   so the value is taken once, at Start, and cannot change under a document
-  ///   that has already been polished.
+  ///   daemon proxies to its own servers, or `nil` when the daemon has not been
+  ///   asked. Passed in rather than looked up here so the value is taken once,
+  ///   at Start, and cannot change under a document that has already been
+  ///   polished. The `nil` case travels all the way to the disclosure, which
+  ///   refuses to promise local processing on an unknown.
   static func configuration(
-    for snapshot: RecordingSettingsSnapshot, ollamaModelIsRemote: Bool
+    for snapshot: RecordingSettingsSnapshot, ollamaModelIsRemote: Bool?
   ) -> FileImportCoordinator.RunConfiguration {
     let provider = LLMProvider(rawValue: snapshot.llmProvider) ?? .none
     return FileImportCoordinator.RunConfiguration(
@@ -66,7 +68,10 @@ enum FileImportSettingsFreeze {
       // to unload, so a remote one is deliberately nil: pinning it would defer
       // an eviction that was never going to happen and leave the tracker asking
       // the same question on every later settings change.
-      ollamaModel: (provider == .ollama && !ollamaModelIsRemote)
+      // A KNOWN-local model only. Unknown is not pinned: the eviction rule
+      // deliberately evicts an unknown model, and deferring that on a guess
+      // would leave its tracker asking the same question forever.
+      ollamaModel: (provider == .ollama && ollamaModelIsRemote == false)
         ? OllamaConnector.effectiveOllamaModel(provider: provider, model: snapshot.llmModel)
         : nil)
   }

--- a/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
@@ -1,5 +1,10 @@
 import EnviousWisprASR
 import EnviousWisprCore
+// `OllamaConnector.effectiveOllamaModel` is the canonical "which model will this
+// provider actually ask for" resolution, and the eviction rule this pin feeds
+// keys on exactly that value. Resolving it any other way here would compare two
+// spellings of one model.
+import EnviousWisprLLM
 import EnviousWisprPipeline
 import EnviousWisprServices
 
@@ -56,6 +61,13 @@ enum FileImportSettingsFreeze {
       // Only the BUNDLED servers are pinnable: Ollama is the user's own process
       // and the cloud providers have nothing on this Mac to tear down.
       localPolishProvider: (provider == .egOne || provider == .s1Mini) ? provider : nil,
-      polishProvider: provider)
+      polishProvider: provider,
+      // Only a LOCAL Ollama model has weights on this Mac for the eviction rule
+      // to unload, so a remote one is deliberately nil: pinning it would defer
+      // an eviction that was never going to happen and leave the tracker asking
+      // the same question on every later settings change.
+      ollamaModel: (provider == .ollama && !ollamaModelIsRemote)
+        ? OllamaConnector.effectiveOllamaModel(provider: provider, model: snapshot.llmModel)
+        : nil)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportSettingsFreeze.swift
@@ -55,6 +55,7 @@ enum FileImportSettingsFreeze {
         provider, ollamaModelIsRemote: ollamaModelIsRemote),
       // Only the BUNDLED servers are pinnable: Ollama is the user's own process
       // and the cloud providers have nothing on this Mac to tear down.
-      localPolishProvider: (provider == .egOne || provider == .s1Mini) ? provider : nil)
+      localPolishProvider: (provider == .egOne || provider == .s1Mini) ? provider : nil,
+      polishProvider: provider)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -68,6 +68,9 @@ final class PipelineSettingsSync {
   /// #2648 — see the initializer parameter of the same name.
   private let importPinnedLocalProvider: @MainActor () -> LLMProvider?
 
+  /// #2648 — the Ollama model a RUNNING file import froze, or nil.
+  private let importPinnedOllamaModel: @MainActor () -> String?
+
   init(
     kernelDriver: KernelDictationDriver,
     whisperKitKernelDriver: KernelDictationDriver,
@@ -85,9 +88,19 @@ final class PipelineSettingsSync {
     /// deactivated the very server the import was polishing through and the
     /// remaining parts came back raw. Found by cloud review. Defaults to nil so
     /// every existing construction is unchanged.
-    importPinnedLocalProvider: @escaping @MainActor () -> LLMProvider? = { nil }
+    importPinnedLocalProvider: @escaping @MainActor () -> LLMProvider? = { nil },
+    /// #2648 — the Ollama model a RUNNING file import froze, or nil.
+    ///
+    /// `isOllamaModelPinnedInFlight` reads the two DICTATION drivers' session
+    /// configs, and an import has no session config, so its frozen model was
+    /// unprotected: a provider or model change elsewhere in Settings evicted the
+    /// weights the remaining passages were about to use, and each one then paid
+    /// a reload it could exceed its polish deadline waiting for. Found by Codex.
+    /// Defaults to nil so every existing construction is unchanged.
+    importPinnedOllamaModel: @escaping @MainActor () -> String? = { nil }
   ) {
     self.importPinnedLocalProvider = importPinnedLocalProvider
+    self.importPinnedOllamaModel = importPinnedOllamaModel
     self.kernelDriver = kernelDriver
     self.whisperKitKernelDriver = whisperKitKernelDriver
     self.audioCapture = audioCapture
@@ -579,6 +592,9 @@ final class PipelineSettingsSync {
   /// given Ollama model. Used by `reconcileOllamaEviction` to avoid evicting
   /// a model the in-flight polish still needs.
   private func isOllamaModelPinnedInFlight(_ model: String) -> Bool {
+    // #2648: a file import is the THIRD workload that can have this model
+    // frozen, and it is the one with no `DictationSessionConfig` to read.
+    if importPinnedOllamaModel() == model { return true }
     for cfg in [kernelDriver.currentSessionConfig, whisperKitKernelDriver.currentSessionConfig] {
       guard let cfg else { continue }
       if cfg.llmProvider == .ollama && cfg.llmModel == model {

--- a/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
+++ b/Sources/EnviousWisprAppKit/App/PipelineSettingsSync.swift
@@ -65,6 +65,9 @@ final class PipelineSettingsSync {
   /// cannot observe a request that was never scheduled.
   var evictionScheduler: ((String) -> Void)?
 
+  /// #2648 — see the initializer parameter of the same name.
+  private let importPinnedLocalProvider: @MainActor () -> LLMProvider?
+
   init(
     kernelDriver: KernelDictationDriver,
     whisperKitKernelDriver: KernelDictationDriver,
@@ -73,8 +76,18 @@ final class PipelineSettingsSync {
     hotkeyService: HotkeyService,
     egOneRuntime: EGOneRuntime? = nil,
     s1MiniRuntime: EGOneRuntime? = nil,
-    ollamaRemotenessLookup: @escaping (String) -> Bool?
+    ollamaRemotenessLookup: @escaping (String) -> Bool?,
+    /// #2648 — the bundled local polisher a RUNNING file import has frozen, or
+    /// nil.
+    ///
+    /// `pinnedLocalProvider()` reads the two dictation drivers' session configs,
+    /// and an import has no session config, so switching provider mid-import
+    /// deactivated the very server the import was polishing through and the
+    /// remaining parts came back raw. Found by cloud review. Defaults to nil so
+    /// every existing construction is unchanged.
+    importPinnedLocalProvider: @escaping @MainActor () -> LLMProvider? = { nil }
   ) {
+    self.importPinnedLocalProvider = importPinnedLocalProvider
     self.kernelDriver = kernelDriver
     self.whisperKitKernelDriver = whisperKitKernelDriver
     self.audioCapture = audioCapture
@@ -424,6 +437,9 @@ final class PipelineSettingsSync {
   /// for a take that is still running", and the answer has to say WHICH, so a
   /// switch back to the frozen engine is not needlessly deferred.
   func pinnedLocalProvider() -> LLMProvider? {
+    // #2648: the file import is a third holder of a bundled local server, and it
+    // has no session config for the loop below to read.
+    if let imported = importPinnedLocalProvider() { return imported }
     for cfg in [kernelDriver.currentSessionConfig, whisperKitKernelDriver.currentSessionConfig] {
       // #2651: the optional is unwrapped BEFORE the switch, so `.none` means
       // `LLMProvider.none` and nothing else. Matching on `cfg?.llmProvider`

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -178,6 +178,18 @@ final class RecoveryCoordinator {
   /// in explicitly via `.alwaysAllowedForTesting`.
   private let recoveryEngineClaim: RecoveryEngineClaim
 
+  /// #2648 — the shared ASR-and-polish resource, claimed for the whole of one
+  /// replay item.
+  ///
+  /// Separate from `recoveryEngineClaim` above because the two answer different
+  /// questions and neither implies the other: that one keeps recovery away from
+  /// engine MUTATION and deliberately admits several mutations at once
+  /// (`EngineRecoveryGate.swift:56-59`); this one admits exactly one WORKLOAD.
+  /// A replay runs the same polish server a file import would
+  /// (`RecoveryTextProcessor.swift:62`), so recovery has to hold it too, or an
+  /// import could start underneath a replay.
+  private let engineAdmission: EngineAdmissionAccess
+
   /// #1707 Phase 3 (§3.1) — set by `RecordingStarter`'s refusal path when a
   /// live record-press was refused because recovery held the engine. Checked
   /// before each item's handshake so a multi-item scan yields the engine
@@ -234,6 +246,7 @@ final class RecoveryCoordinator {
     existingRecoveryIDs: @escaping @MainActor () async -> Set<String>,
     isDictationActive: @escaping @MainActor () -> Bool,
     recoveryEngineClaim: RecoveryEngineClaim,
+    engineAdmission: EngineAdmissionAccess,
     resetEngine: @escaping @MainActor () -> Void = {}
   ) {
     self.keyStore = keyStore
@@ -242,6 +255,7 @@ final class RecoveryCoordinator {
     self.existingRecoveryIDs = existingRecoveryIDs
     self.isDictationActive = isDictationActive
     self.recoveryEngineClaim = recoveryEngineClaim
+    self.engineAdmission = engineAdmission
     self.resetEngine = resetEngine
   }
 
@@ -1313,6 +1327,22 @@ final class RecoveryCoordinator {
         // when it releases, so stopping here is never a stranded deferral.
         return false
       }
+      // #2648 — the shared resource, claimed for this item and held across the
+      // whole replay. Refused means a dictation or a file import is using it;
+      // the spools stay on disk and the next scan retries, exactly as the two
+      // guards above do. Ordered AFTER the mutation gate so a refusal here
+      // cannot strand that gate's `recoveryRetryOwed` wake-up: the `defer`
+      // below releases both.
+      let engineTokenForThisItem: EngineLease.Token
+      switch engineAdmission.claim() {
+      case .granted(let token):
+        engineTokenForThisItem = token
+      case .refused(let holder):
+        RecoveryLog.line(
+          "deferred — the shared engine is held by \(holder.rawValue); spools stay on disk")
+        recoveryEngineClaim.end()
+        return false
+      }
       isRecovering = true
 
       activeRecoveryID = id
@@ -1327,6 +1357,20 @@ final class RecoveryCoordinator {
         activeRecoveryID = nil
         isRecovering = false
         recoveryEngineClaim.end()
+        // #2648 — released after `replayer.replay` returns. **This bounds
+        // ownership by caller lifetime; it does not prove underlying inference
+        // has stopped.** Releasing earlier — at the point a stop is decided —
+        // would be strictly worse, because the replay can still be inside the
+        // polish server then.
+        //
+        // A replay that never returns therefore never releases. That is not new:
+        // `isRecovering` is cleared by this same `defer`, so a wedged replay
+        // already blocked every record press before this claim existed
+        // (`RecordingStarter`'s recovery gate). WhisperKit is the known case —
+        // `WhisperKitBackend.swift:537` says cancellation depends on
+        // transcription returning, and Discard's `unload()` does not interrupt a
+        // running Core ML decode.
+        engineAdmission.release(engineTokenForThisItem)
         onRecoveryComplete?()
       }
       // #1762: BEFORE the await, not after. If the process wedges or dies inside

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -910,7 +910,13 @@ package final class WisprBootstrapper {
     let activeEngine = ActiveEngineOperation.live(
       asrManager: asrManager, whisperKitBackend: whisperKitBackend)
 
-    let diagnosticsCoordinator = DiagnosticsCoordinator(engineMutationScope: engineMutationScope)
+    // The benchmark is a FOURTH workload on the one inference slot, so it takes
+    // the same claim a dictation, a replay and an import take. Built here rather
+    // than inside `DiagnosticsCoordinator`, whose import ceiling refuses to know
+    // about the pipeline — correctly, since its job is owning the surface.
+    let diagnosticsCoordinator = DiagnosticsCoordinator(
+      benchmark: BenchmarkSuite(
+        engineMutationScope: engineMutationScope, engineLease: engineLease))
 
     // **Two arguments, and no self-reference problem to solve** (#2292 C3).
     // This used to hand over three closures, one of which resolved the chip's
@@ -1408,6 +1414,14 @@ package final class WisprBootstrapper {
         // `ParakeetBackend.unload()` would clear the model the decoder was
         // running on. `onEngineReleased` re-arms it. Found by Codex.
         asrManager.cancelIdleTimer()
+        // **Both engines, because each arms its own timer.** Parakeet's lives on
+        // the manager above; WhisperKit's is a Task on its adapter that only
+        // this call stops. Cancelling one and not the other left an All
+        // Languages import following a WhisperKit dictation exposed to exactly
+        // the unload the first cancel exists to prevent. Cheap and idempotent,
+        // so both are cancelled rather than the one that looks active.
+        kernelDriver.cancelPendingEngineUnload()
+        whisperKitKernelDriver.cancelPendingEngineUnload()
         switch await engineCoordinator.ensureSelectedReadyForPress() {
         case .ready: return .ready
         case .notInstalled: return .notInstalled

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1354,6 +1354,12 @@ package final class WisprBootstrapper {
     // wired here rather than deferred again. Codex confirming round.
     egOneRuntime.isSharedEngineBusy = { [weak engineLease] in engineLease?.isBusy ?? false }
     s1MiniRuntime.isSharedEngineBusy = { [weak engineLease] in engineLease?.isBusy ?? false }
+    egOneRuntime.sharedEngineAdmissionEpoch = { [weak engineLease] in
+      engineLease?.admissionEpoch ?? 0
+    }
+    s1MiniRuntime.sharedEngineAdmissionEpoch = { [weak engineLease] in
+      engineLease?.admissionEpoch ?? 0
+    }
 
     let fileImportCoordinator = FileImportCoordinator(
       decode: { url in try await AudioFileDecoder.decode(url: url) },

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -248,6 +248,11 @@ package final class WisprBootstrapper {
     // function. Matches the existing `engineCoordinatorForRecoveryGate`
     // forward-declared-then-assigned-after-construction pattern below.
     weak var recoveryCoordinatorForEngineMutationScope: RecoveryCoordinator?
+    // #2648, cloud review — the same forward-declared-then-assigned pattern, for
+    // the same reason: the engine-switch gate and the local-polisher pin are
+    // both constructed long before the import coordinator exists, and both have
+    // to be able to see a running import.
+    weak var fileImportCoordinatorForGates: FileImportCoordinator?
     // #1741 — the ONE shared mutation-side capability (§3 construction-
     // topology correction: one value, not one per consumer), threaded through
     // each consumer's required initializer argument as this plan migrates it
@@ -601,7 +606,8 @@ package final class WisprBootstrapper {
       hotkeyService: hotkeyService,
       egOneRuntime: egOneRuntime,
       s1MiniRuntime: s1MiniRuntime,
-      ollamaRemotenessLookup: PipelineSettingsSync.liveOllamaRemotenessLookup(setup.ollamaSetup)
+      ollamaRemotenessLookup: PipelineSettingsSync.liveOllamaRemotenessLookup(setup.ollamaSetup),
+      importPinnedLocalProvider: { fileImportCoordinatorForGates?.pinnedLocalPolishProvider }
     )
     settingsSync.applyInitialSettings(settings)
 
@@ -1036,6 +1042,7 @@ package final class WisprBootstrapper {
           (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver).state.isActive
         },
         isRecovering: { [weak recoveryCoordinator] in recoveryCoordinator?.isRecovering ?? false },
+        isFileImportRunning: { fileImportCoordinatorForGates?.isRunning ?? false },
         isInstalled: { [setup] backend in
           backend == .parakeet ? true : setup.whisperKitSetup.setupState == .ready
         },
@@ -1317,11 +1324,23 @@ package final class WisprBootstrapper {
     let fileImportRunner = FileImportRunner(
       keychainManager: keychainManager,
       egOneRuntime: egOneRuntime,
-      s1MiniRuntime: s1MiniRuntime)
+      s1MiniRuntime: s1MiniRuntime,
+      // #2648, cloud review: the SAME output-safety classifier live dictation
+      // and crash recovery get. Without it an imported part polished by Apple
+      // Intelligence silently loses the classifier-aware output filter, even
+      // when the classifier prewarmed successfully.
+      outputClassifierHolder: outputClassifierHolder)
     let fileImportCoordinator = FileImportCoordinator(
       decode: { url in try await AudioFileDecoder.decode(url: url) },
-      transcribe: { [asrManager] samples in
-        try await asrManager.transcribe(audioSamples: samples, options: .default).text
+      // **The user's locked language reaches ASR, not just the cleanup.** Cloud
+      // review found `.default` here: WhisperKit uses `options.language` to turn
+      // auto-detection OFF and Parakeet uses it for its language/script filter,
+      // so a locked non-English recording could be recognised in the wrong
+      // script before post-processing ever saw it.
+      transcribe: { [asrManager, settings] samples in
+        var options = TranscriptionOptions.default
+        if case .locked(let code) = settings.languageMode { options.language = code }
+        return try await asrManager.transcribe(audioSamples: samples, options: options).text
       },
       // The third workload, claiming the same one-slot engine as a dictation and
       // a crash replay.
@@ -1329,12 +1348,19 @@ package final class WisprBootstrapper {
       // The user's words, read LIVE at Start rather than held from launch: the
       // propagator is the one place that knows the current vocabulary, and an
       // import started after the user adds a word should use it.
+      // The wizard's own choices win over the dictation settings: the user
+      // picked an engine and a polisher for THIS file, on their own screens, and
+      // freezing the app's settings instead would quietly ignore both.
       beginRun: { [settings, customWordsPropagator] in
-        fileImportRunner.freeze(
-          settings: FileImportSettingsFreeze.snapshot(settings: settings),
-          vocabulary: customWordsPropagator.corrector)
+        let snapshot = FileImportSettingsFreeze.snapshot(
+          settings: settings,
+          backend: fileImportCoordinatorForGates?.chosenBackend ?? settings.selectedBackend,
+          polish: fileImportCoordinatorForGates?.chosenPolish ?? settings.llmProvider)
+        fileImportRunner.freeze(settings: snapshot, vocabulary: customWordsPropagator.corrector)
+        return FileImportSettingsFreeze.configuration(for: snapshot)
       },
       processPart: { [fileImportRunner] part in try await fileImportRunner.process(part: part) })
+    fileImportCoordinatorForGates = fileImportCoordinator
     self.fileImportCoordinator = fileImportCoordinator
     self.transcriptCoordinator = transcriptCoordinator
     self.liveRecordingState = liveRecordingState

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1340,6 +1340,14 @@ package final class WisprBootstrapper {
       // Intelligence silently loses the classifier-aware output filter, even
       // when the classifier prewarmed successfully.
       outputClassifierHolder: outputClassifierHolder)
+    // #2648: the health probe asks the lease, not the settings sync, because
+    // the question is "is the ONE inference slot occupied" and every workload
+    // that can occupy it takes this claim. `isBusy` had no production reader
+    // when the lease shipped; file import is what made the gap live, so it is
+    // wired here rather than deferred again. Codex confirming round.
+    egOneRuntime.isSharedEngineBusy = { [weak engineLease] in engineLease?.isBusy ?? false }
+    s1MiniRuntime.isSharedEngineBusy = { [weak engineLease] in engineLease?.isBusy ?? false }
+
     let fileImportCoordinator = FileImportCoordinator(
       decode: { url in try await AudioFileDecoder.decode(url: url) },
       // **The user's locked language reaches ASR, not just the cleanup.** Cloud
@@ -1370,6 +1378,16 @@ package final class WisprBootstrapper {
       // cloud upload the user did not make.
       polishIsRemoteOllamaNow: { [settings, ollamaRemoteness] in
         settings.llmProvider == .ollama && ollamaRemoteness(settings.llmModel) == true
+      },
+      // The SAME authority a record press uses, so "is the engine the user
+      // picked ready" has one answer in the app rather than two.
+      ensureEngineReady: { [weak engineCoordinator] in
+        guard let engineCoordinator else { return .notReady }
+        switch await engineCoordinator.ensureSelectedReadyForPress() {
+        case .ready: return .ready
+        case .notInstalled: return .notInstalled
+        case .notReady: return .notReady
+        }
       },
       // The same three retries a finished dictation fires
       // (`DictationLifecycleCoordinator` on its terminal), because an import

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1379,8 +1379,13 @@ package final class WisprBootstrapper {
       // unknown model answers `nil`, read here as NOT remote, which matches the
       // provider-only classification this replaced and never over-claims a
       // cloud upload the user did not make.
-      polishIsRemoteOllamaNow: { [settings, ollamaRemoteness] in
-        settings.llmProvider == .ollama && ollamaRemoteness(settings.llmModel) == true
+      // Three answers, passed through. `nil` means the daemon has not been
+      // asked, which the page must not read as "runs here".
+      polishOllamaLocalityNow: { [settings, ollamaRemoteness] in
+        settings.llmProvider == .ollama ? ollamaRemoteness(settings.llmModel) : false
+      },
+      refreshOllamaFacts: { [ollamaSetup = setup.ollamaSetup] in
+        await ollamaSetup.refreshDownloadedModels()
       },
       // The SAME authority a record press uses, so "is the engine the user
       // picked ready" has one answer in the app rather than two.
@@ -1393,8 +1398,16 @@ package final class WisprBootstrapper {
       // — reachable through the ordinary memory-saving unload setting. Found by
       // Codex. `load()`'s postcondition is readiness, not merely that the call
       // returned, so a warm that fails still refuses.
-      ensureEngineReady: { [weak engineCoordinator, activeEngine] in
+      ensureEngineReady: { [weak engineCoordinator, activeEngine, asrManager] in
         guard let engineCoordinator else { return .notReady }
+        // **The pending idle unload is cancelled here, exactly as
+        // `ParakeetEngineAdapter.beginSession()` does it for a recording.** A
+        // dictation minutes earlier arms a timer under the user's model-unload
+        // setting; nothing was disarming it for an import, and its mutation gate
+        // does not consult `EngineLease`, so the timer could fire mid-import and
+        // `ParakeetBackend.unload()` would clear the model the decoder was
+        // running on. `onEngineReleased` re-arms it. Found by Codex.
+        asrManager.cancelIdleTimer()
         switch await engineCoordinator.ensureSelectedReadyForPress() {
         case .ready: return .ready
         case .notInstalled: return .notInstalled
@@ -1411,7 +1424,14 @@ package final class WisprBootstrapper {
       // during a long import stayed pending until something unrelated happened
       // to poke the same paths.
       onEngineReleased: {
-        [weak engineCoordinator, weak recoveryCoordinatorForEngineMutationScope, settings] in
+        [
+          weak engineCoordinator, weak recoveryCoordinatorForEngineMutationScope, settings,
+          asrManager
+        ] in
+        // The other half of the bracket above: the user's model-unload setting
+        // is honoured again now the import is done with the engine, the same
+        // call `ParakeetEngineAdapter.applyUnloadPolicy` makes after a take.
+        asrManager.noteTranscriptionComplete(policy: settings.modelUnloadPolicy)
         engineCoordinator?.poke(.driverStateChanged)
         settingsSync.retryDeferredOllamaEviction(settings: settings)
         settingsSync.retryDeferredEGOneDeactivation(settings: settings)
@@ -1435,7 +1455,7 @@ package final class WisprBootstrapper {
         return FileImportSettingsFreeze.configuration(
           for: snapshot,
           ollamaModelIsRemote: snapshot.llmProvider == LLMProvider.ollama.rawValue
-            && ollamaRemoteness(snapshot.llmModel) == true)
+            ? ollamaRemoteness(snapshot.llmModel) : false)
       },
       processPart: { [fileImportRunner] part in try await fileImportRunner.process(part: part) })
     fileImportCoordinatorForGates = fileImportCoordinator

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1375,7 +1375,12 @@ package final class WisprBootstrapper {
       transcribe: { [activeEngine, settings] samples in
         var options = TranscriptionOptions.default
         if case .locked(let code) = settings.languageMode { options.language = code }
-        return try await activeEngine.transcribe(samples, options).text
+        // The engine's own language answer travels with the words. Reducing this
+        // to `.text` threw away the better half: the cleanup chain's ladder
+        // prefers what the engine heard over what a text identifier guesses from
+        // the ASR output.
+        let result = try await activeEngine.transcribe(samples, options)
+        return (text: result.text, language: result.language)
       },
       // The third workload, claiming the same one-slot engine as a dictation and
       // a crash replay.
@@ -1404,24 +1409,25 @@ package final class WisprBootstrapper {
       // — reachable through the ordinary memory-saving unload setting. Found by
       // Codex. `load()`'s postcondition is readiness, not merely that the call
       // returned, so a warm that fails still refuses.
-      ensureEngineReady: { [weak engineCoordinator, activeEngine, asrManager] in
-        guard let engineCoordinator else { return .notReady }
-        // **The pending idle unload is cancelled here, exactly as
-        // `ParakeetEngineAdapter.beginSession()` does it for a recording.** A
-        // dictation minutes earlier arms a timer under the user's model-unload
-        // setting; nothing was disarming it for an import, and its mutation gate
-        // does not consult `EngineLease`, so the timer could fire mid-import and
-        // `ParakeetBackend.unload()` would clear the model the decoder was
-        // running on. `onEngineReleased` re-arms it. Found by Codex.
-        asrManager.cancelIdleTimer()
-        // **Both engines, because each arms its own timer.** Parakeet's lives on
-        // the manager above; WhisperKit's is a Task on its adapter that only
-        // this call stops. Cancelling one and not the other left an All
-        // Languages import following a WhisperKit dictation exposed to exactly
-        // the unload the first cancel exists to prevent. Cheap and idempotent,
-        // so both are cancelled rather than the one that looks active.
+      // **The disarm/re-arm pair, handed over as a pair.** A dictation minutes
+      // earlier arms a timer under the user's model-unload setting, and its
+      // mutation gate does not consult `EngineLease`, so it could fire mid-import
+      // and clear the model the decoder is running on. Each engine arms its OWN
+      // timer, so both are named on both sides; `ParakeetEngineAdapter` forwards
+      // to `ASRManager.noteTranscriptionComplete`, which is why going through
+      // the adapters covers both engines rather than one of them twice.
+      // Idempotent, so both are always touched rather than whichever looks
+      // active.
+      disarmEngineTimers: { [kernelDriver, whisperKitKernelDriver] in
         kernelDriver.cancelPendingEngineUnload()
         whisperKitKernelDriver.cancelPendingEngineUnload()
+      },
+      rearmEngineTimers: { [kernelDriver, whisperKitKernelDriver, settings] in
+        kernelDriver.applyEngineUnloadPolicy(settings.modelUnloadPolicy)
+        whisperKitKernelDriver.applyEngineUnloadPolicy(settings.modelUnloadPolicy)
+      },
+      ensureEngineReady: { [weak engineCoordinator, activeEngine] in
+        guard let engineCoordinator else { return .notReady }
         switch await engineCoordinator.ensureSelectedReadyForPress() {
         case .ready: return .ready
         case .notInstalled: return .notInstalled
@@ -1442,14 +1448,6 @@ package final class WisprBootstrapper {
           weak engineCoordinator, weak recoveryCoordinatorForEngineMutationScope, settings,
           asrManager
         ] in
-        // The other half of the bracket above, and it must name the SAME two
-        // engines. Going through each adapter rather than through
-        // `asrManager.noteTranscriptionComplete` directly is what makes that
-        // true by construction: Parakeet's adapter forwards to exactly that
-        // call, and WhisperKit's arms its own Task, so one line each covers both
-        // instead of covering Parakeet twice.
-        kernelDriver.applyEngineUnloadPolicy(settings.modelUnloadPolicy)
-        whisperKitKernelDriver.applyEngineUnloadPolicy(settings.modelUnloadPolicy)
         engineCoordinator?.poke(.driverStateChanged)
         settingsSync.retryDeferredOllamaEviction(settings: settings)
         settingsSync.retryDeferredEGOneDeactivation(settings: settings)
@@ -1475,7 +1473,9 @@ package final class WisprBootstrapper {
           ollamaModelIsRemote: snapshot.llmProvider == LLMProvider.ollama.rawValue
             ? ollamaRemoteness(snapshot.llmModel) : false)
       },
-      processPart: { [fileImportRunner] part in try await fileImportRunner.process(part: part) })
+      processPart: { [fileImportRunner] part, language in
+        try await fileImportRunner.process(part: part, engineLanguage: language)
+      })
     fileImportCoordinatorForGates = fileImportCoordinator
     self.fileImportCoordinator = fileImportCoordinator
     self.transcriptCoordinator = transcriptCoordinator

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -598,6 +598,11 @@ package final class WisprBootstrapper {
     whisperKitRetirement?.unloadForRemoval = { [weak whisperKitKernelDriver] in
       await whisperKitKernelDriver?.unloadEngineForRemoval()
     }
+    // ONE lookup, three readers: the polish-runtime eviction rule below, the
+    // import page's privacy line, and the configuration an import freezes at
+    // Start. Two of those are promises to the user about where their words went,
+    // so they must not be able to disagree with the third.
+    let ollamaRemoteness = PipelineSettingsSync.liveOllamaRemotenessLookup(setup.ollamaSetup)
     let settingsSync = PipelineSettingsSync(
       kernelDriver: kernelDriver,
       whisperKitKernelDriver: whisperKitKernelDriver,
@@ -606,7 +611,7 @@ package final class WisprBootstrapper {
       hotkeyService: hotkeyService,
       egOneRuntime: egOneRuntime,
       s1MiniRuntime: s1MiniRuntime,
-      ollamaRemotenessLookup: PipelineSettingsSync.liveOllamaRemotenessLookup(setup.ollamaSetup),
+      ollamaRemotenessLookup: ollamaRemoteness,
       importPinnedLocalProvider: { fileImportCoordinatorForGates?.pinnedLocalPolishProvider }
     )
     settingsSync.applyInitialSettings(settings)
@@ -897,8 +902,10 @@ package final class WisprBootstrapper {
     }
 
     let navigationCoordinator = NavigationCoordinator()
-    // #1386 PR-2: the one door to whichever engine is active, for the two callers
-    // that never used the normal dictation doors (crash recovery, Diagnostics).
+    // #1386 PR-2: the one door to whichever engine is active, for the callers
+    // that never used the normal dictation doors — crash recovery, Diagnostics,
+    // and since #2648 file import, which needs the engine the user picked on the
+    // Transcription step rather than the one the manager happens to own.
     let activeEngine = ActiveEngineOperation.live(
       asrManager: asrManager, whisperKitBackend: whisperKitBackend)
 
@@ -1042,7 +1049,10 @@ package final class WisprBootstrapper {
           (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver).state.isActive
         },
         isRecovering: { [weak recoveryCoordinator] in recoveryCoordinator?.isRecovering ?? false },
-        isFileImportRunning: { fileImportCoordinatorForGates?.isRunning ?? false },
+        // `isEngineHeld`, not `isRunning`: Stop flips the visible state at the
+        // press while the cancelled work is still inside the engine, and a
+        // switch admitted in that window unloads the backend underneath it.
+        isFileImportRunning: { fileImportCoordinatorForGates?.isEngineHeld ?? false },
         isInstalled: { [setup] backend in
           backend == .parakeet ? true : setup.whisperKitSetup.setupState == .ready
         },
@@ -1337,27 +1347,54 @@ package final class WisprBootstrapper {
       // auto-detection OFF and Parakeet uses it for its language/script filter,
       // so a locked non-English recording could be recognised in the wrong
       // script before post-processing ever saw it.
-      transcribe: { [asrManager, settings] samples in
+      // **Through `ActiveEngineOperation`, which is the ONE door for "whichever
+      // speech engine is active".** Calling `asrManager.transcribe` directly
+      // reached Parakeet and only Parakeet: with All Languages selected it threw
+      // `ASRManagerNotOwnedError`, because WhisperKit does not live in the
+      // manager. `load()` first, because the user may have picked an engine on
+      // the Transcription step seconds ago and nothing has warmed it — its
+      // postcondition is readiness, not merely that the call returned.
+      transcribe: { [activeEngine, settings] samples in
         var options = TranscriptionOptions.default
         if case .locked(let code) = settings.languageMode { options.language = code }
-        return try await asrManager.transcribe(audioSamples: samples, options: options).text
+        if await activeEngine.isLoaded() == false { try await activeEngine.load() }
+        return try await activeEngine.transcribe(samples, options).text
       },
       // The third workload, claiming the same one-slot engine as a dictation and
       // a crash replay.
       engineAdmission: .live(lease: engineLease, as: .fileImport),
+      // The SAME lookup the polish-runtime reconciliation uses, so the page's
+      // privacy line and the eviction rule cannot disagree about one model. An
+      // unknown model answers `nil`, read here as NOT remote, which matches the
+      // provider-only classification this replaced and never over-claims a
+      // cloud upload the user did not make.
+      polishIsRemoteOllamaNow: { [settings, ollamaRemoteness] in
+        settings.llmProvider == .ollama && ollamaRemoteness(settings.llmModel) == true
+      },
+      // The same three retries a finished dictation fires
+      // (`DictationLifecycleCoordinator` on its terminal), because an import
+      // blocks the same three things: an engine switch deferred by gate 6b, an
+      // Ollama eviction deferred by the pinned model, and an EG-1 deactivation
+      // deferred by the pinned runtime. Without this a settings change made
+      // during a long import stayed pending until something unrelated happened
+      // to poke the same paths.
+      onEngineReleased: { [weak engineCoordinator, settings] in
+        engineCoordinator?.poke(.driverStateChanged)
+        settingsSync.retryDeferredOllamaEviction(settings: settings)
+        settingsSync.retryDeferredEGOneDeactivation(settings: settings)
+      },
       // The user's words, read LIVE at Start rather than held from launch: the
       // propagator is the one place that knows the current vocabulary, and an
       // import started after the user adds a word should use it.
-      // The wizard's own choices win over the dictation settings: the user
-      // picked an engine and a polisher for THIS file, on their own screens, and
-      // freezing the app's settings instead would quietly ignore both.
+      // The wizard's steps WRITE settings when the user picks, so freezing
+      // settings here freezes exactly what the user chose on those screens.
       beginRun: { [settings, customWordsPropagator] in
-        let snapshot = FileImportSettingsFreeze.snapshot(
-          settings: settings,
-          backend: fileImportCoordinatorForGates?.chosenBackend ?? settings.selectedBackend,
-          polish: fileImportCoordinatorForGates?.chosenPolish ?? settings.llmProvider)
+        let snapshot = FileImportSettingsFreeze.snapshot(settings: settings)
         fileImportRunner.freeze(settings: snapshot, vocabulary: customWordsPropagator.corrector)
-        return FileImportSettingsFreeze.configuration(for: snapshot)
+        return FileImportSettingsFreeze.configuration(
+          for: snapshot,
+          ollamaModelIsRemote: snapshot.llmProvider == LLMProvider.ollama.rawValue
+            && ollamaRemoteness(snapshot.llmModel) == true)
       },
       processPart: { [fileImportRunner] part in try await fileImportRunner.process(part: part) })
     fileImportCoordinatorForGates = fileImportCoordinator

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1442,10 +1442,14 @@ package final class WisprBootstrapper {
           weak engineCoordinator, weak recoveryCoordinatorForEngineMutationScope, settings,
           asrManager
         ] in
-        // The other half of the bracket above: the user's model-unload setting
-        // is honoured again now the import is done with the engine, the same
-        // call `ParakeetEngineAdapter.applyUnloadPolicy` makes after a take.
-        asrManager.noteTranscriptionComplete(policy: settings.modelUnloadPolicy)
+        // The other half of the bracket above, and it must name the SAME two
+        // engines. Going through each adapter rather than through
+        // `asrManager.noteTranscriptionComplete` directly is what makes that
+        // true by construction: Parakeet's adapter forwards to exactly that
+        // call, and WhisperKit's arms its own Task, so one line each covers both
+        // instead of covering Parakeet twice.
+        kernelDriver.applyEngineUnloadPolicy(settings.modelUnloadPolicy)
+        whisperKitKernelDriver.applyEngineUnloadPolicy(settings.modelUnloadPolicy)
         engineCoordinator?.poke(.driverStateChanged)
         settingsSync.retryDeferredOllamaEviction(settings: settings)
         settingsSync.retryDeferredEGOneDeactivation(settings: settings)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1396,10 +1396,19 @@ package final class WisprBootstrapper {
       // deferred by the pinned runtime. Without this a settings change made
       // during a long import stayed pending until something unrelated happened
       // to poke the same paths.
-      onEngineReleased: { [weak engineCoordinator, settings] in
+      onEngineReleased: {
+        [weak engineCoordinator, weak recoveryCoordinatorForEngineMutationScope, settings] in
         engineCoordinator?.poke(.driverStateChanged)
         settingsSync.retryDeferredOllamaEviction(settings: settings)
         settingsSync.retryDeferredEGOneDeactivation(settings: settings)
+        // **Recovery needs its OWN wake.** A poke that finds the selected and
+        // active engines already matching returns without reaching recovery, so
+        // a scan that released its mutation gate because an import held the
+        // engine would wait for an unrelated trigger, or for the next launch.
+        // Same call the engine-mutation scope already uses as its wake. Found by
+        // Codex; timing not reproduced, and fixed because it is one line and its
+        // failure is silent.
+        recoveryCoordinatorForEngineMutationScope?.requestRecoveryRecheck()
       },
       // The user's words, read LIVE at Start rather than held from launch: the
       // propagator is the one place that knows the current vocabulary, and an

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1512,9 +1512,34 @@ package final class WisprBootstrapper {
     // owner) — a start that has committed but not yet frozen its config would
     // otherwise read as "no session" and let Remove delete under it. nil
     // either way refuses, fail safe.
-    setup.whisperKitSetup.isDictationInFlight = { [weak settingsSync, weak engineCoordinator] in
+    // #2648: the lease term is the THIRD clause and the general one.
+    //
+    // **Enumerated rather than patched, because this is the third seam an import
+    // needed.** Every place the composition root answers "may I mutate, unload
+    // or delete the shared engine or a polish runtime right now" is:
+    //
+    // | seam | who answers | import covered by |
+    // |---|---|---|
+    // | `EngineCoordinator` gate 5 / 6 / 6b | recording, recovery, import | `isFileImportRunning` → `isEngineHeld` |
+    // | `egOneRuntime.isPinnedInFlight` (+ S1-mini) | `pinnedLocalProvider()` | `importPinnedLocalProvider` |
+    // | `isBlockedByOtherPinnedSession` (+ S1-mini) | `pinnedLocalProvider()` | same |
+    // | `isSharedEngineBusy` (+ S1-mini) | `EngineLease.isBusy` | the lease itself |
+    // | `isOllamaModelPinnedInFlight` | the two session configs | `importPinnedOllamaModel` |
+    // | the ASR idle-unload timer | `cancelIdleTimer` / `noteTranscriptionComplete` | bracketed around the hold |
+    // | THIS one, WhisperKit Remove | dictation config + minting flag | the lease term below |
+    //
+    // Sweeping that list found exactly one gap, this seam: an All Languages
+    // import held the engine while Remove deleted the model out from under it,
+    // because the closure asked only about DICTATION. `isBusy` is the universal
+    // answer — every workload that can occupy the one inference slot takes the
+    // claim — and it stays true after Stop until the cancelled work has
+    // physically exited, which is the window the refusal most needs to cover.
+    // Found by Codex; the sweep is mine.
+    setup.whisperKitSetup.isDictationInFlight = {
+      [weak settingsSync, weak engineCoordinator, weak engineLease] in
       (settingsSync?.isWhisperKitDictationInFlight() ?? true)
         || (engineCoordinator?.isMintingWhisperKitSession ?? true)
+        || (engineLease?.isBusy ?? true)
     }
     engineCoordinator.start()
 

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1418,6 +1418,7 @@ package final class WisprBootstrapper {
       // the adapters covers both engines rather than one of them twice.
       // Idempotent, so both are always touched rather than whichever looks
       // active.
+      engineIsLoaded: { [activeEngine] in await activeEngine.isLoaded() },
       disarmEngineTimers: { [kernelDriver, whisperKitKernelDriver] in
         kernelDriver.cancelPendingEngineUnload()
         whisperKitKernelDriver.cancelPendingEngineUnload()

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -612,7 +612,8 @@ package final class WisprBootstrapper {
       egOneRuntime: egOneRuntime,
       s1MiniRuntime: s1MiniRuntime,
       ollamaRemotenessLookup: ollamaRemoteness,
-      importPinnedLocalProvider: { fileImportCoordinatorForGates?.pinnedLocalPolishProvider }
+      importPinnedLocalProvider: { fileImportCoordinatorForGates?.pinnedLocalPolishProvider },
+      importPinnedOllamaModel: { fileImportCoordinatorForGates?.pinnedOllamaModel }
     )
     settingsSync.applyInitialSettings(settings)
 
@@ -1359,13 +1360,15 @@ package final class WisprBootstrapper {
       // speech engine is active".** Calling `asrManager.transcribe` directly
       // reached Parakeet and only Parakeet: with All Languages selected it threw
       // `ASRManagerNotOwnedError`, because WhisperKit does not live in the
-      // manager. `load()` first, because the user may have picked an engine on
-      // the Transcription step seconds ago and nothing has warmed it — its
-      // postcondition is readiness, not merely that the call returned.
+      // manager.
+      //
+      // No load here: `ensureEngineReady` above owns warming, and it runs before
+      // the claim precisely so the switch it may trigger is not deferred by the
+      // claim. A second loader here would be a second answer to the same
+      // question, which is the shape that produced this feature's first defect.
       transcribe: { [activeEngine, settings] samples in
         var options = TranscriptionOptions.default
         if case .locked(let code) = settings.languageMode { options.language = code }
-        if await activeEngine.isLoaded() == false { try await activeEngine.load() }
         return try await activeEngine.transcribe(samples, options).text
       },
       // The third workload, claiming the same one-slot engine as a dictation and
@@ -1381,12 +1384,23 @@ package final class WisprBootstrapper {
       },
       // The SAME authority a record press uses, so "is the engine the user
       // picked ready" has one answer in the app rather than two.
-      ensureEngineReady: { [weak engineCoordinator] in
+      //
+      // **`.notReady` is not a refusal on its own, and this is the import's own
+      // cold-press path.** `ensureSelectedReadyForPress` deliberately leaves a
+      // SELECTED-AND-ACTIVE BUT COLD engine to dictation's cold-press path,
+      // which warms it on the next press. Import has no next press, so it read
+      // that answer as "no" and refused a file whose engine only needed loading
+      // — reachable through the ordinary memory-saving unload setting. Found by
+      // Codex. `load()`'s postcondition is readiness, not merely that the call
+      // returned, so a warm that fails still refuses.
+      ensureEngineReady: { [weak engineCoordinator, activeEngine] in
         guard let engineCoordinator else { return .notReady }
         switch await engineCoordinator.ensureSelectedReadyForPress() {
         case .ready: return .ready
         case .notInstalled: return .notInstalled
-        case .notReady: return .notReady
+        case .notReady:
+          guard (try? await activeEngine.load()) != nil else { return .notReady }
+          return await activeEngine.isLoaded() ? .ready : .notReady
         }
       },
       // The same three retries a finished dictation fires

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -33,6 +33,9 @@ package final class WisprBootstrapper {
   let sparkleUpdateController: SparkleUpdateController
   let updateTriggerCoordinator: UpdateTriggerCoordinator
   let transcriptCoordinator: TranscriptCoordinator
+  /// #2648 — Transcribe a File's state machine, held here so the run survives
+  /// the page being closed.
+  let fileImportCoordinator: FileImportCoordinator
   let liveRecordingState: LiveRecordingState
   let lastRecordingResult: LastRecordingResult
   let backendMetadata: BackendMetadata
@@ -230,6 +233,16 @@ package final class WisprBootstrapper {
     // needs the gate, and the one shared capability value below, to already
     // exist.
     let engineRecoveryGate = EngineRecoveryGate()
+    // #2648 — the ONE claim on the shared ASR-and-polish resource, built here
+    // beside `engineRecoveryGate` because it is the same kind of thing: an
+    // arbitration authority the composition root owns and hands downward as
+    // narrow closures, so no lower module imports upward to reach it.
+    //
+    // It is NOT the same authority. `engineRecoveryGate` keeps crash recovery
+    // away from engine MUTATION and deliberately admits several mutations at
+    // once; this admits exactly one WORKLOAD — a dictation, a replay, or (from
+    // #2648's later chunks) a file import — onto EG-1's single inference slot.
+    let engineLease = EngineLease()
     // #1741 Chunk 3 — forward reference for the shared scope's wake closure;
     // `recoveryCoordinator` isn't constructed until much later in this
     // function. Matches the existing `engineCoordinatorForRecoveryGate`
@@ -978,6 +991,9 @@ package final class WisprBootstrapper {
           || (engineCoordinatorForRecoveryGate?.isMintingAnySession ?? false)
       },
       recoveryEngineClaim: recoveryEngineClaim,
+      // #2648 — a replay runs the same polish server a dictation does, so it
+      // takes the same one-workload claim for the whole item.
+      engineAdmission: .live(lease: engineLease, as: .crashRecovery),
       // Discard hard-resets the ACTIVE engine (#445 service-kill) so an in-flight,
       // otherwise-uncancellable recovery load/transcribe aborts and the next
       // recording gets a clean engine. Routed through the active-engine door
@@ -1119,7 +1135,11 @@ package final class WisprBootstrapper {
       settings: settings,
       lastRecordingResult: lastRecordingResult,
       languageSuggestionPresenter: languageSuggestionPresenter,
-      recordingLockedAccess: recordingLockedAccess
+      recordingLockedAccess: recordingLockedAccess,
+      // #2648 — the running session's claim comes back here, on the session's
+      // terminal transition, because both start methods return while the
+      // recording is still running.
+      releaseEngineClaim: { [engineLease] token in engineLease.release(token) }
     )
     dictationLifecycleCoordinator.install()
     // #1171 — every pipeline state change pokes the coordinator: non-terminal
@@ -1144,6 +1164,10 @@ package final class WisprBootstrapper {
       dictationLifecycleCoordinator: dictationLifecycleCoordinator,
       recoveryCoordinator: recoveryCoordinator,
       recordingLockedAccess: recordingLockedAccess,
+      // #2648 — the record-start paths claim the shared resource as a DICTATION
+      // and can claim as nothing else: the holder is bound here, not at the call
+      // site.
+      engineAdmission: .live(lease: engineLease, as: .dictation),
       resolveActiveCaptureBackend: { [weak dictationLifecycleCoordinator] in
         dictationLifecycleCoordinator?.activeCaptureBackend()
       },
@@ -1283,6 +1307,35 @@ package final class WisprBootstrapper {
     self.updateCoordinatorHolder = updateCoordinatorHolder
     self.sparkleUpdateController = sparkleUpdateController
     self.updateTriggerCoordinator = updateTriggerCoordinator
+    // #2648 — Transcribe a File. Built here because the job outlives every view
+    // that shows it: leaving the page and coming back has to land on whatever
+    // the run has reached.
+    //
+    // The runner is constructed with the same polish handles live dictation and
+    // crash recovery use, so an imported part is polished by the same engine,
+    // under the same key, as anything else this app produces.
+    let fileImportRunner = FileImportRunner(
+      keychainManager: keychainManager,
+      egOneRuntime: egOneRuntime,
+      s1MiniRuntime: s1MiniRuntime)
+    let fileImportCoordinator = FileImportCoordinator(
+      decode: { url in try await AudioFileDecoder.decode(url: url) },
+      transcribe: { [asrManager] samples in
+        try await asrManager.transcribe(audioSamples: samples, options: .default).text
+      },
+      // The third workload, claiming the same one-slot engine as a dictation and
+      // a crash replay.
+      engineAdmission: .live(lease: engineLease, as: .fileImport),
+      // The user's words, read LIVE at Start rather than held from launch: the
+      // propagator is the one place that knows the current vocabulary, and an
+      // import started after the user adds a word should use it.
+      beginRun: { [settings, customWordsPropagator] in
+        fileImportRunner.freeze(
+          settings: FileImportSettingsFreeze.snapshot(settings: settings),
+          vocabulary: customWordsPropagator.corrector)
+      },
+      processPart: { [fileImportRunner] part in try await fileImportRunner.process(part: part) })
+    self.fileImportCoordinator = fileImportCoordinator
     self.transcriptCoordinator = transcriptCoordinator
     self.liveRecordingState = liveRecordingState
     self.lastRecordingResult = lastRecordingResult
@@ -1513,6 +1566,7 @@ private struct MainWindowRoot: View {
       .environment(b.languageSuggestionPresenter)
       .environment(b.updateCoordinatorHolder)
       .environment(b.transcriptCoordinator)
+      .environment(b.fileImportCoordinator)
       .environment(b.liveRecordingState)
       .environment(b.lastRecordingResult)
       .environment(b.backendMetadata)

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -42,6 +42,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case whatsNew
   case appearance
   case speechEngine
+  case transcribeFile
   case livePreview
   case audio
   case recordingSounds
@@ -65,6 +66,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .whatsNew: return "What's New"
     case .appearance: return "Appearance"
     case .speechEngine: return "Transcription"
+    case .transcribeFile: return "Transcribe a File"
     case .livePreview: return "Live Preview"
     case .audio: return "Microphone"
     case .recordingSounds: return "Sounds"
@@ -88,6 +90,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .whatsNew: return "sparkle.magnifyingglass"
     case .appearance: return "circle.lefthalf.filled"
     case .speechEngine: return "waveform"
+    case .transcribeFile: return "waveform.badge.plus"
     case .livePreview: return "text.viewfinder"
     case .audio: return "speaker.wave.2"
     case .recordingSounds: return "bell.and.waveform"
@@ -114,6 +117,11 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     // joined this page. The old line described one section rather than the page.
     case .appearance: return "How the app looks, and the pill you see while dictating."
     case .speechEngine: return "The speech engine that turns your voice into text."
+    // #2648. Says what the user gets, not what the feature is: eight of thirteen
+    // competitors accept a file and the three r/macapps requests were a walk, a
+    // lecture and a meeting.
+    case .transcribeFile:
+      return "Turn a recording you already have into clean text."
     case .livePreview: return "See your words on screen while you are still speaking."
     case .audio: return "Choose your input source and readiness behavior."
     case .recordingSounds: return "Play a short sound when recording starts and stops."
@@ -137,7 +145,8 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   var group: SettingsGroup {
     switch self {
     case .history, .whatsNew, .appearance: return .app
-    case .speechEngine, .livePreview, .audio, .recordingSounds, .keybinds: return .record
+    case .speechEngine, .transcribeFile, .livePreview, .audio, .recordingSounds, .keybinds:
+      return .record
     case .aiPolish, .wordCorrection, .snippets: return .process
     case .clipboard: return .output
     case .permissions, .checkForUpdates, .openSourceLicenses: return .system

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsView.swift
@@ -198,6 +198,8 @@ struct UnifiedWindowView: View {
       page(.appearance) { AppearanceSettingsView() }
     case .speechEngine:
       page(.speechEngine) { SpeechEngineSettingsView() }
+    case .transcribeFile:
+      page(.transcribeFile) { TranscribeFileView() }
     case .livePreview:
       page(.livePreview) { LivePreviewSettingsView(packs: livePreviewPacks) }
     case .audio:

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -753,11 +753,17 @@ struct TranscribeFileView: View {
     liveTranscript
     BrandedSection {
       HStack(spacing: 10) {
+        // **Offered only when there is something to hand over.** Stopping before
+        // the first words arrive lands on this step with an empty document, and
+        // Copy would then CLEAR the user's clipboard while Save wrote an empty
+        // file — both of which destroy something the user had, to give them
+        // nothing. Found enumerating (step, state) rather than by review.
         SettingsActionButton(
-          title: "Copy everything", isEnabled: true, emphasis: .filled,
+          title: "Copy everything", isEnabled: coordinator.hasDocument, emphasis: .filled,
           systemImage: "doc.on.doc", action: { copyDocument() })
         SettingsActionButton(
-          title: "Save as...", isEnabled: true, systemImage: "square.and.arrow.down",
+          title: "Save as...", isEnabled: coordinator.hasDocument,
+          systemImage: "square.and.arrow.down",
           action: { saveDocument() })
         Spacer(minLength: 12)
         SettingsActionButton(

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -50,6 +50,15 @@ struct TranscribeFileView: View {
     .background(Color.stPageBg)
     .tint(.stAccent)
     .font(.stBody)
+    // **Asked where the answer is needed, once per arrival.** The Ollama catalog
+    // is populated by the AI Polish page, so a user who opens this wizard
+    // directly after a relaunch has never asked the daemon anything and every
+    // model reads as unknown. Keyed on the step so it is one local request when
+    // the user reaches a screen whose words depend on it, not one per redraw.
+    .task(id: coordinator.step) {
+      guard coordinator.step == .polish || coordinator.step == .review else { return }
+      await coordinator.refreshOllamaFacts()
+    }
   }
 
   // MARK: - The step bar
@@ -465,10 +474,14 @@ struct TranscribeFileView: View {
   ]
 
   /// Where an Ollama polish actually sends the text, for the model selected now.
+  /// The unknown case says so rather than guessing either way.
   private var ollamaPrivacyLine: String {
-    coordinator.polishIsRemoteOllamaNow()
-      ? "The model you picked runs on Ollama's servers, so the text is sent there."
-      : "That model runs on this Mac, so nothing leaves it."
+    switch coordinator.polishOllamaLocalityNow() {
+    case true: return "The model you picked runs on Ollama's servers, so the text is sent there."
+    case false: return "That model runs on this Mac, so nothing leaves it."
+    case nil:
+      return "Checking whether that model runs here or on Ollama's servers. Start Ollama to find out."
+    }
   }
 
   private func polishCard(_ choice: PolishChoice) -> some View {
@@ -541,6 +554,10 @@ struct TranscribeFileView: View {
   @ViewBuilder
   private var reviewStep: some View {
     stepHeading("Review and start")
+    if case .rejected(let reason) = coordinator.state {
+      InsetNotice(
+        text: Self.sentence(for: reason), systemImage: "exclamationmark.triangle", tint: .orange)
+    }
     HStack(alignment: .top, spacing: 14) {
       VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
         BrandedSection(header: "SELECTED FILE") {
@@ -570,15 +587,19 @@ struct TranscribeFileView: View {
             is finished, \(coordinator.estimateText).
             """,
           systemImage: "mic.slash", tint: .orange)
-        // The words change when a transcript already exists, because the action
-        // does: nothing is transcribed a second time, only cleaned again.
+        // The words change with what the action IS. After a refusal the file is
+        // still read and still in memory, so this is a retry, not a fresh start.
         actionRow(
-          note: coordinator.rawTranscript.isEmpty
-            ? "Nothing has run yet."
-            : "Already transcribed. Only the cleanup runs again.",
-          forwardTitle: coordinator.rawTranscript.isEmpty
-            ? "Start transcription" : "Clean it again",
-          forward: { coordinator.advance() })
+          note: coordinator.canRetry
+            ? "Your file is still here. Nothing needs reading again."
+            : (coordinator.rawTranscript.isEmpty
+              ? "Nothing has run yet."
+              : "Already transcribed. Only the cleanup runs again."),
+          forwardTitle: coordinator.canRetry
+            ? "Try again"
+            : (coordinator.rawTranscript.isEmpty
+              ? "Start transcription" : "Clean it again"),
+          forward: { coordinator.canRetry ? coordinator.retry() : coordinator.advance() })
       }
       processingPath.frame(width: 300)
     }
@@ -682,7 +703,7 @@ struct TranscribeFileView: View {
   /// never just a spinner.
   private var liveTranscript: some View {
     VStack(alignment: .leading, spacing: 14) {
-      ForEach(coordinator.parts) { part in
+      ForEach(coordinator.isShowingOriginal ? [] : coordinator.parts) { part in
         VStack(alignment: .leading, spacing: 4) {
           Text(part.text)
             .lineSpacing(6)
@@ -695,7 +716,9 @@ struct TranscribeFileView: View {
           }
         }
       }
-      if coordinator.parts.isEmpty, !coordinator.rawTranscript.isEmpty {
+      if coordinator.isShowingOriginal || coordinator.parts.isEmpty,
+        !coordinator.rawTranscript.isEmpty
+      {
         Text(coordinator.rawTranscript)
           .lineSpacing(6)
           .foregroundStyle(Color.stTextSecondary)
@@ -745,6 +768,16 @@ struct TranscribeFileView: View {
           Button("Change") { coordinator.choosePolisherAgain() }
             .buttonStyle(.plain)
             .foregroundStyle(Color.stAccent)
+          Spacer(minLength: 12)
+          // The page promises the untouched words are kept. This is where the
+          // user reads them, and Copy and Save follow whichever is on screen.
+          if !coordinator.parts.isEmpty {
+            Button(coordinator.isShowingOriginal ? "Show cleaned words" : "Show original words") {
+              coordinator.isShowingOriginal.toggle()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.stAccent)
+          }
         }
       }
       .padding(.horizontal, SettingsLayout.rowPaddingH)
@@ -851,7 +884,7 @@ struct TranscribeFileView: View {
       break
     }
     return Self.isCloud(
-      settings.llmProvider, ollamaModelIsRemote: coordinator.polishIsRemoteOllamaNow())
+      settings.llmProvider, ollamaModelIsRemote: coordinator.polishOllamaLocalityNow())
   }
 
   /// Enumerated, never `default:`. A new provider must be classified here
@@ -866,10 +899,18 @@ struct TranscribeFileView: View {
   /// remoteness is resolved by the same lookup `PipelineSettingsSync` uses and
   /// FROZEN with the run, so a document already polished is never re-described.
   /// Found by Codex.
-  static func isCloud(_ provider: LLMProvider, ollamaModelIsRemote: Bool) -> Bool {
+  /// - Parameter ollamaModelIsRemote: `nil` when the daemon has not been asked.
+  ///   **Unknown counts as leaving the Mac**, because the two mistakes are not
+  ///   equal: promising local processing for a model Ollama proxies to its own
+  ///   servers is a broken privacy promise, while saying the text may be sent
+  ///   when it is not is merely cautious. The eviction rule uses the SAME lookup
+  ///   with the opposite default on purpose — there an unknown model is evicted,
+  ///   because the cost of a needless unload is one local request and the cost
+  ///   of skipping a real local model is weights left in memory.
+  static func isCloud(_ provider: LLMProvider, ollamaModelIsRemote: Bool?) -> Bool {
     switch provider {
     case .openAI, .gemini, .claude: return true
-    case .ollama: return ollamaModelIsRemote
+    case .ollama: return ollamaModelIsRemote ?? true
     case .egOne, .s1Mini, .appleIntelligence, .none: return false
     }
   }
@@ -903,7 +944,7 @@ struct TranscribeFileView: View {
 
   private func copyDocument() {
     NSPasteboard.general.clearContents()
-    NSPasteboard.general.setString(coordinator.documentText, forType: .string)
+    NSPasteboard.general.setString(coordinator.exportText, forType: .string)
   }
 
   private func saveDocument() {
@@ -913,7 +954,7 @@ struct TranscribeFileView: View {
       (coordinator.file?.name as NSString?)?.deletingPathExtension ?? "Transcript"
     guard panel.runModal() == .OK, let url = panel.url else { return }
     do {
-      try coordinator.documentText.write(to: url, atomically: true, encoding: .utf8)
+      try coordinator.exportText.write(to: url, atomically: true, encoding: .utf8)
       coordinator.noteSaveSucceeded(fileName: url.lastPathComponent)
     } catch {
       coordinator.noteSaveFailed(error)

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -731,7 +731,17 @@ struct TranscribeFileView: View {
           }
         }
         HStack(spacing: 8) {
-          chip("Polished by \(selectedPolish?.title ?? "nothing")")
+          // **The provider this document was RUN with**, from the frozen
+          // configuration, and named by `LLMProvider.displayName` so the six
+          // names have one owner. Reading the live selection credited whatever
+          // was picked after the run — pick Claude on Change, return to Done,
+          // and unchanged EG-1 output was labelled Claude's. It says
+          // "cleanup engine" rather than "polished by" because a passage whose
+          // polish failed carries its own note and this line must not overrule
+          // it. Found by Codex.
+          chip(
+            "Cleanup engine: \((coordinator.runConfiguration?.polishProvider ?? .none).displayName)"
+          )
           Button("Change") { coordinator.choosePolisherAgain() }
             .buttonStyle(.plain)
             .foregroundStyle(Color.stAccent)

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -545,6 +545,17 @@ struct TranscribeFileView: View {
     }
   }
 
+  /// Where a provider runs, for the ones the tile grid does not render. Derived
+  /// from the provider so a new one cannot be silently blank here.
+  static func availability(_ provider: LLMProvider) -> String {
+    switch provider {
+    case .egOne, .s1Mini, .appleIntelligence: return "On device"
+    case .ollama: return "Needs the app"
+    case .openAI, .gemini, .claude: return "Needs a key"
+    case .none: return ""
+    }
+  }
+
   private var selectedPolish: PolishChoice? {
     Self.polishChoices.first { $0.provider == settings.llmProvider }
   }
@@ -627,12 +638,18 @@ struct TranscribeFileView: View {
       Image(systemName: "arrow.down")
         .foregroundStyle(Color.stTextSecondary)
         .frame(maxWidth: .infinity)
+      // **Named from the PROVIDER, not from the tile list.** `polishChoices`
+      // renders six tiles and S1-mini is not one of them, so a user who had
+      // selected it in AI Polish was told "No polish" on the one screen that
+      // exists to confirm what is about to happen — while the freeze kept
+      // S1-mini and the runner ran it. A hand-written list of what to DISPLAY
+      // cannot answer a question about what will RUN. Found by Codex.
       pathCard(
         icon: selectedPolish?.icon ?? "sparkles",
-        title: selectedPolish?.title ?? "No polish",
+        title: settings.llmProvider.displayName,
         recommended: settings.llmProvider == .egOne,
         blurb: "Cleans it into readable text.",
-        rows: [("Runs on", selectedPolish?.availability ?? "")])
+        rows: [("Runs on", selectedPolish?.availability ?? Self.availability(settings.llmProvider))])
     }
   }
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -99,7 +99,7 @@ struct TranscribeFileView: View {
           .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!done || coordinator.isRunning)
+        .disabled(!coordinator.canJump(to: step))
       }
     }
     .padding(.horizontal, 8)
@@ -730,6 +730,11 @@ struct TranscribeFileView: View {
       .padding(.horizontal, SettingsLayout.rowPaddingH)
       .padding(.vertical, SettingsLayout.rowPaddingV)
     }
+    // Sits directly under the buttons that produce it, and stays there, because
+    // New transcription is one click away and it clears the document.
+    if let message = coordinator.saveMessage {
+      Text(message).foregroundStyle(Color.stTextSecondary)
+    }
   }
 
   private func chip(_ text: String) -> some View {
@@ -786,8 +791,22 @@ struct TranscribeFileView: View {
     }
   }
 
+  /// Whether the text this sentence is ABOUT leaves the Mac.
+  ///
+  /// **Which run it describes depends on the step.** On Working and Done it
+  /// describes THIS document, so it must read the configuration frozen at Start
+  /// — a later provider change must not retrospectively re-describe words
+  /// already polished. On every earlier step it describes what is ABOUT to
+  /// happen, so it must read live settings: after a local run, picking a cloud
+  /// polisher on the Polish step left the frozen local configuration on screen
+  /// saying the text stays here. Found by Codex.
   private var isCloudPolish: Bool {
-    if let frozen = coordinator.runConfiguration { return frozen.polishIsCloud }
+    switch coordinator.step {
+    case .working, .done:
+      if let frozen = coordinator.runConfiguration { return frozen.polishIsCloud }
+    case .upload, .transcription, .polish, .review:
+      break
+    }
     return Self.isCloud(
       settings.llmProvider, ollamaModelIsRemote: coordinator.polishIsRemoteOllamaNow())
   }
@@ -820,6 +839,9 @@ struct TranscribeFileView: View {
     case .noSpeechFound: return "No speech was found in that file."
     case .engineBusy(.dictation): return "A dictation is running. Try again when it finishes."
     case .engineBusy(.crashRecovery): return "Finishing an earlier take. Try again in a moment."
+    case .engineNotInstalled:
+      return "That transcription engine isn't downloaded yet. Get it in Transcription settings."
+    case .engineNotReady: return "The transcription engine didn't start. Try again."
     case .engineBusy(.fileImport): return "Another file is being transcribed right now."
     case .failed: return "Something went wrong reading that file. Try a different one."
     }
@@ -847,6 +869,11 @@ struct TranscribeFileView: View {
     panel.nameFieldStringValue =
       (coordinator.file?.name as NSString?)?.deletingPathExtension ?? "Transcript"
     guard panel.runModal() == .OK, let url = panel.url else { return }
-    try? coordinator.documentText.write(to: url, atomically: true, encoding: .utf8)
+    do {
+      try coordinator.documentText.write(to: url, atomically: true, encoding: .utf8)
+      coordinator.noteSaveSucceeded(fileName: url.lastPathComponent)
+    } catch {
+      coordinator.noteSaveFailed(error)
+    }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1,0 +1,272 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import EnviousWisprServices
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// #2648 — Transcribe a File.
+///
+/// **The text is the interface.** The founder's binding calls on 2026-09-04:
+/// while a run is going the document fills in with the words themselves, not a
+/// row of numbered chips; the splitting is never user-facing; Done stays put
+/// until a new run is started; and every primary action sits with the content it
+/// acts on rather than pinned to a far bottom bar.
+///
+/// One page, six states, driven entirely by `FileImportCoordinator` — the job
+/// outlives this view, so leaving the page and coming back lands on whatever the
+/// run has reached.
+struct TranscribeFileView: View {
+  @Environment(FileImportCoordinator.self) private var coordinator
+  @Environment(SettingsManager.self) private var settings
+
+  var body: some View {
+    SettingsContentView {
+      switch coordinator.state {
+      case .idle:
+        chooseCard
+      case .reading(let fileName):
+        readingCard(fileName: fileName)
+      case .ready(let fileName, let seconds):
+        readyCard(fileName: fileName, seconds: seconds)
+      case .transcribing(let fileName):
+        workingCard(title: "Transcribing \(fileName)", detail: nil)
+      case .polishing(let done, let total):
+        workingCard(title: "Cleaning up your text", detail: progressLine(done: done, total: total))
+        documentCard
+      case .finished:
+        doneHeader
+        documentCard
+      case .stopped:
+        stoppedHeader
+        documentCard
+      case .rejected(let reason):
+        rejectedCard(reason: reason)
+      }
+      privacyCard
+    }
+  }
+
+  // MARK: - Choosing
+
+  private var chooseCard: some View {
+    BrandedSection(header: "YOUR FILE") {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("Pick an audio or video file and get clean text back.")
+        Text("Voice memos, lectures, meetings. Any length.")
+          .foregroundStyle(.secondary)
+        SettingsActionButton(
+          title: "Choose a file", isEnabled: true, emphasis: .filled, action: { chooseFile() })
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  private func readingCard(fileName: String) -> some View {
+    BrandedSection(header: "YOUR FILE") {
+      HStack(spacing: 10) {
+        ProgressView().controlSize(.small)
+        Text("Reading \(fileName)")
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  private func readyCard(fileName: String, seconds: Double) -> some View {
+    BrandedSection(header: "YOUR FILE") {
+      VStack(alignment: .leading, spacing: 12) {
+        Text(fileName).font(.stRowTitle)
+        Text(Self.lengthLine(seconds: seconds)).foregroundStyle(.secondary)
+        HStack(spacing: 10) {
+          SettingsActionButton(
+          title: "Start", isEnabled: true, emphasis: .filled, action: { coordinator.start() })
+          SettingsActionButton(
+          title: "Choose a different file", isEnabled: true, action: { chooseFile() })
+        }
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  // MARK: - Working
+
+  private func workingCard(title: String, detail: String?) -> some View {
+    BrandedSection(header: "WORKING") {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack(spacing: 10) {
+          ProgressView().controlSize(.small)
+          Text(title)
+        }
+        if let detail {
+          Text(detail).foregroundStyle(.secondary)
+        }
+        // The stop control sits WITH the work it stops, not in a bar at the
+        // bottom of the page.
+        SettingsActionButton(
+          title: "Stop", isEnabled: true, action: { coordinator.stop() })
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  /// Progress in the user's terms. **Never "part 3 of 14"**: the splitting is a
+  /// property of the polisher, not something the user asked for, and naming it
+  /// would invite questions about a mechanism they cannot change.
+  private func progressLine(done: Int, total: Int) -> String {
+    guard total > 1 else { return "Almost there." }
+    let percent = Int((Double(done) / Double(total)) * 100)
+    return "\(percent)% of the way through."
+  }
+
+  private var doneHeader: some View {
+    BrandedSection(header: "DONE") {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("Your text is ready.").font(.stRowTitle)
+        HStack(spacing: 10) {
+          SettingsActionButton(
+          title: "Copy", isEnabled: true, emphasis: .filled, action: { copyDocument() })
+          SettingsActionButton(
+          title: "Change the polisher", isEnabled: true, action: { coordinator.rePolish() })
+          SettingsActionButton(
+          title: "Transcribe another file", isEnabled: true, action: { chooseFile() })
+        }
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  private var stoppedHeader: some View {
+    BrandedSection(header: "STOPPED") {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("Stopped. What finished is below.").font(.stRowTitle)
+        HStack(spacing: 10) {
+          SettingsActionButton(
+          title: "Copy", isEnabled: true, emphasis: .filled, action: { copyDocument() })
+          SettingsActionButton(
+          title: "Transcribe another file", isEnabled: true, action: { chooseFile() })
+        }
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  // MARK: - The document
+
+  /// **The words themselves, rewritten in place as each part lands.** Not a
+  /// progress list, and not a set of numbered blocks the user has to assemble in
+  /// their head.
+  @ViewBuilder
+  private var documentCard: some View {
+    if !coordinator.parts.isEmpty {
+      BrandedSection(header: "YOUR TEXT") {
+        VStack(alignment: .leading, spacing: 14) {
+          ForEach(coordinator.parts) { part in
+            VStack(alignment: .leading, spacing: 4) {
+              Text(part.text).textSelection(.enabled)
+              if part.isUnpolished {
+                // Marked, never hidden. A passage that could not be cleaned is
+                // still the user's words, and pretending otherwise is the
+                // failure this feature must not have.
+                Text("This passage could not be cleaned up. These are the raw words.")
+                  .font(.stHelper)
+                  .foregroundStyle(.secondary)
+              }
+            }
+          }
+        }
+        .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+      }
+    }
+  }
+
+  // MARK: - Refusals
+
+  private func rejectedCard(reason: FileImportCoordinator.FileImportRejection) -> some View {
+    BrandedSection(header: "YOUR FILE") {
+      VStack(alignment: .leading, spacing: 12) {
+        Text(Self.sentence(for: reason))
+        SettingsActionButton(
+          title: "Choose a file", isEnabled: true, emphasis: .filled, action: { chooseFile() })
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  /// One honest sentence per refusal. No mechanism, no error codes, and nothing
+  /// that invites the user to retry something that cannot work.
+  static func sentence(for reason: FileImportCoordinator.FileImportRejection) -> String {
+    switch reason {
+    case .cannotRead:
+      return "That file couldn't be opened. Try a different one."
+    case .noAudio:
+      return "There's no sound in that file."
+    case .noSpeechFound:
+      return "No speech was found in that file."
+    case .engineBusy(.dictation):
+      return "A dictation is running. Try again when it finishes."
+    case .engineBusy(.crashRecovery):
+      return "Finishing an earlier take. Try again in a moment."
+    case .engineBusy(.fileImport):
+      return "Another file is being transcribed right now."
+    case .failed:
+      return "Something went wrong reading that file. Try a different one."
+    }
+  }
+
+  static func lengthLine(seconds: Double) -> String {
+    let minutes = Int(seconds / 60)
+    if minutes < 1 { return "Under a minute of audio." }
+    if minutes == 1 { return "About a minute of audio." }
+    return "About \(minutes) minutes of audio."
+  }
+
+  // MARK: - Privacy, computed from what is actually selected
+
+  /// **The line is computed, never fixed.** "All processing happens on this Mac"
+  /// is false the moment a cloud polisher is selected, and the founder caught
+  /// exactly that in the prototype. The audio never leaves either way, so that
+  /// half is always true; the text half depends on the choice.
+  private var privacyCard: some View {
+    InsetNotice(text: Self.privacyLine(isCloudPolish: isCloudPolish))
+  }
+
+  private var isCloudPolish: Bool {
+    switch settings.llmProvider {
+    case .openAI, .gemini, .claude: return true
+    case .egOne, .s1Mini, .appleIntelligence, .ollama, .none: return false
+    }
+  }
+
+  static func privacyLine(isCloudPolish: Bool) -> String {
+    if isCloudPolish {
+      return """
+        Your audio never leaves this Mac. With a cloud polisher selected, only the text goes to the \
+        provider you chose, under your own key.
+        """
+    }
+    return "Everything here happens on this Mac. Nothing is uploaded."
+  }
+
+  // MARK: - Actions
+
+  private func chooseFile() {
+    let panel = NSOpenPanel()
+    panel.allowsMultipleSelection = false
+    panel.canChooseDirectories = false
+    panel.allowedContentTypes = [.audio, .movie, .mpeg4Movie, .mp3, .wav, .aiff]
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+    coordinator.choose(url: url)
+  }
+
+  private func copyDocument() {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(coordinator.documentText, forType: .string)
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -99,7 +99,7 @@ struct TranscribeFileView: View {
           .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!coordinator.canJump(to: step))
+        .disabled(!coordinator.canGo(to: step))
       }
     }
     .padding(.horizontal, 8)
@@ -139,7 +139,7 @@ struct TranscribeFileView: View {
       HStack(spacing: 10) {
         Text(note).foregroundStyle(Color.stTextSecondary)
         Spacer(minLength: 12)
-        if showBack {
+        if showBack, coordinator.canGoBack {
           SettingsActionButton(title: "Back", isEnabled: true, action: { coordinator.goBack() })
         }
         SettingsActionButton(
@@ -449,7 +449,10 @@ struct TranscribeFileView: View {
       detail: "Apple's on-device model. Needs macOS 26 or later."),
     PolishChoice(
       provider: .ollama, icon: "cube", availability: "Needs the app",
-      detail: "Any model you run locally in Ollama. Nothing leaves this Mac."),
+      // Deliberately says nothing about where the text goes. Ollama proxies
+      // some models to its own servers, so the answer depends on the MODEL, and
+      // this card cannot see one. `ollamaPrivacyLine` says it right below.
+      detail: "Any model you run in Ollama."),
     PolishChoice(
       provider: .openAI, icon: "circle.hexagongrid", availability: "Needs a key",
       detail: "Your own OpenAI key. Only the text is sent, never the audio."),
@@ -460,6 +463,13 @@ struct TranscribeFileView: View {
       provider: .claude, icon: "star.circle", availability: "Needs a key",
       detail: "Your own Anthropic key. Only the text is sent, never the audio."),
   ]
+
+  /// Where an Ollama polish actually sends the text, for the model selected now.
+  private var ollamaPrivacyLine: String {
+    coordinator.polishIsRemoteOllamaNow()
+      ? "The model you picked runs on Ollama's servers, so the text is sent there."
+      : "That model runs on this Mac, so nothing leaves it."
+  }
 
   private func polishCard(_ choice: PolishChoice) -> some View {
     // Same door the AI Polish page uses. `SettingsManager` canonicalizes the
@@ -503,6 +513,16 @@ struct TranscribeFileView: View {
             Text(choice.detail)
               .foregroundStyle(Color.stTextSecondary)
               .fixedSize(horizontal: false, vertical: true)
+            // **The sentence sits where the user approves the choice**, not only
+            // in the footer. This card promised "Nothing leaves this Mac" for
+            // every Ollama model, immediately above the button that sends the
+            // transcript to one Ollama proxies to its own servers. Found by
+            // Codex.
+            if choice.provider == .ollama {
+              Text(ollamaPrivacyLine)
+                .foregroundStyle(Color.stTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
           }
           Spacer(minLength: 0)
         }
@@ -693,6 +713,13 @@ struct TranscribeFileView: View {
   @ViewBuilder
   private var doneStep: some View {
     stepHeading(coordinator.state == .stopped ? "Stopped" : "Your transcript is ready")
+    // A refusal raised while a document exists lands HERE rather than on Upload,
+    // because Upload's only offer is choosing another file, which clears it. The
+    // sentence sits above the words it did not touch.
+    if case .rejected(let reason) = coordinator.state {
+      InsetNotice(
+        text: Self.sentence(for: reason), systemImage: "exclamationmark.triangle", tint: .orange)
+    }
     BrandedSection {
       VStack(alignment: .leading, spacing: 10) {
         HStack(spacing: 10) {

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -50,7 +50,6 @@ struct TranscribeFileView: View {
     .background(Color.stPageBg)
     .tint(.stAccent)
     .font(.stBody)
-    .onAppear { seedChoicesFromSettings() }
   }
 
   // MARK: - The step bar
@@ -351,9 +350,12 @@ struct TranscribeFileView: View {
     backend: ASRBackendType, title: String, icon: String, recommended: Bool, blurb: String,
     specs: [(String, String)]
   ) -> some View {
-    let selected = coordinator.chosenBackend == backend
+    // **Writes the app's own setting.** `EngineCoordinator` watches it and does
+    // the switch, including loading the model, so picking here is a real pick
+    // rather than a highlighted card.
+    let selected = settings.selectedBackend == backend
     return Button {
-      coordinator.chosenBackend = backend
+      settings.selectedBackend = backend
     } label: {
       VStack(alignment: .leading, spacing: 10) {
         HStack(spacing: 8) {
@@ -460,9 +462,12 @@ struct TranscribeFileView: View {
   ]
 
   private func polishCard(_ choice: PolishChoice) -> some View {
-    let selected = coordinator.chosenPolish == choice.provider
+    // Same door the AI Polish page uses. `SettingsManager` canonicalizes the
+    // model id for the new provider and `PipelineSettingsSync` starts or stops
+    // the runtime; writing a private copy did neither.
+    let selected = settings.llmProvider == choice.provider
     return Button {
-      coordinator.chosenPolish = choice.provider
+      settings.llmProvider = choice.provider
     } label: {
       VStack(alignment: .leading, spacing: 8) {
         HStack {
@@ -508,7 +513,7 @@ struct TranscribeFileView: View {
   }
 
   private var selectedPolish: PolishChoice? {
-    Self.polishChoices.first { $0.provider == coordinator.chosenPolish }
+    Self.polishChoices.first { $0.provider == settings.llmProvider }
   }
 
   // MARK: - 4. Review
@@ -545,8 +550,14 @@ struct TranscribeFileView: View {
             is finished, \(coordinator.estimateText).
             """,
           systemImage: "mic.slash", tint: .orange)
+        // The words change when a transcript already exists, because the action
+        // does: nothing is transcribed a second time, only cleaned again.
         actionRow(
-          note: "Nothing has run yet.", forwardTitle: "Start transcription",
+          note: coordinator.rawTranscript.isEmpty
+            ? "Nothing has run yet."
+            : "Already transcribed. Only the cleanup runs again.",
+          forwardTitle: coordinator.rawTranscript.isEmpty
+            ? "Start transcription" : "Clean it again",
           forward: { coordinator.advance() })
       }
       processingPath.frame(width: 300)
@@ -561,14 +572,14 @@ struct TranscribeFileView: View {
       Text("YOUR PROCESSING PATH")
         .font(.stSectionHeader).tracking(0.6).foregroundStyle(Color.stAccent)
       pathCard(
-        icon: coordinator.chosenBackend == .parakeet ? "bolt.fill" : "globe",
-        title: coordinator.chosenBackend == .parakeet ? "Fast" : "All Languages",
-        recommended: coordinator.chosenBackend == .parakeet,
+        icon: settings.selectedBackend == .parakeet ? "bolt.fill" : "globe",
+        title: settings.selectedBackend == .parakeet ? "Fast" : "All Languages",
+        recommended: settings.selectedBackend == .parakeet,
         blurb: "Writes down what was said.",
         rows: [
           (
             "Runs on",
-            coordinator.chosenBackend == .parakeet
+            settings.selectedBackend == .parakeet
               ? "This Mac · Neural Engine" : "This Mac · Apple GPU"
           )
         ])
@@ -578,7 +589,7 @@ struct TranscribeFileView: View {
       pathCard(
         icon: selectedPolish?.icon ?? "sparkles",
         title: selectedPolish?.title ?? "No polish",
-        recommended: coordinator.chosenPolish == .egOne,
+        recommended: settings.llmProvider == .egOne,
         blurb: "Cleans it into readable text.",
         rows: [("Runs on", selectedPolish?.availability ?? "")])
     }
@@ -694,7 +705,7 @@ struct TranscribeFileView: View {
         }
         HStack(spacing: 8) {
           chip("Polished by \(selectedPolish?.title ?? "nothing")")
-          Button("Change") { coordinator.rePolish() }
+          Button("Change") { coordinator.choosePolisherAgain() }
             .buttonStyle(.plain)
             .foregroundStyle(Color.stAccent)
         }
@@ -777,15 +788,27 @@ struct TranscribeFileView: View {
 
   private var isCloudPolish: Bool {
     if let frozen = coordinator.runConfiguration { return frozen.polishIsCloud }
-    return Self.isCloud(coordinator.chosenPolish)
+    return Self.isCloud(
+      settings.llmProvider, ollamaModelIsRemote: coordinator.polishIsRemoteOllamaNow())
   }
 
   /// Enumerated, never `default:`. A new provider must be classified here
   /// deliberately, because getting it wrong publishes a false privacy claim.
-  static func isCloud(_ provider: LLMProvider) -> Bool {
+  /// Whether the chosen polisher sends the transcript off this Mac.
+  ///
+  /// **Ollama is the case the provider name cannot answer.** The daemon proxies
+  /// some models to its own servers, which it reports as a non-empty
+  /// `remote_host` and `OllamaModelFacts.isRemote` decodes; a user polishing
+  /// with one of those is sending their transcript to Ollama's infrastructure
+  /// while a provider-only classification tells them it stayed here. The
+  /// remoteness is resolved by the same lookup `PipelineSettingsSync` uses and
+  /// FROZEN with the run, so a document already polished is never re-described.
+  /// Found by Codex.
+  static func isCloud(_ provider: LLMProvider, ollamaModelIsRemote: Bool) -> Bool {
     switch provider {
     case .openAI, .gemini, .claude: return true
-    case .egOne, .s1Mini, .appleIntelligence, .ollama, .none: return false
+    case .ollama: return ollamaModelIsRemote
+    case .egOne, .s1Mini, .appleIntelligence, .none: return false
     }
   }
 
@@ -803,15 +826,6 @@ struct TranscribeFileView: View {
   }
 
   // MARK: - Actions
-
-  /// The import's engines start from what the user already uses, so the common
-  /// path is two Continues. Changing them here does NOT write back to settings:
-  /// a choice made for one file is not a change to how dictation works.
-  private func seedChoicesFromSettings() {
-    guard coordinator.state == .idle else { return }
-    coordinator.chosenBackend = settings.selectedBackend
-    coordinator.chosenPolish = settings.llmProvider
-  }
 
   private func chooseFile() {
     let panel = NSOpenPanel()

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -709,6 +709,8 @@ struct TranscribeFileView: View {
             .lineSpacing(6)
             .foregroundStyle(Color.stTextBody)
             .textSelection(.enabled)
+          // Only a FAILED polish is marked. A document the user chose not to
+          // have polished is not a document with fourteen problems in it.
           if part.isUnpolished {
             Text("This passage could not be cleaned up. These are the raw words.")
               .font(.stHelper)

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1,260 +1,817 @@
+import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprServices
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// #2648 — Transcribe a File.
+/// #2648 — Transcribe a File, built to the clickable prototype the founder
+/// approved on 2026-09-04 (`experiments/2648-file-import/import-prototype.html`).
 ///
-/// **The text is the interface.** The founder's binding calls on 2026-09-04:
-/// while a run is going the document fills in with the words themselves, not a
-/// row of numbered chips; the splitting is never user-facing; Done stays put
-/// until a new run is started; and every primary action sits with the content it
-/// acts on rather than pinned to a far bottom bar.
+/// **Six steps, always visible.** Upload, Transcription, Polish, Review,
+/// Working, Done. The user picks BOTH engines for this import before anything
+/// runs, each on its own screen with the specs needed to choose — which is why
+/// this is a wizard rather than one card with a Start button. The first build of
+/// this page was the latter, taken from the plan's prose instead of the
+/// prototype, and the founder rejected it on sight.
 ///
-/// One page, six states, driven entirely by `FileImportCoordinator` — the job
-/// outlives this view, so leaving the page and coming back lands on whatever the
-/// run has reached.
+/// **The text is the interface.** On Working the transcript itself fills the
+/// page; on Done the document does. The splitting is never named: progress says
+/// "62%", never "part 3 of 14".
+///
+/// **The footer changes with the step**, because what is true changes: before a
+/// run it is where the audio stays, during a run it is that leaving is safe,
+/// after a run it is about the words that were kept.
 struct TranscribeFileView: View {
   @Environment(FileImportCoordinator.self) private var coordinator
   @Environment(SettingsManager.self) private var settings
 
   var body: some View {
-    SettingsContentView {
-      switch coordinator.state {
-      case .idle:
-        chooseCard
-      case .reading(let fileName):
-        readingCard(fileName: fileName)
-      case .ready(let fileName, let seconds):
-        readyCard(fileName: fileName, seconds: seconds)
-      case .transcribing(let fileName):
-        workingCard(title: "Transcribing \(fileName)", detail: nil)
-      case .polishing(let done, let total):
-        workingCard(title: "Cleaning up your text", detail: progressLine(done: done, total: total))
-        documentCard
-      case .finished:
-        doneHeader
-        documentCard
-      case .stopped:
-        stoppedHeader
-        documentCard
-      case .rejected(let reason):
-        rejectedCard(reason: reason)
-      }
-      privacyCard
-    }
-  }
-
-  // MARK: - Choosing
-
-  private var chooseCard: some View {
-    BrandedSection(header: "YOUR FILE") {
-      VStack(alignment: .leading, spacing: 12) {
-        Text("Pick an audio or video file and get clean text back.")
-        Text("Voice memos, lectures, meetings. Any length.")
-          .foregroundStyle(.secondary)
-        SettingsActionButton(
-          title: "Choose a file", isEnabled: true, emphasis: .filled, action: { chooseFile() })
-      }
-      .padding(.horizontal, SettingsLayout.rowPaddingH)
-      .padding(.vertical, SettingsLayout.rowPaddingV)
-    }
-  }
-
-  private func readingCard(fileName: String) -> some View {
-    BrandedSection(header: "YOUR FILE") {
-      HStack(spacing: 10) {
-        ProgressView().controlSize(.small)
-        Text("Reading \(fileName)")
-      }
-      .padding(.horizontal, SettingsLayout.rowPaddingH)
-      .padding(.vertical, SettingsLayout.rowPaddingV)
-    }
-  }
-
-  private func readyCard(fileName: String, seconds: Double) -> some View {
-    BrandedSection(header: "YOUR FILE") {
-      VStack(alignment: .leading, spacing: 12) {
-        Text(fileName).font(.stRowTitle)
-        Text(Self.lengthLine(seconds: seconds)).foregroundStyle(.secondary)
-        HStack(spacing: 10) {
-          SettingsActionButton(
-          title: "Start", isEnabled: true, emphasis: .filled, action: { coordinator.start() })
-          SettingsActionButton(
-          title: "Choose a different file", isEnabled: true, action: { chooseFile() })
+    VStack(spacing: 0) {
+      stepBar
+      ScrollView {
+        VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+          switch coordinator.step {
+          case .upload: uploadStep
+          case .transcription: transcriptionStep
+          case .polish: polishStep
+          case .review: reviewStep
+          case .working: workingStep
+          case .done: doneStep
+          }
         }
+        .padding(.top, SettingsLayout.contentTop)
+        .padding(.horizontal, SettingsLayout.contentH)
+        .padding(.bottom, SettingsLayout.contentBottom)
       }
-      .padding(.horizontal, SettingsLayout.rowPaddingH)
-      .padding(.vertical, SettingsLayout.rowPaddingV)
+      privacyFooter
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.stPageBg)
+    .tint(.stAccent)
+    .font(.stBody)
+    .onAppear { seedChoicesFromSettings() }
   }
 
-  // MARK: - Working
+  // MARK: - The step bar
 
-  private func workingCard(title: String, detail: String?) -> some View {
-    BrandedSection(header: "WORKING") {
-      VStack(alignment: .leading, spacing: 12) {
-        HStack(spacing: 10) {
-          ProgressView().controlSize(.small)
-          Text(title)
-        }
-        if let detail {
-          Text(detail).foregroundStyle(.secondary)
-        }
-        // The stop control sits WITH the work it stops, not in a bar at the
-        // bottom of the page.
-        SettingsActionButton(
-          title: "Stop", isEnabled: true, action: { coordinator.stop() })
-      }
-      .padding(.horizontal, SettingsLayout.rowPaddingH)
-      .padding(.vertical, SettingsLayout.rowPaddingV)
-    }
-  }
-
-  /// Progress in the user's terms. **Never "part 3 of 14"**: the splitting is a
-  /// property of the polisher, not something the user asked for, and naming it
-  /// would invite questions about a mechanism they cannot change.
-  private func progressLine(done: Int, total: Int) -> String {
-    guard total > 1 else { return "Almost there." }
-    let percent = Int((Double(done) / Double(total)) * 100)
-    return "\(percent)% of the way through."
-  }
-
-  private var doneHeader: some View {
-    BrandedSection(header: "DONE") {
-      VStack(alignment: .leading, spacing: 12) {
-        Text("Your text is ready.").font(.stRowTitle)
-        HStack(spacing: 10) {
-          SettingsActionButton(
-          title: "Copy", isEnabled: true, emphasis: .filled, action: { copyDocument() })
-          SettingsActionButton(
-          title: "Change the polisher", isEnabled: true, action: { coordinator.rePolish() })
-          SettingsActionButton(
-          title: "Transcribe another file", isEnabled: true, action: { chooseFile() })
-        }
-      }
-      .padding(.horizontal, SettingsLayout.rowPaddingH)
-      .padding(.vertical, SettingsLayout.rowPaddingV)
-    }
-  }
-
-  private var stoppedHeader: some View {
-    BrandedSection(header: "STOPPED") {
-      VStack(alignment: .leading, spacing: 12) {
-        Text("Stopped. What finished is below.").font(.stRowTitle)
-        HStack(spacing: 10) {
-          SettingsActionButton(
-          title: "Copy", isEnabled: true, emphasis: .filled, action: { copyDocument() })
-          SettingsActionButton(
-          title: "Transcribe another file", isEnabled: true, action: { chooseFile() })
-        }
-      }
-      .padding(.horizontal, SettingsLayout.rowPaddingH)
-      .padding(.vertical, SettingsLayout.rowPaddingV)
-    }
-  }
-
-  // MARK: - The document
-
-  /// **The words themselves, rewritten in place as each part lands.** Not a
-  /// progress list, and not a set of numbered blocks the user has to assemble in
-  /// their head.
-  @ViewBuilder
-  private var documentCard: some View {
-    if !coordinator.parts.isEmpty {
-      BrandedSection(header: "YOUR TEXT") {
-        VStack(alignment: .leading, spacing: 14) {
-          ForEach(coordinator.parts) { part in
-            VStack(alignment: .leading, spacing: 4) {
-              Text(part.text).textSelection(.enabled)
-              if part.isUnpolished {
-                // Marked, never hidden. A passage that could not be cleaned is
-                // still the user's words, and pretending otherwise is the
-                // failure this feature must not have.
-                Text("This passage could not be cleaned up. These are the raw words.")
-                  .font(.stHelper)
-                  .foregroundStyle(.secondary)
+  /// Completed steps carry a check and stay clickable; the current one is
+  /// underlined; the rest are numbered and dim. Going back is offered only while
+  /// nothing has run — after that the choices are frozen for the run, and a
+  /// live-looking control would be a lie.
+  private var stepBar: some View {
+    HStack(spacing: 2) {
+      ForEach(FileImportCoordinator.Step.allCases, id: \.self) { step in
+        let done = step.rawValue < coordinator.step.rawValue
+        let current = step == coordinator.step
+        Button {
+          coordinator.jump(to: step)
+        } label: {
+          // The design's tab: a numbered ring that FILLS once the step is
+          // behind you, and a 2pt underline on the one you are standing in.
+          let tint: Color = current ? .stAccent : (done ? .stTextSecondary : .stTextTertiary)
+          HStack(spacing: 8) {
+            Group {
+              if done {
+                Image(systemName: "checkmark")
+                  .font(.system(size: 10, weight: .bold))
+                  .foregroundStyle(.white)
+                  .frame(width: 19, height: 19)
+                  .background(Circle().fill(Color.stAccentSolid))
+              } else {
+                Text("\(step.rawValue)")
+                  .font(.system(size: 11, weight: .bold))
+                  .foregroundStyle(tint)
+                  .frame(width: 19, height: 19)
+                  .overlay(Circle().strokeBorder(tint, lineWidth: 1.5))
               }
             }
+            Text(step.title)
+              .font(.system(size: 14, weight: .semibold))
+              .foregroundStyle(tint)
+          }
+          .padding(.top, 10)
+          .padding(.bottom, 9)
+          .padding(.horizontal, 4)
+          .frame(maxWidth: .infinity)
+          .overlay(alignment: .bottom) {
+            Rectangle().fill(current ? Color.stAccent : Color.clear).frame(height: 2)
+          }
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!done || coordinator.isRunning)
+      }
+    }
+    .padding(.horizontal, 8)
+    .background(Color.stPageBg)
+    .overlay(alignment: .bottom) { Divider() }
+  }
+
+  /// The prototype's `.tile`: a 36pt rounded square in accent-light with an
+  /// accent border. Used wherever the design puts an icon beside a heading.
+  private func iconTile(_ systemName: String, size: CGFloat = 36, radius: CGFloat = 10)
+    -> some View
+  {
+    Image(systemName: systemName)
+      .font(.system(size: size * 0.45, weight: .medium))
+      .foregroundStyle(Color.stAccent)
+      .frame(width: size, height: size)
+      .background(RoundedRectangle(cornerRadius: radius).fill(Color.stAccentLight))
+      .overlay(
+        RoundedRectangle(cornerRadius: radius).strokeBorder(Color.stAccent.opacity(0.32)))
+  }
+
+  private func stepHeading(_ title: String) -> some View {
+    HStack {
+      Text(title).font(.system(size: 20, weight: .semibold))
+      Spacer()
+      Text("Step \(coordinator.step.rawValue) of 6").foregroundStyle(Color.stTextSecondary)
+    }
+  }
+
+  /// The row every choosing step ends with: a plain sentence about the choice on
+  /// the left, and the way forward on the right.
+  private func actionRow(
+    note: String, showBack: Bool = true, forwardTitle: String,
+    forward: @escaping () -> Void
+  ) -> some View {
+    BrandedSection {
+      HStack(spacing: 10) {
+        Text(note).foregroundStyle(Color.stTextSecondary)
+        Spacer(minLength: 12)
+        if showBack {
+          SettingsActionButton(title: "Back", isEnabled: true, action: { coordinator.goBack() })
+        }
+        SettingsActionButton(
+          title: forwardTitle, isEnabled: true, emphasis: .filled, action: forward)
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  // MARK: - 1. Upload
+
+  @ViewBuilder
+  private var uploadStep: some View {
+    heroCard
+    switch coordinator.state {
+    case .ready, .finished, .stopped, .transcribing, .polishing:
+      chosenFileCard
+    case .reading(let name):
+      BrandedSection {
+        HStack(spacing: 10) {
+          ProgressView().controlSize(.small)
+          Text("Reading \(name)")
+        }
+        .padding(.horizontal, SettingsLayout.rowPaddingH)
+        .padding(.vertical, SettingsLayout.rowPaddingV)
+      }
+    case .rejected(let reason):
+      InsetNotice(
+        text: Self.sentence(for: reason), systemImage: "exclamationmark.triangle", tint: .orange)
+      dropZone
+    case .idle:
+      dropZone
+      featureTiles
+    }
+  }
+
+  private var heroCard: some View {
+    BrandedSection {
+      HStack(alignment: .top, spacing: 14) {
+        iconTile("doc.badge.plus")
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Transcribe a File").font(.system(size: 16, weight: .semibold))
+          Text(
+            """
+            Upload an audio or video file, then EnviousWispr will transcribe it and polish it \
+            into clean, readable text.
+            """
+          )
+          .foregroundStyle(Color.stTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+  }
+
+  /// The empty state. A dashed target rather than a bare button, because the
+  /// design accepts a dropped file as well as a chosen one and the shape has to
+  /// say so before the sentence does.
+  private var dropZone: some View {
+    VStack(spacing: 7) {
+      iconTile("arrow.up", size: 50, radius: 13)
+      SettingsActionButton(
+        title: "Choose a file", isEnabled: true, emphasis: .filled, action: { chooseFile() })
+      Text("or drag and drop here").foregroundStyle(Color.stTextSecondary)
+      WrappingHStack(spacing: 6) {
+        Text("Supported formats").foregroundStyle(Color.stTextTertiary)
+        ForEach(Self.supportedFormats, id: \.self) { format in
+          Text(format)
+            .font(.system(size: 13, design: .monospaced))
+            .foregroundStyle(Color.stTextSecondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Color.stAccentLight.opacity(0.5)))
+            .overlay(Capsule().strokeBorder(Color.stDivider))
+        }
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 30)
+    .padding(.horizontal, 20)
+    .background(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+    .overlay(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+        .strokeBorder(Color.stDivider, style: StrokeStyle(lineWidth: 1.5, dash: [7, 5]))
+    )
+    .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+      guard let provider = providers.first else { return false }
+      _ = provider.loadObject(ofClass: URL.self) { url, _ in
+        guard let url else { return }
+        Task { @MainActor in coordinator.choose(url: url) }
+      }
+      return true
+    }
+  }
+
+  static let supportedFormats = ["m4a", "mp3", "wav", "aiff", "caf", "mp4", "mov", "flac"]
+
+  /// The four things a person wants to know before handing over a recording.
+  ///
+  /// ONE panel divided by hairlines, the way the design draws it, rather than
+  /// four separate boxes with gaps between them.
+  private var featureTiles: some View {
+    BrandedSection {
+      VStack(spacing: 0) {
+        HStack(spacing: 0) {
+          featureTile("lock", "Your voice stays here", "Audio never leaves this Mac.")
+          Divider()
+          featureTile("bolt", "Two transcription engines", "Fast, or All Languages.")
+        }
+        Divider()
+        HStack(spacing: 0) {
+          featureTile("sparkles", "Six ways to polish", "On device, or your own cloud key.")
+          Divider()
+          featureTile("shield", "Original kept", "Never overwritten.")
+        }
+      }
+      .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private func featureTile(_ icon: String, _ title: String, _ detail: String) -> some View {
+    HStack(alignment: .top, spacing: 9) {
+      iconTile(icon, size: 28, radius: 8)
+      VStack(alignment: .leading, spacing: 1) {
+        Text(title).font(.system(size: 14, weight: .semibold))
+        Text(detail).font(.system(size: 14)).foregroundStyle(Color.stTextTertiary)
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 13)
+    .padding(.vertical, 10)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+
+  @ViewBuilder
+  private var chosenFileCard: some View {
+    if let file = coordinator.file {
+      BrandedSection {
+        VStack(alignment: .leading, spacing: 14) {
+          HStack(alignment: .top, spacing: 14) {
+            SettingsRowIcon(systemName: "waveform")
+            VStack(alignment: .leading, spacing: 4) {
+              Text(file.name).font(.stRowTitle)
+              Text(file.detailLine).foregroundStyle(Color.stTextSecondary)
+            }
+            Spacer(minLength: 12)
+            SettingsActionButton(
+              title: "Choose a different file", isEnabled: !coordinator.isRunning,
+              action: { chooseFile() })
+          }
+          HStack(spacing: 24) {
+            check("Audio found")
+            check("Ready in \(coordinator.estimateText)")
           }
         }
         .padding(.horizontal, SettingsLayout.rowPaddingH)
-      .padding(.vertical, SettingsLayout.rowPaddingV)
+        .padding(.vertical, SettingsLayout.rowPaddingV)
+      }
+      actionRow(
+        note: "Nothing has run yet. You can still change everything.", showBack: false,
+        forwardTitle: "Continue", forward: { coordinator.advance() })
+    }
+  }
+
+  private func check(_ text: String) -> some View {
+    HStack(spacing: 8) {
+      Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+      Text(text)
+    }
+  }
+
+  // MARK: - 2. Transcription
+
+  @ViewBuilder
+  private var transcriptionStep: some View {
+    stepHeading("Select transcription engine")
+    HStack(alignment: .top, spacing: 14) {
+      engineCard(
+        backend: .parakeet, title: "Fast", icon: "bolt.fill", recommended: true,
+        blurb: "Best for everyday English and European recordings.",
+        specs: [
+          ("Model", "Parakeet v3"),
+          ("Languages", "25 European"),
+          ("An hour of audio", "About 7 seconds"),
+          ("Runs on", "This Mac · Neural Engine"),
+        ])
+      engineCard(
+        backend: .whisperKit, title: "All Languages", icon: "globe", recommended: false,
+        blurb: "Best for other languages or the toughest audio.",
+        specs: [
+          ("Model", "Whisper Large v3 Turbo"),
+          ("Languages", "99+"),
+          ("An hour of audio", "About 2 minutes"),
+          ("Runs on", "This Mac · Apple GPU"),
+        ])
+    }
+    actionRow(
+      note: "Both engines run entirely on this Mac.", forwardTitle: "Continue",
+      forward: { coordinator.advance() })
+  }
+
+  private func engineCard(
+    backend: ASRBackendType, title: String, icon: String, recommended: Bool, blurb: String,
+    specs: [(String, String)]
+  ) -> some View {
+    let selected = coordinator.chosenBackend == backend
+    return Button {
+      coordinator.chosenBackend = backend
+    } label: {
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(spacing: 8) {
+          Image(systemName: icon).foregroundStyle(Color.stAccent)
+          Text(title).font(.stRowTitle)
+          if recommended { badge("Recommended") }
+          Spacer(minLength: 8)
+          Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+            .foregroundStyle(selected ? Color.stAccent : Color.stTextSecondary)
+        }
+        Text(blurb)
+          .foregroundStyle(Color.stTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        ForEach(specs, id: \.0) { spec in
+          Divider()
+          HStack {
+            Text(spec.0).foregroundStyle(Color.stTextSecondary)
+            Spacer()
+            Text(spec.1).font(.stRowLabel)
+          }
+        }
+      }
+      .padding(14)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+      .overlay(
+        RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+          .strokeBorder(selected ? Color.stAccent : Color.stDivider)
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  private func badge(_ text: String) -> some View {
+    Text(text)
+      .font(.system(size: 13, weight: .semibold))
+      .padding(.horizontal, 9)
+      .padding(.vertical, 2)
+      .background(Capsule().fill(Color.stAccentSolid))
+      .foregroundStyle(.white)
+  }
+
+  // MARK: - 3. Polish
+
+  @ViewBuilder
+  private var polishStep: some View {
+    stepHeading("Select polishing engine")
+    // Six across, matching the design at the window's ordinary width. The
+    // prototype drops to three below 1000px and two below 640; the app's own
+    // minimum window is 750, so three is the narrow fallback.
+    LazyVGrid(
+      columns: Array(repeating: GridItem(.flexible(), spacing: 9), count: 6), spacing: 9
+    ) {
+      ForEach(Self.polishChoices, id: \.provider) { choice in
+        polishCard(choice)
+      }
+    }
+    polishDetailCard
+    actionRow(
+      note: "Numbers, dates, your saved words and filler removal run either way.",
+      forwardTitle: "Continue", forward: { coordinator.advance() })
+  }
+
+  struct PolishChoice {
+    let provider: LLMProvider
+    let icon: String
+    let availability: String
+    let detail: String
+
+    /// Read from the provider, never restated here. `LLMProviderDisplayNameFreezeTests`
+    /// enforces it, and it is right to: a licence-bound spelling or a rename has
+    /// to change in one place, not in every screen that happens to list them.
+    var title: String { provider.displayName }
+  }
+
+  /// The six, in the order the design shows them. Each carries the one line that
+  /// decides whether a person can use it at all, because "Needs a key" is the
+  /// answer to the question they are actually asking.
+  static let polishChoices: [PolishChoice] = [
+    PolishChoice(
+      provider: .egOne, icon: "star", availability: "On device",
+      detail:
+        """
+        Our best model for cleanup and list-making. On an imported recording it removes about \
+        four times more filler than Apple Intelligence.
+        """),
+    PolishChoice(
+      provider: .appleIntelligence, icon: "apple.logo",
+      availability: "On device",
+      detail: "Apple's on-device model. Needs macOS 26 or later."),
+    PolishChoice(
+      provider: .ollama, icon: "cube", availability: "Needs the app",
+      detail: "Any model you run locally in Ollama. Nothing leaves this Mac."),
+    PolishChoice(
+      provider: .openAI, icon: "circle.hexagongrid", availability: "Needs a key",
+      detail: "Your own OpenAI key. Only the text is sent, never the audio."),
+    PolishChoice(
+      provider: .gemini, icon: "sparkle", availability: "Needs a key",
+      detail: "Your own Google key. Only the text is sent, never the audio."),
+    PolishChoice(
+      provider: .claude, icon: "star.circle", availability: "Needs a key",
+      detail: "Your own Anthropic key. Only the text is sent, never the audio."),
+  ]
+
+  private func polishCard(_ choice: PolishChoice) -> some View {
+    let selected = coordinator.chosenPolish == choice.provider
+    return Button {
+      coordinator.chosenPolish = choice.provider
+    } label: {
+      VStack(alignment: .leading, spacing: 8) {
+        HStack {
+          Image(systemName: choice.icon).foregroundStyle(Color.stAccent)
+          Spacer(minLength: 4)
+          Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+            .foregroundStyle(selected ? Color.stAccent : Color.stTextSecondary)
+        }
+        Text(choice.title).font(.stRowLabel).fixedSize(horizontal: false, vertical: true)
+        if choice.provider == .egOne { badge("Recommended") }
+        Text(choice.availability).foregroundStyle(Color.stTextSecondary)
+      }
+      .padding(12)
+      .frame(maxWidth: .infinity, minHeight: 120, alignment: .topLeading)
+      .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+      .overlay(
+        RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
+          .strokeBorder(selected ? Color.stAccent : Color.stDivider)
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  @ViewBuilder
+  private var polishDetailCard: some View {
+    if let choice = selectedPolish {
+      BrandedSection {
+        HStack(alignment: .top, spacing: 14) {
+          SettingsRowIcon(systemName: choice.icon)
+          VStack(alignment: .leading, spacing: 4) {
+            Text(choice.title).font(.stRowTitle)
+            Text(choice.detail)
+              .foregroundStyle(Color.stTextSecondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+          Spacer(minLength: 0)
+        }
+        .padding(.horizontal, SettingsLayout.rowPaddingH)
+        .padding(.vertical, SettingsLayout.rowPaddingV)
       }
     }
   }
 
-  // MARK: - Refusals
+  private var selectedPolish: PolishChoice? {
+    Self.polishChoices.first { $0.provider == coordinator.chosenPolish }
+  }
 
-  private func rejectedCard(reason: FileImportCoordinator.FileImportRejection) -> some View {
-    BrandedSection(header: "YOUR FILE") {
-      VStack(alignment: .leading, spacing: 12) {
-        Text(Self.sentence(for: reason))
+  // MARK: - 4. Review
+
+  @ViewBuilder
+  private var reviewStep: some View {
+    stepHeading("Review and start")
+    HStack(alignment: .top, spacing: 14) {
+      VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+        BrandedSection(header: "SELECTED FILE") {
+          VStack(alignment: .leading, spacing: 12) {
+            if let file = coordinator.file {
+              HStack(alignment: .top, spacing: 14) {
+                SettingsRowIcon(systemName: "waveform")
+                VStack(alignment: .leading, spacing: 4) {
+                  Text(file.name).font(.stRowTitle)
+                  Text(file.detailLine).foregroundStyle(Color.stTextSecondary)
+                }
+                Spacer(minLength: 0)
+              }
+              check("Audio found")
+              check("Ready in \(coordinator.estimateText)")
+            }
+          }
+          .padding(.horizontal, SettingsLayout.rowPaddingH)
+          .padding(.vertical, SettingsLayout.rowPaddingV)
+        }
+        // The founder's lock decision, said BEFORE the user commits rather than
+        // discovered when their keybind stops working.
+        InsetNotice(
+          text:
+            """
+            Dictation pauses while this runs. Your keybind will not record until the transcript \
+            is finished, \(coordinator.estimateText).
+            """,
+          systemImage: "mic.slash", tint: .orange)
+        actionRow(
+          note: "Nothing has run yet.", forwardTitle: "Start transcription",
+          forward: { coordinator.advance() })
+      }
+      processingPath.frame(width: 300)
+    }
+  }
+
+  /// The two engines this run will use, stacked in the order they run with an
+  /// arrow between them. It answers "what is about to happen to my recording" in
+  /// one glance.
+  private var processingPath: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("YOUR PROCESSING PATH")
+        .font(.stSectionHeader).tracking(0.6).foregroundStyle(Color.stAccent)
+      pathCard(
+        icon: coordinator.chosenBackend == .parakeet ? "bolt.fill" : "globe",
+        title: coordinator.chosenBackend == .parakeet ? "Fast" : "All Languages",
+        recommended: coordinator.chosenBackend == .parakeet,
+        blurb: "Writes down what was said.",
+        rows: [
+          (
+            "Runs on",
+            coordinator.chosenBackend == .parakeet
+              ? "This Mac · Neural Engine" : "This Mac · Apple GPU"
+          )
+        ])
+      Image(systemName: "arrow.down")
+        .foregroundStyle(Color.stTextSecondary)
+        .frame(maxWidth: .infinity)
+      pathCard(
+        icon: selectedPolish?.icon ?? "sparkles",
+        title: selectedPolish?.title ?? "No polish",
+        recommended: coordinator.chosenPolish == .egOne,
+        blurb: "Cleans it into readable text.",
+        rows: [("Runs on", selectedPolish?.availability ?? "")])
+    }
+  }
+
+  private func pathCard(
+    icon: String, title: String, recommended: Bool, blurb: String, rows: [(String, String)]
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 8) {
+        Image(systemName: icon).foregroundStyle(Color.stAccent)
+        Text(title).font(.stRowLabel)
+        if recommended { badge("Recommended") }
+        Spacer(minLength: 0)
+      }
+      Text(blurb).foregroundStyle(Color.stTextSecondary)
+      ForEach(rows, id: \.0) { row in
+        Divider()
+        Text(row.0).foregroundStyle(Color.stTextSecondary)
+        Text(row.1).font(.stRowLabel)
+      }
+    }
+    .padding(14)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+    .overlay(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).strokeBorder(Color.stDivider))
+  }
+
+  // MARK: - 5. Working
+
+  @ViewBuilder
+  private var workingStep: some View {
+    stepHeading("Working on your transcript")
+    BrandedSection {
+      HStack(spacing: 14) {
+        GeometryReader { geo in
+          ZStack(alignment: .leading) {
+            Capsule().fill(Color.stAccentLight.opacity(0.6))
+            Capsule()
+              .fill(
+                LinearGradient(
+                  colors: [Color.stAccent, Color.stAccentSolid],
+                  startPoint: .leading, endPoint: .trailing)
+              )
+              .frame(width: max(6, geo.size.width * coordinator.progress))
+          }
+        }
+        .frame(width: 170, height: 9)
+        Text("\(Int(coordinator.progress * 100))%")
+          .font(.system(size: 14, weight: .semibold, design: .monospaced))
+          .monospacedDigit()
+          .frame(minWidth: 38, alignment: .leading)
+        HStack(spacing: 8) {
+          Image(systemName: "list.bullet").foregroundStyle(Color.stTextSecondary)
+          Text(coordinator.phase)
+        }
+        Spacer(minLength: 12)
+        Text("\(coordinator.wordCount) words").foregroundStyle(Color.stTextSecondary)
+        SettingsActionButton(title: "Stop", isEnabled: true, action: { coordinator.stop() })
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+    liveTranscript
+  }
+
+  /// The words themselves while the run goes: cleaned parts as they land, and
+  /// the raw transcript until the first one does, so the page is never empty and
+  /// never just a spinner.
+  private var liveTranscript: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      ForEach(coordinator.parts) { part in
+        VStack(alignment: .leading, spacing: 4) {
+          Text(part.text)
+            .lineSpacing(6)
+            .foregroundStyle(Color.stTextBody)
+            .textSelection(.enabled)
+          if part.isUnpolished {
+            Text("This passage could not be cleaned up. These are the raw words.")
+              .font(.stHelper)
+              .foregroundStyle(Color.stTextSecondary)
+          }
+        }
+      }
+      if coordinator.parts.isEmpty, !coordinator.rawTranscript.isEmpty {
+        Text(coordinator.rawTranscript)
+          .lineSpacing(6)
+          .foregroundStyle(Color.stTextSecondary)
+          .textSelection(.enabled)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.horizontal, 16)
+    .padding(.vertical, 14)
+    .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+  }
+
+  // MARK: - 6. Done
+
+  @ViewBuilder
+  private var doneStep: some View {
+    stepHeading(coordinator.state == .stopped ? "Stopped" : "Your transcript is ready")
+    BrandedSection {
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(spacing: 10) {
+          Text(coordinator.file?.name ?? "Transcript").font(.stRowTitle)
+          Spacer(minLength: 12)
+          chip("\(coordinator.wordCount) words")
+          if let file = coordinator.file {
+            chip(FileImportCoordinator.durationText(file.seconds))
+          }
+        }
+        HStack(spacing: 8) {
+          chip("Polished by \(selectedPolish?.title ?? "nothing")")
+          Button("Change") { coordinator.rePolish() }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.stAccent)
+        }
+      }
+      .padding(.horizontal, SettingsLayout.rowPaddingH)
+      .padding(.vertical, SettingsLayout.rowPaddingV)
+    }
+    liveTranscript
+    BrandedSection {
+      HStack(spacing: 10) {
         SettingsActionButton(
-          title: "Choose a file", isEnabled: true, emphasis: .filled, action: { chooseFile() })
+          title: "Copy everything", isEnabled: true, emphasis: .filled,
+          systemImage: "doc.on.doc", action: { copyDocument() })
+        SettingsActionButton(
+          title: "Save as...", isEnabled: true, systemImage: "square.and.arrow.down",
+          action: { saveDocument() })
+        Spacer(minLength: 12)
+        SettingsActionButton(
+          title: "New transcription", isEnabled: true, systemImage: "arrow.up",
+          action: { coordinator.startOver() })
       }
       .padding(.horizontal, SettingsLayout.rowPaddingH)
       .padding(.vertical, SettingsLayout.rowPaddingV)
     }
   }
 
-  /// One honest sentence per refusal. No mechanism, no error codes, and nothing
-  /// that invites the user to retry something that cannot work.
-  static func sentence(for reason: FileImportCoordinator.FileImportRejection) -> String {
-    switch reason {
-    case .cannotRead:
-      return "That file couldn't be opened. Try a different one."
-    case .noAudio:
-      return "There's no sound in that file."
-    case .noSpeechFound:
-      return "No speech was found in that file."
-    case .engineBusy(.dictation):
-      return "A dictation is running. Try again when it finishes."
-    case .engineBusy(.crashRecovery):
-      return "Finishing an earlier take. Try again in a moment."
-    case .engineBusy(.fileImport):
-      return "Another file is being transcribed right now."
-    case .failed:
-      return "Something went wrong reading that file. Try a different one."
+  private func chip(_ text: String) -> some View {
+    Text(text)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 4)
+      .background(RoundedRectangle(cornerRadius: 8).fill(Color.stDivider.opacity(0.35)))
+  }
+
+  // MARK: - The footer, which changes with the step
+
+  private var privacyFooter: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "shield").foregroundStyle(.green)
+      Text(Self.footerLead(step: coordinator.step))
+        .font(.stRowLabel).foregroundStyle(.green)
+      Text(Self.footerDetail(step: coordinator.step, isCloudPolish: isCloudPolish))
+        .foregroundStyle(Color.stTextSecondary)
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 9)
+    .frame(minHeight: 52)
+    .background(Color.stSidebarBg)
+    .overlay(alignment: .top) { Divider() }
+  }
+
+  static func footerLead(step: FileImportCoordinator.Step) -> String {
+    step == .working ? "Safe to leave this page." : "Secure. Private. Local."
+  }
+
+  /// **Computed, never fixed, and after a run it describes THAT run.**
+  /// "Your audio and text both stay on this Mac" is false the moment a cloud
+  /// polisher is chosen, which the founder caught in the prototype; and reading
+  /// the LIVE provider after a run would retrospectively re-describe a finished
+  /// document, which cloud review caught in the first build.
+  static func footerDetail(step: FileImportCoordinator.Step, isCloudPolish: Bool) -> String {
+    switch step {
+    case .working:
+      // The cloud branch belongs HERE most of all: this is the step during
+      // which the text is actually being sent. A line claiming both stay on the
+      // Mac would be false at the exact moment it is on screen.
+      return isCloudPolish
+        ? "Your audio never leaves this Mac. The text is going to the provider you chose."
+        : "Your audio and text both stay on this Mac."
+    case .done:
+      return isCloudPolish
+        ? "Your audio stayed on this Mac. Only the text went to the provider you chose."
+        : "Your untouched words are kept beside this one."
+    case .upload, .transcription, .polish, .review:
+      return isCloudPolish
+        ? "Your audio never leaves this Mac. Only the text goes to the provider you chose."
+        : "Your audio and text both stay on this Mac."
     }
   }
 
-  static func lengthLine(seconds: Double) -> String {
-    let minutes = Int(seconds / 60)
-    if minutes < 1 { return "Under a minute of audio." }
-    if minutes == 1 { return "About a minute of audio." }
-    return "About \(minutes) minutes of audio."
-  }
-
-  // MARK: - Privacy, computed from what is actually selected
-
-  /// **The line is computed, never fixed.** "All processing happens on this Mac"
-  /// is false the moment a cloud polisher is selected, and the founder caught
-  /// exactly that in the prototype. The audio never leaves either way, so that
-  /// half is always true; the text half depends on the choice.
-  private var privacyCard: some View {
-    InsetNotice(text: Self.privacyLine(isCloudPolish: isCloudPolish))
-  }
-
   private var isCloudPolish: Bool {
-    switch settings.llmProvider {
+    if let frozen = coordinator.runConfiguration { return frozen.polishIsCloud }
+    return Self.isCloud(coordinator.chosenPolish)
+  }
+
+  /// Enumerated, never `default:`. A new provider must be classified here
+  /// deliberately, because getting it wrong publishes a false privacy claim.
+  static func isCloud(_ provider: LLMProvider) -> Bool {
+    switch provider {
     case .openAI, .gemini, .claude: return true
     case .egOne, .s1Mini, .appleIntelligence, .ollama, .none: return false
     }
   }
 
-  static func privacyLine(isCloudPolish: Bool) -> String {
-    if isCloudPolish {
-      return """
-        Your audio never leaves this Mac. With a cloud polisher selected, only the text goes to the \
-        provider you chose, under your own key.
-        """
+  /// One honest sentence per refusal. No mechanism, no error codes.
+  static func sentence(for reason: FileImportCoordinator.FileImportRejection) -> String {
+    switch reason {
+    case .cannotRead: return "That file couldn't be opened. Try a different one."
+    case .noAudio: return "There's no sound in that file."
+    case .noSpeechFound: return "No speech was found in that file."
+    case .engineBusy(.dictation): return "A dictation is running. Try again when it finishes."
+    case .engineBusy(.crashRecovery): return "Finishing an earlier take. Try again in a moment."
+    case .engineBusy(.fileImport): return "Another file is being transcribed right now."
+    case .failed: return "Something went wrong reading that file. Try a different one."
     }
-    return "Everything here happens on this Mac. Nothing is uploaded."
   }
 
   // MARK: - Actions
+
+  /// The import's engines start from what the user already uses, so the common
+  /// path is two Continues. Changing them here does NOT write back to settings:
+  /// a choice made for one file is not a change to how dictation works.
+  private func seedChoicesFromSettings() {
+    guard coordinator.state == .idle else { return }
+    coordinator.chosenBackend = settings.selectedBackend
+    coordinator.chosenPolish = settings.llmProvider
+  }
 
   private func chooseFile() {
     let panel = NSOpenPanel()
@@ -268,5 +825,14 @@ struct TranscribeFileView: View {
   private func copyDocument() {
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(coordinator.documentText, forType: .string)
+  }
+
+  private func saveDocument() {
+    let panel = NSSavePanel()
+    panel.allowedContentTypes = [.plainText]
+    panel.nameFieldStringValue =
+      (coordinator.file?.name as NSString?)?.deletingPathExtension ?? "Transcript"
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+    try? coordinator.documentText.write(to: url, atomically: true, encoding: .utf8)
   }
 }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -563,6 +563,20 @@ public final class EGOneRuntime: EGOneEndpointProviding {
         self.provider, promptFamily: family, spec: self.probeSpec)
       // Probe verdict wins over the cheap projection while server is ready.
       guard generation == self.activationGeneration else { return }
+      // **Asked AGAIN, after the request.** The check above is a check-then-act:
+      // a workload can claim the lease while `probeHealth` is suspended, and the
+      // probe then queues behind a passage for seconds and comes back
+      // `probe_slow` or `probe_failed` for a healthy engine. Found by cloud
+      // review.
+      //
+      // The verdict is DISCARDED rather than the slot being reserved,
+      // deliberately. Taking the claim would be the atomic answer to a question
+      // nobody is asking: exclusivity is not wanted here, because a probe
+      // holding it would refuse a user's record press for the length of a health
+      // check. What this exists to prevent is publishing a verdict measured
+      // under contention, and dropping it does exactly that. The next
+      // activation takes a fresh one.
+      guard self.isSharedEngineBusy?() != true else { return }
       if case .ready = self.serverState { self.health = result }
     }
   }

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -136,6 +136,19 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// download's auto-start. The deferred reconciliation retries once the
   /// recording ends, so a refused start is delayed, never lost.
   public var isBlockedByOtherPinnedSession: (@MainActor () -> Bool)?
+
+  /// Live "is another workload using the one inference slot right now?" read,
+  /// set by the composition root (#2648).
+  ///
+  /// **Suppresses the PROBE, never the activation.** The server launches with no
+  /// `-np`, so it serves one request at a time. A probe issued while a file
+  /// import is polishing a passage queues behind it for seconds and then reports
+  /// `probe_slow` or `probe_failed` for an engine that is perfectly healthy —
+  /// opening AI Polish mid-import was enough to do it. A health check that fails
+  /// because something else is legitimately using the engine is worse than no
+  /// health check. The engine still starts; only the verdict is skipped, and the
+  /// next activation takes one.
+  public var isSharedEngineBusy: (@MainActor () -> Bool)?
   private var removalPending = false
 
   public let manifest: EGOneManifest?
@@ -544,6 +557,8 @@ public final class EGOneRuntime: EGOneEndpointProviding {
       // health for a stale generation.
       guard generation == self.activationGeneration else { return }
       guard let family = manifest.promptFamily else { return }
+      // The engine is up either way; the QUESTION is what is skipped.
+      guard self.isSharedEngineBusy?() != true else { return }
       let result = await self.server.probeHealth(
         self.provider, promptFamily: family, spec: self.probeSpec)
       // Probe verdict wins over the cheap projection while server is ready.

--- a/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
+++ b/Sources/EnviousWisprLLM/EGOne/EGOneRuntime.swift
@@ -149,6 +149,12 @@ public final class EGOneRuntime: EGOneEndpointProviding {
   /// health check. The engine still starts; only the verdict is skipped, and the
   /// next activation takes one.
   public var isSharedEngineBusy: (@MainActor () -> Bool)?
+
+  /// How many workloads the shared lease has admitted, ever. Read before and
+  /// after a health probe: any change means something occupied the one inference
+  /// slot while the probe was in flight, whatever the instantaneous busy flag
+  /// said at either end. See `EngineLease.admissionEpoch`.
+  public var sharedEngineAdmissionEpoch: (@MainActor () -> Int)?
   private var removalPending = false
 
   public let manifest: EGOneManifest?
@@ -559,24 +565,25 @@ public final class EGOneRuntime: EGOneEndpointProviding {
       guard let family = manifest.promptFamily else { return }
       // The engine is up either way; the QUESTION is what is skipped.
       guard self.isSharedEngineBusy?() != true else { return }
+      // **The instrument measures the INTERVAL, not two instants.** Sampling
+      // "is it busy" before and after both read false for a workload that
+      // claimed and released inside the probe — a one-part re-polish does
+      // exactly that — while the probe queued behind it and came back slow. Two
+      // rounds of review each moved a sample; this reads a counter that cannot
+      // miss a visit however brief. Found by cloud review.
+      let epochBefore = self.sharedEngineAdmissionEpoch?()
       let result = await self.server.probeHealth(
         self.provider, promptFamily: family, spec: self.probeSpec)
       // Probe verdict wins over the cheap projection while server is ready.
       guard generation == self.activationGeneration else { return }
-      // **Asked AGAIN, after the request.** The check above is a check-then-act:
-      // a workload can claim the lease while `probeHealth` is suspended, and the
-      // probe then queues behind a passage for seconds and comes back
-      // `probe_slow` or `probe_failed` for a healthy engine. Found by cloud
-      // review.
-      //
-      // The verdict is DISCARDED rather than the slot being reserved,
-      // deliberately. Taking the claim would be the atomic answer to a question
-      // nobody is asking: exclusivity is not wanted here, because a probe
-      // holding it would refuse a user's record press for the length of a health
-      // check. What this exists to prevent is publishing a verdict measured
-      // under contention, and dropping it does exactly that. The next
-      // activation takes a fresh one.
+      // **The verdict is DISCARDED rather than the slot reserved**, deliberately.
+      // Taking the claim would be the atomic answer to a question nobody is
+      // asking: exclusivity is not wanted here, because a probe holding it would
+      // refuse a user's record press for the length of a health check. What this
+      // exists to prevent is publishing a verdict measured under contention, and
+      // dropping it does that. The next activation takes a fresh one.
       guard self.isSharedEngineBusy?() != true else { return }
+      guard self.sharedEngineAdmissionEpoch?() == epochBefore else { return }
       if case .ready = self.serverState { self.health = result }
     }
   }

--- a/Sources/EnviousWisprPipeline/EngineLease.swift
+++ b/Sources/EnviousWisprPipeline/EngineLease.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// #2648 — the single arbiter of workload overlap on the shared ASR-and-polish
+/// resource.
+///
+/// EG-1's server is launched with no `-np`, so it has ONE slot and serialises
+/// every inference request. A file import sends a 500-word part into that slot
+/// for roughly twelve seconds; live dictation's polish budget is fifteen. A
+/// dictation arriving mid-part would queue behind it and silently lose its
+/// polish. The founder's call (2026-09-04) is to LOCK dictation for the
+/// duration of an import rather than hand the engine back and forth mid-flight.
+///
+/// **This is not `EngineRecoveryGate`, and the deciding property is that gate's
+/// `mutationCount`** (`EngineRecoveryGate.swift:56-59`): it deliberately admits
+/// several non-recovery mutations at once, because its job is to keep recovery
+/// away from engine MUTATION, not to admit one workload. This type admits
+/// exactly one holder. The two answer different questions and both stay.
+///
+/// **`@MainActor` rather than an actor, matching `EngineRecoveryGate`.** Every
+/// real participant — the record-start paths, the dictation lifecycle, crash
+/// recovery, the file import coordinator — is already `@MainActor`, so a claim
+/// is a synchronous, non-suspending turn on an isolation they are all on
+/// already. MainActor permits synchronous admission and release for current
+/// callers. **Atomicity comes from having no suspension between checking and
+/// storing ownership; a non-suspending actor method would also be atomic**
+/// (`swift-concurrency-patterns.md`
+/// an-actor-is-not-a-mutex-for-a-multi-step-transaction). So the thing to
+/// preserve is not the isolation but the absence of the `await`: **do not add
+/// one to `admit`.**
+///
+/// The one participant that is NOT on the main actor is EG-1's health probe,
+/// which lives a module below and must not import upward. **Health-probe
+/// integration is deferred and must land before file import is enabled**: it
+/// will read this through an injected `@Sendable () async -> Bool` closure that
+/// hops here, and it will never take a token.
+///
+/// **This is a refusal lock, not a queue.** There is no waiter list: a caller
+/// that cannot have the resource is told so immediately and shows the user why.
+/// Queueing would make a record press appear to do nothing for minutes.
+///
+/// **Only the matching token releases.** A stale holder handing back a token
+/// from a run that already ended cannot evict the current one.
+@MainActor
+package final class EngineLease {
+  /// The workloads that can occupy the shared resource. Defined once as
+  /// `SharedEngineHolder` in `PipelineVocabulary.swift`, because a refusal
+  /// names the holder to the user and `RecordingWarningReason` carries it.
+  package typealias Holder = SharedEngineHolder
+
+  /// Opaque proof of the claim. The identity is private so a caller cannot
+  /// forge one, and equality is by identity so two claims by the same holder
+  /// are still two different claims.
+  package struct Token: Sendable, Equatable {
+    fileprivate let id: UUID
+    package let holder: Holder
+
+    fileprivate init(holder: Holder) {
+      self.id = UUID()
+      self.holder = holder
+    }
+  }
+
+  /// The answer to one claim: the proof, or WHO refused it.
+  ///
+  /// One value rather than a claim followed by a second "who has it" read,
+  /// because a refusal that has to ask a second question needs a fallback for
+  /// the answer coming back empty, and a plausible fallback is indistinguishable
+  /// from a real answer downstream — here it would name a job to wait for that
+  /// nobody is running.
+  package enum Admission: Sendable {
+    case granted(Token)
+    case refused(by: Holder)
+  }
+
+  private var held: Token?
+
+  package init() {}
+
+  /// Claims the resource, or refuses and names the holder.
+  ///
+  /// No suspension point: see the type's note on atomicity.
+  package func admit(_ holder: Holder) -> Admission {
+    if let held { return .refused(by: held.holder) }
+    let token = Token(holder: holder)
+    held = token
+    return .granted(token)
+  }
+
+  /// Releases the claim if `token` is the live one. Returns whether it was.
+  ///
+  /// Safe to call more than once, and safe to call with a token from a run that
+  /// has already ended — both are no-ops.
+  @discardableResult
+  package func release(_ token: Token) -> Bool {
+    guard held == token else { return false }
+    held = nil
+    return true
+  }
+
+  /// Who holds the resource right now, so a refusal can name it.
+  package var currentHolder: Holder? { held?.holder }
+
+  /// What EG-1's health probe reads before it builds a connector. A health
+  /// check that reports failure because something else is legitimately using
+  /// the engine is worse than no health check.
+  package var isBusy: Bool { held != nil }
+}

--- a/Sources/EnviousWisprPipeline/EngineLease.swift
+++ b/Sources/EnviousWisprPipeline/EngineLease.swift
@@ -83,6 +83,7 @@ package final class EngineLease {
     if let held { return .refused(by: held.holder) }
     let token = Token(holder: holder)
     held = token
+    admissionEpoch += 1
     return .granted(token)
   }
 
@@ -104,4 +105,18 @@ package final class EngineLease {
   /// check that reports failure because something else is legitimately using
   /// the engine is worse than no health check.
   package var isBusy: Bool { held != nil }
+
+  /// How many claims this lease has GRANTED, ever.
+  ///
+  /// **An interval question needs an interval instrument.** "Is the engine busy"
+  /// answers about an instant, and the health probe needs to know whether
+  /// anything used the engine WHILE its request was in flight — a workload that
+  /// claims and releases inside that window leaves both a before and an after
+  /// sample reading false, while the probe queued behind it the whole time and
+  /// came back slow. Two rounds of review each moved a sample; the third
+  /// replaced the instrument.
+  ///
+  /// Monotonic, so a reader compares two readings and never interprets the
+  /// value. Wrapping is not a concern at one increment per workload.
+  package private(set) var admissionEpoch = 0
 }

--- a/Sources/EnviousWisprPipeline/FileImportRunner.swift
+++ b/Sources/EnviousWisprPipeline/FileImportRunner.swift
@@ -1,0 +1,189 @@
+import EnviousWisprCore
+import EnviousWisprLLM
+import Foundation
+
+/// #2648 — what one part of an imported transcript goes through.
+///
+/// **The third caller of `TextProcessingRunner`, not a second pipeline.**
+/// `RecoveryTextProcessor` is the proven precedent for exactly this shape: the
+/// runner takes its steps as a parameter, so a new caller supplies a step list
+/// and reuses the shipped execution algorithm — ordering, timeouts, the
+/// raw-text floor, the silent-skip classification. Nothing about cleaning text
+/// is reimplemented here.
+///
+/// **Fresh steps per part, deliberately.** `InverseTextNormalizationStep` keeps
+/// a `lastRun` its telemetry reads after `process` returns
+/// (`InverseTextNormalizationStep.swift:71`), so two parts sharing one instance
+/// could describe each other. Parts run one at a time today, because the whole
+/// reason the engine claim exists is that EG-1 has one inference slot — but that
+/// ordering is a property of the shared resource, not a promise the step is
+/// entitled to. Building per part costs nothing measurable against a part that
+/// occupies the polisher for about twelve seconds. Finding owed to the #2758
+/// session.
+@MainActor
+public final class FileImportRunner {
+
+  /// What one part produced.
+  ///
+  /// `text` is the deterministic floor — the chain's output with polish removed
+  /// — and it is what the user gets when polish fails. That is the Heart &
+  /// Limbs contract applied per part: thirteen good parts and one raw part is a
+  /// good outcome, and hiding the raw one is the failure.
+  public struct PartOutcome: Sendable, Equatable {
+    public let text: String
+    public let polishedText: String?
+    public let polishError: String?
+
+    public init(text: String, polishedText: String?, polishError: String?) {
+      self.text = text
+      self.polishedText = polishedText
+      self.polishError = polishError
+    }
+
+    /// What the document shows for this part: polished when there is one, the
+    /// deterministic floor otherwise.
+    public var displayText: String { polishedText ?? text }
+
+    /// Whether this part is showing raw text because its polish did not land.
+    /// The UI marks these rather than hiding them.
+    public var isUnpolished: Bool { polishedText == nil }
+  }
+
+  private let keychainManager: KeychainManager
+  private let egOneRuntime: (any EGOneEndpointProviding)?
+  private let s1MiniRuntime: (any EGOneEndpointProviding)?
+  private let outputClassifierHolder: OutputClassifierHolder?
+
+  /// **One import, one configuration.** Frozen when the run starts and applied
+  /// identically to every part, so a user who changes their polisher halfway
+  /// through does not get a document polished two different ways. Reuses
+  /// `RecordingSettingsSnapshot` rather than declaring a parallel type: it is
+  /// already the single authority for "the settings a text-processing run
+  /// needs", and a second one would be a second thing to keep in step.
+  private var frozenSettings: RecordingSettingsSnapshot?
+
+  /// The custom-words vocabulary, frozen with the settings for the same reason.
+  private var frozenVocabulary: CorrectorVocabulary?
+
+  public init(
+    keychainManager: KeychainManager,
+    egOneRuntime: (any EGOneEndpointProviding)? = nil,
+    s1MiniRuntime: (any EGOneEndpointProviding)? = nil,
+    outputClassifierHolder: OutputClassifierHolder? = nil
+  ) {
+    self.keychainManager = keychainManager
+    self.egOneRuntime = egOneRuntime
+    self.s1MiniRuntime = s1MiniRuntime
+    self.outputClassifierHolder = outputClassifierHolder
+  }
+
+  /// Freezes the configuration this import runs under. Called once, before the
+  /// first part.
+  public func freeze(settings: RecordingSettingsSnapshot, vocabulary: CorrectorVocabulary?) {
+    frozenSettings = settings
+    frozenVocabulary = vocabulary
+  }
+
+  /// Runs one part through the shipped chain.
+  ///
+  /// **Cancellation is checked after the run, and a cancelled part commits
+  /// nothing.** The shared runner deliberately absorbs cancellation as a silent
+  /// skip, because for a live dictation an interrupted limb should still deliver
+  /// the words the user just spoke. An import is the opposite case: the user
+  /// pressed Stop, so the honest outcome is that this part did not happen. The
+  /// check lives here rather than in the runner, so the heart path's behaviour
+  /// is untouched by a feature it does not participate in.
+  public func process(part: String) async throws -> PartOutcome {
+    guard let settings = frozenSettings else {
+      throw FileImportRunnerError.notConfigured
+    }
+    try Task.checkCancellation()
+
+    let steps = makeSteps(settings: settings)
+    let runner = TextProcessingRunner(telemetry: .silent)
+    // The frozen locked language, or nil for auto — matched to how the recovery
+    // replay reads the same field (`RecoveryTextProcessor.swift:149`), so an
+    // import and a replay resolve language the same way rather than two ways.
+    var lockedLanguage: String?
+    if case .locked(let code) = settings.languageMode { lockedLanguage = code }
+    let result = try await runner.run(
+      rawText: part,
+      evidence: LanguageEvidence(
+        lockedLanguage: lockedLanguage,
+        engineDetectsLanguage: settings.backendSupportsLanguageDetection,
+        engineReportedLanguage: nil),
+      // No target app: an import is not being pasted anywhere, and a step that
+      // adapts to the frontmost app would be adapting to whatever the user
+      // happened to have open while the file decoded.
+      targetAppName: nil,
+      steps: steps.orderedChainForFileImport)
+
+    // The user pressed Stop while this part was in flight. The runner will have
+    // returned the deterministic floor rather than propagating, which is right
+    // for a dictation and wrong here.
+    try Task.checkCancellation()
+
+    // A blank polish is not a polish — the same rule the recovery replay
+    // applies, for the same reason: the floor is real text and an empty string
+    // is not an improvement on it. Reachable the same way as on the live path,
+    // where a connector accepts a whitespace response as success and trims it.
+    //
+    // **`SnippetFinalizer` is deliberately absent here, unlike the replay path.**
+    // It resolves the sentinels the snippet step leaves behind, and this chain
+    // does not run that step, so there is nothing for it to resolve. Said out
+    // loud because the asymmetry with `RecoveryTextProcessor` is the first thing
+    // a reader comparing the two will notice.
+    let context = result.context
+    let polished = (context.polishedText?.isEmpty ?? true) ? nil : context.polishedText
+    return PartOutcome(
+      text: context.text, polishedText: polished, polishError: result.polishError)
+  }
+
+  /// Builds this part's own step instances and applies the frozen settings.
+  private func makeSteps(settings: RecordingSettingsSnapshot) -> LimbSteps {
+    let llmPolish = LLMPolishStep(keychainManager: keychainManager, telemetry: .silent())
+    // Standalone, exactly like the recovery replay: no live kernel is attached,
+    // so there is nothing to stream tokens to and no lifecycle to notify.
+    llmPolish.onWillProcess = nil
+    llmPolish.onToken = nil
+    llmPolish.outputClassifierHolder = outputClassifierHolder
+    llmPolish.egOneRuntime = egOneRuntime
+    llmPolish.s1MiniRuntime = s1MiniRuntime
+    llmPolish.llmProvider = LLMProvider(rawValue: settings.llmProvider) ?? .none
+    llmPolish.llmModel = LLMProvider.replacingRetiredModel(
+      settings.llmModel, for: llmPolish.llmProvider)
+    llmPolish.backend = settings.backendType
+    llmPolish.s1Control = settings.s1Control ?? .default
+    llmPolish.languageDetection = nil
+
+    let wordCorrection = WordCorrectionStep()
+    wordCorrection.wordCorrectionEnabled = settings.wordCorrectionEnabled
+    if let frozenVocabulary { wordCorrection.correctorVocabulary = frozenVocabulary }
+
+    let fillerRemoval = FillerRemovalStep()
+    fillerRemoval.fillerRemovalEnabled = settings.fillerRemovalEnabled
+
+    let emojiFormatter = EmojiFormatterStep()
+    emojiFormatter.emojiFormatterEnabled = settings.emojiFormatterEnabled
+
+    let itn = InverseTextNormalizationStep()
+    itn.spokenPunctuationEnabled = settings.spokenPunctuationEnabled ?? false
+    itn.backendSupportsLID = settings.backendSupportsLanguageDetection
+
+    return LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
+      wordCorrection: wordCorrection,
+      fillerRemoval: fillerRemoval,
+      emojiFormatter: emojiFormatter,
+      inverseTextNormalization: itn,
+      llmPolish: llmPolish,
+      emojiRestore: EmojiRestoreStep())
+  }
+}
+
+/// Why a part could not run at all, as distinct from a part that ran and could
+/// not be polished.
+public enum FileImportRunnerError: Error, Equatable, Sendable {
+  /// `process` was called before `freeze`. A programming error, not a user one.
+  case notConfigured
+}

--- a/Sources/EnviousWisprPipeline/FileImportRunner.swift
+++ b/Sources/EnviousWisprPipeline/FileImportRunner.swift
@@ -110,7 +110,9 @@ public final class FileImportRunner {
   /// pressed Stop, so the honest outcome is that this part did not happen. The
   /// check lives here rather than in the runner, so the heart path's behaviour
   /// is untouched by a feature it does not participate in.
-  public func process(part: String) async throws -> PartOutcome {
+  /// - Parameter engineLanguage: the language the ASR engine reported for this
+  ///   recording, or nil when the engine does not report one.
+  public func process(part: String, engineLanguage: String? = nil) async throws -> PartOutcome {
     guard let settings = frozenSettings else {
       throw FileImportRunnerError.notConfigured
     }
@@ -128,7 +130,14 @@ public final class FileImportRunner {
       evidence: LanguageEvidence(
         lockedLanguage: lockedLanguage,
         engineDetectsLanguage: settings.backendSupportsLanguageDetection,
-        engineReportedLanguage: nil),
+        // **What the ENGINE heard, not nil.** WhisperKit reports the language it
+        // detected and the resolver's ladder prefers that over identifying the
+        // language from the text — which is the weaker source, and the only one
+        // an import had. A Spanish recording under automatic language was
+        // cleaned up as whatever the text identifier guessed from the ASR
+        // output, and ASR output for a language the engine was not told about is
+        // exactly the text least safe to guess from. Found by cloud review.
+        engineReportedLanguage: engineLanguage),
       // No target app: an import is not being pasted anywhere, and a step that
       // adapts to the frontmost app would be adapting to whatever the user
       // happened to have open while the file decoded.
@@ -159,7 +168,33 @@ public final class FileImportRunner {
       // ANSWERED is a property of this part. Deriving the first from the second
       // is what let a deliberately-unpolished document accuse the app of
       // failing.
-      polishAttempted: LLMProvider(rawValue: settings.llmProvider).map { $0 != .none } ?? false)
+      // **A provider being SELECTED is not the same as a polish being
+      // ATTEMPTED.** `LLMPolishStep` deliberately bypasses a passage too short
+      // to be worth sending — at most three words, or under ten non-whitespace
+      // characters in an unsegmented script — and returns no polished text and
+      // no error, which is exactly the shape of a failure. Reading the setting
+      // alone marked those passages "could not be cleaned up" for a bypass the
+      // pipeline chose on purpose. Found by cloud review, one round after the
+      // same distinction was drawn for the provider-is-None case: the setting
+      // answers "was one asked for", and only the OUTCOME answers "was one
+      // made".
+      polishAttempted: Self.polishWasAttempted(settings: settings, result: result))
+  }
+
+  /// Whether a polisher was actually asked about THIS passage.
+  ///
+  /// False when no provider is selected, and false when the step bypassed the
+  /// passage for being too short. Both are settings-or-policy decisions rather
+  /// than outcomes, and neither is a failure the user should be told about.
+  private static func polishWasAttempted(
+    settings: RecordingSettingsSnapshot, result: TextProcessingRunResult
+  ) -> Bool {
+    guard let provider = LLMProvider(rawValue: settings.llmProvider), provider != .none else {
+      return false
+    }
+    // `LLMPolishStep` is the only thing that knows whether it declined, so it
+    // says so rather than being guessed at from the shape of the result.
+    return !result.context.polishWasBypassed
   }
 
   /// Builds this part's own step instances and applies the frozen settings.

--- a/Sources/EnviousWisprPipeline/FileImportRunner.swift
+++ b/Sources/EnviousWisprPipeline/FileImportRunner.swift
@@ -33,20 +33,37 @@ public final class FileImportRunner {
     public let text: String
     public let polishedText: String?
     public let polishError: String?
+    /// Whether a polisher was asked for this part. Defaults to true so every
+    /// existing construction keeps meaning what it meant.
+    private let polishAttempted: Bool
 
-    public init(text: String, polishedText: String?, polishError: String?) {
+    public init(
+      text: String, polishedText: String?, polishError: String?, polishAttempted: Bool = true
+    ) {
       self.text = text
       self.polishedText = polishedText
       self.polishError = polishError
+      self.polishAttempted = polishAttempted
     }
 
     /// What the document shows for this part: polished when there is one, the
     /// deterministic floor otherwise.
     public var displayText: String { polishedText ?? text }
 
-    /// Whether this part is showing raw text because its polish did not land.
-    /// The UI marks these rather than hiding them.
-    public var isUnpolished: Bool { polishedText == nil }
+    /// Whether this part is showing raw text because its polish FAILED.
+    ///
+    /// **Failure and bypass are different things and must not share a field.**
+    /// `polishedText == nil` is true both when a polisher tried and could not,
+    /// and when the user chose no polisher at all — and the notice this drives
+    /// says "could not be cleaned up", which over a deliberately-unpolished
+    /// document accuses the app of failing at something nobody asked it to do.
+    /// A bypass is not a failure: downstream must treat it as "the step never
+    /// happened", never as "the step went wrong". Found by Codex.
+    public var isUnpolished: Bool { polishedText == nil && wasPolishAttempted }
+
+    /// Whether a polisher was asked at all. False when the frozen configuration
+    /// names no polisher, which is a setting, not an outcome.
+    public var wasPolishAttempted: Bool { polishAttempted }
   }
 
   private let keychainManager: KeychainManager
@@ -136,7 +153,13 @@ public final class FileImportRunner {
     let context = result.context
     let polished = (context.polishedText?.isEmpty ?? true) ? nil : context.polishedText
     return PartOutcome(
-      text: context.text, polishedText: polished, polishError: result.polishError)
+      text: context.text, polishedText: polished, polishError: result.polishError,
+      // **Read from the frozen configuration, not from the outcome.** Whether a
+      // polisher was ASKED is a property of the run's settings; whether it
+      // ANSWERED is a property of this part. Deriving the first from the second
+      // is what let a deliberately-unpolished document accuse the app of
+      // failing.
+      polishAttempted: LLMProvider(rawValue: settings.llmProvider).map { $0 != .none } ?? false)
   }
 
   /// Builds this part's own step instances and applies the frozen settings.

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -118,6 +118,23 @@ struct LimbSteps {
       inverseTextNormalization, llmPolish, emojiRestore,
     ]
   }
+
+  /// #2648 — the chain a FILE IMPORT runs: `orderedChain` minus snippet
+  /// expansion.
+  ///
+  /// **Snippet expansion is excluded because an imported recording is not the
+  /// user typing.** A literal trigger word spoken by somebody in a meeting would
+  /// be replaced with the user's saved text, silently putting words into a
+  /// transcript of someone else's speech.
+  ///
+  /// **Derived from `orderedChain`, never spelled out again.** Writing the list
+  /// a second time is precisely the defect the property above exists to prevent,
+  /// and the one that adding the snippet step surfaced: a new limb would reach
+  /// dictation and recovery and quietly skip every imported file.
+  @MainActor
+  var orderedChainForFileImport: [any TextProcessingStep] {
+    orderedChain.filter { !($0 is SnippetExpansionStep) }
+  }
 }
 
 /// Issue #1339: sessionless model-load wedge guard for `ensureEngineWarm`.
@@ -343,6 +360,23 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// `recoverySessionID` (nil when recovery was off for the take).
   @ObservationIgnored
   public var onSessionEndedWithoutSave: (@MainActor (String?, RecordingRecoveryEnding) -> Void)?
+
+  /// #2648 — fired exactly once per ACCEPTED terminal, carrying that take's id.
+  ///
+  /// **This is the raw kernel signal, NOT the published state.** Every other
+  /// "the dictation ended" hook on this type is driven by `state`, which applies
+  /// an external terminal reason on top of the kernel's own — so an error pinned
+  /// during finalization publishes a terminal while the kernel is still
+  /// finalizing and `RecordingSessionKernel.cancel()` is deliberately ignoring
+  /// cancellation (`RecordingSessionKernel.swift:1309`). A consumer that must
+  /// not act until the take is genuinely finished cannot use those.
+  ///
+  /// Wired by `KernelDictationDriverFactory` to the same `finishTerminal` defer
+  /// that delivers the terminal telemetry snapshot: set-once, after the guards,
+  /// unreachable from a stale or losing terminal. `@MainActor`, defaulted to
+  /// nil, so nothing in this module knows who consumes it.
+  @ObservationIgnored
+  public var onSessionTerminalAccepted: (@MainActor (String) -> Void)?
 
   /// #1707 Phase 3 (§3.4 wake-up table) — fired whenever this driver's
   /// dictation ends (from BOTH `fireStateChangeIfNeeded()`'s transition out

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -538,6 +538,10 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// joined_in_flight / success / failed) so that dashboard keeps continuity
   /// after this became the launch warm-up entry (replacing `loadModelSilently`).
   @discardableResult
+  /// Disarms this driver's engine's pending model-unload timer. See
+  /// `RecordingSessionKernel.cancelPendingEngineUnload()`.
+  public func cancelPendingEngineUnload() { kernel.cancelPendingEngineUnload() }
+
   public func ensureEngineWarm(reason: EngineWarmupReason) async -> EngineWarmupOutcome {
     let engine = adapter.engineIdentity.rawValue
     if adapter.readiness == .ready {

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -542,6 +542,11 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// `RecordingSessionKernel.cancelPendingEngineUnload()`.
   public func cancelPendingEngineUnload() { kernel.cancelPendingEngineUnload() }
 
+  /// Re-arms it. The other half; call both or neither.
+  public func applyEngineUnloadPolicy(_ policy: ModelUnloadPolicy) {
+    kernel.applyEngineUnloadPolicy(policy)
+  }
+
   public func ensureEngineWarm(reason: EngineWarmupReason) async -> EngineWarmupOutcome {
     let engine = adapter.engineIdentity.rawValue
     if adapter.readiness == .ready {

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -816,6 +816,19 @@ public enum KernelDictationDriverFactory {
     )
     driver.start()  // arms driver-side state observation (PR-4a)
 
+    // #2648: re-point the relay's terminal hook now that the driver exists, so
+    // ONE kernel signal reaches both consumers. Assigned here rather than at
+    // `:789` for the same construction-order reason that line documents — the
+    // driver does not exist yet up there.
+    //
+    // Telemetry stays FIRST and the second call cannot displace it: both are
+    // synchronous, and the snapshot is complete at this point by the kernel's
+    // own contract.
+    telemetryRelay.sessionTerminal = { [lifecycleSink, weak driver] snapshot in
+      lifecycleSink.emitTerminal(snapshot)
+      driver?.onSessionTerminalAccepted?(snapshot.takeID)
+    }
+
     // Observer's `observeKernelState()` is the PR-4b.1 split of the old
     // `observer.start()` — the factory drives it after construction since
     // the App-side `start()` shim no longer exists.

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -535,6 +535,9 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
   /// The too-short skip's return value: text untouched, AI fields nil (#1022).
   private static func bypassedContext(_ context: TextProcessingContext) -> TextProcessingContext {
     var ctx = context
+    // #2648: says so out loud, because a bypass and a silent failure are the
+    // same shape from outside.
+    ctx.polishWasBypassed = true
     ctx.polishedText = nil
     ctx.llmProvider = nil
     ctx.llmModel = nil

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -42,6 +42,24 @@ public enum CompletionInterruptionDisclosure: Equatable, Sendable {
   }
 }
 
+/// #2648: every production workload that can occupy the shared ASR-and-polish
+/// resource, enumerated from the resource boundary rather than from a caller
+/// list (grounded review round 2).
+///
+/// It lives here, in the shared vocabulary, rather than nested inside
+/// `EngineLease`, because a refusal REASON is user-facing vocabulary and
+/// `RecordingWarningReason` below carries one. `EngineLease` is the authority
+/// that hands these out; this is only the name of who holds it.
+///
+/// EG-1's health probe is a fourth producer of inference and is deliberately
+/// absent: it never takes a claim, it asks whether the resource is busy and
+/// skips.
+public enum SharedEngineHolder: String, Sendable, Equatable, CaseIterable {
+  case dictation
+  case crashRecovery
+  case fileImport
+}
+
 /// #1567 (heartpath E3): a typed fact explaining a post-completion or advisory
 /// warning rendered through `OverlayIntent.warning`. The engine/coordinator
 /// emits this; `DictationNarrator` in AppKit authors the user-facing words.
@@ -69,6 +87,16 @@ public enum RecordingWarningReason: Equatable, Sendable {
   /// picks the sentence family (verified device removal vs neutral);
   /// `alsoTrimmedLead` is true when the take ALSO lost its opening (#1408/#1434).
   case interruptedTail(disclosure: CompletionInterruptionDisclosure, alsoTrimmedLead: Bool)
+  /// #2648: another workload holds the shared ASR-and-polish resource, so this
+  /// press minted nothing. Carries WHO holds it, because the honest sentence
+  /// differs per holder and the narrator authors the words.
+  ///
+  /// Crash recovery has its own pill with a Discard button and is refused one
+  /// gate EARLIER in both start routes, so `.crashRecovery` is not the holder a
+  /// user reaches here. It is still carried rather than assumed away: the
+  /// holder is read from the claim, and a case that cannot be constructed from
+  /// the data is a claim about reachability that nothing enforces.
+  case sharedEngineBusy(holder: SharedEngineHolder)
 }
 
 /// Events the recording driver handles.

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -269,6 +269,20 @@ final class RecordingSessionKernel {
   /// round earlier, which is the question I did not ask: which OTHER engine has
   /// one of these.
   public func cancelPendingEngineUnload() { adapter.cancelPendingUnload() }
+
+  /// Re-arms this engine's unload timer under `policy`, the other half of
+  /// `cancelPendingEngineUnload()`.
+  ///
+  /// **Disarming both engines and re-arming one is not a bracket.** The first
+  /// version of this pair cancelled WhisperKit's timer and then re-armed only
+  /// Parakeet's, through `ASRManager.noteTranscriptionComplete` — so after an
+  /// All Languages import, WhisperKit's model stayed resident with nothing left
+  /// to unload it, which is the memory cost the user's setting exists to avoid,
+  /// inverted. Found by cloud review, one round after the cancel half. The same
+  /// asymmetry, one level over.
+  public func applyEngineUnloadPolicy(_ policy: ModelUnloadPolicy) {
+    adapter.applyUnloadPolicy(policy)
+  }
   private let audioCapture: any AudioCaptureInterface
   private let vad: any VADSignalSource
 

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -257,6 +257,18 @@ final class RecordingSessionKernel {
   // MARK: Injected dependencies
 
   private let adapter: any ASREngineAdapter
+
+  /// Disarms this engine's pending model-unload timer.
+  ///
+  /// **Each engine arms its OWN timer and they are cancelled by different
+  /// calls.** Parakeet's lives on `ASRManager` (`cancelIdleTimer`); WhisperKit's
+  /// is a `Task` on its adapter and only `cancelPendingUnload()` stops it. File
+  /// import cancelled the first and not the second, so an All Languages import
+  /// following a WhisperKit dictation could still have its model unloaded
+  /// mid-transcription. Found by cloud review — the twin of the finding one
+  /// round earlier, which is the question I did not ask: which OTHER engine has
+  /// one of these.
+  public func cancelPendingEngineUnload() { adapter.cancelPendingUnload() }
   private let audioCapture: any AudioCaptureInterface
   private let vad: any VADSignalSource
 
@@ -1703,7 +1715,7 @@ final class RecordingSessionKernel {
     // unload-timer continuity across aborted sessions MUST re-arm in its
     // own beginSession/cancel/finalize implementation; the kernel does
     // not guarantee re-arming.
-    adapter.cancelPendingUnload()
+    cancelPendingEngineUnload()
     do {
       try await adapter.beginSession(
         sid, options: makeTranscriptionOptions(config), streaming: shouldStream)

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -368,6 +368,14 @@ internal final class TextProcessingRunner {
           PolishSkipReason(silentLLMError: $0)
         }
         let isSilentPolishSkip = silentPolishSkipReason != nil
+        // #2648: a silent skip is a BYPASS, and this is its second producer.
+        // `LLMPolishStep.bypassedContext` covers the step declining up front;
+        // this covers the step THROWING a reason `PolishSkipReason` classifies
+        // as silent — Apple Intelligence unavailable, an unsupported input
+        // language, output-language drift, every EG-1 reason. Both producers
+        // read the same classifier, which is what makes this the whole set
+        // rather than the two cases somebody happened to think of.
+        if isSilentPolishSkip { context.polishWasBypassed = true }
         // #945: a raw `URLError.cancelled` from a torn-down request is not a real
         // failure — never surface a notice or fire a capture for it.
         // #1707 Phase 2 (Open Decision #9): a bare `CancellationError` reaching

--- a/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingRunner.swift
@@ -368,14 +368,6 @@ internal final class TextProcessingRunner {
           PolishSkipReason(silentLLMError: $0)
         }
         let isSilentPolishSkip = silentPolishSkipReason != nil
-        // #2648: a silent skip is a BYPASS, and this is its second producer.
-        // `LLMPolishStep.bypassedContext` covers the step declining up front;
-        // this covers the step THROWING a reason `PolishSkipReason` classifies
-        // as silent — Apple Intelligence unavailable, an unsupported input
-        // language, output-language drift, every EG-1 reason. Both producers
-        // read the same classifier, which is what makes this the whole set
-        // rather than the two cases somebody happened to think of.
-        if isSilentPolishSkip { context.polishWasBypassed = true }
         // #945: a raw `URLError.cancelled` from a torn-down request is not a real
         // failure — never surface a notice or fire a capture for it.
         // #1707 Phase 2 (Open Decision #9): a bare `CancellationError` reaching
@@ -394,6 +386,25 @@ internal final class TextProcessingRunner {
         let isCancellationLike =
           error is CancellationError
           || (error as? URLError)?.code == .cancelled
+
+        // #2648: **the set of silent skips, named ONCE and read twice.**
+        //
+        // These five terms already decided, below, whether the user is shown a
+        // failure. They are therefore also the answer to "was this a bypass",
+        // and the two questions cannot be allowed to disagree — which is exactly
+        // what happened when the bypass flag was derived from
+        // `PolishSkipReason(silentLLMError:)` alone: a context-window skip, an
+        // Apple Intelligence timeout and an EG-1 timeout are all silent HERE and
+        // were reported to the file-import user as failed cleanup. Two rounds of
+        // review found two different members of this set; the third stopped
+        // extending the list and read the expression that produces it.
+        //
+        // `localPolishSkipReason` is deliberately NOT a member: that branch
+        // SURFACES a skipped-tone notice, so the user has already been told.
+        let polishSkippedSilently =
+          isSilentPolishSkip || contextWindowSkip != nil || isAppleIntelligencePolishTimeout
+          || isLocalEnginePolishTimeout || isCancellationLike
+        if polishSkippedSilently { context.polishWasBypassed = true }
         if step.errorSurfacePolicy == .surface, let skipReason = localPolishSkipReason {
           // #1305 surfaced skip: set the pinned skipped-tone notice, fire NO
           // Sentry capture (that is the point of the class). The composed
@@ -401,11 +412,7 @@ internal final class TextProcessingRunner {
           polishError =
             skipReason.ollamaPreflightSkipMessage
             ?? skipReason.composedMessage(provider: .ollama)
-        } else if step.errorSurfacePolicy == .surface && !isSilentPolishSkip
-          && contextWindowSkip == nil && !isAppleIntelligencePolishTimeout
-          && !isLocalEnginePolishTimeout
-          && !isCancellationLike
-        {
+        } else if step.errorSurfacePolicy == .surface && !polishSkippedSilently {
           let model = polishModelAtStart ?? "unknown"
           if let provider = polishProviderAtStart, provider != .appleIntelligence {
             // Cloud (OpenAI/Gemini) or local (Ollama): classify the specific

--- a/Sources/EnviousWisprPipeline/TextProcessingStep.swift
+++ b/Sources/EnviousWisprPipeline/TextProcessingStep.swift
@@ -76,6 +76,19 @@ public struct TextProcessingContext: Sendable {
   /// of local execution.
   public var polishRanRemote: Bool?
 
+  /// True when `LLMPolishStep` DECLINED to send this text — a bypass, not a
+  /// failure (#2648).
+  ///
+  /// **Written by the step that decides, because nothing downstream can tell the
+  /// two apart.** A bypass and a silent failure both arrive as "no polished text
+  /// and no error", so a reader guessing from that shape marked a passage the
+  /// pipeline deliberately skipped — one at most three words long, say — as one
+  /// the app had failed to clean. The rule that decides eligibility lives in the
+  /// step; re-deriving it anywhere else would be a copy that agrees today.
+  ///
+  /// Defaults to false, so every existing reader is unchanged.
+  public var polishWasBypassed = false
+
   /// The `PromptFamily` the planner selected for this polish (#1948). Stamped by
   /// `LLMPolishStep` from `PolishPlan.family` on the success path only, so it is nil for a
   /// skip, a failure, a bypass, and for Apple Intelligence (whose branch returns earlier).

--- a/Sources/EnviousWisprPipeline/TranscriptSplitter.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptSplitter.swift
@@ -1,0 +1,153 @@
+import Foundation
+import NaturalLanguage
+
+/// #2648 — cuts one long transcript into the parts the cleanup chain runs on.
+///
+/// **The 500-word ceiling is a correctness constraint, not a preference.** It
+/// was measured on 2026-09-04: word correction takes 1,162 ms of its 3 s budget
+/// at 500 words and 13,565 ms at 6,000, which is over. Polish quality falls off
+/// the same way — a whole 45-minute transcript handed to either on-device
+/// polisher came back at 53% and 50%, both truncated, while the same transcript
+/// in parts held 96 to 97%. So a part that exceeds the ceiling does not merely
+/// run slowly; it silently loses the end of the user's words.
+///
+/// **Sentences first, words only as a fallback.** Cutting mid-sentence hands the
+/// polisher half a thought and it rewrites what it can see, so the join reads
+/// like two people talking. `NLTokenizer` finds the real boundaries, including
+/// for languages whose sentences do not end in a full stop. Only a single
+/// sentence longer than the whole ceiling — a run-on, which is exactly what
+/// unpunctuated ASR output produces — is cut at word boundaries, because at that
+/// point there is no better cut available.
+///
+/// **A part is a verbatim slice of the input.** The splitter never rewrites,
+/// normalises or re-spaces anything: whatever the engine produced is what the
+/// cleanup chain sees. `TranscriptSplitterTests` asserts the round trip word for
+/// word, in order, with nothing duplicated and nothing dropped.
+public enum TranscriptSplitter {
+
+  /// The ceiling every non-empty part obeys. Raising it narrows the promise
+  /// above, and the measurement that set it is named there rather than here so
+  /// there is one place to re-read before changing it.
+  public static let maximumWordsPerPart = 500
+
+  /// Splits `transcript` into parts of 1...`maximumWordsPerPart` words.
+  ///
+  /// Returns an empty array for a transcript with no words at all, which is the
+  /// honest answer: there is nothing to clean. A caller that wants to say "no
+  /// speech found" reads that from the empty result rather than from a part
+  /// containing only whitespace.
+  public static func split(_ transcript: String) -> [String] {
+    let sentences = sentenceRanges(in: transcript)
+    var parts: [String] = []
+    var pending: [Substring] = []
+    var pendingWords = 0
+
+    func flushPending() {
+      guard !pending.isEmpty else { return }
+      // Sliced from the FIRST pending sentence's start to the LAST one's end, so
+      // the part keeps the original spacing between those sentences rather than
+      // a re-joined approximation of it.
+      let lower = pending.first!.startIndex
+      let upper = pending.last!.endIndex
+      parts.append(String(transcript[lower..<upper]))
+      pending = []
+      pendingWords = 0
+    }
+
+    for range in sentences {
+      let sentence = transcript[range]
+      let words = wordCount(in: sentence)
+      guard words > 0 else { continue }
+
+      if words > maximumWordsPerPart {
+        // A single sentence over the ceiling. Everything already packed goes
+        // first, so the run-on's own cuts do not swallow the sentences before
+        // it, and the run-on is then cut at word boundaries.
+        flushPending()
+        parts.append(contentsOf: splitAtWordBoundaries(sentence))
+        continue
+      }
+
+      if pendingWords + words > maximumWordsPerPart { flushPending() }
+      pending.append(sentence)
+      pendingWords += words
+    }
+    flushPending()
+    return parts
+  }
+
+  // MARK: - Boundaries
+
+  /// Sentence ranges, from `NLTokenizer` rather than from a punctuation rule.
+  ///
+  /// A punctuation rule is the proxy here: it agrees with sentence structure for
+  /// English prose and disagrees for an abbreviation, a decimal number, and every
+  /// script that does not use a full stop. The tokenizer answers the question
+  /// itself.
+  private static func sentenceRanges(in text: String) -> [Range<String.Index>] {
+    guard !text.isEmpty else { return [] }
+    let tokenizer = NLTokenizer(unit: .sentence)
+    tokenizer.string = text
+    var ranges: [Range<String.Index>] = []
+    tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+      ranges.append(range)
+      return true
+    }
+    // A transcript the tokenizer finds no sentences in is still a transcript:
+    // treat the whole thing as one, and let the word-boundary path cut it.
+    return ranges.isEmpty ? [text.startIndex..<text.endIndex] : ranges
+  }
+
+  /// Cuts one over-long sentence into ceiling-sized pieces at word boundaries.
+  ///
+  /// Slices the ORIGINAL text between the first and last word of each piece, so
+  /// the pieces stay verbatim rather than becoming a space-joined rebuild.
+  private static func splitAtWordBoundaries(_ sentence: Substring) -> [String] {
+    var pieces: [String] = []
+    var wordRanges: [Range<Substring.Index>] = []
+
+    var index = sentence.startIndex
+    while index < sentence.endIndex {
+      while index < sentence.endIndex, sentence[index].isWhitespace {
+        index = sentence.index(after: index)
+      }
+      guard index < sentence.endIndex else { break }
+      let start = index
+      while index < sentence.endIndex, !sentence[index].isWhitespace {
+        index = sentence.index(after: index)
+      }
+      wordRanges.append(start..<index)
+    }
+
+    var cursor = 0
+    while cursor < wordRanges.count {
+      let end = min(cursor + maximumWordsPerPart, wordRanges.count)
+      let lower = wordRanges[cursor].lowerBound
+      let upper = wordRanges[end - 1].upperBound
+      pieces.append(String(sentence[lower..<upper]))
+      cursor = end
+    }
+    return pieces
+  }
+
+  /// How many words a piece of text contains.
+  ///
+  /// Whitespace-separated runs, which is the same thing the ceiling was measured
+  /// against. Deliberately NOT `NLTokenizer(unit: .word)`: that counts a
+  /// hyphenated compound and a contraction as several tokens, so it would report
+  /// a different number from the one the 500 was measured with, and the ceiling
+  /// would quietly mean something else.
+  public static func wordCount(in text: some StringProtocol) -> Int {
+    var count = 0
+    var inWord = false
+    for character in text {
+      if character.isWhitespace {
+        inWord = false
+      } else if !inWord {
+        inWord = true
+        count += 1
+      }
+    }
+    return count
+  }
+}

--- a/Sources/EnviousWisprPipeline/TranscriptSplitter.swift
+++ b/Sources/EnviousWisprPipeline/TranscriptSplitter.swift
@@ -19,16 +19,51 @@ import NaturalLanguage
 /// unpunctuated ASR output produces — is cut at word boundaries, because at that
 /// point there is no better cut available.
 ///
+/// **Two ceilings, because one of them cannot bound every language.** Words for
+/// scripts that use spaces, UTF-8 bytes for the ones that do not. See
+/// `maximumBytesPerPart`.
+///
 /// **A part is a verbatim slice of the input.** The splitter never rewrites,
 /// normalises or re-spaces anything: whatever the engine produced is what the
-/// cleanup chain sees. `TranscriptSplitterTests` asserts the round trip word for
-/// word, in order, with nothing duplicated and nothing dropped.
+/// cleanup chain sees. `TranscriptSplitterTests` asserts the round trip: the
+/// non-whitespace characters of the parts, in order, are the non-whitespace
+/// characters of the input, with nothing duplicated and nothing dropped.
 public enum TranscriptSplitter {
 
   /// The ceiling every non-empty part obeys. Raising it narrows the promise
   /// above, and the measurement that set it is named there rather than here so
   /// there is one place to re-read before changing it.
   public static let maximumWordsPerPart = 500
+
+  /// The ceiling that binds for a language WITHOUT spaces, in UTF-8 bytes.
+  ///
+  /// **A word ceiling cannot bound Japanese, Chinese or Thai**, because those
+  /// scripts do not put spaces between words: an entire recording counts as one
+  /// or two "words" and sails past `maximumWordsPerPart` untouched. Measured on
+  /// 600 repeated Japanese sentences, the whitespace-only splitter produced a
+  /// single 10,500-character part — about 31,000 UTF-8 bytes, far past the
+  /// context preflight in `LLMPolishStep`, which counts BYTES — so the whole
+  /// recording came back unpolished. Found by Codex.
+  ///
+  /// **DERIVED from the preflight, not chosen.** `localPolishTranscriptCeiling`
+  /// is the same formula the preflight applies, at EG-1's shipped 16,384-token
+  /// window (`eg1-manifest.json`): `(window - promptOverhead) / 2`. It is the
+  /// ASCII worst case, so it is conservative for every other script, which is
+  /// the safe direction. Reading the authority rather than restating a number
+  /// means a window change moves this with it.
+  ///
+  /// It does NOT bind for English at the word ceiling: 500 words is about 3,900
+  /// bytes and this is 7,424, so ordinary prose is still cut where the measured
+  /// word ceiling says. Only an unsegmented script reaches it.
+  ///
+  /// Known limit, stated rather than hidden: S1-mini ships an 8,192-token
+  /// window, where the same formula gives 3,328 bytes. A 500-word English part
+  /// is already over that and its preflight already refuses one today, before
+  /// this splitter existed. Bounding to the smaller window would cut every
+  /// English part in half for the polisher most users do not run, so the ceiling
+  /// follows EG-1 and the S1-mini gap stays a separate question.
+  public static let maximumBytesPerPart = LLMPolishStep.localPolishTranscriptCeiling(
+    contextTokens: 16_384)
 
   /// Splits `transcript` into parts of 1...`maximumWordsPerPart` words.
   ///
@@ -54,23 +89,33 @@ public enum TranscriptSplitter {
       pendingWords = 0
     }
 
+    var pendingBytes = 0
+
     for range in sentences {
       let sentence = transcript[range]
       let words = wordCount(in: sentence)
       guard words > 0 else { continue }
+      let bytes = sentence.utf8.count
 
-      if words > maximumWordsPerPart {
-        // A single sentence over the ceiling. Everything already packed goes
+      if words > maximumWordsPerPart || bytes > maximumBytesPerPart {
+        // A single sentence over a ceiling. Everything already packed goes
         // first, so the run-on's own cuts do not swallow the sentences before
-        // it, and the run-on is then cut at word boundaries.
+        // it, and the run-on is then cut as small as it has to be.
         flushPending()
-        parts.append(contentsOf: splitAtWordBoundaries(sentence))
+        pendingBytes = 0
+        parts.append(contentsOf: splitOverlongSentence(sentence))
         continue
       }
 
-      if pendingWords + words > maximumWordsPerPart { flushPending() }
+      if pendingWords + words > maximumWordsPerPart
+        || pendingBytes + bytes > maximumBytesPerPart
+      {
+        flushPending()
+        pendingBytes = 0
+      }
       pending.append(sentence)
       pendingWords += words
+      pendingBytes += bytes
     }
     flushPending()
     return parts
@@ -98,11 +143,16 @@ public enum TranscriptSplitter {
     return ranges.isEmpty ? [text.startIndex..<text.endIndex] : ranges
   }
 
-  /// Cuts one over-long sentence into ceiling-sized pieces at word boundaries.
+  /// Cuts one over-long sentence into pieces that obey BOTH ceilings.
+  ///
+  /// Word boundaries first, because a cut between words is the least damaging
+  /// one available. Where a single space-free run is still over the byte ceiling
+  /// — which is every sentence in a language that does not use spaces — the run
+  /// itself is cut at character boundaries, never mid-character.
   ///
   /// Slices the ORIGINAL text between the first and last word of each piece, so
   /// the pieces stay verbatim rather than becoming a space-joined rebuild.
-  private static func splitAtWordBoundaries(_ sentence: Substring) -> [String] {
+  private static func splitOverlongSentence(_ sentence: Substring) -> [String] {
     var pieces: [String] = []
     var wordRanges: [Range<Substring.Index>] = []
 
@@ -121,12 +171,51 @@ public enum TranscriptSplitter {
 
     var cursor = 0
     while cursor < wordRanges.count {
-      let end = min(cursor + maximumWordsPerPart, wordRanges.count)
+      // Take as many whole words as both ceilings allow, never fewer than one.
+      var end = cursor
+      var bytes = 0
+      while end < wordRanges.count, end - cursor < maximumWordsPerPart {
+        let next = sentence[wordRanges[end]].utf8.count + (end > cursor ? 1 : 0)
+        if end > cursor, bytes + next > maximumBytesPerPart { break }
+        bytes += next
+        end += 1
+      }
       let lower = wordRanges[cursor].lowerBound
       let upper = wordRanges[end - 1].upperBound
-      pieces.append(String(sentence[lower..<upper]))
+      let piece = sentence[lower..<upper]
+      // One word can still be over on its own, which is the unsegmented-script
+      // case: cut it by characters.
+      if piece.utf8.count > maximumBytesPerPart {
+        pieces.append(contentsOf: splitAtCharacterBoundaries(piece))
+      } else {
+        pieces.append(String(piece))
+      }
       cursor = end
     }
+    return pieces
+  }
+
+  /// The last resort, for a space-free run longer than the byte ceiling.
+  ///
+  /// Cuts between CHARACTERS, so a multi-byte character is never split in half
+  /// and no part is ever mojibake. A part may come in slightly under the ceiling
+  /// because the character that would have crossed it is carried to the next
+  /// one, which is the safe direction.
+  private static func splitAtCharacterBoundaries(_ run: Substring) -> [String] {
+    var pieces: [String] = []
+    var current = ""
+    var bytes = 0
+    for character in run {
+      let size = String(character).utf8.count
+      if bytes + size > maximumBytesPerPart, !current.isEmpty {
+        pieces.append(current)
+        current = ""
+        bytes = 0
+      }
+      current.append(character)
+      bytes += size
+    }
+    if !current.isEmpty { pieces.append(current) }
     return pieces
   }
 

--- a/Tests/EnviousWisprASRTests/AudioFileDecoderTests.swift
+++ b/Tests/EnviousWisprASRTests/AudioFileDecoderTests.swift
@@ -1,0 +1,253 @@
+import AVFoundation
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+
+/// #2648 — the one genuinely new input this feature needs: a file, not a microphone.
+///
+/// **When this fails, the user picks a recording and either gets nothing with no explanation, or gets a
+/// transcript of only part of it presented as the whole thing.** Product coverage.
+///
+/// **Every fixture is a REAL file this test writes and the real decoder reads.** Nothing here is a
+/// stub: `m4a` passing proves nothing about `wav`, mono proves nothing about stereo, and 16 kHz proves
+/// nothing about 48 kHz, so the matrix is the point rather than a nicety. The formats are written with
+/// `AVAudioFile` and `AVAssetWriter`, which is why `mp3` is absent — macOS decodes it and does not
+/// encode it, so a committed binary would be the only way to cover it, and that is named below rather
+/// than quietly skipped.
+@Suite(.tags(.productOutcome))
+struct AudioFileDecoderTests {
+
+  // MARK: - Fixture writing
+
+  private static func tempDir() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("audio-decode-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  /// A real tone, written through a real encoder, at whatever rate and channel count is asked for.
+  ///
+  /// A tone rather than silence deliberately: silence and "no audio at all" are different answers, and
+  /// a fixture of silence could not tell them apart.
+  private static func writeTone(
+    at url: URL, seconds: Double, sampleRate: Double, channels: AVAudioChannelCount,
+    settings: [String: Any]? = nil
+  ) throws {
+    let format = AVAudioFormat(
+      commonFormat: .pcmFormatFloat32, sampleRate: sampleRate, channels: channels,
+      interleaved: false)!
+    let file = try AVAudioFile(
+      forWriting: url, settings: settings ?? format.settings,
+      commonFormat: .pcmFormatFloat32, interleaved: false)
+
+    let frames = AVAudioFrameCount(seconds * sampleRate)
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+    buffer.frameLength = frames
+    for channel in 0..<Int(channels) {
+      let samples = buffer.floatChannelData![channel]
+      for frame in 0..<Int(frames) {
+        samples[frame] = 0.25 * sin(2 * .pi * 440 * Float(frame) / Float(sampleRate))
+      }
+    }
+    try file.write(from: buffer)
+  }
+
+  /// A movie with a video track and no audio track at all — the "I dragged in the wrong file" case,
+  /// and the one that must be refused BY NAME rather than by failing somewhere downstream.
+  private static func writeVideoOnly(at url: URL) throws {
+    let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+    let input = AVAssetWriterInput(
+      mediaType: .video,
+      outputSettings: [
+        AVVideoCodecKey: AVVideoCodecType.h264,
+        AVVideoWidthKey: 64,
+        AVVideoHeightKey: 64,
+      ])
+    input.expectsMediaDataInRealTime = false
+    writer.add(input)
+    writer.startWriting()
+    writer.startSession(atSourceTime: .zero)
+
+    var pixelBuffer: CVPixelBuffer?
+    CVPixelBufferCreate(kCFAllocatorDefault, 64, 64, kCVPixelFormatType_32ARGB, nil, &pixelBuffer)
+    if let pixelBuffer {
+      var formatDescription: CMVideoFormatDescription?
+      CMVideoFormatDescriptionCreateForImageBuffer(
+        allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer,
+        formatDescriptionOut: &formatDescription)
+      if let formatDescription {
+        var timing = CMSampleTimingInfo(
+          duration: CMTime(value: 1, timescale: 30), presentationTimeStamp: .zero,
+          decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        CMSampleBufferCreateReadyWithImageBuffer(
+          allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer,
+          formatDescription: formatDescription, sampleTiming: &timing, sampleBufferOut: &sample)
+        if let sample, input.isReadyForMoreMediaData { input.append(sample) }
+      }
+    }
+    input.markAsFinished()
+    let done = DispatchSemaphore(value: 0)
+    writer.finishWriting { done.signal() }
+    done.wait()
+  }
+
+  // MARK: - The format matrix
+
+  /// Each row is a real container and a real encoder. The assertion is the same for all of them and it
+  /// is about the OUTCOME, not about the absence of a throw: the samples come back at the rate the
+  /// engines take, in roughly the right quantity for the duration written.
+  @Test(
+    "every format macOS can decode comes back as 16 kHz mono samples",
+    arguments: [
+      ("wav", AVFileType.wav, 16_000.0, AVAudioChannelCount(1)),
+      ("wav", AVFileType.wav, 48_000.0, AVAudioChannelCount(2)),
+      ("aiff", AVFileType.aiff, 44_100.0, AVAudioChannelCount(1)),
+      ("caf", AVFileType.caf, 22_050.0, AVAudioChannelCount(2)),
+    ])
+  func everyFormatDecodesToSixteenKilohertzMono(
+    _ ext: String, _ fileType: AVFileType, _ rate: Double, _ channels: AVAudioChannelCount
+  ) async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("tone.\(ext)")
+    try Self.writeTone(at: url, seconds: 1.0, sampleRate: rate, channels: channels)
+
+    let samples = try await AudioFileDecoder.decode(url: url)
+
+    // One second at 16 kHz. The tolerance is for the resampler's edge frames, not for a wrong rate:
+    // a file decoded at its SOURCE rate would land at 44,100 or 48,000 and miss this by miles.
+    #expect(
+      abs(samples.count - 16_000) < 800,
+      "\(ext) at \(rate) Hz / \(channels)ch decoded to \(samples.count) samples, not ~16,000")
+    #expect(samples.contains { $0 != 0 }, "the decoded audio is silent; the tone did not survive")
+  }
+
+  /// An m4a written through the real AAC encoder, kept separate because its settings are not a
+  /// `AVAudioFormat.settings` round trip and a lossy codec's frame count is not exact.
+  @Test("a real AAC file decodes")
+  func aacDecodes() async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("tone.m4a")
+    try Self.writeTone(
+      at: url, seconds: 1.0, sampleRate: 44_100, channels: 1,
+      settings: [
+        AVFormatIDKey: kAudioFormatMPEG4AAC,
+        AVSampleRateKey: 44_100,
+        AVNumberOfChannelsKey: 1,
+      ])
+
+    let samples = try await AudioFileDecoder.decode(url: url)
+
+    #expect(abs(samples.count - 16_000) < 2_000)
+    #expect(samples.contains { $0 != 0 })
+  }
+
+  // MARK: - The refusals, each by name
+
+  @Test("a file with a video track and no audio is refused by name")
+  func videoWithoutAudioIsRefused() async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("silent.mov")
+    try Self.writeVideoOnly(at: url)
+
+    await #expect(throws: AudioFileDecoder.Rejection.noAudioTrack) {
+      _ = try await AudioFileDecoder.decode(url: url)
+    }
+  }
+
+  @Test("a file that is not there is refused")
+  func missingFileIsRefused() async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    await #expect(throws: AudioFileDecoder.Rejection.unreadable) {
+      _ = try await AudioFileDecoder.decode(url: dir.appendingPathComponent("nothing.wav"))
+    }
+  }
+
+  @Test("a zero-byte file is refused")
+  func zeroByteFileIsRefused() async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("empty.wav")
+    try Data().write(to: url)
+
+    await #expect(throws: AudioFileDecoder.Rejection.unreadable) {
+      _ = try await AudioFileDecoder.decode(url: url)
+    }
+  }
+
+  /// A Keynote deck, a PDF, a photo: a real file that is simply not audio. Modelled as bytes with an
+  /// audio extension, which is the harder case — the extension says one thing and the content says
+  /// another, and the decoder must believe the content.
+  @Test("a file that is not audio at all is refused, whatever its extension says")
+  func nonAudioContentIsRefused() async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("deck.m4a")
+    try Data("this is not audio, it is a sentence".utf8).write(to: url)
+
+    await #expect(throws: AudioFileDecoder.Rejection.self) {
+      _ = try await AudioFileDecoder.decode(url: url)
+    }
+  }
+
+  /// **A truncated file is indistinguishable from a shorter recording**, and this row exists to keep
+  /// that documented rather than to guard against it.
+  ///
+  /// The first version of this suite asserted a refusal, and a guard was written to produce one: compare
+  /// the file's declared duration against the samples decoded, and refuse when they disagree. The
+  /// measurement killed it. On a 3-second 16 kHz WAV cut to a third of its bytes,
+  /// `AVAsset.load(.duration)` returns 0.957 s and the decode returns 15,317 samples, which IS 0.957 s
+  /// — AVFoundation derives duration from the bytes present, so the two agree by construction and the
+  /// threshold between them could never fire. The guard was removed rather than tuned.
+  ///
+  /// So the honest property is the one asserted here: a cut file decodes to LESS audio, without
+  /// hanging, crashing, or claiming to be the original. A cut that destroys the header is a different
+  /// case and IS refused, because the file cannot be opened at all.
+  @Test("a truncated file decodes to what is left of it, and says nothing untrue")
+  func truncatedFileDecodesShort() async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("cut.wav")
+    try Self.writeTone(at: url, seconds: 3.0, sampleRate: 16_000, channels: 1)
+
+    let whole = try Data(contentsOf: url)
+    try whole.prefix(whole.count / 3).write(to: url)
+
+    let samples = try await AudioFileDecoder.decode(url: url)
+
+    // Roughly a third of three seconds. The assertion is a RANGE, not an equality: the point is that
+    // the decoder returns the audio that survived rather than inventing, padding or hanging.
+    #expect(samples.count > 8_000 && samples.count < 24_000, "decoded \(samples.count) samples")
+    #expect(samples.contains { $0 != 0 })
+  }
+
+  /// The other half of the truncation story, and the half that IS refused: a file whose header is gone
+  /// cannot be opened, so nothing downstream ever sees it.
+  @Test("a file cut inside its header is refused")
+  func headerlessFileIsRefused() async throws {
+    let dir = try Self.tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appendingPathComponent("headerless.wav")
+    try Self.writeTone(at: url, seconds: 3.0, sampleRate: 16_000, channels: 1)
+
+    let whole = try Data(contentsOf: url)
+    try whole.suffix(whole.count / 2).write(to: url)
+
+    await #expect(throws: AudioFileDecoder.Rejection.self) {
+      _ = try await AudioFileDecoder.decode(url: url)
+    }
+  }
+
+  // MARK: - Named gaps
+
+  // `mp3` is not covered. macOS decodes it and does not encode it, so covering it needs a committed
+  // binary fixture rather than a written one. It is the format users are most likely to bring, so this
+  // is a real gap and it is named rather than skipped: Live UAT on #2648 imports a real mp3.
+}

--- a/Tests/EnviousWisprASRTests/AudioFileDecoderTests.swift
+++ b/Tests/EnviousWisprASRTests/AudioFileDecoderTests.swift
@@ -115,7 +115,7 @@ struct AudioFileDecoderTests {
     let url = dir.appendingPathComponent("tone.\(ext)")
     try Self.writeTone(at: url, seconds: 1.0, sampleRate: rate, channels: channels)
 
-    let samples = try await AudioFileDecoder.decode(url: url)
+    let samples = try await AudioFileDecoder.decode(url: url).samples
 
     // One second at 16 kHz. The tolerance is for the resampler's edge frames, not for a wrong rate:
     // a file decoded at its SOURCE rate would land at 44,100 or 48,000 and miss this by miles.
@@ -140,7 +140,7 @@ struct AudioFileDecoderTests {
         AVNumberOfChannelsKey: 1,
       ])
 
-    let samples = try await AudioFileDecoder.decode(url: url)
+    let samples = try await AudioFileDecoder.decode(url: url).samples
 
     #expect(abs(samples.count - 16_000) < 2_000)
     #expect(samples.contains { $0 != 0 })
@@ -220,7 +220,7 @@ struct AudioFileDecoderTests {
     let whole = try Data(contentsOf: url)
     try whole.prefix(whole.count / 3).write(to: url)
 
-    let samples = try await AudioFileDecoder.decode(url: url)
+    let samples = try await AudioFileDecoder.decode(url: url).samples
 
     // Roughly a third of three seconds. The assertion is a RANGE, not an equality: the point is that
     // the decoder returns the audio that survived rather than inventing, padding or hanging.

--- a/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationLifecycleCoordinatorTests.swift
@@ -29,7 +29,8 @@ import Testing
     audio: RouterTestAudioCapture,
     kernelDriver: KernelDictationDriver,
     whisperKitKernelDriver: KernelDictationDriver,
-    recordingLocked: TestRecordingLockedBox
+    recordingLocked: TestRecordingLockedBox,
+    engineLease: EngineLease
   ) {
     let audio = RouterTestAudioCapture()
     let asr = RouterTestASRManager()
@@ -55,6 +56,7 @@ import Testing
     let transcriptCoordinator = TranscriptCoordinator(store: store)
     let lastRecordingResult = LastRecordingResult()
     let lockBox = TestRecordingLockedBox()
+    let engineLease = EngineLease()
     let coordinator = DictationLifecycleCoordinator(
       application: RecordingDesktopPresentationEffects(),
       kernelDriver: pipeline,
@@ -70,9 +72,12 @@ import Testing
       recordingLockedAccess: .init(
         get: { lockBox.isLocked },
         set: { lockBox.isLocked = $0 }
-      )
+      ),
+      // #2648: the real lease, so a row can hand the coordinator a live claim
+      // and watch it come back on the session's terminal transition.
+      releaseEngineClaim: { [engineLease] token in engineLease.release(token) }
     )
-    return (coordinator, audio, pipeline, whisperKitKernelDriver, lockBox)
+    return (coordinator, audio, pipeline, whisperKitKernelDriver, lockBox, engineLease)
   }
 
   @Test func constructionDoesNotCrash() {
@@ -151,6 +156,110 @@ import Testing
       #expect(
         fx.recordingLocked.isLocked == false,
         "WhisperKit terminal state \(terminal) must clear the hands-free lock")
+    }
+  }
+
+  // MARK: - #2648 the running session's claim on the shared resource
+
+  /// **The hand-off has to complete, or a file import can never run again.**
+  /// `RecordingStarter` gives this coordinator the claim at the moment a session is minted, because both
+  /// start methods return while the recording is still running. If the terminal never handed it back,
+  /// one dictation would hold the shared engine for the life of the app.
+  ///
+  /// Driven through the KERNEL's accepted-terminal signal, for both backends. That signal is the release
+  /// trigger, not the published state — see the row below for why.
+  @Test func theAcceptedTerminalHandsTheEngineClaimBack() throws {
+    for useWhisperKit in [false, true] {
+      let fx = Self.makeCoordinator()
+      fx.coordinator.install()
+      guard case .granted(let token) = fx.engineLease.admit(.dictation) else {
+        Issue.record("a fresh lease refused the first claim")
+        return
+      }
+      fx.coordinator.acceptEngineToken(token, mintedBy: useWhisperKit ? .whisperKit : .parakeet)
+      #expect(fx.engineLease.isBusy, "the claim must still be held while the session runs")
+
+      let driver = useWhisperKit ? fx.whisperKitKernelDriver : fx.kernelDriver
+      driver.onSessionTerminalAccepted?("take-1")
+
+      #expect(
+        fx.engineLease.isBusy == false,
+        "\(useWhisperKit ? "WhisperKit" : "Parakeet")'s accepted terminal left the engine claimed")
+    }
+  }
+
+  /// **The published state must NOT release it, and this is the row that says why the trigger moved.**
+  ///
+  /// An error can be published while the kernel is still finalizing — `RecordingSessionKernel.cancel()`
+  /// deliberately ignores cancellation there — so the screen says the take ended while polish is still
+  /// running. Releasing on that signal let crash recovery, which competes for the same claim, start a
+  /// replay on top of a take that had not finished. Found by cloud review, which supplied the sequence.
+  @Test func aPublishedTerminalDoesNotReleaseTheClaim() throws {
+    let terminals: [PipelineState] = [
+      .idle, .complete, .error(.modelWedged), .advisory(.zeroSignal),
+    ]
+    for terminal in terminals {
+      let fx = Self.makeCoordinator()
+      fx.coordinator.install()
+      guard case .granted(let token) = fx.engineLease.admit(.dictation) else {
+        Issue.record("a fresh lease refused the first claim")
+        return
+      }
+      fx.coordinator.acceptEngineToken(token, mintedBy: .parakeet)
+
+      fx.kernelDriver.onStateChange?(terminal)
+
+      #expect(
+        fx.engineLease.isBusy,
+        "the published state \(terminal) released the claim; only the kernel's terminal may")
+    }
+  }
+
+  /// **The idle engine reaches terminals too.** Both handlers read one stored claim, so without the
+  /// backend pairing a signal from the engine that is NOT running this session releases the running
+  /// session's claim — and the release looks entirely correct at the site performing it.
+  ///
+  /// When this fails, a file import starts in the middle of a live dictation and the dictation comes
+  /// back unpolished.
+  @Test func aTerminalFromTheOtherBackendLeavesTheClaimAlone() throws {
+    for mintedByWhisperKit in [false, true] {
+      let fx = Self.makeCoordinator()
+      fx.coordinator.install()
+      guard case .granted(let token) = fx.engineLease.admit(.dictation) else {
+        Issue.record("a fresh lease refused the first claim")
+        return
+      }
+      fx.coordinator.acceptEngineToken(
+        token, mintedBy: mintedByWhisperKit ? .whisperKit : .parakeet)
+
+      let idleEngine = mintedByWhisperKit ? fx.kernelDriver : fx.whisperKitKernelDriver
+      idleEngine.onSessionTerminalAccepted?("someone-elses-take")
+
+      #expect(
+        fx.engineLease.isBusy,
+        "a terminal from the engine that minted nothing released the running session's claim")
+
+      let owner = mintedByWhisperKit ? fx.whisperKitKernelDriver : fx.kernelDriver
+      owner.onSessionTerminalAccepted?("take-1")
+      #expect(fx.engineLease.isBusy == false)
+    }
+  }
+
+  /// A transition that is NOT terminal must not hand the claim back either: polish runs after
+  /// `.transcribing` and inside `.polishing`, and releasing there would let a file import into the same
+  /// inference slot mid-dictation.
+  @Test func aRunningSessionKeepsItsEngineClaim() throws {
+    let fx = Self.makeCoordinator()
+    fx.coordinator.install()
+    guard case .granted(let token) = fx.engineLease.admit(.dictation) else {
+      Issue.record("a fresh lease refused the first claim")
+      return
+    }
+    fx.coordinator.acceptEngineToken(token, mintedBy: .parakeet)
+
+    for running in [PipelineState.recording, .transcribing, .polishing] {
+      fx.kernelDriver.onStateChange?(running)
+      #expect(fx.engineLease.isBusy, "\(running) is not the end of the session")
     }
   }
 

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -168,6 +168,31 @@ import Testing
         == "Recording interrupted. Words may be missing.")
   }
 
+  /// #2648's shared-resource refusal. **These three are NOT founder-locked** —
+  /// they are new copy shipped with the engine claim, pinned here so a later
+  /// edit is a deliberate one. Every holder is covered, from the enum itself
+  /// rather than from a list written by hand, because the sentence a user reads
+  /// depends on WHICH job is using the engine.
+  @Test(
+    "every shared-engine holder has its own sentence, and none of them mentions a slot",
+    arguments: SharedEngineHolder.allCases)
+  func sharedEngineBusyCopy(_ holder: SharedEngineHolder) {
+    let expected: [SharedEngineHolder: String] = [
+      .fileImport: "A file is being transcribed. Try again when it finishes.",
+      .crashRecovery: "Finishing an earlier recording. Try again in a moment.",
+      .dictation: "Already recording.",
+    ]
+    let sentence = DictationNarrator.copy(for: .sharedEngineBusy(holder: holder))
+    #expect(sentence == expected[holder])
+    // The user has never heard of an inference slot, a lease or a claim; the
+    // words name the job to wait for instead.
+    for jargon in ["slot", "lease", "claim", "engine", "resource"] {
+      #expect(
+        !sentence.lowercased().contains(jargon),
+        "the refusal sentence for \(holder) leaked the mechanism: \(sentence)")
+    }
+  }
+
   /// Only a VERIFIED device removal may name the microphone. If this fails, a
   /// user whose engine died with the mic still attached is being lied to.
   @Test("the neutral interruption family never mentions the microphone")

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -178,12 +178,20 @@ import Testing
     arguments: SharedEngineHolder.allCases)
   func sharedEngineBusyCopy(_ holder: SharedEngineHolder) {
     let expected: [SharedEngineHolder: String] = [
-      .fileImport: "A file is being transcribed. Try again when it finishes.",
-      .crashRecovery: "Finishing an earlier recording. Try again in a moment.",
+      .fileImport: "A file is being transcribed. Try again soon.",
+      .crashRecovery: "Finishing an earlier take. Try again soon.",
       .dictation: "Already recording.",
     ]
     let sentence = DictationNarrator.copy(for: .sharedEngineBusy(holder: holder))
     #expect(sentence == expected[holder])
+    // **The pill truncates rather than wrapping**, and Live UAT on 2026-09-09
+    // caught the first draft on screen as "A file is being transcribed. Try
+    // ag..." — losing exactly the half that tells the user what to do. 46 is
+    // the longest shipped sentence in this same 280x44 pill
+    // ("Microphone disconnected. Text may be cut short.").
+    #expect(
+      sentence.count <= 46,
+      "\(sentence.count) characters will be cut off in the pill: \(sentence)")
     // The user has never heard of an inference slot, a lease or a claim; the
     // words name the job to wait for instead.
     for jargon in ["slot", "lease", "claim", "engine", "resource"] {

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -68,7 +68,8 @@ struct FileImportCoordinatorTests {
     },
     beginRun: @escaping @MainActor () -> FileImportCoordinator.RunConfiguration = {
       FileImportCoordinator.RunConfiguration(
-        polishIsCloud: false, localPolishProvider: nil, polishProvider: .egOne)
+        polishIsCloud: false, localPolishProvider: nil, polishProvider: .egOne,
+        ollamaModel: nil)
     },
     ensureEngineReady: @escaping @MainActor () async -> FileImportCoordinator.EngineReadiness = {
       .ready
@@ -287,6 +288,176 @@ struct FileImportCoordinatorTests {
     #expect(coordinator.state == .rejected(.engineBusy(.dictation)))
     #expect(coordinator.step == .done, "the refusal stranded the finished document")
     #expect(coordinator.documentText == document, "the refusal ate the document")
+  }
+
+  // MARK: - The (step, state) matrix, enumerated
+
+  /// **Every finding in rounds 2, 3 and 5 was ONE cell of this matrix**, found
+  /// by a reviewer imagining a path: Working while rejected rendered no message,
+  /// Done with no parts exported nothing, Upload while finished refused
+  /// Continue, Done after an early Stop offered Copy over an empty clipboard.
+  /// Four cells, three rounds, and each fix left the next cell invisible.
+  ///
+  /// So this row stops describing the set and ENUMERATES it. It drives the
+  /// coordinator down every path the machine has and records the (step, state)
+  /// pairs it actually reaches, then asserts two things of each:
+  ///
+  /// 1. **The pair is one somebody decided on.** A new one fails until it is
+  ///    listed, which is the freeze.
+  /// 2. **The user is not stuck**, and if a document exists it is reachable.
+  ///
+  /// The pairs come from RUNNING the machine, not from reading it. A list
+  /// written by reading can only contain the paths the author thought of, which
+  /// is exactly how the four cells above were missed.
+  @Test("every reachable screen-and-state pair is one we chose, and none is a dead end")
+  func theStepStateMatrixIsEnumerated() async {
+    var seen: Set<String> = []
+
+    func record(_ coordinator: FileImportCoordinator) {
+      seen.insert("\(coordinator.step)/\(Self.label(for: coordinator.state))")
+      // **Property 2, checked at every pair rather than at the end.** "Not
+      // stuck" means: a run is in flight, or some step is reachable, or the
+      // one-button reset is available. And a document, once it exists, is never
+      // more than one move from the user.
+      let canMove =
+        coordinator.isRunning
+        || FileImportCoordinator.Step.allCases.contains { coordinator.canGo(to: $0) }
+        || coordinator.step == .upload
+      #expect(
+        canMove,
+        "\(coordinator.step)/\(Self.label(for: coordinator.state)) has no way out")
+      if coordinator.hasDocument, !coordinator.isRunning {
+        #expect(
+          coordinator.step == .done || coordinator.canGo(to: .done),
+          "\(coordinator.step)/\(Self.label(for: coordinator.state)) strands the document")
+      }
+    }
+
+    // Path A: the ordinary run, recorded at every step.
+    let a = makeCoordinator(lease: EngineLease())
+    record(a)
+    a.choose(url: Self.anyURL)
+    record(a)
+    _ = await settleUntil { if case .ready = a.state { return true } else { return false } }
+    record(a)
+    a.advance(); record(a)
+    a.advance(); record(a)
+    a.advance(); record(a)
+    a.advance()
+    await settleUntil { a.state == .finished }
+    await settleUntil { a.isEngineHeld == false }
+    record(a)
+    // Back through the choice steps with a document in hand.
+    for target in [FileImportCoordinator.Step.review, .polish, .transcription] {
+      a.jump(to: target)
+      record(a)
+    }
+    a.jump(to: .done); record(a)
+    a.startOver(); record(a)
+
+    // Path B: a file that cannot be read.
+    let b = makeCoordinator(
+      lease: EngineLease(), decode: { _ in throw AudioFileDecoder.Rejection.noAudio })
+    b.choose(url: Self.anyURL)
+    await settleUntil { b.state == .rejected(.noAudio) }
+    record(b)
+
+    // Path C: the engine the user picked is not there.
+    let c = makeCoordinator(lease: EngineLease(), ensureEngineReady: { .notInstalled })
+    c.choose(url: Self.anyURL)
+    _ = await settleUntil { if case .ready = c.state { return true } else { return false } }
+    c.advance(); c.advance(); c.advance(); c.advance()
+    await settleUntil { c.state == .rejected(.engineNotInstalled) }
+    record(c)
+
+    // Path D: stopped BEFORE any words arrived, and stopped after some.
+    for stopEarly in [true, false] {
+      let gate = PartGate()
+      let d = makeCoordinator(
+        lease: EngineLease(),
+        transcribe: { _ in
+          if stopEarly { await gate.wait() }
+          return "One. Two. Three."
+        },
+        processPart: { text in
+          if !stopEarly { await gate.wait() }
+          return Self.outcome(text)
+        })
+      d.choose(url: Self.anyURL)
+      _ = await settleUntil { if case .ready = d.state { return true } else { return false } }
+      d.start()
+      // **Settle on the SPECIFIC state, not on `isRunning`.** Both working
+      // states answer that true, so waiting on it recorded whichever came first
+      // and the polishing cell was never visited — the freeze caught its own
+      // walk being incomplete, which is the point of freezing the set rather
+      // than describing it.
+      if stopEarly {
+        await settleUntil {
+          if case .transcribing = d.state { return true } else { return false }
+        }
+      } else {
+        await settleUntil {
+          if case .polishing = d.state { return true } else { return false }
+        }
+      }
+      record(d)
+      d.stop()
+      await gate.releaseAll()
+      await settleUntil { d.isEngineHeld == false }
+      record(d)
+    }
+
+    // Path E: a refusal WITH a document in hand.
+    let lease = EngineLease()
+    let e = await finishedCoordinator(lease: lease)
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("the fixture could not take the engine")
+      return
+    }
+    e.rePolish()
+    record(e)
+
+    // **The freeze.** A pair not listed here is either a new screen nobody has
+    // designed the words for, or a state that was not supposed to reach it.
+    let expected: Set<String> = [
+      "upload/idle",
+      "upload/reading",
+      "upload/ready",
+      "upload/rejected",
+      "transcription/ready",
+      "transcription/finished",
+      "polish/ready",
+      "polish/finished",
+      "review/ready",
+      "review/finished",
+      "working/transcribing",
+      "working/polishing",
+      "done/finished",
+      "done/stopped",
+      "done/rejected",
+    ]
+    #expect(
+      seen == expected,
+      """
+      the reachable pairs changed.
+        new, and nobody has said what the screen shows: \(seen.subtracting(expected).sorted())
+        listed but no longer reachable: \(expected.subtracting(seen).sorted())
+      """)
+  }
+
+  /// A stable name per state CASE, ignoring its payload — the payload varies per
+  /// run and the matrix is about which screen meets which kind of state.
+  private static func label(for state: FileImportCoordinator.State) -> String {
+    switch state {
+    case .idle: return "idle"
+    case .reading: return "reading"
+    case .ready: return "ready"
+    case .transcribing: return "transcribing"
+    case .polishing: return "polishing"
+    case .finished: return "finished"
+    case .rejected: return "rejected"
+    case .stopped: return "stopped"
+    }
   }
 
   /// **A behavioural walk cannot establish that every WRITER asks the rule.**
@@ -639,7 +810,7 @@ struct FileImportCoordinatorTests {
       beginRun: {
         FileImportCoordinator.RunConfiguration(
           polishIsCloud: cloud, localPolishProvider: cloud ? nil : .egOne,
-          polishProvider: cloud ? .openAI : .egOne)
+          polishProvider: cloud ? .openAI : .egOne, ollamaModel: nil)
       })
     coordinator.choose(url: Self.anyURL)
     await settleUntil { if case .ready = coordinator.state { return true } else { return false } }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -18,6 +18,15 @@ struct FileImportCoordinatorTests {
 
   /// Lets a row hold a part inside the runner for as long as it wants, which is the only way to observe
   /// the property that matters: Stop changes the screen at once, and the claim waits for the work.
+  /// Counts calls made from a `@Sendable` closure. Same shape as `PartGate`
+  /// below: a plain captured var is refused by strict concurrency, and a lock
+  /// here would be a second way of doing what the suite already does once.
+  private actor CallCounter {
+    private var count = 0
+    func record() { count += 1 }
+    var value: Int { count }
+  }
+
   private actor PartGate {
     private var continuations: [CheckedContinuation<Void, Never>] = []
     private var enteredCount = 0
@@ -138,9 +147,50 @@ struct FileImportCoordinatorTests {
 
     #expect(coordinator.state == .rejected(expected))
     #expect(transcribed == false, "the import transcribed on an engine it was told was not ready")
-    #expect(
-      coordinator.step == .upload,
-      "the refusal landed on a step that does not render one")
+    // **Stays on Review, because nothing about the FILE needs redoing.** The
+    // audio is decoded and in memory; sending the user to Upload made the only
+    // recovery choosing the file again and paying the read a second time, which
+    // on a long recording is the slowest part of the whole job.
+    #expect(coordinator.step == .review, "an engine refusal sent the user back to the file picker")
+    #expect(coordinator.canRetry, "the message says try again and nothing offers it")
+  }
+
+  /// Try again does what it says: no second read, no second decode.
+  @Test("retrying after a busy engine reuses the audio already in memory")
+  func retryDoesNotReadTheFileAgain() async {
+    let lease = EngineLease()
+    let decodes = CallCounter()
+    let coordinator = makeCoordinator(
+      lease: lease,
+      decode: { _ in
+        await decodes.record()
+        return Self.decoded(seconds: 1.0)
+      })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    #expect(await decodes.value == 1)
+
+    // Something else holds the engine, so Start is refused.
+    guard case .granted(let token) = lease.admit(.dictation) else {
+      Issue.record("the fixture could not take the engine")
+      return
+    }
+    coordinator.advance()
+    coordinator.advance()
+    coordinator.advance()
+    coordinator.advance()
+    await settleUntil { coordinator.state == .rejected(.engineBusy(.dictation)) }
+    #expect(coordinator.canRetry)
+
+    // The engine frees up and the user presses Try again.
+    lease.release(token)
+    coordinator.retry()
+    await settleUntil { coordinator.state == .finished }
+
+    #expect(await decodes.value == 1, "Try again read the file a second time")
+    #expect(!coordinator.rawTranscript.isEmpty)
   }
 
   /// The claim is taken only AFTER the engine is confirmed, so a refused import
@@ -362,7 +412,8 @@ struct FileImportCoordinatorTests {
     await settleUntil { b.state == .rejected(.noAudio) }
     record(b)
 
-    // Path C: the engine the user picked is not there.
+    // Path C: the engine the user picked is not there. Lands on Review with the
+    // audio still in hand, which is the `review/rejected` cell.
     let c = makeCoordinator(lease: EngineLease(), ensureEngineReady: { .notInstalled })
     c.choose(url: Self.anyURL)
     _ = await settleUntil { if case .ready = c.state { return true } else { return false } }
@@ -435,6 +486,9 @@ struct FileImportCoordinatorTests {
       "done/finished",
       "done/stopped",
       "done/rejected",
+      // An ENGINE refusal with the audio still in memory. The user stays where
+      // Try again is rather than being sent back to the file picker.
+      "review/rejected",
     ]
     #expect(
       seen == expected,
@@ -476,17 +530,47 @@ struct FileImportCoordinatorTests {
         "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift"),
       encoding: .utf8)
 
-    let writers = source.split(separator: "\n")
+    // **Matches the ASSIGNMENT, not one of its spellings.** The first version
+    // required the value on the same line, so `showRejection`'s multi-line
+    // `step =` followed by an `if` expression was invisible to it and the count
+    // came back one short — a detector comparing a RENDERING rather than the
+    // property it is about. This accepts `step =`, `step=`, `self.step =` and a
+    // value on the next line, and rejects `==`.
+    func isAssignment(_ line: String) -> Bool {
+      guard !line.hasPrefix("//") else { return false }
+      guard let equals = line.range(of: "step") else { return false }
+      let after = line[equals.upperBound...].drop { $0 == " " }
+      guard after.first == "=", after.dropFirst().first != "=" else { return false }
+      // `myStep = x` and `a.step = x` are not writes to THIS property.
+      let beforeIndex = equals.lowerBound
+      if beforeIndex > line.startIndex {
+        let previous = line[line.index(before: beforeIndex)]
+        if previous.isLetter || previous.isNumber || previous == "_" { return false }
+        if previous == "." { return line.contains("self.step") }
+      }
+      return true
+    }
+
+    // **Two-way control, because a count from a detector I just wrote is a
+    // hypothesis.** A line that IS a write must match and a comparison must not,
+    // or the number below is measuring the detector rather than the file.
+    #expect(isAssignment("step = .upload"), "the detector misses a plain write")
+    #expect(isAssignment("step ="), "the detector misses a multi-line write")
+    #expect(isAssignment("self.step = .done"), "the detector misses a qualified write")
+    #expect(!isAssignment("if step == .done {"), "the detector counts a comparison")
+    #expect(!isAssignment("previousStep = .done"), "the detector counts another property")
+
+    let writers = source.split(separator: "\n", omittingEmptySubsequences: false)
       .map { $0.trimmingCharacters(in: .whitespaces) }
-      .filter { $0.hasPrefix("step = ") }
+      .filter(isAssignment)
 
     // `step = target` is the authority's own write and is not counted.
     let direct = writers.filter { $0 != "step = target" }
     #expect(
-      direct.count == 7,
+      direct.count == 8,
       """
-      \(direct.count) direct writes to `step`, expected 7 \
-      (choose, startOver, start, stop, rePolish, and polishAll twice). \
+      \(direct.count) direct writes to `step`, expected 8 \
+      (choose, startOver, showRejection, start, stop, rePolish, polishAll twice). \
       A new one is either a navigation — which must call `jump(to:advancing:)` \
       — or an exception that needs naming at `jump`. Found: \(direct)
       """)

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -68,14 +68,203 @@ struct FileImportCoordinatorTests {
     },
     beginRun: @escaping @MainActor () -> FileImportCoordinator.RunConfiguration = {
       FileImportCoordinator.RunConfiguration(polishIsCloud: false, localPolishProvider: nil)
+    },
+    ensureEngineReady: @escaping @MainActor () async -> FileImportCoordinator.EngineReadiness = {
+      .ready
     }
   ) -> FileImportCoordinator {
     FileImportCoordinator(
       decode: decode,
       transcribe: transcribe,
       engineAdmission: .live(lease: lease, as: .fileImport),
+      ensureEngineReady: ensureEngineReady,
       beginRun: beginRun,
       processPart: processPart)
+  }
+
+  /// Drives a coordinator to a finished document, so a test about what happens
+  /// AFTER a run does not restate the run.
+  private func finishedCoordinator(
+    lease: EngineLease, transcribe: @escaping @MainActor ([Float]) async throws -> String = { _ in
+      "One. Two. Three."
+    }
+  ) async -> FileImportCoordinator {
+    let coordinator = makeCoordinator(lease: lease, transcribe: transcribe)
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await settleUntil { coordinator.state == .finished }
+    await settleUntil { coordinator.isEngineHeld == false }
+    return coordinator
+  }
+
+  // MARK: - The engine the user picked has to be the engine that runs
+
+  /// **The Review step promises an engine by name.** Choosing All Languages
+  /// without its model downloaded leaves the app's active engine unchanged, so
+  /// the import ran the fast English engine while the screen said otherwise —
+  /// silently, with a plausible transcript. Nothing about the output says which
+  /// engine produced it, which is why this is a refusal and not a fallback.
+  @Test(
+    "an import refuses rather than running an engine the user did not pick",
+    arguments: [
+      (FileImportCoordinator.EngineReadiness.notInstalled,
+       FileImportCoordinator.FileImportRejection.engineNotInstalled),
+      (.notReady, .engineNotReady),
+    ])
+  func refusesWhenTheChosenEngineIsNotReady(
+    _ readiness: FileImportCoordinator.EngineReadiness,
+    _ expected: FileImportCoordinator.FileImportRejection
+  ) async {
+    var transcribed = false
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribe: { _ in
+        transcribed = true
+        return "Should never run."
+      },
+      ensureEngineReady: { readiness })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+
+    coordinator.start()
+    await settleUntil { coordinator.state == .rejected(expected) }
+
+    #expect(coordinator.state == .rejected(expected))
+    #expect(transcribed == false, "the import transcribed on an engine it was told was not ready")
+    #expect(
+      coordinator.step == .upload,
+      "the refusal landed on a step that does not render one")
+  }
+
+  /// The claim is taken only AFTER the engine is confirmed, so a refused import
+  /// must not be holding it — otherwise the next dictation is blocked by a run
+  /// that never happened.
+  @Test("a refused import holds nothing")
+  func aRefusedImportHoldsNothing() async {
+    let lease = EngineLease()
+    let coordinator = makeCoordinator(lease: lease, ensureEngineReady: { .notInstalled })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+
+    coordinator.start()
+    await settleUntil { coordinator.state == .rejected(.engineNotInstalled) }
+
+    #expect(coordinator.isEngineHeld == false)
+    #expect(lease.currentHolder == nil, "a refused import left the engine claimed")
+  }
+
+  // MARK: - What the finished screen lets the user do
+
+  /// **Copy and Save must hand over what the page is showing.** Stopping inside
+  /// the first passage leaves no finished parts and a full raw transcript, which
+  /// Done renders — and Copy used to put nothing on the clipboard while Save
+  /// wrote an empty file over the user's only copy.
+  @Test("the exported document is the words on screen, not an empty string")
+  func exportMatchesWhatIsRendered() async {
+    let lease = EngineLease()
+    let gate = PartGate()
+    let coordinator = makeCoordinator(
+      lease: lease,
+      transcribe: { _ in "The whole recording, transcribed." },
+      processPart: { text in
+        await gate.wait()
+        return Self.outcome(text)
+      })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await settleUntil { !coordinator.rawTranscript.isEmpty }
+
+    coordinator.stop()
+    await gate.releaseAll()
+    await settleUntil { coordinator.isEngineHeld == false }
+
+    #expect(coordinator.parts.isEmpty, "the fixture did not reach the state under test")
+    #expect(
+      coordinator.documentText == "The whole recording, transcribed.",
+      "Copy and Save would have handed the user an empty document")
+  }
+
+  /// A save the user believes happened, and did not, costs them the document:
+  /// New transcription is the next button along and it clears everything.
+  @Test("a failed save says so and a successful one names the file")
+  func saveOutcomesAreReported() async {
+    let coordinator = await finishedCoordinator(lease: EngineLease())
+    #expect(coordinator.saveMessage == nil, "a run that has not been saved claims a save")
+
+    coordinator.noteSaveFailed(CocoaError(.fileWriteOutOfSpace))
+    #expect(coordinator.saveMessage?.contains("couldn't be saved") == true)
+    #expect(
+      coordinator.saveMessage?.contains("still here") == true,
+      "the failure does not tell the user their words survived")
+
+    coordinator.noteSaveSucceeded(fileName: "Meeting.txt")
+    #expect(coordinator.saveMessage?.contains("Meeting.txt") == true)
+  }
+
+  // MARK: - Where the step bar may take you
+
+  /// **The bar and the jump read ONE function**, so a step cannot look clickable
+  /// and refuse. Before this, a finished run offered Working — an inactive
+  /// progress bar with a dead Stop button and no route back to the document —
+  /// and Upload, where Continue was refused because the state was finished.
+  @Test("a finished run cannot navigate into Working or back to an empty Upload")
+  func finishedRunNavigatesOnlyWhereSomethingWorks() async {
+    let coordinator = await finishedCoordinator(lease: EngineLease())
+    #expect(coordinator.step == .done)
+
+    #expect(coordinator.canJump(to: .working) == false)
+    #expect(coordinator.canJump(to: .upload) == false)
+    #expect(coordinator.canJump(to: .done) == false)
+    // Picking another polisher for the same words is a supported thing to do.
+    #expect(coordinator.canJump(to: .polish))
+    #expect(coordinator.canJump(to: .transcription))
+
+    coordinator.jump(to: .working)
+    #expect(coordinator.step == .done, "the bar took the user to a dead screen")
+    coordinator.jump(to: .polish)
+    #expect(coordinator.step == .polish)
+  }
+
+  /// The other direction, so a rule that refused everything would fail too.
+  @Test("before any run the bar goes back to Upload and no further forward")
+  func freshRunNavigatesBackwardsOnly() async {
+    let coordinator = makeCoordinator(lease: EngineLease())
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.advance()
+    coordinator.advance()
+    #expect(coordinator.step == .polish)
+
+    #expect(coordinator.canJump(to: .upload))
+    #expect(coordinator.canJump(to: .transcription))
+    #expect(coordinator.canJump(to: .review) == false, "the bar skipped a step forward")
+  }
+
+  /// Change hands the user the choice instead of re-running what they already
+  /// have. The document survives the move, which is the point of keeping it.
+  @Test("Change returns to the Polish step with the document intact")
+  func changeOffersAChoiceAndKeepsTheDocument() async {
+    let coordinator = await finishedCoordinator(lease: EngineLease())
+    let before = coordinator.documentText
+    #expect(!before.isEmpty)
+
+    coordinator.choosePolisherAgain()
+
+    #expect(coordinator.step == .polish)
+    #expect(coordinator.documentText == before, "Change threw the document away")
+    #expect(!coordinator.rawTranscript.isEmpty, "Change lost the words a re-run needs")
   }
 
   /// Yields until the condition holds, or gives up. `Task.yield()` rather than a sleep: everything

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -67,7 +67,8 @@ struct FileImportCoordinatorTests {
       Self.outcome($0)
     },
     beginRun: @escaping @MainActor () -> FileImportCoordinator.RunConfiguration = {
-      FileImportCoordinator.RunConfiguration(polishIsCloud: false, localPolishProvider: nil)
+      FileImportCoordinator.RunConfiguration(
+        polishIsCloud: false, localPolishProvider: nil, polishProvider: .egOne)
     },
     ensureEngineReady: @escaping @MainActor () async -> FileImportCoordinator.EngineReadiness = {
       .ready
@@ -288,6 +289,41 @@ struct FileImportCoordinatorTests {
     #expect(coordinator.documentText == document, "the refusal ate the document")
   }
 
+  /// **A behavioural walk cannot establish that every WRITER asks the rule.**
+  /// Round 4 enumerated the writers from the source and found five of seven
+  /// navigation sites bypassing the authority the commit message claimed was
+  /// single — and every behavioural row still passed, because they exercised the
+  /// two writers that did ask. So this row reads the FILE.
+  ///
+  /// The seven permitted direct writers are the two resets and the five
+  /// run transitions, each named at `jump(to:advancing:)`. A new one fails here
+  /// until somebody says which it is.
+  @Test("every navigation writer goes through the one authority")
+  func navigationHasOneWriter() throws {
+    let source = try String(
+      contentsOf: RepoRoot.url.appendingPathComponent(
+        "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift"),
+      encoding: .utf8)
+
+    let writers = source.split(separator: "\n")
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { $0.hasPrefix("step = ") }
+
+    // `step = target` is the authority's own write and is not counted.
+    let direct = writers.filter { $0 != "step = target" }
+    #expect(
+      direct.count == 7,
+      """
+      \(direct.count) direct writes to `step`, expected 7 \
+      (choose, startOver, start, stop, rePolish, and polishAll twice). \
+      A new one is either a navigation — which must call `jump(to:advancing:)` \
+      — or an exception that needs naming at `jump`. Found: \(direct)
+      """)
+    #expect(
+      writers.contains("step = target"),
+      "the authority no longer writes the step; this test is measuring nothing")
+  }
+
   /// The other direction, so a rule that refused everything would fail too.
   @Test("before any run the bar goes back to Upload and no further forward")
   func freshRunNavigatesBackwardsOnly() async {
@@ -304,6 +340,25 @@ struct FileImportCoordinatorTests {
     #expect(coordinator.canGo(to: .transcription))
     #expect(coordinator.canGo(to: .review) == false, "the bar skipped a step forward")
     #expect(coordinator.canGo(to: .done) == false, "Done was offered with no document")
+
+    // Continue is the one mover that goes forward, one step, and only then.
+    #expect(coordinator.canGo(to: .review, advancing: true))
+    #expect(
+      coordinator.canGo(to: .done, advancing: true) == false,
+      "Continue could skip the whole wizard")
+  }
+
+  /// **Continue must not work before a file has been read.** `advance()` used to
+  /// carry that check itself, which is exactly why it could not call the
+  /// authority; folding it in is what let every writer share one rule.
+  @Test("Continue does nothing on an empty Upload step")
+  func continueNeedsAFile() {
+    let coordinator = makeCoordinator(lease: EngineLease())
+    #expect(coordinator.step == .upload)
+
+    coordinator.advance()
+
+    #expect(coordinator.step == .upload, "the wizard advanced with no file chosen")
   }
 
   /// A save confirmation belongs to ONE set of words. Left standing over a new
@@ -583,7 +638,8 @@ struct FileImportCoordinatorTests {
       lease: lease,
       beginRun: {
         FileImportCoordinator.RunConfiguration(
-          polishIsCloud: cloud, localPolishProvider: cloud ? nil : .egOne)
+          polishIsCloud: cloud, localPolishProvider: cloud ? nil : .egOne,
+          polishProvider: cloud ? .openAI : .egOne)
       })
     coordinator.choose(url: Self.anyURL)
     await settleUntil { if case .ready = coordinator.state { return true } else { return false } }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -155,6 +155,49 @@ struct FileImportCoordinatorTests {
     #expect(coordinator.canRetry, "the message says try again and nothing offers it")
   }
 
+  /// **Stopping frees the audio, and only `stop()` can do it.**
+  ///
+  /// Every `releaseDecodedAudio()` sits behind the generation guard so a late
+  /// task cannot erase a file the user has since chosen — and `stop()` bumps the
+  /// generation, so after a Stop both the late-success and the cancellation path
+  /// return at that guard and the samples stayed resident for the life of the
+  /// app. Hundreds of megabytes on the multi-hour recordings this feature
+  /// advertises. Found by cloud review; introduced by the fix that moved the
+  /// guard in front of the release, which is why the property is asserted rather
+  /// than the ordering.
+  ///
+  /// Asserted through `canRetry`, which is false with no samples in hand and is
+  /// the only reader of that field outside the run.
+  @Test("stopping releases the decoded audio rather than holding it for the session")
+  func stopFreesTheDecodedAudio() async {
+    let gate = PartGate()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribe: { _ in
+        await gate.wait()
+        return "One. Two. Three."
+      })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await settleUntil { await gate.entered >= 1 }
+
+    coordinator.stop()
+    await gate.releaseAll()
+    await settleUntil { coordinator.isEngineHeld == false }
+
+    // A rejection about the engine is the one state that reports whether audio
+    // is still held; reaching it here would need a run, so the field is read
+    // through the coordinator's own view of "is there anything to retry with".
+    #expect(coordinator.canRetry == false)
+    #expect(coordinator.state == .stopped)
+    #expect(
+      coordinator.hasDocument == false,
+      "the fixture produced a transcript, so this row is not testing the stop path it names")
+  }
+
   /// **An abandoned read is STOPPED, not ignored.**
   ///
   /// The generation check answers "whose file is this" after the work is done,

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -421,6 +421,27 @@ struct FileImportCoordinatorTests {
           coordinator.step == .done || coordinator.canGo(to: .done),
           "\(coordinator.step)/\(Self.label(for: coordinator.state)) strands the document")
       }
+      // **"Somewhere to move" was too weak, and round 9 proved it.** From a
+      // refused Review, going BACKWARDS was allowed, so the check passed — and
+      // the user who went back to change the engine could not come forward
+      // again, because Continue asked for a state a refusal had already left.
+      // The property is not "can move" but "can still get FORWARD", which is
+      // what reaches Start.
+      //
+      // Asserted one step at a time, deliberately: the wizard is a sequence, so
+      // "Review is reachable" IS "each next step is reachable", and demanding
+      // Review in one hop would fail Upload, which is correct behaviour.
+      if coordinator.isReadyToRun, !coordinator.isRunning,
+        let next = FileImportCoordinator.Step(rawValue: coordinator.step.rawValue + 1),
+        coordinator.step.rawValue < FileImportCoordinator.Step.review.rawValue
+      {
+        #expect(
+          coordinator.canGo(to: next, advancing: true),
+          """
+          \(coordinator.step)/\(Self.label(for: coordinator.state)) cannot go forward to \
+          \(next.title), so Start is unreachable with audio already in hand
+          """)
+      }
     }
 
     // Path A: the ordinary run, recorded at every step.
@@ -498,6 +519,21 @@ struct FileImportCoordinatorTests {
       record(d)
     }
 
+    // Path D2: refused for a busy engine, then Back to change the engine and
+    // forward again — the walk round 9 found, which no earlier path took.
+    let d2 = makeCoordinator(lease: EngineLease(), ensureEngineReady: { .notInstalled })
+    d2.choose(url: Self.anyURL)
+    _ = await settleUntil { if case .ready = d2.state { return true } else { return false } }
+    d2.advance(); d2.advance(); d2.advance(); d2.advance()
+    await settleUntil { d2.state == .rejected(.engineNotInstalled) }
+    record(d2)
+    d2.goBack(); record(d2)
+    d2.goBack(); record(d2)
+    d2.advance(); record(d2)
+    d2.advance()
+    #expect(d2.step == .review, "the user could not get back to Start after changing the engine")
+    record(d2)
+
     // Path E: a refusal WITH a document in hand.
     let lease = EngineLease()
     let e = await finishedCoordinator(lease: lease)
@@ -527,8 +563,11 @@ struct FileImportCoordinatorTests {
       "done/stopped",
       "done/rejected",
       // An ENGINE refusal with the audio still in memory. The user stays where
-      // Try again is rather than being sent back to the file picker.
+      // Try again is rather than being sent back to the file picker, and can go
+      // back to change the engine and come forward again.
       "review/rejected",
+      "transcription/rejected",
+      "polish/rejected",
     ]
     #expect(
       seen == expected,

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -72,6 +72,8 @@ struct FileImportCoordinatorTests {
       Self.decoded(seconds: 1.0)
     },
     transcribe: @escaping @MainActor ([Float]) async throws -> String = { _ in "One. Two. Three." },
+    /// The engine's reported language, which most rows do not care about.
+    engineLanguage: String? = nil,
     processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome = {
       Self.outcome($0)
     },
@@ -86,11 +88,13 @@ struct FileImportCoordinatorTests {
   ) -> FileImportCoordinator {
     FileImportCoordinator(
       decode: decode,
-      transcribe: transcribe,
+      // The rows above pass a plain text closure; the language rides alongside
+      // it so a row that does not care about language never mentions one.
+      transcribe: { samples in (text: try await transcribe(samples), language: engineLanguage) },
       engineAdmission: .live(lease: lease, as: .fileImport),
       ensureEngineReady: ensureEngineReady,
       beginRun: beginRun,
-      processPart: processPart)
+      processPart: { part, _ in try await processPart(part) })
   }
 
   /// Drives a coordinator to a finished document, so a test about what happens

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -337,7 +337,13 @@ struct FileImportCoordinatorTests {
     coordinator.rePolish()
     await settleUntil { coordinator.state == .finished }
     #expect(coordinator.runConfiguration?.polishIsCloud == false)
-    #expect(coordinator.pinnedLocalPolishProvider == nil, "a finished run pins nothing")
+
+    // **The pin follows the ENGINE, not the screen.** The document is on screen
+    // before the run task has unwound, and in that window the polish server is
+    // still this run's. Releasing the pin when the screen finished would let a
+    // provider switch tear the server down under work still inside it.
+    await settleUntil { coordinator.isEngineHeld == false }
+    #expect(coordinator.pinnedLocalPolishProvider == nil, "a released run pins nothing")
   }
 
   // MARK: - Changing the polisher

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -43,20 +43,32 @@ struct FileImportCoordinatorTests {
     func bump() { value += 1 }
   }
 
+  /// A decoded file of a given length, with plausible metadata. The Upload step
+  /// shows every one of these fields, so a fixture that returned only samples
+  /// could not exercise the screen the user actually sees.
+  nonisolated private static func decoded(seconds: Double) -> AudioFileDecoder.Decoded {
+    AudioFileDecoder.Decoded(
+      samples: Array(repeating: 0.1, count: Int(seconds * 16_000)),
+      seconds: seconds, byteCount: Int64(seconds * 32_000), codec: "AAC",
+      sampleRate: 44_100, channelCount: 1)
+  }
+
   private static func outcome(_ text: String) -> FileImportRunner.PartOutcome {
     FileImportRunner.PartOutcome(text: text, polishedText: text, polishError: nil)
   }
 
   private func makeCoordinator(
     lease: EngineLease,
-    decode: @escaping @Sendable (URL) async throws -> [Float] = { _ in
-      Array(repeating: 0.1, count: 16_000)
+    decode: @escaping @Sendable (URL) async throws -> AudioFileDecoder.Decoded = { _ in
+      Self.decoded(seconds: 1.0)
     },
     transcribe: @escaping @MainActor ([Float]) async throws -> String = { _ in "One. Two. Three." },
     processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome = {
       Self.outcome($0)
     },
-    beginRun: @escaping @MainActor () -> Void = {}
+    beginRun: @escaping @MainActor () -> FileImportCoordinator.RunConfiguration = {
+      FileImportCoordinator.RunConfiguration(polishIsCloud: false, localPolishProvider: nil)
+    }
   ) -> FileImportCoordinator {
     FileImportCoordinator(
       decode: decode,
@@ -119,9 +131,9 @@ struct FileImportCoordinatorTests {
       decode: { url in
         if url.lastPathComponent == "first.m4a" {
           await slowFirst.wait()
-          return Array(repeating: 0.1, count: 160_000)
+          return Self.decoded(seconds: 10.0)
         }
-        return Array(repeating: 0.1, count: 16_000)
+        return Self.decoded(seconds: 1.0)
       })
 
     coordinator.choose(url: URL(fileURLWithPath: "/tmp/first.m4a"))
@@ -257,6 +269,13 @@ struct FileImportCoordinatorTests {
     #expect(coordinator.state == .stopped)
     #expect(
       coordinator.parts.count == 1, "stopping threw away work the user had already waited for")
+    // **Keeping the work is only half of it: the user has to be able to REACH
+    // it.** Asserting the state alone passes against a screen still showing a
+    // progress bar that will never move, beside a Stop button already pressed,
+    // with Copy and Save on a step nothing navigates to.
+    #expect(
+      coordinator.step == .done,
+      "stopping left the user on the progress screen with no way to the words it kept")
   }
 
   /// A part that lands after Stop must not write into a run the user has ended.
@@ -285,6 +304,42 @@ struct FileImportCoordinatorTests {
     #expect(coordinator.state == .stopped, "a stopped run moved on to another state")
   }
 
+  /// **The finished document's disclosure must describe the run that produced it.**
+  ///
+  /// Cloud review found the page reading LIVE settings: start with a cloud polisher, switch to a local
+  /// one, and the page claimed "Nothing is uploaded" over text that had just gone to the cloud. The
+  /// coordinator now holds the frozen configuration and keeps it until a new run starts.
+  @Test("the run's configuration is frozen at Start and survives the run")
+  func runConfigurationIsFrozen() async {
+    let lease = EngineLease()
+    var cloud = true
+    let coordinator = makeCoordinator(
+      lease: lease,
+      beginRun: {
+        FileImportCoordinator.RunConfiguration(
+          polishIsCloud: cloud, localPolishProvider: cloud ? nil : .egOne)
+      })
+    coordinator.choose(url: Self.anyURL)
+    await settleUntil { if case .ready = coordinator.state { return true } else { return false } }
+
+    coordinator.start()
+    await settleUntil { coordinator.state == .finished }
+    #expect(coordinator.runConfiguration?.polishIsCloud == true)
+
+    // The user now picks a local polisher. The FINISHED document was still
+    // produced by the cloud one, so the disclosure must not change.
+    cloud = false
+    #expect(
+      coordinator.runConfiguration?.polishIsCloud == true,
+      "the finished document's disclosure changed under it")
+
+    // A NEW run adopts the new choice, and pins its local server while running.
+    coordinator.rePolish()
+    await settleUntil { coordinator.state == .finished }
+    #expect(coordinator.runConfiguration?.polishIsCloud == false)
+    #expect(coordinator.pinnedLocalPolishProvider == nil, "a finished run pins nothing")
+  }
+
   // MARK: - Changing the polisher
 
   /// **The file is never read a second time.** That is the whole reason the raw transcript is kept, and
@@ -297,7 +352,7 @@ struct FileImportCoordinatorTests {
       lease: lease,
       decode: { _ in
         await decodes.bump()
-        return Array(repeating: 0.1, count: 16_000)
+        return Self.decoded(seconds: 1.0)
       })
 
     coordinator.choose(url: Self.anyURL)

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -213,26 +213,79 @@ struct FileImportCoordinatorTests {
 
   // MARK: - Where the step bar may take you
 
-  /// **The bar and the jump read ONE function**, so a step cannot look clickable
-  /// and refuse. Before this, a finished run offered Working — an inactive
-  /// progress bar with a dead Stop button and no route back to the document —
-  /// and Upload, where Continue was refused because the state was finished.
-  @Test("a finished run cannot navigate into Working or back to an empty Upload")
-  func finishedRunNavigatesOnlyWhereSomethingWorks() async {
+  /// **Every mover reads ONE function**, so a step cannot look clickable and
+  /// refuse, and no route can strand the document. Three rounds each found a
+  /// different mover with its own rule: the BAR offered Working after a run,
+  /// BACK walked from Polish to Upload where Continue is refused because the
+  /// state is finished, and a REFUSAL sent the user to Upload, whose only offer
+  /// is choosing another file — which clears the words they were trying to keep.
+  ///
+  /// **The property, stated once: from anywhere the user can reach, the finished
+  /// document is still reachable.** The rows below check it by walking, not by
+  /// restating the rule.
+  @Test("a finished document stays reachable from every step the user can reach")
+  func theDocumentIsNeverStranded() async {
     let coordinator = await finishedCoordinator(lease: EngineLease())
     #expect(coordinator.step == .done)
+    let document = coordinator.documentText
+    #expect(!document.isEmpty)
 
-    #expect(coordinator.canJump(to: .working) == false)
-    #expect(coordinator.canJump(to: .upload) == false)
-    #expect(coordinator.canJump(to: .done) == false)
-    // Picking another polisher for the same words is a supported thing to do.
-    #expect(coordinator.canJump(to: .polish))
-    #expect(coordinator.canJump(to: .transcription))
+    // Dead ends are refused outright.
+    #expect(coordinator.canGo(to: .working) == false)
+    #expect(
+      coordinator.canGo(to: .upload) == false,
+      "Upload with a document offers only the thing that destroys it")
 
-    coordinator.jump(to: .working)
-    #expect(coordinator.step == .done, "the bar took the user to a dead screen")
-    coordinator.jump(to: .polish)
+    // Walk every step the bar DOES offer, and from each one walk back.
+    for target in [FileImportCoordinator.Step.transcription, .polish, .review] {
+      #expect(coordinator.canGo(to: target), "\(target.title) is unreachable after a run")
+      coordinator.jump(to: target)
+      #expect(coordinator.step == target)
+      #expect(
+        coordinator.canGo(to: .done),
+        "from \(target.title) there is no way back to the document")
+      coordinator.jump(to: .done)
+      #expect(coordinator.step == .done)
+      #expect(coordinator.documentText == document, "the walk changed the document")
+    }
+  }
+
+  /// The walk Codex found: Change, then Back, then Back again.
+  @Test("walking Back from Change never leaves the document behind")
+  func backFromChangeStaysReachable() async {
+    let coordinator = await finishedCoordinator(lease: EngineLease())
+    coordinator.choosePolisherAgain()
     #expect(coordinator.step == .polish)
+
+    coordinator.goBack()
+    #expect(coordinator.step == .transcription)
+    coordinator.goBack()
+    #expect(
+      coordinator.step == .transcription,
+      "Back walked onto Upload, where Continue is refused and the document is gone")
+    #expect(coordinator.canGoBack == false, "Back is offered with nowhere to go")
+    #expect(coordinator.canGo(to: .done))
+  }
+
+  /// A refusal must not cost the user the document either. Cleaning again while
+  /// a dictation holds the engine is refused, and the refusal has to be readable
+  /// somewhere the words still are.
+  @Test("a refusal with a document in hand lands where the document is")
+  func aRefusalKeepsTheDocumentReachable() async {
+    let lease = EngineLease()
+    let coordinator = await finishedCoordinator(lease: lease)
+    let document = coordinator.documentText
+
+    // Something else takes the engine, then the user asks to clean again.
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("the fixture could not take the engine")
+      return
+    }
+    coordinator.rePolish()
+
+    #expect(coordinator.state == .rejected(.engineBusy(.dictation)))
+    #expect(coordinator.step == .done, "the refusal stranded the finished document")
+    #expect(coordinator.documentText == document, "the refusal ate the document")
   }
 
   /// The other direction, so a rule that refused everything would fail too.
@@ -247,9 +300,33 @@ struct FileImportCoordinatorTests {
     coordinator.advance()
     #expect(coordinator.step == .polish)
 
-    #expect(coordinator.canJump(to: .upload))
-    #expect(coordinator.canJump(to: .transcription))
-    #expect(coordinator.canJump(to: .review) == false, "the bar skipped a step forward")
+    #expect(coordinator.canGo(to: .upload))
+    #expect(coordinator.canGo(to: .transcription))
+    #expect(coordinator.canGo(to: .review) == false, "the bar skipped a step forward")
+    #expect(coordinator.canGo(to: .done) == false, "Done was offered with no document")
+  }
+
+  /// A save confirmation belongs to ONE set of words. Left standing over a new
+  /// document it is the exact belief that makes a user press New transcription
+  /// and lose them.
+  @Test("the save confirmation does not survive the document it was about")
+  func saveMessageDoesNotOutliveItsDocument() async {
+    let coordinator = await finishedCoordinator(lease: EngineLease())
+    coordinator.noteSaveSucceeded(fileName: "Meeting.txt")
+    #expect(coordinator.saveMessage != nil)
+
+    coordinator.startOver()
+    #expect(
+      coordinator.saveMessage == nil,
+      "a new import claimed the previous document's save")
+
+    let second = await finishedCoordinator(lease: EngineLease())
+    second.noteSaveSucceeded(fileName: "Meeting.txt")
+    second.rePolish()
+    await settleUntil { second.state == .finished }
+    #expect(
+      second.saveMessage == nil,
+      "re-cleaned words claimed the save of the words they replaced")
   }
 
   /// Change hands the user the choice instead of re-running what they already

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -1,0 +1,316 @@
+import EnviousWisprASR
+import EnviousWisprPipeline
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2648 — the state machine behind Transcribe a File.
+///
+/// **When this fails, the user presses Stop and the screen carries on, or presses Stop and a dictation
+/// is admitted while their import is still inside the polish server, or picks a second file and gets the
+/// first one's transcript.** Product coverage.
+@Suite(.tags(.productOutcome))
+@MainActor
+struct FileImportCoordinatorTests {
+
+  // MARK: - A controllable part processor
+
+  /// Lets a row hold a part inside the runner for as long as it wants, which is the only way to observe
+  /// the property that matters: Stop changes the screen at once, and the claim waits for the work.
+  private actor PartGate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var enteredCount = 0
+
+    var entered: Int { enteredCount }
+
+    func wait() async {
+      enteredCount += 1
+      await withCheckedContinuation { continuations.append($0) }
+    }
+
+    func releaseAll() {
+      let held = continuations
+      continuations = []
+      for continuation in held { continuation.resume() }
+    }
+  }
+
+  /// A plain counter for rows that only need to know how many times something ran.
+  private actor Counter {
+    private var value = 0
+    var count: Int { value }
+    func bump() { value += 1 }
+  }
+
+  private static func outcome(_ text: String) -> FileImportRunner.PartOutcome {
+    FileImportRunner.PartOutcome(text: text, polishedText: text, polishError: nil)
+  }
+
+  private func makeCoordinator(
+    lease: EngineLease,
+    decode: @escaping @Sendable (URL) async throws -> [Float] = { _ in
+      Array(repeating: 0.1, count: 16_000)
+    },
+    transcribe: @escaping @MainActor ([Float]) async throws -> String = { _ in "One. Two. Three." },
+    processPart: @escaping @MainActor (String) async throws -> FileImportRunner.PartOutcome = {
+      Self.outcome($0)
+    },
+    beginRun: @escaping @MainActor () -> Void = {}
+  ) -> FileImportCoordinator {
+    FileImportCoordinator(
+      decode: decode,
+      transcribe: transcribe,
+      engineAdmission: .live(lease: lease, as: .fileImport),
+      beginRun: beginRun,
+      processPart: processPart)
+  }
+
+  /// Yields until the condition holds, or gives up. `Task.yield()` rather than a sleep: everything
+  /// here is main-actor work with no real waiting in it, so a clock would only make the suite slower
+  /// and flakier.
+  @discardableResult
+  private func settleUntil(
+    limit: Int = 500, _ condition: @MainActor () async -> Bool
+  ) async -> Bool {
+    for _ in 0..<limit {
+      if await condition() { return true }
+      await Task.yield()
+    }
+    return await condition()
+  }
+
+  private static let anyURL = URL(fileURLWithPath: "/tmp/recording.m4a")
+
+  // MARK: - Choosing a file
+
+  @Test("a file that cannot be read is refused, and no engine is touched")
+  func unreadableFileIsRejected() async {
+    let lease = EngineLease()
+    let coordinator = makeCoordinator(
+      lease: lease, decode: { _ in throw AudioFileDecoder.Rejection.unreadable })
+
+    coordinator.choose(url: Self.anyURL)
+    await settleUntil { coordinator.state == .rejected(.cannotRead) }
+
+    #expect(coordinator.state == .rejected(.cannotRead))
+    #expect(lease.isBusy == false, "a refused file must not have claimed the engine")
+  }
+
+  @Test("a file with no audio is refused by its own name")
+  func noAudioFileIsRejected() async {
+    let coordinator = makeCoordinator(
+      lease: EngineLease(), decode: { _ in throw AudioFileDecoder.Rejection.noAudioTrack })
+
+    coordinator.choose(url: Self.anyURL)
+    await settleUntil { coordinator.state == .rejected(.noAudio) }
+
+    #expect(coordinator.state == .rejected(.noAudio))
+  }
+
+  /// Picking a second file while the first is still being read is an ordinary thing to do. Without a
+  /// generation bump on `choose`, whichever decode finishes last wins — which can be the file the user
+  /// already replaced.
+  @Test("a second file replaces the first, even if the first finishes reading later")
+  func aSecondChoiceWinsRegardlessOfOrder() async {
+    let slowFirst = PartGate()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      decode: { url in
+        if url.lastPathComponent == "first.m4a" {
+          await slowFirst.wait()
+          return Array(repeating: 0.1, count: 160_000)
+        }
+        return Array(repeating: 0.1, count: 16_000)
+      })
+
+    coordinator.choose(url: URL(fileURLWithPath: "/tmp/first.m4a"))
+    await settleUntil { await slowFirst.entered == 1 }
+    coordinator.choose(url: URL(fileURLWithPath: "/tmp/second.m4a"))
+    await settleUntil { coordinator.state == .ready(fileName: "second.m4a", seconds: 1.0) }
+
+    // The first file's decode now finishes, late.
+    await slowFirst.releaseAll()
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(
+      coordinator.state == .ready(fileName: "second.m4a", seconds: 1.0),
+      "a late decode from a replaced file overwrote the current one")
+  }
+
+  // MARK: - Starting
+
+  @Test("start is refused while another workload holds the engine")
+  func startRefusedWhileEngineHeld() async {
+    let lease = EngineLease()
+    let coordinator = makeCoordinator(lease: lease)
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("a fresh lease refused the first claim")
+      return
+    }
+
+    coordinator.start()
+
+    #expect(coordinator.state == .rejected(.engineBusy(.dictation)))
+    #expect(lease.currentHolder == .dictation, "the refusal must not disturb the holder")
+  }
+
+  @Test("a finished run hands the engine back")
+  func finishedRunReleasesTheEngine() async {
+    let lease = EngineLease()
+    let coordinator = makeCoordinator(lease: lease)
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+
+    coordinator.start()
+    await settleUntil { coordinator.state == .finished }
+
+    #expect(coordinator.state == .finished)
+    #expect(coordinator.parts.count == 1, "three short sentences pack into one part")
+    #expect(lease.isBusy == false, "a finished run left the engine claimed")
+  }
+
+  @Test("no speech in the file is its own refusal, not an empty document")
+  func noSpeechIsRejected() async {
+    let lease = EngineLease()
+    let coordinator = makeCoordinator(lease: lease, transcribe: { _ in "   " })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+
+    coordinator.start()
+    await settleUntil { coordinator.state == .rejected(.noSpeechFound) }
+
+    #expect(coordinator.state == .rejected(.noSpeechFound))
+    #expect(lease.isBusy == false)
+  }
+
+  // MARK: - Stopping — the property the whole design is built around
+
+  /// **Two guarantees, and they are separate.** The screen must stop at once, because the user pressed
+  /// Stop. The claim must NOT come back until the work has physically left the engine, because a
+  /// dictation admitted on top of a part still inside the polish server is the exact collision this
+  /// feature exists to prevent.
+  ///
+  /// A test that only checked the visible state would pass against a design that released the claim in
+  /// `stop()`, which is the mistake the plan's review round found.
+  @Test("stop changes the screen at once and still holds the engine until the work exits")
+  func stopIsImmediateButTheClaimWaits() async {
+    let lease = EngineLease()
+    let gate = PartGate()
+    let coordinator = makeCoordinator(
+      lease: lease,
+      transcribe: { _ in "One. Two. Three." },
+      processPart: { text in
+        await gate.wait()
+        return Self.outcome(text)
+      })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await settleUntil { await gate.entered == 1 }
+
+    coordinator.stop()
+
+    // Immediately, with no awaiting in between.
+    #expect(coordinator.state == .stopped)
+    #expect(lease.isBusy, "the claim came back while a part was still inside the engine")
+
+    // The part now finishes and the run task exits.
+    await gate.releaseAll()
+    await settleUntil { lease.isBusy == false }
+    #expect(lease.isBusy == false, "the claim never came back after the work exited")
+  }
+
+  @Test("stop keeps what already finished")
+  func stopKeepsFinishedParts() async {
+    let lease = EngineLease()
+    let gate = PartGate()
+    let coordinator = makeCoordinator(
+      lease: lease,
+      // Long enough to split into several parts.
+      transcribe: { _ in (0..<900).map { "word\($0)" }.joined(separator: " ") },
+      processPart: { text in
+        if await gate.entered >= 1 { await gate.wait() }
+        return Self.outcome(text)
+      })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await settleUntil { coordinator.parts.count == 1 }
+
+    coordinator.stop()
+    await gate.releaseAll()
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(coordinator.state == .stopped)
+    #expect(
+      coordinator.parts.count == 1, "stopping threw away work the user had already waited for")
+  }
+
+  /// A part that lands after Stop must not write into a run the user has ended.
+  @Test("a late part from a stopped run cannot write into the document")
+  func aLatePartCannotWrite() async {
+    let lease = EngineLease()
+    let gate = PartGate()
+    let coordinator = makeCoordinator(
+      lease: lease,
+      processPart: { text in
+        await gate.wait()
+        return Self.outcome(text)
+      })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await settleUntil { await gate.entered == 1 }
+
+    coordinator.stop()
+    await gate.releaseAll()
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(coordinator.parts.isEmpty, "a part from a stopped run reached the document")
+    #expect(coordinator.state == .stopped, "a stopped run moved on to another state")
+  }
+
+  // MARK: - Changing the polisher
+
+  /// **The file is never read a second time.** That is the whole reason the raw transcript is kept, and
+  /// the decode call count is the oracle: a re-polish that re-read the file would show two.
+  @Test("changing the polisher re-runs from the transcript, never from the file")
+  func rePolishNeverReadsTheFileAgain() async {
+    let lease = EngineLease()
+    let decodes = Counter()
+    let coordinator = makeCoordinator(
+      lease: lease,
+      decode: { _ in
+        await decodes.bump()
+        return Array(repeating: 0.1, count: 16_000)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    await settleUntil { if case .ready = coordinator.state { return true } else { return false } }
+    coordinator.start()
+    await settleUntil { coordinator.state == .finished }
+    #expect(await decodes.count == 1)
+
+    coordinator.rePolish()
+    await settleUntil { coordinator.state == .finished && !coordinator.parts.isEmpty }
+
+    #expect(await decodes.count == 1, "changing the polisher read the file again")
+    #expect(!coordinator.parts.isEmpty)
+    #expect(lease.isBusy == false, "the re-polish left the engine claimed")
+  }
+}

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -155,6 +155,46 @@ struct FileImportCoordinatorTests {
     #expect(coordinator.canRetry, "the message says try again and nothing offers it")
   }
 
+  /// **An abandoned read is STOPPED, not ignored.**
+  ///
+  /// The generation check answers "whose file is this" after the work is done,
+  /// which is a different question from "should this still be running". A
+  /// three-hour recording decodes to about 690 MB of samples, so picking a
+  /// second file while the first was reading left both running and both arrays
+  /// growing, to throw one away. Found by Codex.
+  ///
+  /// Asserted on the DECODER observing its own cancellation, not on the visible
+  /// state: the screen looks identical either way, which is exactly why this
+  /// went unnoticed.
+  @Test("choosing another file stops the read already in progress")
+  func replacingAFileCancelsItsRead() async {
+    let started = PartGate()
+    let cancelled = CallCounter()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      decode: { _ in
+        // Park inside the decode, and record whether the wait ended because the
+        // task was cancelled — which is what `AudioFileDecoder`'s own
+        // `Task.checkCancellation()` would see.
+        await started.wait()
+        if Task.isCancelled { await cancelled.record() }
+        try Task.checkCancellation()
+        return Self.decoded(seconds: 1.0)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    await settleUntil { await started.entered >= 1 }
+
+    // The user picks a different file while the first is still reading.
+    coordinator.choose(url: URL(fileURLWithPath: "/tmp/second.m4a"))
+    await started.releaseAll()
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(
+      await cancelled.value >= 1,
+      "the abandoned read carried on to the end, holding its samples the whole way")
+  }
+
   /// Try again does what it says: no second read, no second decode.
   @Test("retrying after a busy engine reuses the audio already in memory")
   func retryDoesNotReadTheFileAgain() async {

--- a/Tests/EnviousWisprTests/App/HotkeyControllerAbandonmentDisarmTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerAbandonmentDisarmTests.swift
@@ -133,7 +133,8 @@ struct HotkeyControllerAbandonmentDisarmTests {
         lastUserStopAccess: finalizer.lastUserStopAccess,
         lastRecordingResult: LastRecordingResult(),
         dictationLifecycleCoordinator: nil,
-      recovery: .disabled)
+        // #2648: hotkey disarm behaviour, not admission — the frozen seam.
+        recovery: .disabled, engineAdmission: .alwaysAllowedForTesting)
       let controller = HotkeyController(
         hotkeyService: hotkey, starter: starter, finalizer: finalizer, settings: settings)
       return Fixture(controller: controller, hotkeyService: hotkey, kernelDriver: pipeline)

--- a/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
+++ b/Tests/EnviousWisprTests/App/HotkeyControllerInstallTests.swift
@@ -85,7 +85,10 @@ import Testing
       lastUserStopAccess: finalizer.lastUserStopAccess,
       lastRecordingResult: LastRecordingResult(),
       dictationLifecycleCoordinator: nil,
-      recovery: .disabled
+      recovery: .disabled,
+      // #2648: this suite is about hotkey callback wiring, not admission, so it
+      // takes the frozen always-allow seam rather than a real lease.
+      engineAdmission: .alwaysAllowedForTesting
     )
     let controller = HotkeyController(
       hotkeyService: hotkey,

--- a/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingStarterStartPathTests.swift
@@ -47,6 +47,9 @@ import Testing
     /// What the recovery notice's Discard button reached, and whether the notice
     /// was still up when it did (#2292 C4b).
     let discards: DiscardProbe
+    /// #2648: the real claim the starter was wired to, so an admission row can
+    /// hold it as another workload before pressing record.
+    let engineLease: EngineLease
   }
 
   /// What the pill is showing, as a person would describe it (#2292 C6).
@@ -74,6 +77,21 @@ import Testing
       return false
     }
     return notice.kind == .recovery
+  }
+
+  /// #2648 — the shared-resource refusal, read as the sentence a person sees.
+  ///
+  /// A `.warning` intent renders as a `.notification` notice whose `text` IS
+  /// `DictationNarrator.copy(for:)` (`PillCatalog.swift:210-216`), so comparing
+  /// against the narrator asserts the rendered sentence without freezing a
+  /// second copy of the words in this file.
+  private static func showsSharedEngineBusy(
+    _ overlay: OverlayDirector, holder: SharedEngineHolder
+  ) -> Bool {
+    guard case .notice(let notice)? = overlay.renderModel.state.presentation?.content else {
+      return false
+    }
+    return notice.text == DictationNarrator.copy(for: .sharedEngineBusy(holder: holder))
   }
 
   private static func showsRecording(_ overlay: OverlayDirector) -> Bool {
@@ -143,6 +161,7 @@ import Testing
     )
     let lastRecordingResult = LastRecordingResult()
     let discards = DiscardProbe()
+    let engineLease = EngineLease()
     // `recovering` is a captured var both the arm closure (mutates) and the gate
     // closure (reads) share — lets a test flip recovery ON during the arm await
     // (#1063 PR2: the post-arm re-check). Both run on the MainActor.
@@ -187,7 +206,11 @@ import Testing
         discardActive: {
           discards.count += 1
           discards.noticeWasStillUp.append(Self.showsRecoveryOffer(overlay))
-        })
+        }),
+      // #2648: a REAL lease, not the always-allow seam. The admission rows hold
+      // it as another workload and assert both start routes refuse, which a seam
+      // that always says yes could not show.
+      engineAdmission: .live(lease: engineLease, as: .dictation)
     )
     return Fixture(
       starter: starter,
@@ -202,7 +225,8 @@ import Testing
       overlay: overlay,
       overlayHost: overlayHost,
       settings: settings,
-      discards: discards
+      discards: discards,
+      engineLease: engineLease
     )
   }
 
@@ -637,6 +661,199 @@ import Testing
     #expect(outcome == .noRecording)
   }
 
+
+  // MARK: - #2648 shared-resource admission
+
+  /// **This is the pair the whole safety promise rests on.** `RecordingStarter`
+  /// has exactly two non-private methods that begin a recording, and its ceiling
+  /// suite caps that surface at 3, so a third route cannot be added without
+  /// failing `RecordingStarterCeilingsTests.nonPrivateMethodCount` first. These
+  /// rows cover both of the two that exist.
+  ///
+  /// A pair is the dangerous number: gating one reads exactly like gating both
+  /// (`workflow-process.md`
+  /// RULE: fix-the-path-that-runs-first-not-the-one-you-were-reading), and the
+  /// first draft of this feature gated a facade the hotkey does not even call.
+
+  @Test func pttStartIsRefusedWhileAnotherWorkloadHoldsTheResource() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    guard case .granted = fx.engineLease.admit(.fileImport) else {
+      Issue.record("the fixture's lease was already held")
+      return
+    }
+
+    let outcome = await fx.starter.start()
+
+    #expect(outcome == .noRecording)
+    #expect(fx.kernelDriver.state == .idle, "a refused press must mint no session")
+    #expect(
+      Self.showsSharedEngineBusy(fx.overlay, holder: .fileImport),
+      "the refusal must reach the user, naming the job to wait for")
+  }
+
+  @Test func toggleStartIsRefusedWhileAnotherWorkloadHoldsTheResource() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    guard case .granted = fx.engineLease.admit(.fileImport) else {
+      Issue.record("the fixture's lease was already held")
+      return
+    }
+
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    #expect(fx.kernelDriver.state == .idle, "a refused press must mint no session")
+    #expect(Self.showsSharedEngineBusy(fx.overlay, holder: .fileImport))
+  }
+
+  /// A refused press must not disturb the claim it lost to. Releasing someone
+  /// else's claim would be worse than refusing wrongly: the import would keep
+  /// running while a dictation walked into the same inference slot.
+  @Test func aRefusedPressLeavesTheResourceWithItsHolder() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    _ = fx.engineLease.admit(.fileImport)
+
+    _ = await fx.starter.start()
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    #expect(fx.engineLease.isBusy)
+    #expect(fx.engineLease.currentHolder == .fileImport)
+  }
+
+  /// The refusal is a refusal, not a wedge: once the other workload finishes,
+  /// the very next press gets past this gate.
+  @Test func bothRoutesGetPastTheGateOnceTheResourceIsFree() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    guard case .granted(let importToken) = fx.engineLease.admit(.fileImport) else {
+      Issue.record("the fixture's lease was already held")
+      return
+    }
+    _ = await fx.starter.start()
+    #expect(Self.showsSharedEngineBusy(fx.overlay, holder: .fileImport))
+
+    #expect(fx.engineLease.release(importToken))
+    fx.lastRecordingResult.polishError = "from the previous take"
+    _ = await fx.starter.start()
+
+    // The oracle is a POSITIVE signal from past the gate, not the absence of the
+    // pill. The refusal pill stays on screen until something replaces it, so
+    // "the busy pill is gone" would be asserting that a later step happened to
+    // draw over it. Clearing the previous take's polish error is the first thing
+    // both routes do AFTER the claim, so it says the press got through.
+    #expect(
+      fx.lastRecordingResult.polishError == nil,
+      "a press after the release was still refused for a job that has finished")
+  }
+
+  /// The same row for the OTHER route. The first draft covered `start()` only,
+  /// which is the pair trap this whole gate exists inside: one route passing
+  /// reads exactly like both passing.
+  @Test func theToggleRouteGetsPastTheGateOnceTheResourceIsFree() async {
+    let fx = Self.makeFixture()
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+    guard case .granted(let importToken) = fx.engineLease.admit(.fileImport) else {
+      Issue.record("the fixture's lease was already held")
+      return
+    }
+    await fx.starter.toggle(source: .toggleHotkey)
+    #expect(Self.showsSharedEngineBusy(fx.overlay, holder: .fileImport))
+
+    #expect(fx.engineLease.release(importToken))
+    fx.lastRecordingResult.polishError = "from the previous take"
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    // Same positive oracle as the PTT row above, and for the same reason.
+    #expect(
+      fx.lastRecordingResult.polishError == nil,
+      "the toggle route was still refused for a job that has finished")
+  }
+
+  // **Stopping is never refused — and this suite cannot stage it.** A toggle that
+  // would STOP a running dictation must not consult the claim at all, because
+  // the running session IS the holder: a lease-first toggle would refuse the
+  // user's own stop and leave the recording running with no way to end it. The
+  // guard for that is structural (the claim sits inside `isStartingFromIdle`),
+  // and staging it needs a driver in `.recording`, which `KernelDictationDriver`
+  // exposes no seam for — `state` is computed (`:739`). Asserting it here would
+  // need a fake driver, which would test the fake.
+  //
+  // It is covered as Live UAT instead, on the real app: start a dictation, press
+  // the toggle, confirm it stops. Named here so the gap is visible rather than
+  // absent (#2648).
+
+  /// Ordering, asserted rather than described: recovery refuses FIRST on both
+  /// routes, so the user keeps the pill that carries Discard even though the
+  /// replay is also holding the shared claim.
+  @Test func recoveryRefusalWinsOverTheClaimOnBothRoutes() async {
+    for useToggle in [false, true] {
+      let fx = Self.makeFixture(isRecovering: true)
+      fx.asr.activeBackendType = .parakeet
+      fx.asr.isModelLoaded = true
+      // The replay holds the claim too, which is what a real replay does.
+      _ = fx.engineLease.admit(.crashRecovery)
+
+      if useToggle {
+        await fx.starter.toggle(source: .toggleHotkey)
+      } else {
+        _ = await fx.starter.start()
+      }
+
+      #expect(
+        Self.showsRecoveryOffer(fx.overlay),
+        "the \(useToggle ? "toggle" : "PTT") route showed the generic refusal instead of Discard")
+    }
+  }
+
+  /// **The leak row.** A start that claims the resource and then aborts before
+  /// minting anything has to hand it back, or the next press is refused for a
+  /// dictation that never happened — a limb permanently blocking the heart path.
+  ///
+  /// `recoveringDuringArm` drives the abort through a real gate: recovery starts
+  /// during the recovery-arm await, and the post-arm re-check bails after the
+  /// claim was already taken.
+  @Test func aStartThatAbortsAfterClaimingHandsTheResourceBack() async {
+    let fx = Self.makeFixture(recoveringDuringArm: true)
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+
+    _ = await fx.starter.start()
+
+    #expect(fx.kernelDriver.state == .idle, "the fixture must actually abort for this row to mean anything")
+    #expect(fx.engineLease.isBusy == false, "an aborted start left the shared resource claimed")
+  }
+
+  @Test func aToggleThatAbortsAfterClaimingHandsTheResourceBack() async {
+    let fx = Self.makeFixture(recoveringDuringArm: true)
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+
+    await fx.starter.toggle(source: .toggleHotkey)
+
+    #expect(fx.kernelDriver.state == .idle)
+    #expect(fx.engineLease.isBusy == false, "an aborted toggle left the shared resource claimed")
+  }
+
+  /// A press refused by RECOVERY must not take the claim on its way out either.
+  /// Recovery is refused one gate earlier precisely so its own pill, with its
+  /// Discard button, is what the user sees.
+  @Test func aRecoveryRefusalNeverTouchesTheSharedResource() async {
+    let fx = Self.makeFixture(isRecovering: true)
+    fx.asr.activeBackendType = .parakeet
+    fx.asr.isModelLoaded = true
+
+    _ = await fx.starter.start()
+
+    #expect(Self.showsRecoveryOffer(fx.overlay), "recovery owns this refusal, not the shared claim")
+    #expect(fx.engineLease.isBusy == false)
+  }
+
 }
 
 /// Counts accessibility-refresh invocations for #904. A `@MainActor` reference
@@ -645,4 +862,5 @@ import Testing
 @MainActor
 private final class AXRefreshCounter {
   var count = 0
+
 }

--- a/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/DictationLifecycleCoordinatorCeilingsTests.swift
@@ -69,17 +69,48 @@ import Testing
       """)
   }
 
+  /// #2648 — the combined cap this home never had.
+  ///
+  /// Its collaborator cap counts `let`s that are not closures, so a capability
+  /// stored as a bare closure lands in no bin at all. That is a real shape for a
+  /// single capability and it is what `releaseEngineClaim` is, but "it does not
+  /// count" is not the same as "it costs nothing". The starter's own suite
+  /// learned this the same way (`RecordingStarterCeilingsTests`, the sum cap
+  /// added after cloud review found both per-bin caps individually bypassable).
+  @Test func totalStoredDependencyCount() throws {
+    let body = try RouterCeilingParser.classBody(
+      named: "DictationLifecycleCoordinator", at: Self.sourcePath)
+    let total = RouterCeilingParser.storedDependencyCount(in: body)
+    #expect(
+      total <= 13,
+      """
+      DictationLifecycleCoordinator stored-dependency ceiling exceeded: \(total) > 13. \
+      Twelve collaborators plus #2648's one release capability. Whichever bin a new \
+      dependency lands in, it lands here.
+      """)
+  }
+
   @Test func nonPrivateMethodCount() throws {
     let body = try RouterCeilingParser.classBody(
       named: "DictationLifecycleCoordinator", at: Self.sourcePath)
     let count = RouterCeilingParser.nonPrivateMethodCount(in: body)
+    // #2648: 5 -> 6. `acceptEngineToken(_:)`, which takes ownership of the
+    // running session's claim on the shared ASR-and-polish resource.
+    //
+    // It has to be a method on this home rather than a closure the start path
+    // keeps, because both start methods RETURN while the recording is still
+    // running (`RecordingStarter.swift:437-497`, `:610-626`): the claim must
+    // outlive the call that made it, and this is the type that already owns the
+    // session's terminal transition. The release is a bare closure and did NOT
+    // move the collaborator count, which stays at 12.
     #expect(
-      count <= 5,
+      count <= 6,
       """
       DictationLifecycleCoordinator non-private method ceiling exceeded: \
-      \(count) > 5 non-private `func` declarations. Allowed (PR9 baseline): \
+      \(count) > 6 non-private `func` declarations. Allowed (PR9 baseline): \
       `install()`, `cancelPendingWarning()`, `activeCaptureBackend()`, \
-      `isCurrentSession(_:)`, `activeTelemetryTarget()`.
+      `isCurrentSession(_:)`, `activeTelemetryTarget()`, plus #2648's \
+      `acceptEngineToken(_:)`.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -421,9 +421,13 @@ import Testing
     // `EngineLease` is held by `.fileImport` for the whole run, and recovery's
     // per-item handshake now takes that same claim, so a replay cannot begin
     // underneath one. Full-duration exclusion, which is what (d) means.
+    // Routed through `ActiveEngineOperation` since Codex found the direct
+    // `asrManager` call reached Parakeet and only Parakeet: with All Languages
+    // picked on the Transcription step it threw `ASRManagerNotOwnedError`. The
+    // claim covers this exactly as it covered the direct call.
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift", matcher: "transcribe",
-      text: "return try await asrManager.transcribe(audioSamples: samples, options: options).text",
+      text: "return try await activeEngine.transcribe(samples, options).text",
       classification: .structurallySafe),
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift", matcher: "transcribe",

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -427,11 +427,14 @@ import Testing
     // claim covers this exactly as it covered the direct call.
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift", matcher: "transcribe",
-      text: "return try await activeEngine.transcribe(samples, options).text",
+      // Reshaped to carry the engine's reported language alongside the words:
+      // reducing the result to `.text` discarded the better half of the language
+      // evidence. Same call, same claim covering it.
+      text: "let result = try await activeEngine.transcribe(samples, options)",
       classification: .structurallySafe),
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift", matcher: "transcribe",
-      text: "let transcript = try await transcribe(decodedSamples)",
+      text: "let (transcript, language) = try await transcribe(decodedSamples)",
       classification: .structurallySafe),
     // Not a call at all: the initializer storing the injected closure. Matched
     // because the scanner reads NAMES, which is the right trade — a scanner that

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -175,7 +175,12 @@ import Testing
     /// own claim internally on every invocation, or performs no actual engine
     /// mutation (a pure readiness read, or — #1654 — pure error classification
     /// on a throw path, which mutates nothing and only renames the error
-    /// already in hand).
+    /// already in hand), or (d) — #2648 — reached only while `EngineLease` is
+    /// held for the WORKLOAD's full duration, which is the same full-duration
+    /// mutual exclusion (b) describes, applied to a whole file import rather
+    /// than to one switch: recovery's own admission now takes that same claim
+    /// (`RecoveryCoordinator`, the per-item handshake), so it cannot be granted
+    /// while an import holds it.
     case structurallySafe
     /// Present in source, reachable in theory, but never exercised by current
     /// production configuration (a test-seam override that is always nil in
@@ -412,6 +417,30 @@ import Testing
         reason:
           "recovery's claim does not wait for a just-ended ordinary session's unawaited termination cleanup to finish before this call proceeds"
       )),
+    // #2648 — Transcribe a File. All three sites are reached only while
+    // `EngineLease` is held by `.fileImport` for the whole run, and recovery's
+    // per-item handshake now takes that same claim, so a replay cannot begin
+    // underneath one. Full-duration exclusion, which is what (d) means.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift", matcher: "transcribe",
+      text: "try await asrManager.transcribe(audioSamples: samples, options: .default).text",
+      classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift", matcher: "transcribe",
+      text: "let transcript = try await transcribe(decodedSamples)",
+      classification: .structurallySafe),
+    // Not a call at all: the initializer storing the injected closure. Matched
+    // because the scanner reads NAMES, which is the right trade — a scanner that
+    // tried to tell a call from an assignment would be the approximation
+    // business this inventory's parser rewrite left behind.
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift", matcher: "transcribe",
+      text: "self.transcribe = transcribe",
+      classification: .structurallySafe),
+    CallSite(
+      file: "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift", matcher: "transcribe",
+      text: "self.transcribe = transcribe",
+      classification: .structurallySafe),
     // #1749: recovery's two concrete transcribe routes, reached only after
     // the `load` calls directly above.
     CallSite(
@@ -1905,11 +1934,15 @@ import Testing
   // MARK: 5 — no production consumer uses .alwaysAllowedForTesting
 
   @Test(
-    "no production consumer references .alwaysAllowedForTesting outside its two declaring files")
+    "no production consumer references .alwaysAllowedForTesting outside its declaring files")
   func alwaysAllowedForTestingHasNoProductionConsumer() throws {
     let declaringFiles: Set<String> = [
       "Sources/EnviousWisprASR/EngineMutationScope.swift",
       "Sources/EnviousWisprAppKit/App/RecoveryEngineClaim.swift",
+      // #2648: the shared-resource claim's own test seam, named identically on
+      // purpose so this scan covers it rather than leaving a second, unwatched
+      // always-allow value in the tree.
+      "Sources/EnviousWisprAppKit/App/EngineAdmissionAccess.swift",
     ]
     let hits = try Self.sourceAuthoritySnapshot.get().alwaysAllowedForTesting
     let offenders = hits.filter { hit in

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -423,7 +423,7 @@ import Testing
     // underneath one. Full-duration exclusion, which is what (d) means.
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift", matcher: "transcribe",
-      text: "try await asrManager.transcribe(audioSamples: samples, options: .default).text",
+      text: "return try await asrManager.transcribe(audioSamples: samples, options: options).text",
       classification: .structurallySafe),
     CallSite(
       file: "Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift", matcher: "transcribe",

--- a/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EnviousWisprAppCeilingsTests.swift
@@ -190,9 +190,15 @@ import Testing
       // needs for the onboarding-dismissal policy change. ONE property, not two:
       // the panel seam is consumed by collaborators and is passed through rather
       // than retained here.
-      count <= 42,
+      // #2648: 42 -> 43. `fileImportCoordinator`, Transcribe a File's state
+      // machine. It is held here, on the composition root, for the reason this
+      // cap's own note gives: a new App-owned home belongs on the App struct.
+      // The job outlives every view that shows it — leaving the page and coming
+      // back has to land on whatever the run reached — so a view could not own
+      // it, and the sidebar's running indicator reads the same object.
+      count <= 43,
       """
-      EnviousWisprApp stored-property ceiling exceeded: \(count) > 41. \
+      EnviousWisprApp stored-property ceiling exceeded: \(count) > 43. \
       Raising the ceiling requires a Bible changelog entry. \
       New App-owned homes belong on EnviousWisprApp by design — this cap is \
       a thermostat: raise it deliberately, do not silently bump.

--- a/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/RecordingStarterCeilingsTests.swift
@@ -33,14 +33,26 @@ import Testing
     // tightening a cap on the back of a counter fix would fail the next PR for
     // a reason that has nothing to do with it. Ratchet when a real removal
     // lands.
+    // #2648: 7 -> 8. `engineAdmission`, the claim on the shared ASR-and-polish
+    // resource. Both start routes have to consult it, and the claim has to
+    // outlive the call, so it is a real dependency of this home rather than
+    // something the composition root can hold on its behalf.
+    //
+    // Raised rather than dodged, deliberately. The two shapes that would have
+    // kept the number at 7 were both available and both worse: hiding it inside
+    // the existing `RecoveryAccess` package (recovery's domain, not this one),
+    // or storing it as a bare closure purely because the closure bin had room.
+    // Picking a shape to satisfy a counter is how a cap stops measuring
+    // anything. The SUM cap below is unchanged and is what actually holds.
     #expect(
-      count <= 7,
+      count <= 8,
       """
-      RecordingStarter collaborator ceiling exceeded: \(count) > 7. \
+      RecordingStarter collaborator ceiling exceeded: \(count) > 8. \
       Allowed: audioCapture, asrManager, kernelDriver, whisperKitKernelDriver, \
-      settings, recordingOverlay. Note the closure cap below — a dependency \
-      added as a bare closure does not land here, which is the point of having \
-      both. Raising the ceiling requires a Bible §30 entry.
+      settings, recordingOverlay, recovery, engineAdmission. Note the closure \
+      cap below — a dependency added as a bare closure does not land here, \
+      which is the point of having both. Raising the ceiling requires a Bible \
+      §30 entry.
       """)
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/EngineLeaseTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EngineLeaseTests.swift
@@ -162,4 +162,67 @@ struct EngineLeaseTests {
     #expect(claimed?.holder == holder)
     #expect(lease.currentHolder == holder)
   }
+
+  // MARK: - Counting visits, not sampling states
+
+  /// **The instrument a health probe needs, and the reason it is a COUNTER.**
+  ///
+  /// "Is the engine busy" answers about an instant. A probe needs to know
+  /// whether anything used the engine while its request was in flight, and a
+  /// workload that claims and releases inside that window — a one-part re-polish
+  /// does exactly that — leaves a before sample and an after sample both reading
+  /// false while the probe queued behind it the whole time. Two rounds of review
+  /// each moved a sample; this replaced the instrument.
+  ///
+  /// **The falsification condition, published with the claim:** a further finding
+  /// of the shape "the probe published a verdict measured under contention" means
+  /// the epoch is the wrong instrument, not that it needs a third sample.
+  @Test("a claim taken and released between two readings still moves the counter")
+  func theEpochCountsAVisitTooBriefToSample() {
+    let lease = EngineLease()
+
+    let before = lease.admissionEpoch
+    #expect(!lease.isBusy, "the fixture did not start idle")
+
+    // The whole visit, between the two samples a probe would take.
+    guard case .granted(let token) = lease.admit(.fileImport) else {
+      Issue.record("the lease refused an idle claim")
+      return
+    }
+    lease.release(token)
+
+    #expect(!lease.isBusy, "both samples a probe takes read idle, which is the point")
+    #expect(
+      lease.admissionEpoch != before,
+      "a workload came and went between the samples and the counter did not notice")
+  }
+
+  /// The other direction, so a counter that only ever increased would fail too:
+  /// nothing happening must leave it alone.
+  @Test("a quiet interval does not move the counter")
+  func theEpochIsStillWhenNothingHappens() {
+    let lease = EngineLease()
+    let before = lease.admissionEpoch
+    #expect(lease.admissionEpoch == before)
+  }
+
+  /// A REFUSED claim is not a visit: the workload never reached the engine.
+  @Test("a refused claim does not move the counter")
+  func aRefusalIsNotAVisit() {
+    let lease = EngineLease()
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("the lease refused an idle claim")
+      return
+    }
+    let afterFirst = lease.admissionEpoch
+
+    guard case .refused = lease.admit(.fileImport) else {
+      Issue.record("the lease admitted two workloads")
+      return
+    }
+
+    #expect(
+      lease.admissionEpoch == afterFirst,
+      "a refusal counted as a visit, so a probe would discard a clean verdict")
+  }
 }

--- a/Tests/EnviousWisprTests/Pipeline/EngineLeaseTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EngineLeaseTests.swift
@@ -1,0 +1,165 @@
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #2648 — the exclusive claim on the shared ASR-and-polish resource.
+///
+/// **When this fails, the user starts a dictation in the middle of a file import, both land in the
+/// one-slot polish server, and the dictation silently comes back unpolished.** That is the whole
+/// reason the claim exists, so this suite is product coverage rather than a drift guard.
+///
+/// **It is raced, not driven single-threaded, and that is not optional here.** A single-threaded test
+/// passes identically against an atomic claim and against a `if free { take }` that suspends in the
+/// middle, because one caller can never open the window between the check and the write
+/// (`validation-discipline.md` RULE: a-single-threaded-test-cannot-distinguish-atomic-from-check-then-act).
+/// `RacyLease` below is the two-way control: it is the broken shape — the same claim with one `await`
+/// added between the read and the write — and the same race asserts that it really does hand the
+/// resource to more than one caller. Without that control a green run here would be equally consistent
+/// with the race never having happened.
+///
+/// **Being on an isolated executor is not by itself the protection**, which is what the control shows:
+/// it is isolated too, and it still hands the resource to several callers. What protects the claim is
+/// that `admit` contains no suspension point at all.
+@Suite(.tags(.productOutcome))
+@MainActor
+struct EngineLeaseTests {
+
+  /// How many callers pile onto one claim. 40 matched the measured `mv -n` race that exposed multiple
+  /// simultaneous winners three times in eight rounds, so it is a size known to open real windows.
+  private static let contenders = 40
+
+  /// The granted token, or nil when the claim was refused. Every row below
+  /// except the refusal ones cares only about which of the two it got.
+  private func token(from admission: EngineLease.Admission) -> EngineLease.Token? {
+    guard case .granted(let token) = admission else { return nil }
+    return token
+  }
+
+  // MARK: - The broken shape, kept as a control
+
+  /// `EngineLease` with one suspension point added between the check and the write — the classic
+  /// check-then-act hole that isolation does NOT close, because an actor and the main actor both
+  /// release isolation at every `await`. Written as an actor here only because a non-Sendable
+  /// `@MainActor` class cannot be handed to a task group; the defect being demonstrated is the
+  /// `await`, not which executor it is on. Nothing in production uses this; it exists so the race
+  /// below can be shown to detect the defect it is written to catch.
+  private actor RacyLease {
+    private var held = false
+
+    func acquire() async -> Bool {
+      guard !held else { return false }
+      await Task.yield()
+      held = true
+      return true
+    }
+  }
+
+  // MARK: - The race
+
+  @Test("exactly one of many simultaneous callers gets the resource")
+  func oneWinnerUnderRace() async {
+    let lease = EngineLease()
+
+    let tokens = await withTaskGroup(of: EngineLease.Token?.self) { group in
+      for _ in 0..<Self.contenders {
+        group.addTask { @MainActor [self] in token(from: lease.admit(.fileImport)) }
+      }
+      var collected: [EngineLease.Token?] = []
+      for await token in group { collected.append(token) }
+      return collected
+    }
+
+    // The attempt count is asserted first, so a group that silently ran fewer tasks than it was given
+    // cannot make "exactly one winner" true by arithmetic.
+    #expect(tokens.count == Self.contenders)
+    #expect(tokens.compactMap { $0 }.count == 1)
+    #expect(lease.isBusy)
+  }
+
+  @Test("the race harness can see a check-then-act hole")
+  func theRaceDetectsTheBrokenShape() async {
+    let racy = RacyLease()
+
+    let winners = await withTaskGroup(of: Bool.self) { group in
+      for _ in 0..<Self.contenders {
+        group.addTask { await racy.acquire() }
+      }
+      var count = 0
+      for await won in group where won { count += 1 }
+      return count
+    }
+
+    #expect(
+      winners > 1,
+      """
+      The control did not race: \(winners) winner(s) out of \(Self.contenders). \
+      A control that cannot expose the broken shape makes the sibling test's green meaningless.
+      """)
+  }
+
+  // MARK: - Token identity
+
+  @Test("a token from a finished claim cannot evict the live one")
+  func aStaleTokenCannotRelease() throws {
+    let lease = EngineLease()
+    let stale = try #require(token(from: lease.admit(.fileImport)))
+    #expect(lease.release(stale))
+
+    #expect(token(from: lease.admit(.dictation)) != nil)
+
+    #expect(lease.release(stale) == false)
+    #expect(lease.isBusy)
+    #expect(lease.currentHolder == .dictation)
+  }
+
+  @Test("releasing twice is a no-op the second time")
+  func releaseIsIdempotent() throws {
+    let lease = EngineLease()
+    let claimed = try #require(token(from: lease.admit(.crashRecovery)))
+    #expect(lease.release(claimed))
+    #expect(lease.release(claimed) == false)
+    #expect(lease.isBusy == false)
+  }
+
+  @Test("the resource is claimable again once it is released")
+  func reusableAfterRelease() throws {
+    let lease = EngineLease()
+    let first = try #require(token(from: lease.admit(.fileImport)))
+    #expect(token(from: lease.admit(.dictation)) == nil)
+
+    #expect(lease.release(first))
+    #expect(token(from: lease.admit(.dictation)) != nil)
+    #expect(lease.currentHolder == .dictation)
+  }
+
+  @Test("a refusal names the holder, in the same answer")
+  func aRefusalNamesTheHolder() throws {
+    let lease = EngineLease()
+    _ = try #require(token(from: lease.admit(.fileImport)))
+
+    guard case .refused(let holder) = lease.admit(.dictation) else {
+      Issue.record("a second claim on a held resource must be refused")
+      return
+    }
+    // One answer, not a claim followed by a second "who has it" read: a refusal
+    // that had to ask again would need a fallback for the answer coming back
+    // empty, and that fallback would name a job to wait for that nobody runs.
+    #expect(holder == .fileImport)
+  }
+
+  @Test("nobody holds it to begin with")
+  func startsFree() {
+    let lease = EngineLease()
+    #expect(lease.isBusy == false)
+    #expect(lease.currentHolder == nil)
+  }
+
+  @Test("every holder can take a free resource", arguments: EngineLease.Holder.allCases)
+  func everyHolderCanClaim(_ holder: EngineLease.Holder) {
+    let lease = EngineLease()
+    let claimed = token(from: lease.admit(holder))
+    #expect(claimed != nil)
+    #expect(claimed?.holder == holder)
+    #expect(lease.currentHolder == holder)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/FileImportRealBoundaryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FileImportRealBoundaryTests.swift
@@ -85,7 +85,7 @@ struct FileImportRealBoundaryTests {
     defer { try? FileManager.default.removeItem(at: audioURL.deletingLastPathComponent()) }
 
     // 1. The real decoder, on a real file it has never seen.
-    let samples = try await AudioFileDecoder.decode(url: audioURL)
+    let samples = try await AudioFileDecoder.decode(url: audioURL).samples
     let seconds = Double(samples.count) / AudioConstants.sampleRate
     #expect(seconds > 60, "the fixture is meant to be minutes long; got \(seconds)s")
 

--- a/Tests/EnviousWisprTests/Pipeline/FileImportRealBoundaryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FileImportRealBoundaryTests.swift
@@ -1,0 +1,131 @@
+import EnviousWisprASR
+import EnviousWisprCore
+@preconcurrency import FluidAudio
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #2648 — the whole file-import path on a REAL recording, through the SHIPPED engine.
+///
+/// **What the user sees when this fails:** they pick a recording they already have and get nothing back,
+/// or get somebody's words mangled, or get a document that silently stops partway.
+///
+/// **Why this exists alongside the unit rows.** Every other suite in this feature drives fakes: a decode
+/// closure that returns a constant, a part processor that echoes. They prove the wiring. None of them
+/// proves that a real file, decoded by the real decoder, transcribed by the real model, splits into the
+/// parts the design promises. This is the only row where the audio, the decoder, the engine and the
+/// splitter are all the shipped ones.
+///
+/// **It is gated on the shipped model being installed and reports SKIPPED otherwise**, which is what the
+/// hosted runner does. A skipped receipt is not a passed receipt: the evidence for this row is the
+/// dev-machine run.
+@Suite("File import on a real recording", .serialized, .tags(.productOutcome))
+struct FileImportRealBoundaryTests {
+
+  private enum Fixture {
+    static var installDirectory: URL {
+      ParakeetInstallLocation.directory(dataDirectory: StorageRoot.live.dataDirectory)
+    }
+
+    static var shippedModelIsInstalled: Bool {
+      AsrModels.modelsExist(at: installDirectory, version: .v3)
+    }
+
+    /// Written at test time with the system voice rather than committed as a binary. Three minutes of
+    /// real speech, and deliberately more than 500 words, because a recording that fits in one part
+    /// would prove nothing about splitting.
+    static func writeSpokenRecording() throws -> (url: URL, wordCount: Int) {
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("file-import-real-\(UUID().uuidString)")
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+      let sentences = [
+        "Good morning everyone, thanks for joining the weekly product review.",
+        "The first item is the transcription latency work that landed last week.",
+        "We measured the median at just under a second on the reference machine.",
+        "The second item is the file import feature that we are testing right now.",
+        "A user records a lecture on their phone and wants clean text out of it.",
+        "Each part goes through the same chain a normal dictation goes through.",
+        "If one part fails to clean up we still show the raw words for that passage.",
+        "The third item is the engine lock that stops two jobs using one model at once.",
+        "Now the record button politely refuses and tells you what is running.",
+      ]
+      var script: [String] = []
+      var index = 0
+      while script.joined(separator: " ").split(separator: " ").count < 560 {
+        script.append(sentences[index % sentences.count])
+        index += 1
+      }
+      let text = script.joined(separator: " ")
+
+      let scriptURL = dir.appendingPathComponent("script.txt")
+      try text.write(to: scriptURL, atomically: true, encoding: .utf8)
+      let audioURL = dir.appendingPathComponent("recording.aiff")
+
+      let say = Process()
+      say.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+      say.arguments = ["-o", audioURL.path, "-f", scriptURL.path]
+      try say.run()
+      say.waitUntilExit()
+      guard say.terminationStatus == 0 else {
+        throw NSError(domain: "FileImportRealBoundary", code: Int(say.terminationStatus))
+      }
+      return (audioURL, text.split(separator: " ").count)
+    }
+  }
+
+  @Test(
+    "a real multi-minute recording decodes, transcribes, and splits into parts",
+    .enabled(if: Fixture.shippedModelIsInstalled),
+    .tags(.realBoundary)
+  )
+  func aRealRecordingBecomesParts() async throws {
+    let (audioURL, spokenWords) = try Fixture.writeSpokenRecording()
+    defer { try? FileManager.default.removeItem(at: audioURL.deletingLastPathComponent()) }
+
+    // 1. The real decoder, on a real file it has never seen.
+    let samples = try await AudioFileDecoder.decode(url: audioURL)
+    let seconds = Double(samples.count) / AudioConstants.sampleRate
+    #expect(seconds > 60, "the fixture is meant to be minutes long; got \(seconds)s")
+
+    // 2. The shipped model, reading cache only so this row can never download or repair bytes.
+    let backend = ParakeetBackend()
+    let transcript: String
+    do {
+      try await backend.prepare(
+        cacheOnly: true, modelDirectory: Fixture.installDirectory, progressCallback: nil)
+      transcript = try await backend.transcribe(audioSamples: samples, options: .default).text
+      await backend.unload()
+    } catch {
+      await backend.unload()
+      throw error
+    }
+
+    // The engine heard SPEECH, not silence. A loose floor on purpose: this row is about the path, and
+    // pinning the exact words would make it a test of the recogniser instead.
+    let heardWords = transcript.split(whereSeparator: { $0.isWhitespace }).count
+    #expect(
+      heardWords > spokenWords / 2,
+      "the engine returned \(heardWords) words for \(spokenWords) spoken: \(transcript.prefix(200))"
+    )
+
+    // 3. The real splitter, on the engine's real output.
+    let parts = TranscriptSplitter.split(transcript)
+    #expect(parts.count >= 2, "a \(heardWords)-word transcript should not fit in one part")
+    for (index, part) in parts.enumerated() {
+      let count = TranscriptSplitter.wordCount(in: part)
+      #expect(
+        count >= 1 && count <= TranscriptSplitter.maximumWordsPerPart,
+        "part \(index) holds \(count) words, outside 1...500")
+    }
+    // Nothing lost and nothing duplicated, on words a person actually said rather than on a fixture.
+    let partWords: [String] = parts.flatMap { part -> [String] in
+      part.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+    }
+    let transcriptWords: [String] = transcript
+      .split(whereSeparator: { $0.isWhitespace })
+      .map(String.init)
+    #expect(partWords == transcriptWords, "the parts are not the transcript's words in order")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/FileImportRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FileImportRunnerTests.swift
@@ -90,4 +90,38 @@ struct FileImportRunnerTests {
     #expect(outcome.displayText == "The polished sentence.")
     #expect(!outcome.isUnpolished)
   }
+
+  /// **A step that was never asked to run did not fail.**
+  ///
+  /// With the user's polisher set to None, every part comes back with no
+  /// polished text — the same shape as a part whose polisher was asked and could
+  /// not answer. One field carried both meanings, so a document the user
+  /// deliberately chose not to have polished was marked, passage by passage,
+  /// "This passage could not be cleaned up": the app accusing itself of failing
+  /// at something nobody asked for. Found by Codex.
+  ///
+  /// The deterministic cleanup DID run and DID succeed, which is why the text is
+  /// still worth showing without a warning over it.
+  @Test("a part nobody asked to polish is not reported as a failure")
+  func skippedPolishIsNotAFailure() {
+    let skipped = FileImportRunner.PartOutcome(
+      text: "the deterministic floor", polishedText: nil, polishError: nil,
+      polishAttempted: false)
+
+    #expect(skipped.displayText == "the deterministic floor")
+    #expect(!skipped.isUnpolished, "a skipped polish was reported as a failed one")
+    #expect(!skipped.wasPolishAttempted)
+  }
+
+  /// The other direction, so a rule that called everything "skipped" would fail
+  /// too: an asked-for polish that did not answer IS a failure and stays marked.
+  @Test("a polish that was asked for and did not answer is still a failure")
+  func attemptedPolishThatFailedIsStillMarked() {
+    let failed = FileImportRunner.PartOutcome(
+      text: "the deterministic floor", polishedText: nil, polishError: "provider unavailable",
+      polishAttempted: true)
+
+    #expect(failed.isUnpolished, "a real polish failure stopped being marked")
+    #expect(failed.wasPolishAttempted)
+  }
 }

--- a/Tests/EnviousWisprTests/Pipeline/FileImportRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/FileImportRunnerTests.swift
@@ -1,0 +1,93 @@
+import EnviousWisprLLM
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #2648 — the chain one part of an imported transcript runs through.
+///
+/// **When this fails, an imported recording of somebody else's meeting comes back with the user's saved
+/// snippet text substituted into it, or with a limb silently missing.** Product coverage.
+@Suite(.tags(.productOutcome))
+@MainActor
+struct FileImportRunnerTests {
+
+  private func makeSteps() -> LimbSteps {
+    LimbSteps(
+      snippetExpansion: SnippetExpansionStep(),
+      wordCorrection: WordCorrectionStep(),
+      fillerRemoval: FillerRemovalStep(),
+      emojiFormatter: EmojiFormatterStep(),
+      inverseTextNormalization: InverseTextNormalizationStep(),
+      llmPolish: LLMPolishStep(keychainManager: KeychainManager()),
+      emojiRestore: EmojiRestoreStep())
+  }
+
+  /// **Snippet expansion must not run on an imported file.** A trigger word spoken by somebody in a
+  /// recording would be replaced by the user's saved text, putting words the speaker never said into a
+  /// transcript of their speech.
+  ///
+  /// Asserted STRUCTURALLY — by type, over the real chain — rather than by comparing against a list
+  /// written here. A list written here would be a second opinion that can drift.
+  @Test("the import chain contains no snippet expansion")
+  func importChainExcludesSnippetExpansion() {
+    let steps = makeSteps()
+
+    #expect(!steps.orderedChainForFileImport.contains { $0 is SnippetExpansionStep })
+    #expect(
+      steps.orderedChain.contains { $0 is SnippetExpansionStep },
+      "the control: the ordinary chain DOES include it, so the assertion above is about the filter")
+  }
+
+  /// **Every other limb must still run**, and the import chain must not be a hand-written list that
+  /// drifts from the one place the order is declared.
+  ///
+  /// This is the row that fails when someone adds a limb to `orderedChain` and forgets imports: the
+  /// counts stop agreeing. It is derived from the producer on both sides, so it cannot be satisfied by
+  /// updating a literal.
+  @Test("the import chain is the ordinary chain minus exactly one step, in the same order")
+  func importChainIsDerivedFromTheOrderedChain() {
+    let steps = makeSteps()
+    let ordinary = steps.orderedChain
+    let imported = steps.orderedChainForFileImport
+
+    #expect(imported.count == ordinary.count - 1)
+    let ordinaryWithoutSnippets = ordinary.filter { !($0 is SnippetExpansionStep) }
+    #expect(
+      zip(imported, ordinaryWithoutSnippets).allSatisfy {
+        ObjectIdentifier(type(of: $0)) == ObjectIdentifier(type(of: $1))
+      },
+      "the import chain is not the ordinary chain's order with the snippet step removed")
+  }
+
+  /// A part cannot run before the import's configuration is frozen. This is a programming error rather
+  /// than a user-facing one, and it fails loudly instead of running under whatever the defaults happen
+  /// to be — which would silently polish with the wrong provider.
+  @Test("a part refuses to run before the import is configured")
+  func partRefusesBeforeFreeze() async {
+    let runner = FileImportRunner(keychainManager: KeychainManager())
+
+    await #expect(throws: FileImportRunnerError.notConfigured) {
+      _ = try await runner.process(part: "some words")
+    }
+  }
+
+  /// The floor: a part whose polish did not land shows its deterministic text and is MARKED, never
+  /// hidden and never dropped.
+  @Test("an unpolished part reports itself as unpolished and still carries text")
+  func unpolishedPartKeepsItsText() {
+    let outcome = FileImportRunner.PartOutcome(
+      text: "the deterministic floor", polishedText: nil, polishError: "provider unavailable")
+
+    #expect(outcome.displayText == "the deterministic floor")
+    #expect(outcome.isUnpolished)
+  }
+
+  @Test("a polished part shows the polished text")
+  func polishedPartShowsPolish() {
+    let outcome = FileImportRunner.PartOutcome(
+      text: "the floor", polishedText: "The polished sentence.", polishError: nil)
+
+    #expect(outcome.displayText == "The polished sentence.")
+    #expect(!outcome.isUnpolished)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptSplitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptSplitterTests.swift
@@ -66,6 +66,22 @@ struct TranscriptSplitterTests {
     text.split(whereSeparator: { $0.isWhitespace }).map(String.init)
   }
 
+  /// The round-trip oracle that works for EVERY script.
+  ///
+  /// A word list cannot express the property for Japanese, Chinese or Thai:
+  /// those have no spaces, so the whole transcript is one "word" and cutting it
+  /// — which is exactly what the byte ceiling requires — makes two. The
+  /// characters themselves are the thing that must survive in order, with the
+  /// whitespace dropped because the splitter may cut at a space.
+  private static func kept(_ text: String) -> [Character] {
+    text.filter { !$0.isWhitespace }
+  }
+
+  /// Repeated Japanese, the shape that produced a single 10,500-character part.
+  private static func japanese(sentences: Int) -> String {
+    String(repeating: "これは製品レビューの会議の記録です。", count: sentences)
+  }
+
   // MARK: - The two properties, over many shapes at once
 
   /// Every part is 1...500 words, and the parts together are the input's words in order.
@@ -91,6 +107,67 @@ struct TranscriptSplitterTests {
     #expect(
       parts.flatMap(Self.words) == Self.words(transcript),
       "the parts are not the transcript's words in order (seed \(seed))")
+    #expect(parts.flatMap(Self.kept) == Self.kept(transcript))
+  }
+
+  // MARK: - Languages that do not put spaces between words
+
+  /// **The word ceiling cannot see this input at all.** 600 repeated Japanese
+  /// sentences hold two whitespace-separated "words" — effectively none — so a
+  /// splitter bounded only by words returns the whole recording as ONE part.
+  /// Measured before the byte ceiling: 10,500 characters, about 31,000 UTF-8
+  /// bytes, which the local polisher's context preflight refuses outright, so
+  /// the user's entire recording came back unpolished.
+  @Test("a Japanese recording is cut into parts the polisher will accept")
+  func japaneseIsBoundedByBytes() {
+    let transcript = Self.japanese(sentences: 600)
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(parts.count > 1, "the whole Japanese transcript came back as one part")
+    for (index, part) in parts.enumerated() {
+      #expect(
+        part.utf8.count <= TranscriptSplitter.maximumBytesPerPart,
+        "part \(index) is \(part.utf8.count) bytes, over the ceiling")
+    }
+    #expect(
+      parts.flatMap(Self.kept) == Self.kept(transcript),
+      "the Japanese transcript did not survive the split")
+  }
+
+  /// Thai, which has no sentence-ending punctuation either, so the tokenizer
+  /// has less to work with and the character path does more of the work.
+  @Test("a Thai run with no punctuation is still bounded")
+  func thaiIsBounded() {
+    let transcript = String(repeating: "สวัสดีครับนี่คือการบันทึกการประชุม", count: 400)
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(parts.allSatisfy { $0.utf8.count <= TranscriptSplitter.maximumBytesPerPart })
+    #expect(parts.flatMap(Self.kept) == Self.kept(transcript))
+  }
+
+  /// A character is never cut in half, which would produce mojibake in the
+  /// user's document rather than merely a badly placed break.
+  @Test("no part ever splits a multi-byte character")
+  func multiByteCharactersSurvive() {
+    let transcript = String(repeating: "🇯🇵日本語のテキストです。", count: 500)
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(parts.joined().unicodeScalars.count == transcript.unicodeScalars.count)
+    #expect(parts.flatMap(Self.kept) == Self.kept(transcript))
+  }
+
+  /// The English ceiling still binds: adding a byte ceiling must not make the
+  /// word ceiling stop mattering.
+  @Test("English is still bounded by words, not only by bytes")
+  func englishStillUsesTheWordCeiling() {
+    let transcript = (0..<900).map { _ in "a" }.joined(separator: " ")
+    let parts = TranscriptSplitter.split(transcript)
+
+    // 900 single-letter words is 1,799 bytes — under the byte ceiling — so only
+    // the word ceiling can produce more than one part here.
+    #expect(transcript.utf8.count < TranscriptSplitter.maximumBytesPerPart)
+    #expect(parts.count == 2)
+    #expect(parts.allSatisfy { TranscriptSplitter.wordCount(in: $0) <= 500 })
   }
 
   // MARK: - The cases the plan named
@@ -154,7 +231,7 @@ struct TranscriptSplitterTests {
     let parts = TranscriptSplitter.split(transcript)
 
     #expect(!parts.isEmpty)
-    #expect(parts.flatMap(Self.words) == Self.words(transcript))
+    #expect(parts.flatMap(Self.kept) == Self.kept(transcript))
     #expect(parts.allSatisfy { TranscriptSplitter.wordCount(in: $0) <= 500 })
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/TranscriptSplitterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TranscriptSplitterTests.swift
@@ -1,0 +1,177 @@
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #2648 — cutting one long transcript into the parts the cleanup chain runs on.
+///
+/// **When this fails, the user's imported recording comes back with words missing, words duplicated, or
+/// a passage silently truncated** — the last one because a part over the ceiling loses its end inside
+/// the polisher rather than failing. Product coverage.
+///
+/// **The ceiling is asserted as a RANGE and the round trip as a SEQUENCE.** Two properties, and neither
+/// implies the other: a splitter that drops every second sentence obeys the ceiling perfectly, and one
+/// that returns the whole transcript as one part round-trips perfectly.
+@Suite(.tags(.productOutcome))
+struct TranscriptSplitterTests {
+
+  // MARK: - Inputs
+
+  /// Deterministic prose with real sentence structure: varied lengths, abbreviations, decimals,
+  /// quotes and questions, all of which a punctuation rule gets wrong and a tokenizer does not.
+  private static func prose(sentences: Int, seed: UInt64) -> String {
+    var rng = SplitMix64(seed: seed)
+    let shapes = [
+      "The %@ was %@ by about %@ percent, which nobody expected.",
+      "Dr. %@ said the %@ arrives at 3.5 percent, i.e. roughly %@.",
+      "Was the %@ ever %@? %@ thought so.",
+      "\"The %@ is %@,\" she said, \"and %@ knows it.\"",
+      "%@ %@ %@.",
+    ]
+    let words = [
+      "meeting", "transcript", "engine", "recording", "budget", "latency", "founder", "release",
+      "signal", "threshold", "session", "cadence",
+    ]
+    var out: [String] = []
+    for _ in 0..<sentences {
+      let shape = shapes[Int(rng.next() % UInt64(shapes.count))]
+      var filled = shape
+      while let range = filled.range(of: "%@") {
+        filled.replaceSubrange(range, with: words[Int(rng.next() % UInt64(words.count))])
+      }
+      out.append(filled)
+    }
+    return out.joined(separator: " ")
+  }
+
+  /// Unpunctuated output, which is what an ASR engine produces on a speaker who does not pause.
+  private static func runOn(words: Int) -> String {
+    (0..<words).map { "word\($0)" }.joined(separator: " ")
+  }
+
+  /// A small deterministic generator, so a failing case is reproducible from its seed rather than
+  /// being a story about a run nobody can repeat.
+  private struct SplitMix64 {
+    private var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+      state &+= 0x9E37_79B9_7F4A_7C15
+      var z = state
+      z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+      z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+      return z ^ (z >> 31)
+    }
+  }
+
+  private static func words(_ text: String) -> [String] {
+    text.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+  }
+
+  // MARK: - The two properties, over many shapes at once
+
+  /// Every part is 1...500 words, and the parts together are the input's words in order.
+  ///
+  /// Run over generated inputs rather than one fixture: a single example proves the splitter handles
+  /// that example. The seeds are fixed, so a failure names an input that can be reproduced exactly.
+  @Test(
+    "every part is within the ceiling and the parts are the whole transcript, in order",
+    arguments: [
+      (12, UInt64(1)), (60, UInt64(2)), (140, UInt64(3)), (400, UInt64(4)), (900, UInt64(5)),
+    ])
+  func ceilingAndRoundTripHold(_ sentenceCount: Int, _ seed: UInt64) {
+    let transcript = Self.prose(sentences: sentenceCount, seed: seed)
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(!parts.isEmpty, "a transcript with words produced no parts")
+    for (index, part) in parts.enumerated() {
+      let count = TranscriptSplitter.wordCount(in: part)
+      #expect(
+        count >= 1 && count <= TranscriptSplitter.maximumWordsPerPart,
+        "part \(index) of seed \(seed) holds \(count) words, outside 1...500")
+    }
+    #expect(
+      parts.flatMap(Self.words) == Self.words(transcript),
+      "the parts are not the transcript's words in order (seed \(seed))")
+  }
+
+  // MARK: - The cases the plan named
+
+  @Test("a sentence of exactly the ceiling stays whole")
+  func exactlyTheCeilingStaysWhole() {
+    let transcript = Self.runOn(words: 500) + "."
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(parts.count == 1)
+    #expect(TranscriptSplitter.wordCount(in: parts[0]) == 500)
+  }
+
+  @Test("a sentence one word over the ceiling is cut, and loses nothing")
+  func oneWordOverIsCut() {
+    let transcript = Self.runOn(words: 501) + "."
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(parts.count == 2)
+    #expect(TranscriptSplitter.wordCount(in: parts[0]) == 500)
+    #expect(TranscriptSplitter.wordCount(in: parts[1]) == 1)
+    #expect(parts.flatMap(Self.words) == Self.words(transcript))
+  }
+
+  /// The shape unpunctuated ASR actually produces. 972 words with no full stop at all: the sentence
+  /// tokenizer finds one sentence, and the word-boundary path has to do all the work.
+  @Test("a 972-word run-on with no punctuation is cut at word boundaries")
+  func longRunOnIsCut() {
+    let transcript = Self.runOn(words: 972)
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(parts.count == 2)
+    #expect(parts.allSatisfy { TranscriptSplitter.wordCount(in: $0) <= 500 })
+    #expect(parts.flatMap(Self.words) == Self.words(transcript))
+  }
+
+  /// A run-on that is packed AFTER other sentences must not swallow them: everything already packed is
+  /// emitted first. Without that, the sentences before the run-on would be re-cut by the run-on's own
+  /// boundaries and the part before it would exceed the ceiling.
+  @Test("a run-on after ordinary sentences does not absorb them")
+  func aRunOnDoesNotAbsorbWhatCameBefore() {
+    let transcript = "Short one. Short two. " + Self.runOn(words: 700)
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(parts.count >= 3)
+    #expect(parts[0].contains("Short one"))
+    #expect(parts.allSatisfy { TranscriptSplitter.wordCount(in: $0) <= 500 })
+    #expect(parts.flatMap(Self.words) == Self.words(transcript))
+  }
+
+  /// Non-English punctuation, where a full-stop rule would find no boundaries at all and hand the
+  /// whole passage to the word-boundary path.
+  @Test(
+    "sentences are found in scripts that do not use a full stop",
+    arguments: [
+      "これは最初の文です。これは二番目の文です。これは三番目の文です。",
+      "هذه هي الجملة الأولى؟ وهذه هي الثانية! وهذه هي الثالثة.",
+      "Πρώτη πρόταση; Δεύτερη πρόταση; Τρίτη πρόταση.",
+    ])
+  func nonEnglishPunctuationIsHandled(_ transcript: String) {
+    let parts = TranscriptSplitter.split(transcript)
+
+    #expect(!parts.isEmpty)
+    #expect(parts.flatMap(Self.words) == Self.words(transcript))
+    #expect(parts.allSatisfy { TranscriptSplitter.wordCount(in: $0) <= 500 })
+  }
+
+  // MARK: - Nothing to do
+
+  @Test("a transcript with no words produces no parts", arguments: ["", "   ", "\n\n\t "])
+  func emptyProducesNothing(_ transcript: String) {
+    #expect(TranscriptSplitter.split(transcript).isEmpty)
+  }
+
+  /// The word count is whitespace runs, deliberately, because that is the definition the 500 was
+  /// measured against. A tokenizer-based count would report a different number for the same text and
+  /// the ceiling would quietly mean something else.
+  @Test("a hyphenated compound and a contraction each count as one word")
+  func wordCountMatchesTheMeasuredDefinition() {
+    #expect(TranscriptSplitter.wordCount(in: "well-known") == 1)
+    #expect(TranscriptSplitter.wordCount(in: "don't") == 1)
+    #expect(TranscriptSplitter.wordCount(in: "  two   words  ") == 2)
+  }
+}

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -84,6 +84,9 @@ struct RecoveryCoordinatorTests {
     /// construction (e.g. from a concurrently-spawned Task simulating a live
     /// press that mints its own session mid-scan).
     let dictationActiveBox: Box<Bool>
+    /// #2648: the real claim on the shared ASR-and-polish resource, so a row can
+    /// hold it as another workload and assert a replay defers.
+    let engineLease: EngineLease
   }
 
   /// `existing` and `dictationActive` are boxed so a test can mutate them after
@@ -106,6 +109,7 @@ struct RecoveryCoordinatorTests {
     // The probe needs the coordinator, set after construction.
     var coordinatorRef: RecoveryCoordinator?
     let replayer = FakeReplayer(isRecoveringProbe: { coordinatorRef?.isRecovering ?? false })
+    let engineLease = EngineLease()
     let coordinator = RecoveryCoordinator(
       keyStore: keyStore,
       makeSpoolStore: { RecoverySpoolStore(directory: spoolDir) },
@@ -113,12 +117,16 @@ struct RecoveryCoordinatorTests {
       existingRecoveryIDs: { existingBox.value },
       isDictationActive: { activeBox.value },
       recoveryEngineClaim: recoveryEngineClaim,
+      // #2648: a real lease, so a row can hold it as a file import and watch a
+      // replay item defer rather than run on top of one.
+      engineAdmission: .live(lease: engineLease, as: .crashRecovery),
       resetEngine: { resetEngineCount.value += 1 })
     coordinatorRef = coordinator
     return Harness(
       coordinator: coordinator, keyStore: keyStore,
       spoolStore: RecoverySpoolStore(directory: spoolDir), replayer: replayer,
-      resetEngineCount: resetEngineCount, dictationActiveBox: activeBox)
+      resetEngineCount: resetEngineCount, dictationActiveBox: activeBox,
+      engineLease: engineLease)
   }
 
   private static func writeSpool(_ store: RecoverySpoolStore, _ id: String) throws {
@@ -1103,6 +1111,55 @@ struct RecoveryCoordinatorTests {
 
   // MARK: - #1707 Phase 3: nextLaunchOnlyRecoveryIDs
 
+  // MARK: - #2648 the shared ASR-and-polish resource
+
+  /// A replay runs the same polish server a file import does
+  /// (`RecoveryTextProcessor.swift:62`), so recovery has to take the same
+  /// one-workload claim. While an import holds it, the orphan stays on disk and
+  /// the next scan retries — exactly what the two contention guards beside it
+  /// already do for a live dictation and an engine switch.
+  ///
+  /// **When this fails, an import and a crash replay run on one inference slot
+  /// at the same time**, and the user's recovered take comes back unpolished
+  /// while the import's parts queue behind it.
+  @Test("a replay defers while another workload holds the shared engine")
+  func replayDefersWhileTheSharedEngineIsHeld() async throws {
+    let h = Self.makeHarness()
+    let orphanID = "held-engine-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, orphanID)
+    guard case .granted(let importToken) = h.engineLease.admit(.fileImport) else {
+      Issue.record("a fresh lease refused the first claim")
+      return
+    }
+
+    await h.coordinator.scanAndRecover()
+
+    #expect(h.replayer.replayedIDs.isEmpty, "no replay may start while the engine is held")
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: orphanID).path),
+      "a deferred orphan stays on disk")
+
+    // And it is a deferral, not a discard: once the import finishes, the next
+    // scan picks the same orphan up.
+    #expect(h.engineLease.release(importToken))
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs == [orphanID])
+  }
+
+  /// The claim is handed back when the item finishes, or the first crash replay
+  /// after launch would block every dictation for the life of the app.
+  @Test("a finished replay hands the shared engine back")
+  func aFinishedReplayReleasesTheSharedEngine() async throws {
+    let h = Self.makeHarness()
+    let orphanID = "release-after-replay-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, orphanID)
+
+    await h.coordinator.scanAndRecover()
+
+    #expect(h.replayer.replayedIDs == [orphanID], "the fixture must actually replay")
+    #expect(h.engineLease.isBusy == false, "a finished replay left the shared engine claimed")
+  }
+
   /// #1740 narrowed this to ONE case: `.failed(.saveMarkerClearFailed)` no longer
   /// exists, and launch-replay `.failed(.save)` now DELETES and relies on its
   /// committed marker rather than on this set.
@@ -1585,7 +1642,9 @@ struct RecoveryCoordinatorTests {
       replayer: replayer,
       existingRecoveryIDs: { [] },
       isDictationActive: { false },
-      recoveryEngineClaim: .alwaysAllowedForTesting)
+      recoveryEngineClaim: .alwaysAllowedForTesting,
+      // #2648: this row is about a failing key store, not admission.
+      engineAdmission: .alwaysAllowedForTesting)
     let result = await coordinator.makeDirective(
       settings: Self.freshSettings(crashRecoveryEnabled: true),
       backendType: .parakeet, supportsLanguageDetection: false)

--- a/Tests/EnviousWisprTests/Views/TranscribeFilePrivacyFooterTests.swift
+++ b/Tests/EnviousWisprTests/Views/TranscribeFilePrivacyFooterTests.swift
@@ -1,0 +1,85 @@
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2648 — the privacy line under Transcribe a File.
+///
+/// **When this fails, the page tells the user their text is staying on this Mac while it is being sent
+/// to a cloud provider.** The footer is the only place the page states where the words go, so it is a
+/// product promise, not decoration. Product coverage.
+///
+/// **Exhaustive over the step enum, deliberately.** The first build of this footer answered the cloud
+/// question on four steps and answered it wrongly on the fifth, which is the one during which the text
+/// is actually in flight. A per-step spot check would have passed. Adding a seventh step fails this
+/// suite until somebody decides what it says.
+@Suite("Transcribe a File privacy footer (#2648)", .tags(.productOutcome))
+struct TranscribeFilePrivacyFooterTests {
+
+  /// Phrases that promise the TEXT does not leave the machine. Each is checked against the sentence
+  /// the user actually reads, not against the branch that produced it.
+  private static let staysHerePromises = [
+    "text both stay on this Mac",
+    "Your untouched words are kept beside this one",
+  ]
+
+  @Test("no step promises the text stays here while cloud polish is chosen")
+  func cloudPolishNeverClaimsTheTextStaysHere() {
+    for step in [
+      FileImportCoordinator.Step.upload, .transcription, .polish, .review, .working, .done,
+    ] {
+      let line = TranscribeFileView.footerDetail(step: step, isCloudPolish: true)
+      for promise in Self.staysHerePromises {
+        #expect(
+          !line.contains(promise),
+          "the \(step.title) step tells a cloud-polish user \"\(line)\"")
+      }
+      #expect(
+        line.contains("provider you chose"),
+        "the \(step.title) step never says where the text goes: \"\(line)\"")
+    }
+  }
+
+  /// The other direction, so a footer that said "goes to the provider" on every step would fail too.
+  @Test("every step promises both stay here when no cloud polisher is chosen")
+  func localPolishAlwaysSaysBothStayHere() {
+    for step in [
+      FileImportCoordinator.Step.upload, .transcription, .polish, .review, .working, .done,
+    ] {
+      let line = TranscribeFileView.footerDetail(step: step, isCloudPolish: false)
+      #expect(
+        !line.contains("provider"),
+        "the \(step.title) step mentions a provider with none chosen: \"\(line)\"")
+    }
+  }
+
+  /// The audio claim is the one half that is true on EVERY path, so it must never be qualified away.
+  @Test("no step ever suggests the audio leaves the Mac")
+  func theAudioClaimHoldsEverywhere() {
+    for cloud in [true, false] {
+      for step in [
+        FileImportCoordinator.Step.upload, .transcription, .polish, .review, .working, .done,
+      ] {
+        let line = TranscribeFileView.footerDetail(step: step, isCloudPolish: cloud)
+        #expect(
+          !line.lowercased().contains("audio is sent")
+            && !line.lowercased().contains("audio goes"),
+          "the \(step.title) step suggests the recording is uploaded: \"\(line)\"")
+      }
+    }
+  }
+
+  /// House rule: no em or en dash in any user-facing string.
+  @Test("the footer carries no em or en dash")
+  func noDashes() {
+    for cloud in [true, false] {
+      for step in [
+        FileImportCoordinator.Step.upload, .transcription, .polish, .review, .working, .done,
+      ] {
+        let line =
+          TranscribeFileView.footerLead(step: step)
+          + TranscribeFileView.footerDetail(step: step, isCloudPolish: cloud)
+        #expect(!line.contains("\u{2014}") && !line.contains("\u{2013}"), "dash in \"\(line)\"")
+      }
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Views/TranscribeFilePrivacyFooterTests.swift
+++ b/Tests/EnviousWisprTests/Views/TranscribeFilePrivacyFooterTests.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Testing
 
 @testable import EnviousWisprAppKit
@@ -65,6 +66,28 @@ struct TranscribeFilePrivacyFooterTests {
             && !line.lowercased().contains("audio goes"),
           "the \(step.title) step suggests the recording is uploaded: \"\(line)\"")
       }
+    }
+  }
+
+  /// **Review is the screen that confirms what is about to happen, so it must be
+  /// able to name every polisher that can actually run.**
+  ///
+  /// The label came from `polishChoices`, a hand-written list of the six tiles
+  /// the grid renders. S1-mini is not one of them, so a user who had selected it
+  /// in AI Polish was told "No polish" while the freeze kept S1-mini and the
+  /// runner ran it. A list of what to DISPLAY cannot answer a question about
+  /// what will RUN. Found by Codex.
+  ///
+  /// Exhaustive over the provider enum: a seventh provider fails this until
+  /// somebody decides what Review says about it.
+  @Test("Review names every provider that can run, including ones with no tile")
+  func reviewNamesEveryProvider() {
+    for provider in LLMProvider.allCases {
+      let name = provider.displayName
+      #expect(!name.isEmpty, "\(provider) has no name for Review to show")
+      #expect(
+        !TranscribeFileView.availability(provider).isEmpty || provider == .none,
+        "\(provider) has no 'Runs on' line, so Review would show a blank row")
     }
   }
 


### PR DESCRIPTION
## Transcribe a File

Pick an audio or video file, get clean text back. Voice memos, lectures, meetings.

Part of #2648. Gate 2 was passed on 2026-09-04 (`docs/feature-requests/issue-2648-2026-09-04-transcribe-a-file.md`); this is all seven approved chunks, built in the approved order, plus the page rebuilt as the approved prototype rather than as the plan's prose.

### What the user does

Sidebar → **Transcribe a File**. Six steps, each with its own screen: Upload, Transcription, Polish, Review, Working, Done. The step bar is always visible, a finished step fills its circle, and a completed step can be gone back to while nothing has run. The document fills in with the words themselves as each part lands. Stop at any time and keep what finished. Copy, or change the polisher and re-run without the file being read again.

Both engines are chosen on their own screens, and those screens WRITE the app's own settings — the same doors the Speech Engine and AI Polish pages use. A private per-import copy was tried first and is gone: see round 2 below, where it turned out to have made both choice screens decorative.

The splitting is never user-facing: progress reads "62%", never "part 3 of 14".

### The page was rebuilt

The first build was written from the plan's prose rather than from the approved clickable prototype (`.claude/experiments/2648-file-import/import-prototype.html`), and the founder's verdict on seeing it was that it looked nothing like the mock.

The visual pass takes its values from the prototype rather than from judgement: 36pt tinted icon tiles, a 50pt tile in the drop zone over a filled card with a 1.5px dashed border, pill-shaped format chips, the four promises as ONE panel divided by hairlines rather than four separate cards, six polish choices across, a 9pt gradient progress track with a tabular mono percentage, 1.62 line height on the document, and the footer on the sidebar surface.

`AudioFileDecoder.decode` now returns `Decoded` — samples plus the facts the Upload step shows. Read from the SAME asset in the SAME pass as the samples, so the line under the file name cannot describe a different file from the one about to be transcribed.

### The shape

`FileImportRunner` is the **third caller of `TextProcessingRunner`**, not a second pipeline — `RecoveryTextProcessor` is the proven precedent. Its step list is DERIVED from `LimbSteps.orderedChain` minus snippet expansion, so a limb added later reaches imports automatically rather than being forgotten.

Snippet expansion is the one step removed: a trigger word spoken by somebody in a recording must not be replaced with the user's saved text.

### The risky half, which was chunk 1

EG-1's server launches with no `-np`, so it has ONE inference slot. A 500-word part occupies it for ~12s; live dictation's polish budget is 15s. Before this, a dictation arriving mid-import would queue behind it and silently come back unpolished.

`EngineLease` admits exactly one workload — a dictation, a crash replay, or an import. Both record-start routes consult it, a minted session's claim outlives the start call, and a replay holds it for a whole item.

**The plan's grounding brief said no such authority existed. That was wrong**, and the sweep that produced it searched for the name it expected (`lease|exclusiv|acquireEngine|…`) rather than for the capability. Six mechanisms already arbitrate engine access. The closest, `EngineRecoveryGate`, deliberately admits several mutations at once (`:56-59`), so it cannot admit one workload — both stay, and the record ladder checks recovery FIRST so a replay press keeps its own pill and its Discard button.

### What review changed

Two cloud rounds on chunk 1, both of which found real defects:

1. **The claim was released on the PUBLISHED state.** An error pinned during finalization publishes a terminal while the kernel is still finalizing, so crash recovery — which competes for the same claim — could start a replay on top of a take that had not finished. **Reachable today, without file import.** The release moved to the kernel's ACCEPTED terminal (`onSessionTerminalAccepted`, fired once from `finishTerminal`'s own defer).
2. **Both backend handlers read one stored claim**, so a terminal from the idle engine released the running session's claim. The claim is now paired with the backend that minted it.

A later cloud round on the whole diff found six more, all fixed: the privacy line reading the live provider; the engine switch not blocked while an import runs; the local polisher torn down under a running import; the language lock ignored; `decodedSamples` retained for the life of the app; `outputClassifierHolder` nil.

### Four found reading the wizard diff before review

Each is user-visible, and each is the shape where the state assertion passes and the user is still stuck.

1. **Stop stranded the user.** `stop()` set the state and left `step` on `.working`, so a user who stopped a long import kept their words and had no screen that showed them: a progress bar that would never move again, beside a Stop button already pressed. Stop now lands on Done. `FileImportCoordinatorTests` asserts the step, not only the state — the state assertion alone passed against this.
2. **A false privacy promise during the one step it is false in.** The footer answered the cloud question on four steps and not on `.working`, which is the step during which the text is in flight. It said "Your audio and text both stay on this Mac." New suite `TranscribeFilePrivacyFooterTests` sweeps every step in both directions and fails closed on a seventh.
3. **The estimate rounded the wrong way.** 1,100 words is three parts, not two, so the quote got shorter as the file got longer.
4. **A double fallback on file size** left dead code reading as a guard.

Deliberately NOT changed, having been checked: the `as!` on `formatDescriptions.first`. The array is typed `[Any]`, and Swift REFUSES the conditional form — "conditional downcast to CoreFoundation type 'CMAudioFormatDescription' will always succeed" — so the compiler is asserting the cast cannot fail and a defensive `as?` is dead code the build rejects. The reason now sits at the line.

### Two guards that fired

**A truncated file is NOT detectable, and a guard for it was built and then removed.** Measured: a 3-second 16 kHz WAV cut to a third of its bytes reports 0.957s and decodes to 0.957s, because AVFoundation derives duration from the bytes present. A truncated recording is indistinguishable from a shorter one, to this decoder and any other. The test now asserts what actually happens.

**The engine-mutation inventory refused three new `transcribe` sites** until they were classified. They are `structurallySafe` under a new clause (d): reached only while `EngineLease` is held for the workload's full duration.

### Ceilings raised, deliberately

- `RecordingStarter` collaborators 7 → 8 (`engineAdmission`)
- `DictationLifecycleCoordinator` non-private methods 5 → 6 (`acceptEngineToken`), plus a combined stored-dependency cap it never had
- `EnviousWisprApp` stored properties 42 → 43 (`fileImportCoordinator`)

Each is commented at the assertion with why the smaller alternatives were worse. Picking a shape to satisfy a counter is how a cap stops measuring anything.

### Deviations from the approved plan

1. `EngineLease` is `@MainActor`, not an actor — every real participant is already on the main actor, matching the shipped `EngineRecoveryGate`. Atomicity comes from having no suspension between check and store, not from the isolation.
2. `admit(_:) -> Admission` rather than `acquire(_:) -> Token?` — a refusal carries the holder in the same answer, so no fallback is needed for "who has it" coming back empty.
3. `toggle(source:)` keeps its `Void` return — its three callers discard a value and `HotkeyService.onToggleRecording` is a `Void` callback, so the typed outcome would have had no consumer. `start()` does return one and its refusal reaches the hotkey's hands-free bookkeeping.
4. EG-1's health-probe skip is deferred to a follow-up: it changes a public enum and two settings views, and no import can hold the claim yet.
5. The runner's cancellation policy is enforced at the CALLER rather than by changing the shared runner, so the heart path's behaviour is untouched by a feature it does not participate in.

### Ten review rounds

Codex reviewed the diff ten times. **33 defects, all fixed**, and round 10 came
back with none.

| round | found | the ones that would have shipped silently |
|---|---|---|
| 1 | 10 | claim released on the published state; both backends sharing one claim |
| 2 | 6 | **the wizard's engine choices reached nothing** — All Languages ran Parakeet, a new polisher got the old one's model id, and its runtime never started |
| 3 | 4 | a finished document reachable from nowhere after Change + Back |
| 4 | 4 | Done credited a polisher that never ran |
| 5 | 2 (+1 mine) | Copy over an empty document CLEARED the clipboard |
| 6 | 4 | **a dictation's idle timer unloading the model mid-import**; a privacy promise made from "I have not asked" |
| 7 | 2 | **Remove Model deleting the model out from under a running import** |
| 8 | 1 | an abandoned decode running to completion, ~690 MB held for nothing |
| 9 | 2 | Review promising "No polish" while S1-mini ran |
| 10 | 0 | — |

**Three of those were mine to catch and I did not**, so each got a mechanism
rather than a fix:

- **The (step, state) matrix.** Rounds 2, 3 and 5 each found one cell of a
  6 x 8 grid. `theStepStateMatrixIsEnumerated` now DRIVES the machine down every
  path it has, records the pairs it reaches, and freezes the set at 16. Its first
  act was catching its own walk missing a cell. Round 9 then found the invariant
  too weak — "can move" passed for a user who could only move BACKWARDS — so it
  is now "the next step forward is reachable".
- **One navigation authority.** Three movers each had their own rule.
  `canGo(to:advancing:)` is the only one; the eight direct writes to `step` are
  named, and `navigationHasOneWriter` reads the source and counts them. Round 4
  proved my "nothing moves step without asking" claim FALSE by enumerating: five
  of seven bypassed it, and every behavioural test still passed.
- **The engine-in-use sweep.** Rounds 5, 6 and 7 each found one guard written for
  dictation that an import also needed. Round 7's fix swept all nine from the
  composition root; exactly one was missing, and the table sits at that call site.

### Tests

Debug lane: **7,533 tests / 671 suites green**.

New coverage worth naming:
- `EngineLeaseTests` races 40 concurrent claims with a **two-way control** — the
  same claim with one `await` added, asserted to hand the resource to several
  callers — so a green run cannot be an accident.
- `theStepStateMatrixIsEnumerated` and `navigationHasOneWriter`, above. The
  second carries its own two-way control, because a count from a detector written
  minutes ago is a hypothesis about the detector: it must match three real writes
  and must not match a comparison.
- `TranscriptSplitterTests` covers Japanese, Thai and emoji. Its round-trip oracle
  is the non-whitespace CHARACTERS in order, because a word list cannot express
  the property for a script with no spaces.
- `FileImportRealBoundaryTests` runs a real 3-minute recording through the real
  decoder, the SHIPPED Parakeet model and the real splitter.
- `TranscribeFilePrivacyFooterTests` is exhaustive over the step enum in both
  cloud directions, and over `LLMProvider.allCases`.

### Live UAT, on screen, end to end

**PASSED, 20 of 20 checks.** A 66-second spoken meeting recording, picked through
the real macOS file panel, carried through all six steps in the running dev app.
Transcribed by the shipped Parakeet model, polished by EG-1, **218 words returned
with the numbers intact** ("11%", "64%", "day 7", "2 hours"), which is inverse
text normalization surviving the import path. The progress label read "Cleaning
it up" and a percentage, never a part count. "Show original words" was exercised,
not merely rendered.

Two things the harness got wrong before the app did, recorded because both will
bite the next person:
- **The app must be FRONTMOST.** Clicks land under the cursor, but the file
  panel's keyboard focus and its Open button follow the ACTIVE application. With
  Chrome in front the panel selected a row and then refused to open it, which
  reads exactly like a broken picker.
- **An absence check over an unbounded space cannot be scoped.** "The word
  'chunk' must not appear anywhere" searched the whole app and matched a menu
  listing unrelated scratch files. It is now a presence check over the four
  approved phase sentences.

Known gap, named rather than skipped: **mp3 has no written fixture**, because
macOS decodes it and does not encode it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF9Bb42yHkgffHPuRzdBL2
