### PR TITLE
fix(itn): spoken emails ending in a country-code domain now convert (#2764)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -190,8 +190,8 @@ public struct InverseTextNormalizer: Sendable {
   /// turns "he pointed at the dot it made" into "he pointed@the.it made". Excluded on those
   /// grounds: `am as at be by do id in is it my no so to us`.
   ///
-  /// Italy, Austria, Belgium, Norway, the Bahamas, Belarus, Tonga and Indonesia are therefore NOT
-  /// covered, stated rather than hidden.
+  /// Examples excluded by this policy include Italy (.it), Austria (.at), Belgium (.be),
+  /// Norway (.no), American Samoa (.as), Belarus (.by), Tonga (.to) and Indonesia (.id).
   ///
   /// **Only `emailTLDAlt` consumes this table.** URL handling and the production language gate are
   /// unchanged, so non-English-resolved dictation still skips this formatter entirely
@@ -207,13 +207,10 @@ public struct InverseTextNormalizer: Sendable {
 
   // Email and URL allowlists remain independent. `ai`/`app`/`xyz` stay URL-only; the ccTLDs above
   // are added only to the email grammar.
-  // Deliberately NOT derived from urlTLDAlt (#2257, local Codex review round 2):
-  // emails(_:)'s "name at domain dot tld" pattern has no path requirement to disambiguate
-  // it the way urls(_:) does, so ANY newly-added TLD widens "at <domain> dot <tld>" — a
-  // common way to describe a URL out loud, not an email — into a false email conversion.
-  // Measured: adding just ai/app/xyz turned "learn more at startup dot ai" into
-  // "learn more@startup.ai" and "find it at docs dot xyz" into "find it@docs.xyz". Kept
-  // identical to the pre-#2257 list; the new TLDs are URL-only.
+  // #2257 kept ai/app/xyz out of the email grammar because website prose such as
+  // "learn more at startup dot ai" would otherwise become "learn more@startup.ai".
+  // The ccTLD extension accepts that existing ambiguity for its selected suffixes,
+  // as documented above; it does not change either URL pass.
   static let emailTLDAlt = alt(["com", "org", "io", "co", "dev", "me", "net", "edu", "gov"]
     + countryCodeTLDs)
   // A domain label: may start with a letter OR digit (cloud Codex review, PR #2265 —

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -13,6 +13,10 @@ import Foundation
 /// The Python reference is the ORACLE; `Tests/.../InverseTextNormalizer/parity.jsonl`
 /// pins byte-for-byte behavioral equivalence (see `InverseTextNormalizerParityTests`).
 ///
+/// Frozen Python-reference fixtures (`parity.jsonl`, `parity_holdout.jsonl`) pin behaviour on their
+/// RECORDED INPUTS. Later product extensions carry separate explicit expectations; passing the
+/// fixtures does not establish equivalence on inputs outside them (#2764).
+///
 /// Pure value transform, no state, `Sendable`. Context-aware where cheap; ambiguous
 /// minimal pairs ("meet at one twenty" = 1:20 vs "paid one twenty" = $1.20) are left
 /// for the AI-polish layer by design — every rule/grammar engine scores ~39% on those,
@@ -173,31 +177,36 @@ public struct InverseTextNormalizer: Sendable {
   static let commonWordURLTLDAlt = #"ai|app|xyz"#
   static let urlTLDAlt = lowerRiskURLTLDAlt + "|" + commonWordURLTLDAlt
 
-  /// Country-code TLDs, and the reason this is a list rather than "every ccTLD".
+  /// Selected ccTLD additions for the existing English spoken-email grammar.
   ///
-  /// The generic list above has no country code in it at all, so a spoken `.de`, `.nl` or `.fr`
-  /// never converted — for a GERMAN speaker or for an English one dictating a German address.
-  /// That is the same defect in both languages and it is fixed here for both.
+  /// The previous allowlist ALREADY included the ccTLDs `co`, `io` and `me`, so this is not "no
+  /// country codes" being fixed — it is a reviewed extension of a list that omitted the European
+  /// codes our users' addresses actually end in (`de`, `nl`, `fr`, `es`, `pt`, `pl`, …).
   ///
-  /// **A ccTLD that is also an ordinary word is EXCLUDED, because the email frame does not
-  /// protect it.** `emails(_:)` matches `<name> at <dom> dot <tld>`, and `dom` is any single
-  /// token, so admitting `it` would turn the ordinary sentence "he pointed at the dot it made"
-  /// into "he pointed@the.it made". Excluded on those grounds: `it`, `at`, `in`, `is`, `be`,
-  /// `no`, `so`, `us`, `my`, `am`, `do`, `id`. (`me` predates this and stays; it is already
-  /// shipped behaviour and its removal is not this change's business.)
+  /// This is a REVIEWED ALLOWLIST, not an exhaustive ccTLD list and not a guarantee its entries
+  /// have no English dictionary meaning: `de`, `es` and `si` all retain lexical ambiguity. It
+  /// excludes selected HIGH-RISK words, because `emails()` matches `<name> at <dom> dot <tld>`
+  /// with `dom` as any single token, so a word-like code has no protection left — admitting `it`
+  /// turns "he pointed at the dot it made" into "he pointed@the.it made". Excluded on those
+  /// grounds: `am as at be by do id in is it my no so to us`.
   ///
-  /// **Italy, Austria, Belgium, Norway and Indonesia are therefore NOT supported here**, which is
-  /// a real coverage hole and is stated rather than hidden: those need the stronger evidence the
-  /// joined-host pass has (a literal "." the recognizer already committed to) and that route does
-  /// not exist for email. Tracked on #2764.
+  /// Italy, Austria, Belgium, Norway, the Bahamas, Belarus, Tonga and Indonesia are therefore NOT
+  /// covered, stated rather than hidden.
   ///
-  /// Scope is our supported and adjacent European markets plus `eu`; this is deliberately not
-  /// the full IANA list, because every added entry widens the false-positive surface and none of
-  /// the rest has a user behind it. Extending it is adding a string here, not new logic.
+  /// **Only `emailTLDAlt` consumes this table.** URL handling and the production language gate are
+  /// unchanged, so non-English-resolved dictation still skips this formatter entirely
+  /// (`InverseTextNormalizationStep.skipReason`) — this change reaches an ENGLISH-resolved take
+  /// containing a foreign address, and does not by itself deliver support for those languages.
+  ///
+  /// Residual risk, unchanged in kind and now extended to these suffixes: the grammar cannot tell
+  /// an address from prose about a website, so "learn more at example dot de" also converts.
   static let countryCodeTLDs = [
     "de", "nl", "fr", "es", "pt", "pl", "se", "dk", "fi", "hu", "cz", "sk", "ru", "ua",
     "ch", "gr", "ie", "uk", "eu", "si", "hr", "lt", "lv", "ee", "bg", "ro",
   ]
+
+  // Email and URL allowlists remain independent. `ai`/`app`/`xyz` stay URL-only; the ccTLDs above
+  // are added only to the email grammar.
   // Deliberately NOT derived from urlTLDAlt (#2257, local Codex review round 2):
   // emails(_:)'s "name at domain dot tld" pattern has no path requirement to disambiguate
   // it the way urls(_:) does, so ANY newly-added TLD widens "at <domain> dot <tld>" — a

--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -172,6 +172,32 @@ public struct InverseTextNormalizer: Sendable {
   static let lowerRiskURLTLDAlt = #"com|org|io|co|dev|me|net"#
   static let commonWordURLTLDAlt = #"ai|app|xyz"#
   static let urlTLDAlt = lowerRiskURLTLDAlt + "|" + commonWordURLTLDAlt
+
+  /// Country-code TLDs, and the reason this is a list rather than "every ccTLD".
+  ///
+  /// The generic list above has no country code in it at all, so a spoken `.de`, `.nl` or `.fr`
+  /// never converted — for a GERMAN speaker or for an English one dictating a German address.
+  /// That is the same defect in both languages and it is fixed here for both.
+  ///
+  /// **A ccTLD that is also an ordinary word is EXCLUDED, because the email frame does not
+  /// protect it.** `emails(_:)` matches `<name> at <dom> dot <tld>`, and `dom` is any single
+  /// token, so admitting `it` would turn the ordinary sentence "he pointed at the dot it made"
+  /// into "he pointed@the.it made". Excluded on those grounds: `it`, `at`, `in`, `is`, `be`,
+  /// `no`, `so`, `us`, `my`, `am`, `do`, `id`. (`me` predates this and stays; it is already
+  /// shipped behaviour and its removal is not this change's business.)
+  ///
+  /// **Italy, Austria, Belgium, Norway and Indonesia are therefore NOT supported here**, which is
+  /// a real coverage hole and is stated rather than hidden: those need the stronger evidence the
+  /// joined-host pass has (a literal "." the recognizer already committed to) and that route does
+  /// not exist for email. Tracked on #2764.
+  ///
+  /// Scope is our supported and adjacent European markets plus `eu`; this is deliberately not
+  /// the full IANA list, because every added entry widens the false-positive surface and none of
+  /// the rest has a user behind it. Extending it is adding a string here, not new logic.
+  static let countryCodeTLDs = [
+    "de", "nl", "fr", "es", "pt", "pl", "se", "dk", "fi", "hu", "cz", "sk", "ru", "ua",
+    "ch", "gr", "ie", "uk", "eu", "si", "hr", "lt", "lv", "ee", "bg", "ro",
+  ]
   // Deliberately NOT derived from urlTLDAlt (#2257, local Codex review round 2):
   // emails(_:)'s "name at domain dot tld" pattern has no path requirement to disambiguate
   // it the way urls(_:) does, so ANY newly-added TLD widens "at <domain> dot <tld>" — a
@@ -179,7 +205,8 @@ public struct InverseTextNormalizer: Sendable {
   // Measured: adding just ai/app/xyz turned "learn more at startup dot ai" into
   // "learn more@startup.ai" and "find it at docs dot xyz" into "find it@docs.xyz". Kept
   // identical to the pre-#2257 list; the new TLDs are URL-only.
-  static let emailTLDAlt = #"com|org|io|co|dev|me|net|edu|gov"#
+  static let emailTLDAlt = alt(["com", "org", "io", "co", "dev", "me", "net", "edu", "gov"]
+    + countryCodeTLDs)
   // A domain label: may start with a letter OR digit (cloud Codex review, PR #2265 —
   // "3m.com", "1password.com" are real domains excluded by a letter-only start), may
   // contain digits/hyphens, never ENDS on a hyphen (a trailing "-" is not a valid

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerCountryTLDTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerCountryTLDTests.swift
@@ -55,7 +55,7 @@ struct InverseTextNormalizerCountryTLDTests {
   /// alternation when the list grows, so these are regression cover for the existing conversions;
   /// they do not by themselves prove the ordering rule.
   @Test(
-    "the generic domains still convert, and the longer one still wins",
+    "the existing domains still convert",
     arguments: [
       ("send it to tom at example dot com", "tom@example.com"),
       ("send it to tom at example dot co", "tom@example.co"),
@@ -86,9 +86,7 @@ struct InverseTextNormalizerCountryTLDTests {
     #expect(!Self.itn.normalize(input, spokenPunctuation: false).contains("@"))
   }
 
-  /// Structural guard on the table itself, so the reason survives without depending on a reviewer
-  /// remembering it. A word-like code added here would pass every conversion test above and only
-  /// fail the sentences — this fails at the source instead.
+  /// Guards the named exclusions and duplicate entries, not lexical completeness.
   @Test("selected high-risk English words remain excluded")
   func tableExcludesWordLikeCodes() {
     // Named risky words, not a claim of universal unambiguity: `de`, `es` and `si` are dictionary

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerCountryTLDTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerCountryTLDTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// A spoken address ending in a country-code domain now converts, and the ordinary sentences that
+/// look like one still do not.
+///
+/// Why this exists: `emailTLDAlt` and `lowerRiskURLTLDAlt` carried no country code at all, so
+/// `anna at beispiel dot de` stayed spelled out — for a German speaker AND for an English speaker
+/// dictating a German address. Measured on #1677's engine survey, every non-English address in the
+/// corpus ends in a country code, so the missing list blocked the whole category before any
+/// per-language work could matter.
+///
+/// The risky half is the reason the table is a list rather than "every ccTLD". `emails(_:)` matches
+/// `<name> at <dom> dot <tld>` where `dom` is any single token, so a ccTLD that is also an ordinary
+/// English word has no protection left: admitting `it` converts "he pointed at the dot it made".
+/// Those are excluded, and `refusesWordLikeCountryCodes` is what holds that line — it fails if
+/// somebody later "completes" the list from IANA.
+///
+/// **EMAIL ONLY, and the reason is the oracle, not the risk.** `lowerRiskURLTLDAlt` deliberately did
+/// NOT get these codes. `spokenPat`'s path is optional (`*`), so a bare `<host> dot <tld>` converts
+/// with no path at all, and adding `fr` turned the curated parity row `"a at m s n dot fr"` — a
+/// person spelling out MSN — into `"a at m s n.fr"`. `parity.jsonl` is baked from a Python oracle
+/// (`hand_rolled.py`) that is NOT in this repo or on this machine, so that row cannot be re-baked
+/// here and the URL half is blocked until it can be. #2764 carries that.
+///
+/// **Honest limit on the email half:** no parity row exercises a country-code email, so parity
+/// passing means "no regression", NOT "matches the oracle". These conversions are a deliberate
+/// divergence the oracle would not make, and this suite is the only thing asserting them.
+@Suite("Country-code domains in spoken addresses (#2764)", .tags(.productOutcome))
+struct InverseTextNormalizerCountryTLDTests {
+
+  private static let itn = InverseTextNormalizer()
+
+  @Test(
+    "a spoken email ending in a country code converts",
+    arguments: [
+      ("schick das an anna at beispiel dot de", "anna@beispiel.de"),
+      ("mandalo a marco at esempio dot fr", "marco@esempio.fr"),
+      ("send it to jan at voorbeeld dot nl", "jan@voorbeeld.nl"),
+      ("write to maria at ejemplo dot es", "maria@ejemplo.es"),
+      ("email me at exemplo dot pt", "me@exemplo.pt"),
+      ("reach anna at exempel dot se", "anna@exempel.se"),
+      ("contact jan at przyklad dot pl", "jan@przyklad.pl"),
+      ("ping ivan at primer dot ru", "ivan@primer.ru"),
+      ("mail lars at eksempel dot dk", "lars@eksempel.dk"),
+      ("try anna at pelda dot hu", "anna@pelda.hu"),
+      ("ask tom at example dot uk", "tom@example.uk"),
+      ("ask tom at example dot eu", "tom@example.eu"),
+    ] as [(input: String, expected: String)])
+  func countryCodeEmailConverts(input: String, expected: String) {
+    #expect(Self.itn.normalize(input, spokenPunctuation: false).contains(expected))
+  }
+
+  /// The generic domains that already worked must keep working — this list grew by 26 entries and
+  /// `alt(...)` re-sorts the whole alternation, so a longest-first regression would show up here
+  /// as `example.co` swallowing `example.com`.
+  @Test(
+    "the generic domains still convert, and the longer one still wins",
+    arguments: [
+      ("send it to tom at example dot com", "tom@example.com"),
+      ("send it to tom at example dot co", "tom@example.co"),
+      ("send it to tom at example dot org", "tom@example.org"),
+      ("send it to tom at example dot edu", "tom@example.edu"),
+    ] as [(input: String, expected: String)])
+  func genericDomainsUnaffected(input: String, expected: String) {
+    #expect(Self.itn.normalize(input, spokenPunctuation: false).contains(expected))
+  }
+
+  /// The line the exclusion list holds. Each of these is an ordinary sentence whose words happen to
+  /// land in the `<name> at <dom> dot <tld>` frame; admitting the word-like country code would turn
+  /// it into an address.
+  @Test(
+    "an ordinary sentence is not an address",
+    arguments: [
+      "he pointed at the dot it made",
+      "look at the dot in the corner",
+      "she stared at the dot is what I meant",
+      "arrive at the dot no later than five",
+      "aim at the dot at the top",
+      "point at the dot be careful",
+    ])
+  func refusesWordLikeCountryCodes(input: String) {
+    #expect(!Self.itn.normalize(input, spokenPunctuation: false).contains("@"))
+  }
+
+  /// Structural guard on the table itself, so the reason survives without depending on a reviewer
+  /// remembering it. A word-like code added here would pass every conversion test above and only
+  /// fail the sentences — this fails at the source instead.
+  @Test("no country code in the table is an ordinary English word")
+  func tableExcludesWordLikeCodes() {
+    let wordLike: Set<String> = [
+      "it", "at", "in", "is", "be", "no", "so", "us", "my", "am", "do", "id",
+    ]
+    let table = Set(InverseTextNormalizer.countryCodeTLDs)
+    #expect(table.intersection(wordLike).isEmpty)
+    #expect(table.count == InverseTextNormalizer.countryCodeTLDs.count)  // no duplicates
+  }
+
+}

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerCountryTLDTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerCountryTLDTests.swift
@@ -3,31 +3,29 @@ import Testing
 
 @testable import EnviousWisprPostProcessing
 
-/// A spoken address ending in a country-code domain now converts, and the ordinary sentences that
-/// look like one still do not.
+/// Product expectations for selected ccTLDs in the existing spoken-email grammar.
 ///
-/// Why this exists: `emailTLDAlt` and `lowerRiskURLTLDAlt` carried no country code at all, so
-/// `anna at beispiel dot de` stayed spelled out — for a German speaker AND for an English speaker
-/// dictating a German address. Measured on #1677's engine survey, every non-English address in the
-/// corpus ends in a country code, so the missing list blocked the whole category before any
-/// per-language work could matter.
+/// **These tests call the normalizer DIRECTLY, bypassing the production language gate.** A
+/// German-resolved dictation still skips this formatter at `InverseTextNormalizationStep.skipReason`,
+/// so nothing here establishes German product support — it establishes that an ENGLISH-resolved take
+/// containing a foreign address now converts.
 ///
-/// The risky half is the reason the table is a list rather than "every ccTLD". `emails(_:)` matches
+/// The risky half is why the table is a reviewed allowlist rather than every ccTLD. `emails()` matches
 /// `<name> at <dom> dot <tld>` where `dom` is any single token, so a ccTLD that is also an ordinary
 /// English word has no protection left: admitting `it` converts "he pointed at the dot it made".
-/// Those are excluded, and `refusesWordLikeCountryCodes` is what holds that line — it fails if
-/// somebody later "completes" the list from IANA.
+/// `refusesWordLikeCountryCodes` holds that line and fails if somebody later "completes" the list from
+/// IANA. It protects NAMED risky words; it is not a claim that every admitted entry is unambiguous —
+/// `de`, `es` and `si` are dictionary words too.
 ///
-/// **EMAIL ONLY, and the reason is the oracle, not the risk.** `lowerRiskURLTLDAlt` deliberately did
-/// NOT get these codes. `spokenPat`'s path is optional (`*`), so a bare `<host> dot <tld>` converts
-/// with no path at all, and adding `fr` turned the curated parity row `"a at m s n dot fr"` — a
-/// person spelling out MSN — into `"a at m s n.fr"`. `parity.jsonl` is baked from a Python oracle
-/// (`hand_rolled.py`) that is NOT in this repo or on this machine, so that row cannot be re-baked
-/// here and the URL half is blocked until it can be. #2764 carries that.
+/// URL handling is unchanged. Broadening its spoken-host allowlist would partially convert the
+/// spelled-out email in `parity.jsonl`'s `"a at m s n dot fr"`, because `spokenPat`'s path group is
+/// `*` rather than `+`.
 ///
-/// **Honest limit on the email half:** no parity row exercises a country-code email, so parity
-/// passing means "no regression", NOT "matches the oracle". These conversions are a deliberate
-/// divergence the oracle would not make, and this suite is the only thing asserting them.
+/// **What the frozen fixtures do and do not prove here.** `parity.jsonl` DOES contain a country-code
+/// email row (`:1563`), so "no such row exists" would be wrong; what neither it nor the holdout
+/// contains is an input matching the newly accepted single-token ccTLD pattern. Passing them
+/// establishes agreement with their recorded outputs on THOSE cases, not correctness of this
+/// extension. This suite supplies the extension's explicit product expectations.
 @Suite("Country-code domains in spoken addresses (#2764)", .tags(.productOutcome))
 struct InverseTextNormalizerCountryTLDTests {
 
@@ -53,9 +51,9 @@ struct InverseTextNormalizerCountryTLDTests {
     #expect(Self.itn.normalize(input, spokenPunctuation: false).contains(expected))
   }
 
-  /// The generic domains that already worked must keep working — this list grew by 26 entries and
-  /// `alt(...)` re-sorts the whole alternation, so a longest-first regression would show up here
-  /// as `example.co` swallowing `example.com`.
+  /// The generic domains that already worked must keep working. `alt(...)` re-sorts the whole
+  /// alternation when the list grows, so these are regression cover for the existing conversions;
+  /// they do not by themselves prove the ordering rule.
   @Test(
     "the generic domains still convert, and the longer one still wins",
     arguments: [
@@ -80,6 +78,9 @@ struct InverseTextNormalizerCountryTLDTests {
       "arrive at the dot no later than five",
       "aim at the dot at the top",
       "point at the dot be careful",
+      "look at the dot as it moves",
+      "look at the dot by the door",
+      "look at the dot to your left",
     ])
   func refusesWordLikeCountryCodes(input: String) {
     #expect(!Self.itn.normalize(input, spokenPunctuation: false).contains("@"))
@@ -88,13 +89,17 @@ struct InverseTextNormalizerCountryTLDTests {
   /// Structural guard on the table itself, so the reason survives without depending on a reviewer
   /// remembering it. A word-like code added here would pass every conversion test above and only
   /// fail the sentences — this fails at the source instead.
-  @Test("no country code in the table is an ordinary English word")
+  @Test("selected high-risk English words remain excluded")
   func tableExcludesWordLikeCodes() {
-    let wordLike: Set<String> = [
-      "it", "at", "in", "is", "be", "no", "so", "us", "my", "am", "do", "id",
+    // Named risky words, not a claim of universal unambiguity: `de`, `es` and `si` are dictionary
+    // words and ARE admitted. Intersecting a dictionary with the IANA ccTLD list would exclude
+    // Germany itself, so the allowlist stays reviewed rather than derived.
+    let excluded: Set<String> = [
+      "am", "as", "at", "be", "by", "do", "id", "in",
+      "is", "it", "my", "no", "so", "to", "us",
     ]
     let table = Set(InverseTextNormalizer.countryCodeTLDs)
-    #expect(table.intersection(wordLike).isEmpty)
+    #expect(table.intersection(excluded).isEmpty)
     #expect(table.count == InverseTextNormalizer.countryCodeTLDs.count)  // no duplicates
   }
 


### PR DESCRIPTION
Fixes #2764.

## Summary

`emailTLDAlt` omitted every European country-code domain, so a spoken address ending in `.de`, `.nl`, `.fr`, `.es`, `.pt`, `.pl`, `.se`, `.dk`, `.hu` or `.ru` never converted:

```
"send it to anna at beispiel dot de"   ->  left as spoken words
```

26 codes added via a shared `countryCodeTLDs` table and the existing deterministic `alt(...)` helper.

Found by Codex during the plan review of #2763 — it blocked that whole category before any per-language work could matter, since every non-English address in #1677's engine survey ends in a country code.

## What this does NOT do

**It does not deliver support for German, Dutch or any other language.** A non-English-resolved take still skips this formatter entirely at `InverseTextNormalizationStep.skipReason`, untouched here. What this reaches is an **English-resolved take containing a foreign address**. The new suite calls `normalize` directly and therefore bypasses that gate, which the suite says out loud so a green run is not read as product coverage.

The previous list was also not "no country codes at all" — `co`, `io` and `me` are ccTLDs and were already present. What it omitted were the European codes users' addresses actually end in.

## The exclusion list is the load-bearing half

`emails()` matches `<name> at <dom> dot <tld>` with `dom` as any single token, so a ccTLD that is also an ordinary English word has no protection left: admitting `it` turns "he pointed at the dot it made" into "he pointed@the.it made".

Excluded: `am as at be by do id in is it my no so to us`. So Italy (.it), Austria (.at), Belgium (.be), Norway (.no), American Samoa (.as), Belarus (.by), Tonga (.to) and Indonesia (.id) are **not covered** — stated rather than hidden. Italy matters, since Italian is a target language on #1677.

**There is no clean derived source for this class.** Intersecting a dictionary with the IANA ccTLD list would exclude Germany itself — `de`, `es` and `si` are dictionary words and are admitted. So the allowlist stays reviewed, and the guard test is labelled as protecting NAMED words rather than as complete.

## Email only, and why

The codes were first added to `lowerRiskURLTLDAlt` too. That broke one curated parity row: `"a at m s n dot fr"` — a person spelling out MSN — became `"a at m s n.fr"`. Cause: `spokenPat`'s path group is `*`, not `+`, so a bare `<host> dot <tld>` converts with no path at all. Bisected; email-only is parity-clean.

A required path would not have saved it — `"a at m s n dot fr slash help"` still partially converts. A narrower future extension (ccTLDs in the joined-host-plus-required-path pass only, which has the stronger signal of a literal dot the recognizer already committed to) is defensible and needs its own validation.

## What the frozen fixtures prove here, and what they do not

`parity.jsonl` is baked from a Python oracle (`hand_rolled.py`) that is **not in this repo and not on this machine**. `parity.jsonl:1563` *is* a country-code email row, so "no such row exists" would be wrong; what neither fixture contains is an input matching the newly accepted single-token pattern.

So passing them establishes **agreement with their recorded outputs on those inputs**, not correctness of this extension. That boundary is now stated at the normalizer's file header so it governs every future extension, not just this one. This suite supplies the extension's explicit product expectations.

## Residual risk, unchanged in kind

The grammar cannot tell an address from prose about a website, so `"learn more at example dot de"` also converts. That ambiguity pre-existed for `com`/`org`/etc.; it now applies to the added suffixes too.

## Verification

- Full Debug lane on this Mac: **7461 tests in 666 suites, PASS**, including `InverseTextNormalizerParityTests` (curated + holdout).
- Codex independently ran the normalizer over **2,239 curated + 3,881 holdout rows: zero mismatches**, plus the three new refusal cases and the spelled-out `.fr` row.
- Codex review, three rounds, ending in an explicit **ALL-CLEAR**. Round 1 found the incomplete exclusion list (`as`, `by`, `to` missing) and three overclaims in my comments; round 2 found four superseded claims I had left beside their replacements; round 3 confirmed clean.

## Pre-Merge Checklist

- [x] Logic tests pass locally (`scripts/xcode-test.sh`)
- [x] Commits follow conventional commit format
- [x] No hardcoded API keys or secrets
- [x] No `@preconcurrency import` removed

Polish Eval: not applicable — no change under `Sources/EnviousWisprLLM/`, `CustomWordsManager.swift`, or `scripts/eval/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
