### PR TITLE
fix(overlay): the recording pill honours macOS Reduce Motion (#2303)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/Brand/RainbowLipsIcon.swift
+++ b/Sources/EnviousWisprAppKit/App/Brand/RainbowLipsIcon.swift
@@ -73,18 +73,35 @@ struct RainbowLipsIcon: View {
 
   private static let distressRed = Color(red: 1.0, green: 0.165, blue: 0.251)
 
+  /// #2303. The PULSE is decoration; the red bars are the signal and they read the same held
+  /// still. The lips' ordinary movement is not touched here — `OverlayMotion` records why.
+  @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
+  @Environment(\.overlayReduceMotionOverride) private var reduceMotionOverride
+  private var reduceMotion: Bool { reduceMotionOverride ?? systemReduceMotion }
+
+  /// Mid-point of the pulse's own 0.4-to-1.0 range, so the still lips are no dimmer on average
+  /// than the pulsing ones they replace.
+  private static let steadyDistressOpacity: Double = 0.7
+
   var body: some View {
     if isDistress {
-      // Distress mode: lips in normal shape, all bars red, pulsing opacity.
-      // TimelineView drives continuous redraw; Canvas does not respond to @State animation.
-      TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
-        let phase = timeline.date.timeIntervalSinceReferenceDate
-        let pulseOpacity = 0.4 + 0.6 * (0.5 + 0.5 * sin(phase * .pi / 0.35))
+      if OverlayMotion.showsAmbientLoop(reduceMotion: reduceMotion) {
+        // Distress mode: lips in normal shape, all bars red, pulsing opacity.
+        // TimelineView drives continuous redraw; Canvas does not respond to @State animation.
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+          let phase = timeline.date.timeIntervalSinceReferenceDate
+          let pulseOpacity = 0.4 + 0.6 * (0.5 + 0.5 * sin(phase * .pi / 0.35))
+          lipsCanvas(level: 0.3, barColorOverride: Self.distressRed)
+            .opacity(pulseOpacity)
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+      } else {
         lipsCanvas(level: 0.3, barColorOverride: Self.distressRed)
-          .opacity(pulseOpacity)
+          .opacity(Self.steadyDistressOpacity)
+          .frame(width: size, height: size)
+          .accessibilityHidden(true)
       }
-      .frame(width: size, height: size)
-      .accessibilityHidden(true)
     } else {
       lipsCanvas(level: CGFloat(min(max(audioLevel, 0), 1)), barColorOverride: nil)
         .frame(width: size, height: size)

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
@@ -51,24 +51,6 @@ struct OverlayCapsuleBackground: View {
   private static let dimGlowOpacity: Double = 0.3
   private static let brightGlowOpacity: Double = 0.65
 
-  /// Bring the loop into line with `breathes`, in BOTH directions.
-  ///
-  /// The stop branch is not decoration. Nothing reads `glowOpacity` once `breathes` is false,
-  /// so a loop left running would be invisible and would still re-render forever, which is the
-  /// cost #2201 exists to avoid. Parking it also leaves a known value for the next arm.
-  private func syncGlow() {
-    guard breathes else {
-      var stop = Transaction()
-      stop.animation = nil
-      withTransaction(stop) { glowOpacity = Self.dimGlowOpacity }
-      onGlowTarget(Self.dimGlowOpacity)
-      return
-    }
-    withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
-      glowOpacity = Self.brightGlowOpacity
-    }
-    onGlowTarget(Self.brightGlowOpacity)
-  }
 
   /// #2201: the preview pill's rainbow hairline holds still instead of breathing
   /// on a permanent two-second loop.
@@ -161,12 +143,15 @@ struct OverlayCapsuleBackground: View {
       // `glowOpacity`, and the point of this chunk is that the preview pill
       // stops moving on its own.
       //
-      // **Keyed to `breathes` rather than to `onAppear` (#2303, cloud review r1).** Reduce
-      // Motion can be switched off while this pill is still mounted, and an `onAppear` guard
-      // runs once: the loop would never arm, `glowOpacity` would sit at its dim starting
-      // value, and the hairline would be DIMMER than in either state it is meant to have.
-      // `initial: true` keeps the appear case, so this stays one mechanism rather than two.
-      .onChange(of: breathes, initial: true) { _, _ in syncGlow() }
+      // `initial: true` keeps the appear case, so arming and re-arming stay one mechanism
+      // rather than two. `OverlayMotion.syncAmbientLoop` owns both directions and records why
+      // the loop is keyed to the SETTING rather than to this view's appearance.
+      .onChange(of: breathes, initial: true) { _, _ in
+        OverlayMotion.syncAmbientLoop(
+          enabled: breathes, opacity: $glowOpacity,
+          dim: Self.dimGlowOpacity, bright: Self.brightGlowOpacity,
+          duration: 2, onTarget: onGlowTarget)
+      }
       .accessibilityHidden(true)
   }
 }
@@ -199,20 +184,6 @@ struct DistressCapsuleBackground: View {
   private static let dimGlowOpacity: Double = 0.3
   private static let brightGlowOpacity: Double = 0.6
 
-  /// Bring the pulse into line with `pulses`, in BOTH directions (#2303, cloud review r1).
-  private func syncGlow() {
-    guard pulses else {
-      var stop = Transaction()
-      stop.animation = nil
-      withTransaction(stop) { glowOpacity = Self.dimGlowOpacity }
-      onGlowTarget(Self.dimGlowOpacity)
-      return
-    }
-    withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
-      glowOpacity = Self.brightGlowOpacity
-    }
-    onGlowTarget(Self.brightGlowOpacity)
-  }
 
   var body: some View {
     Capsule()
@@ -241,7 +212,12 @@ struct DistressCapsuleBackground: View {
         .padding(.horizontal, 20)
         .offset(y: -1)
       }
-      .onChange(of: pulses, initial: true) { _, _ in syncGlow() }
+      .onChange(of: pulses, initial: true) { _, _ in
+        OverlayMotion.syncAmbientLoop(
+          enabled: pulses, opacity: $glowOpacity,
+          dim: Self.dimGlowOpacity, bright: Self.brightGlowOpacity,
+          duration: 0.4, onTarget: onGlowTarget)
+      }
       .accessibilityHidden(true)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
@@ -28,6 +28,18 @@ struct OverlayCapsuleBackground: View {
   var animatesGlow: Bool = true
   @State private var glowOpacity: Double = 0.3
 
+  /// #2303: the person's own answer, alongside #2201's and #2435's.
+  @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
+  @Environment(\.overlayReduceMotionOverride) private var reduceMotionOverride
+  private var reduceMotion: Bool { reduceMotionOverride ?? systemReduceMotion }
+
+  /// Every condition for the hairline to breathe, in one place. `OverlayMotion` owns the
+  /// Reduce Motion half and states why the still value costs nothing here.
+  private var breathes: Bool {
+    animatesGlow && cornerStyle == .capsule
+      && OverlayMotion.showsAmbientLoop(reduceMotion: reduceMotion)
+  }
+
   /// #2201: the preview pill's rainbow hairline holds still instead of breathing
   /// on a permanent two-second loop.
   ///
@@ -110,9 +122,7 @@ struct OverlayCapsuleBackground: View {
         // Breathing is the ONLY case that reads the animated value. Everything
         // else — the reading well, and any capsule asked to hold still — takes
         // the chosen steady one.
-        .opacity(
-          animatesGlow && cornerStyle == .capsule ? glowOpacity : Self.steadyGlowOpacity
-        )
+        .opacity(breathes ? glowOpacity : Self.steadyGlowOpacity)
         .padding(.horizontal, 20)
         .offset(y: -1)
       }
@@ -121,7 +131,7 @@ struct OverlayCapsuleBackground: View {
         // preview would keep it re-rendering whether or not anything read
         // `glowOpacity`, and the point of this chunk is that the preview pill
         // stops moving on its own.
-        guard animatesGlow, cornerStyle == .capsule else { return }
+        guard breathes else { return }
         withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
           glowOpacity = 0.65
         }
@@ -135,6 +145,20 @@ struct OverlayCapsuleBackground: View {
 /// Capsule background for interruption warnings: red glow instead of rainbow.
 struct DistressCapsuleBackground: View {
   @State private var glowOpacity: Double = 0.3
+
+  /// #2303. The red hairline pulses to draw the eye; the RED is what says something is wrong,
+  /// and it survives holding still.
+  @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
+  @Environment(\.overlayReduceMotionOverride) private var reduceMotionOverride
+  private var reduceMotion: Bool { reduceMotionOverride ?? systemReduceMotion }
+
+  /// Mid-point of this pulse's own 0.3-to-0.6 endpoints, for the same reason
+  /// `OverlayCapsuleBackground.steadyGlowOpacity` is the mid-point of its loop: a still line is
+  /// no dimmer on average than the moving one it replaces.
+  private static let steadyGlowOpacity: Double = 0.45
+
+  /// Whether the red hairline pulses at all.
+  private var pulses: Bool { OverlayMotion.showsAmbientLoop(reduceMotion: reduceMotion) }
 
   var body: some View {
     Capsule()
@@ -156,11 +180,15 @@ struct DistressCapsuleBackground: View {
           endPoint: .trailing
         )
         .frame(height: 1)
-        .opacity(glowOpacity)
+        // The still value is chosen HERE rather than assigned in `onAppear`, so a person with
+        // Reduce Motion on gets it on the FIRST frame — the same shape the rainbow hairline
+        // above already uses.
+        .opacity(pulses ? glowOpacity : Self.steadyGlowOpacity)
         .padding(.horizontal, 20)
         .offset(y: -1)
       }
       .onAppear {
+        guard pulses else { return }
         withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
           glowOpacity = 0.6
         }

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/OverlayCapsuleBackgrounds.swift
@@ -28,6 +28,12 @@ struct OverlayCapsuleBackground: View {
   var animatesGlow: Bool = true
   @State private var glowOpacity: Double = 0.3
 
+  /// Outcome observer for the hairline's target opacity, called every time the loop is armed or
+  /// parked. Production uses the no-op default; tests use it because an off-screen
+  /// `NSHostingView` does not advance a `repeatForever`, so a re-arm cannot be seen in pixels.
+  /// Same shape and same reason as `RainbowLevelMeter.onHistoryChange`.
+  var onGlowTarget: (Double) -> Void = { _ in }
+
   /// #2303: the person's own answer, alongside #2201's and #2435's.
   @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
   @Environment(\.overlayReduceMotionOverride) private var reduceMotionOverride
@@ -38,6 +44,30 @@ struct OverlayCapsuleBackground: View {
   private var breathes: Bool {
     animatesGlow && cornerStyle == .capsule
       && OverlayMotion.showsAmbientLoop(reduceMotion: reduceMotion)
+  }
+
+  /// The loop's own two endpoints, named so the stop branch parks on the value the loop starts
+  /// from rather than on a second opinion about what "dim" means.
+  private static let dimGlowOpacity: Double = 0.3
+  private static let brightGlowOpacity: Double = 0.65
+
+  /// Bring the loop into line with `breathes`, in BOTH directions.
+  ///
+  /// The stop branch is not decoration. Nothing reads `glowOpacity` once `breathes` is false,
+  /// so a loop left running would be invisible and would still re-render forever, which is the
+  /// cost #2201 exists to avoid. Parking it also leaves a known value for the next arm.
+  private func syncGlow() {
+    guard breathes else {
+      var stop = Transaction()
+      stop.animation = nil
+      withTransaction(stop) { glowOpacity = Self.dimGlowOpacity }
+      onGlowTarget(Self.dimGlowOpacity)
+      return
+    }
+    withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
+      glowOpacity = Self.brightGlowOpacity
+    }
+    onGlowTarget(Self.brightGlowOpacity)
   }
 
   /// #2201: the preview pill's rainbow hairline holds still instead of breathing
@@ -126,16 +156,17 @@ struct OverlayCapsuleBackground: View {
         .padding(.horizontal, 20)
         .offset(y: -1)
       }
-      .onAppear {
-        // #2201: only the capsule breathes. Arming a `repeatForever` for the
-        // preview would keep it re-rendering whether or not anything read
-        // `glowOpacity`, and the point of this chunk is that the preview pill
-        // stops moving on its own.
-        guard breathes else { return }
-        withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
-          glowOpacity = 0.65
-        }
-      }
+      // #2201: only the capsule breathes. Arming a `repeatForever` for the
+      // preview would keep it re-rendering whether or not anything read
+      // `glowOpacity`, and the point of this chunk is that the preview pill
+      // stops moving on its own.
+      //
+      // **Keyed to `breathes` rather than to `onAppear` (#2303, cloud review r1).** Reduce
+      // Motion can be switched off while this pill is still mounted, and an `onAppear` guard
+      // runs once: the loop would never arm, `glowOpacity` would sit at its dim starting
+      // value, and the hairline would be DIMMER than in either state it is meant to have.
+      // `initial: true` keeps the appear case, so this stays one mechanism rather than two.
+      .onChange(of: breathes, initial: true) { _, _ in syncGlow() }
       .accessibilityHidden(true)
   }
 }
@@ -145,6 +176,10 @@ struct OverlayCapsuleBackground: View {
 /// Capsule background for interruption warnings: red glow instead of rainbow.
 struct DistressCapsuleBackground: View {
   @State private var glowOpacity: Double = 0.3
+
+  /// Outcome observer for the target opacity, armed or parked. Production uses the no-op
+  /// default; the reason it exists is recorded on `OverlayCapsuleBackground.onGlowTarget`.
+  var onGlowTarget: (Double) -> Void = { _ in }
 
   /// #2303. The red hairline pulses to draw the eye; the RED is what says something is wrong,
   /// and it survives holding still.
@@ -159,6 +194,25 @@ struct DistressCapsuleBackground: View {
 
   /// Whether the red hairline pulses at all.
   private var pulses: Bool { OverlayMotion.showsAmbientLoop(reduceMotion: reduceMotion) }
+
+  /// The pulse's own two endpoints. Same reason as the rainbow hairline's pair above.
+  private static let dimGlowOpacity: Double = 0.3
+  private static let brightGlowOpacity: Double = 0.6
+
+  /// Bring the pulse into line with `pulses`, in BOTH directions (#2303, cloud review r1).
+  private func syncGlow() {
+    guard pulses else {
+      var stop = Transaction()
+      stop.animation = nil
+      withTransaction(stop) { glowOpacity = Self.dimGlowOpacity }
+      onGlowTarget(Self.dimGlowOpacity)
+      return
+    }
+    withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
+      glowOpacity = Self.brightGlowOpacity
+    }
+    onGlowTarget(Self.brightGlowOpacity)
+  }
 
   var body: some View {
     Capsule()
@@ -180,19 +234,14 @@ struct DistressCapsuleBackground: View {
           endPoint: .trailing
         )
         .frame(height: 1)
-        // The still value is chosen HERE rather than assigned in `onAppear`, so a person with
+        // The still value is chosen HERE rather than in the arming closure, so a person with
         // Reduce Motion on gets it on the FIRST frame — the same shape the rainbow hairline
         // above already uses.
         .opacity(pulses ? glowOpacity : Self.steadyGlowOpacity)
         .padding(.horizontal, 20)
         .offset(y: -1)
       }
-      .onAppear {
-        guard pulses else { return }
-        withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
-          glowOpacity = 0.6
-        }
-      }
+      .onChange(of: pulses, initial: true) { _, _ in syncGlow() }
       .accessibilityHidden(true)
   }
 }

--- a/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
+++ b/Sources/EnviousWisprAppKit/App/Overlay/Views/RecordingOverlayView.swift
@@ -348,6 +348,13 @@ struct RecordingOverlayView: View {
   /// | `audioTick` | NONE, deliberately | a counter, not a picture. It exists so the meter appends on every poll INCLUDING silent ones; seeding it to anything but 0 would suppress the meter's first append, and the meter takes its own `initialHistory` instead. |
   @State private var audioLevel: Float = 0
 
+  /// #2303: the pill a person looks at during every dictation now reads the same macOS setting
+  /// the crash-recovery pill and the Settings surfaces already read. `OverlayMotion` owns which
+  /// of this view's three container animations it changes and which it must not.
+  @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
+  @Environment(\.overlayReduceMotionOverride) private var reduceMotionOverride
+  private var reduceMotion: Bool { reduceMotionOverride ?? systemReduceMotion }
+
   /// Counts polls, not level changes. #2216: the meter's history needs a sample
   /// every tick INCLUDING the silent ones, and consecutive silent samples are
   /// bit-identical, so `audioLevel` alone cannot drive it.
@@ -574,7 +581,9 @@ struct RecordingOverlayView: View {
           .transition(.opacity)
       }
     }
-    .animation(.easeInOut(duration: 0.3), value: isLocked)
+    .animation(
+      OverlayMotion.stateChange(.easeInOut(duration: 0.3), reduceMotion: reduceMotion),
+      value: isLocked)
     // Single container animation prevents animation stacking: N per-element
     // modifiers × update rate creates exponential state transitions (gotchas.md).
     //
@@ -595,7 +604,12 @@ struct RecordingOverlayView: View {
     // — that forbids per-child `.animation(value:)`, and this adds none. The
     // container keeps its lock and notice triggers in both layouts.
     .animation(chrome.levelAnimation.resolved, value: audioLevel)
-    .animation(.easeInOut(duration: 0.25), value: noticeText)
+    // #2303: both of this container's discrete triggers become instant under Reduce Motion.
+    // The audio level's easing on the line above deliberately does NOT — `OverlayMotion` states
+    // why removing it would make the pill move more, not less.
+    .animation(
+      OverlayMotion.stateChange(.easeInOut(duration: 0.25), reduceMotion: reduceMotion),
+      value: noticeText)
     // #2202 row 8 of the shared-root table. The capsule keeps its uniform inset;
     // the preview zeroes it and each section supplies its own, because a header
     // strip over a reading well does not want one rectangle of padding wrapped

--- a/Sources/EnviousWisprAppKit/App/OverlayMotion.swift
+++ b/Sources/EnviousWisprAppKit/App/OverlayMotion.swift
@@ -57,6 +57,39 @@ enum OverlayMotion {
   static func stateChange(_ animation: Animation?, reduceMotion: Bool) -> Animation? {
     reduceMotion ? nil : animation
   }
+
+  /// Bring one hairline's forever-loop into line with the setting, in BOTH directions.
+  ///
+  /// **Keyed to the SETTING's lifecycle, never to `onAppear`** (#2303, PR #2767 cloud review r1).
+  /// Reduce Motion can be switched off while a pill is still mounted, and an `onAppear` guard
+  /// runs once: the loop would never arm, the opacity would sit at its dim starting value, and
+  /// the hairline would be DIMMER than in either state it is meant to have.
+  ///
+  /// **The park branch is the load-bearing half, and is why this is written once rather than
+  /// twice.** Nothing reads the animated value once the loop is off, so a loop left running
+  /// would be invisible AND would keep re-rendering forever — the cost #2201 exists to avoid.
+  /// Parking on a nil transaction also leaves a known value for the next arm to start from.
+  @MainActor
+  static func syncAmbientLoop(
+    enabled: Bool,
+    opacity: Binding<Double>,
+    dim: Double,
+    bright: Double,
+    duration: Double,
+    onTarget: (Double) -> Void
+  ) {
+    guard enabled else {
+      var stop = Transaction()
+      stop.animation = nil
+      withTransaction(stop) { opacity.wrappedValue = dim }
+      onTarget(dim)
+      return
+    }
+    withAnimation(.easeInOut(duration: duration).repeatForever(autoreverses: true)) {
+      opacity.wrappedValue = bright
+    }
+    onTarget(bright)
+  }
 }
 
 // MARK: - Reading the setting

--- a/Sources/EnviousWisprAppKit/App/OverlayMotion.swift
+++ b/Sources/EnviousWisprAppKit/App/OverlayMotion.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// What macOS Reduce Motion changes about the recording pill, and what it must NOT change.
+///
+/// #2303. `EscapeRecoveryPillView` and the Settings surfaces already read
+/// `accessibilityReduceMotion`; the pill a person looks at during every dictation did not.
+/// `RailMotion` in `EscapeRecoveryPillView.swift` is the precedent this follows, including
+/// its recorded warning that a nil animation does not SKIP a change, it applies it INSTANTLY.
+///
+/// The split is decoration versus information, and both halves are decisions.
+///
+/// **Suppressed — self-running loops that carry nothing.** The rainbow hairline's two-second
+/// breathe and the distress hairline's red pulse run forever on a timer no state feeds. Each
+/// already has a documented still value chosen as the mid-point of its own loop, so holding
+/// still costs no brightness: `OverlayCapsuleBackground.steadyGlowOpacity` (#2201, #2435) and
+/// the two added beside it here.
+///
+/// **Made instant — discrete state changes.** The lock transition and the notice cross-fade
+/// each animate one change to one value. Instant is the correct outcome for both: the user
+/// still sees the locked pill and still reads the notice.
+///
+/// **KEPT, deliberately, and each would be worse suppressed:**
+/// - *The audio level's easing* (`RecordingOverlayView`, `chrome.levelAnimation`). The level is
+///   repolled every 50 ms. Removing the easing does not still the pill, it makes it jump twenty
+///   times a second — strictly more movement than it has today.
+/// - *The lips reacting to the voice.* Each recording pill header carries exactly one "I can
+///   hear you" signal — `RainbowLipsIcon` on the `mark` header, `RainbowLevelMeter` on the
+///   `meterStrip` one — so stilling it leaves a Reduce Motion user with a muted microphone
+///   nothing that distinguishes a working take from a silent one. Both react to `audioLevel`
+///   and neither runs on a timer of its own, which is what separates them from the loops
+///   above.
+/// - *`SpectrumWheelIcon`'s rotation* on the polishing and cold-start pills, which is OUT OF
+///   SCOPE rather than decided: this issue is the recording pill and the lips, and that wheel is
+///   a progress indicator on two other pills. Checked rather than assumed, because the obvious
+///   justification for keeping it is wrong: it is NOT the only sign that work is happening.
+///   `PolishingOverlayView.swift:22` and `ColdStartNoticeView.swift:38` each draw a text label
+///   beside it. Whether a custom progress spinner should freeze under Reduce Motion is a real
+///   question and this change does not answer it.
+///
+/// **The scope is the recording pill, and OTHER SURFACES STILL IGNORE THE SETTING.** Onboarding
+/// and the main window each run their own forever-loops, and the welcome screens have a second
+/// pair of lips of their own. Deliberately not listed here, because a roster in a comment goes
+/// stale the moment somebody adds a loop without touching this file. Regenerate it instead:
+///
+///     grep -rn "repeatForever\|TimelineView(" Sources/
+///
+/// and read each hit for whether the view it sits in resolves a Reduce Motion value at all.
+///
+/// A person who wants the lips and the gradients gone WITHOUT turning on system-wide Reduce
+/// Motion is asking for a separate in-app setting. That is the open half of #2303 and is not
+/// decided here.
+enum OverlayMotion {
+  /// Whether a decorative loop that repeats forever may run.
+  static func showsAmbientLoop(reduceMotion: Bool) -> Bool { !reduceMotion }
+
+  /// The animation for a discrete state change, or `nil` to apply it instantly.
+  static func stateChange(_ animation: Animation?, reduceMotion: Bool) -> Animation? {
+    reduceMotion ? nil : animation
+  }
+}
+
+// MARK: - Reading the setting
+
+/// Where the pill's answer to "is Reduce Motion on" comes from.
+///
+/// **`EnvironmentValues.accessibilityReduceMotion` is GET-ONLY**, measured against the SDK on
+/// 2026-09-09 (`SwiftUICore.swiftinterface:18070` declares `get` and nothing else, beside a
+/// writable underscored twin this deliberately does not touch). So `.environment(...)` cannot
+/// hand a test a pretend value, and without this key the only claim any test could make about
+/// the pill's paint is that the code READS a flag — never that the flag reaches a pixel.
+///
+/// This key is the seam, and it is inert in the shipped app **by construction: nothing outside
+/// the test target ever sets it**, so every real pill resolves to the system value.
+/// `OverlayReduceMotionTests` asserts that emptiness rather than asserting a promise.
+private struct OverlayReduceMotionOverrideKey: EnvironmentKey {
+  static let defaultValue: Bool? = nil
+}
+
+extension EnvironmentValues {
+  var overlayReduceMotionOverride: Bool? {
+    get { self[OverlayReduceMotionOverrideKey.self] }
+    set { self[OverlayReduceMotionOverrideKey.self] = newValue }
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayReduceMotionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayReduceMotionTests.swift
@@ -130,6 +130,133 @@ struct OverlayReduceMotionTests {
       "the lips changed across time with Reduce Motion on, so the pulse is still running")
   }
 
+  // MARK: - Turning the setting OFF while the pill is on screen
+
+  /// **Measured 2026-09-09: an off-screen `NSHostingView` does NOT advance a `repeatForever`.**
+  /// Three renders 0.4 s apart of a capsule that has been breathing since it mounted are
+  /// byte-identical, so "did the hairline start moving again" has no pixel answer in this
+  /// process. That is why the rows below read the target opacity the view reports at the moment
+  /// it arms or parks the loop, rather than reading paint like every other row in this suite.
+  /// Whether the hairline visibly breathes is a Live UAT row and is claimed nowhere here.
+
+  /// Holds the setting so a mounted pill can watch it change, the way the real environment does.
+  @Observable final class MotionBox {
+    var reduceMotion: Bool
+    init(reduceMotion: Bool) { self.reduceMotion = reduceMotion }
+  }
+
+  final class TargetLog: @unchecked Sendable {
+    private(set) var targets: [Double] = []
+    func record(_ value: Double) { targets.append(value) }
+  }
+
+  /// A CONCRETE wrapper, never `AnyView`. `AnyView` can break SwiftUI's view identity, which
+  /// would remount the capsule on the toggle and re-arm it for free — the exact defect this
+  /// exists to catch would then pass.
+  private struct ToggleHarness: View {
+    let box: MotionBox
+    let log: TargetLog
+    var body: some View {
+      OverlayCapsuleBackground(onGlowTarget: { log.record($0) })
+        .environment(\.overlayReduceMotionOverride, box.reduceMotion)
+        .frame(width: 200, height: 44)
+    }
+  }
+
+  /// The interruption pill carries the identical mechanism, so it carries identical rows. One
+  /// pill passing says nothing about the other: they are two `onChange` wirings, not one.
+  private struct DistressToggleHarness: View {
+    let box: MotionBox
+    let log: TargetLog
+    var body: some View {
+      DistressCapsuleBackground(onGlowTarget: { log.record($0) })
+        .environment(\.overlayReduceMotionOverride, box.reduceMotion)
+        .frame(width: 200, height: 44)
+    }
+  }
+
+  private static func distressTargetsAcrossToggle(
+    startingReduced: Bool, thenReduced: Bool
+  ) -> [Double] {
+    let box = MotionBox(reduceMotion: startingReduced)
+    let log = TargetLog()
+    let host = NSHostingView(rootView: DistressToggleHarness(box: box, log: log))
+    let size = CGSize(width: 200, height: 44)
+    host.frame = NSRect(origin: .zero, size: size)
+    let window = NSWindow(
+      contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    box.reduceMotion = thenReduced
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    return log.targets
+  }
+
+  private static func targetsAcrossToggle(startingReduced: Bool, thenReduced: Bool) -> [Double] {
+    let box = MotionBox(reduceMotion: startingReduced)
+    let log = TargetLog()
+    let host = NSHostingView(rootView: ToggleHarness(box: box, log: log))
+    let size = CGSize(width: 200, height: 44)
+    host.frame = NSRect(origin: .zero, size: size)
+    let window = NSWindow(
+      contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    box.reduceMotion = thenReduced
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+    return log.targets
+  }
+
+  /// #2767 cloud review r1. Reduce Motion can be switched OFF while a pill is still mounted.
+  /// Arming from `onAppear` runs once, so the hairline would sit at its dim starting value
+  /// forever — dimmer than either state it is meant to have.
+  @Test("turning Reduce Motion off re-arms the hairline without remounting the pill")
+  func theGlowReArmsWhenTheSettingGoesOff() {
+    let targets = Self.targetsAcrossToggle(startingReduced: true, thenReduced: false)
+    #expect(
+      targets.count == 2,
+      "\(targets.count) glow decisions across the toggle, not two: it never saw the change")
+    #expect(
+      targets.last == 0.65,
+      "last glow decision \(String(describing: targets.last)), not the bright endpoint: no re-arm")
+  }
+
+  /// The opposite direction, so a view that simply always arms cannot pass the row above.
+  @Test("turning Reduce Motion on parks the hairline without remounting the pill")
+  func theGlowParksWhenTheSettingGoesOn() {
+    let targets = Self.targetsAcrossToggle(startingReduced: false, thenReduced: true)
+    #expect(
+      targets.count == 2,
+      "the capsule reported \(targets.count) glow decisions across the toggle, not two")
+    #expect(
+      targets.last == 0.3,
+      "last glow decision \(String(describing: targets.last)), not the dim endpoint: still looping")
+  }
+
+  @Test("turning Reduce Motion off re-arms the interruption pill without remounting it")
+  func theDistressGlowReArmsWhenTheSettingGoesOff() {
+    let targets = Self.distressTargetsAcrossToggle(startingReduced: true, thenReduced: false)
+    #expect(targets.count == 2, "\(targets.count) glow decisions across the toggle, not two")
+    #expect(
+      targets.last == 0.6,
+      "last glow decision \(String(describing: targets.last)), not the bright endpoint: no re-arm")
+  }
+
+  @Test("turning Reduce Motion on parks the interruption pill without remounting it")
+  func theDistressGlowParksWhenTheSettingGoesOn() {
+    let targets = Self.distressTargetsAcrossToggle(startingReduced: false, thenReduced: true)
+    #expect(targets.count == 2, "\(targets.count) glow decisions across the toggle, not two")
+    #expect(
+      targets.last == 0.3,
+      "last glow decision \(String(describing: targets.last)), not the dim endpoint: still looping")
+  }
+
   // MARK: - The policy, and the seam that lets these rows exist
 
   @Test("an ambient loop runs only while Reduce Motion is off")

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayReduceMotionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayReduceMotionTests.swift
@@ -1,0 +1,175 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2303: the recording pill obeys macOS Reduce Motion.
+///
+/// **Product Outcome.** When these fail, a person who has told macOS to calm every app down is
+/// still shown a hairline breathing on a two-second loop, a red one flashing three times a
+/// second, or lips pulsing, on the surfaces they see during every dictation.
+///
+/// **These rows read PIXELS, because the whole subject is paint.** `RenderedPillHarness` records
+/// that `fittingSize` is blind to colour and opacity, so no size assertion can see this change at
+/// all. `AppearanceRenderHarness` established the mechanism used here.
+///
+/// **Nothing here freezes an absolute reading.** Every row is a RELATION between renders taken in
+/// ONE process, which is what survives another Mac's font metrics and rendering defaults
+/// (`validation-discipline.md` RULE: measure-with-the-real-tool-never-a-simulation). Each
+/// difference row is paired with a control proving the instrument is deterministic, so a renderer
+/// returning noise would fail rather than pass.
+@MainActor
+@Suite(.tags(.productOutcome))
+struct OverlayReduceMotionTests {
+
+  init() { _ = NSApplication.shared }
+
+  /// Paint one view at a fixed box and return the encoded pixels.
+  private static func pixels(
+    _ view: some View,
+    reduceMotion: Bool,
+    size: CGSize = CGSize(width: 200, height: 44)
+  ) throws -> Data {
+    let sized = view.frame(width: size.width, height: size.height)
+    let host = NSHostingView(
+      rootView: AnyView(sized.environment(\.overlayReduceMotionOverride, reduceMotion)))
+    host.frame = NSRect(origin: .zero, size: size)
+    let window = NSWindow(
+      contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    host.layoutSubtreeIfNeeded()
+    window.displayIfNeeded()
+
+    let rep = try #require(
+      host.bitmapImageRepForCachingDisplay(in: host.bounds),
+      "the host produced no bitmap, so this row proved nothing")
+    host.cacheDisplay(in: host.bounds, to: rep)
+    let png: Data? = rep.representation(using: NSBitmapImageRep.FileType.png, properties: [:])
+    return try #require(png, "the bitmap did not encode, so this row proved nothing")
+  }
+
+  // MARK: - The rainbow hairline on the recording pill
+
+  @Test("the recording pill's hairline is painted differently once Reduce Motion is on")
+  func rainbowHairlineHoldsStill() throws {
+    let moving = try Self.pixels(OverlayCapsuleBackground(), reduceMotion: false)
+    let still = try Self.pixels(OverlayCapsuleBackground(), reduceMotion: true)
+    #expect(
+      moving != still,
+      "the capsule painted identically either way, so the setting reached no pixel")
+  }
+
+  @Test("the same capsule painted twice is identical, so a difference means the setting")
+  func rainbowHairlineInstrumentIsDeterministic() throws {
+    let first = try Self.pixels(OverlayCapsuleBackground(), reduceMotion: false)
+    let second = try Self.pixels(OverlayCapsuleBackground(), reduceMotion: false)
+    #expect(
+      first == second,
+      "two identical renders differed, so the row above cannot attribute a difference to anything")
+  }
+
+  // MARK: - The red hairline on the interruption pill
+
+  @Test("the interruption pill's red hairline is painted differently once Reduce Motion is on")
+  func distressHairlineHoldsStill() throws {
+    let moving = try Self.pixels(DistressCapsuleBackground(), reduceMotion: false)
+    let still = try Self.pixels(DistressCapsuleBackground(), reduceMotion: true)
+    #expect(
+      moving != still,
+      "the distress capsule painted identically either way, so the setting reached no pixel")
+  }
+
+  @Test("the same interruption capsule painted twice is identical")
+  func distressHairlineInstrumentIsDeterministic() throws {
+    let first = try Self.pixels(DistressCapsuleBackground(), reduceMotion: false)
+    let second = try Self.pixels(DistressCapsuleBackground(), reduceMotion: false)
+    #expect(
+      first == second,
+      "two identical renders differed, so the row above cannot attribute a difference to anything")
+  }
+
+  // MARK: - The warning lips
+
+  /// A third of the pulse's own 0.7 s period.
+  ///
+  /// The lips' distress pulse is driven by the WALL CLOCK, so it is proven by taking renders at
+  /// different TIMES rather than by comparing the two settings at one instant — at one instant
+  /// the pulse can be passing through the still value and the two would agree by coincidence.
+  /// Three samples make "all three equal" the signal, which no single coincidence produces.
+  private static let pulseSampleGap: TimeInterval = 0.23
+
+  private static func lipSamples(reduceMotion: Bool) throws -> [Data] {
+    var out: [Data] = []
+    for index in 0..<3 {
+      // settle: elapsed time IS this row's independent variable, not a wait for work to finish.
+      if index > 0 { Thread.sleep(forTimeInterval: pulseSampleGap) }
+      out.append(
+        try pixels(
+          RainbowLipsIcon(size: 24, audioLevel: 0, isDistress: true),
+          reduceMotion: reduceMotion,
+          size: CGSize(width: 24, height: 24)))
+    }
+    return out
+  }
+
+  @Test("the warning lips pulse over time while Reduce Motion is off")
+  func warningLipsPulseWhenTheSettingIsOff() throws {
+    let samples = try Self.lipSamples(reduceMotion: false)
+    #expect(
+      Set(samples).count > 1,
+      "three renders spread across the pulse were identical, so the moving arm draws nothing")
+  }
+
+  @Test("the warning lips hold still once Reduce Motion is on")
+  func warningLipsHoldStillWhenTheSettingIsOn() throws {
+    let samples = try Self.lipSamples(reduceMotion: true)
+    #expect(
+      Set(samples).count == 1,
+      "the lips changed across time with Reduce Motion on, so the pulse is still running")
+  }
+
+  // MARK: - The policy, and the seam that lets these rows exist
+
+  @Test("an ambient loop runs only while Reduce Motion is off")
+  func ambientLoopFollowsTheSetting() {
+    #expect(OverlayMotion.showsAmbientLoop(reduceMotion: false))
+    #expect(OverlayMotion.showsAmbientLoop(reduceMotion: true) == false)
+  }
+
+  @Test("a discrete state change keeps its animation off, and becomes instant on")
+  func stateChangeFollowsTheSetting() {
+    #expect(OverlayMotion.stateChange(.easeInOut(duration: 0.3), reduceMotion: false) != nil)
+    #expect(OverlayMotion.stateChange(.easeInOut(duration: 0.3), reduceMotion: true) == nil)
+  }
+
+  /// The override above exists only because the system value is get-only. It is inert in the
+  /// shipped app for one reason: **nothing sets it**. That is a property of the source, so it is
+  /// asserted against the source rather than promised in a comment — if somebody wires it to a
+  /// setting, a build flag or a debug menu, every pill silently stops reading the person's real
+  /// macOS preference, and this row is what says so.
+  @Test("no shipped code sets the override, so every real pill reads the system setting")
+  func theOverrideIsInertInTheShippedApp() throws {
+    let sources = RepoRoot.url.appending(path: "Sources")
+    let files = FileManager.default.enumerator(at: sources, includingPropertiesForKeys: nil)
+    var setters: [String] = []
+    var scanned = 0
+    while let url = files?.nextObject() as? URL {
+      guard url.pathExtension == "swift" else { continue }
+      scanned += 1
+      let text = try String(contentsOf: url, encoding: .utf8)
+      guard text.contains("overlayReduceMotionOverride") else { continue }
+      // The declaration itself is the one legitimate mention.
+      if url.lastPathComponent == "OverlayMotion.swift" { continue }
+      for line in text.split(separator: "\n") where line.contains("overlayReduceMotionOverride") {
+        let mention = line.trimmingCharacters(in: .whitespaces)
+        // Reading it is what every pill does. Only a WRITE breaks the property.
+        if mention.hasPrefix("@Environment(") { continue }
+        setters.append("\(url.lastPathComponent): \(mention)")
+      }
+    }
+    #expect(scanned > 0, "the sweep read no Swift files, so its silence means nothing")
+    #expect(setters.isEmpty, "shipped code writes the override: \(setters)")
+  }
+}

--- a/Tests/EnviousWisprTests/App/Overlay/OverlayReduceMotionTests.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/OverlayReduceMotionTests.swift
@@ -15,6 +15,14 @@ import Testing
 /// that `fittingSize` is blind to colour and opacity, so no size assertion can see this change at
 /// all. `AppearanceRenderHarness` established the mechanism used here.
 ///
+/// **WHAT THESE ROWS DO NOT BIND, stated rather than left to be discovered.** No row constructs
+/// `RecordingOverlayView`, so its two container gates — the lock transition and the notice
+/// cross-fade — have only the helper's own row behind them; if a call site stopped passing the
+/// helper, nothing here would go red. And no row proves a hairline VISIBLY breathes, stops, or
+/// resumes: an off-screen `NSHostingView` does not advance a `repeatForever` (measured
+/// 2026-09-09, three renders 0.4 s apart of a breathing capsule are byte-identical), so the
+/// re-arm rows read the target the view reports instead. Both are Live UAT rows.
+///
 /// **Nothing here freezes an absolute reading.** Every row is a RELATION between renders taken in
 /// ONE process, which is what survives another Mac's font metrics and rendering defaults
 /// (`validation-discipline.md` RULE: measure-with-the-real-tool-never-a-simulation). Each
@@ -53,7 +61,7 @@ struct OverlayReduceMotionTests {
   // MARK: - The rainbow hairline on the recording pill
 
   @Test("the recording pill's hairline is painted differently once Reduce Motion is on")
-  func rainbowHairlineHoldsStill() throws {
+  func rainbowHairlinePaintsDifferently() throws {
     let moving = try Self.pixels(OverlayCapsuleBackground(), reduceMotion: false)
     let still = try Self.pixels(OverlayCapsuleBackground(), reduceMotion: true)
     #expect(
@@ -73,7 +81,7 @@ struct OverlayReduceMotionTests {
   // MARK: - The red hairline on the interruption pill
 
   @Test("the interruption pill's red hairline is painted differently once Reduce Motion is on")
-  func distressHairlineHoldsStill() throws {
+  func distressHairlinePaintsDifferently() throws {
     let moving = try Self.pixels(DistressCapsuleBackground(), reduceMotion: false)
     let still = try Self.pixels(DistressCapsuleBackground(), reduceMotion: true)
     #expect(
@@ -100,6 +108,8 @@ struct OverlayReduceMotionTests {
   /// Three samples make "all three equal" the signal, which no single coincidence produces.
   private static let pulseSampleGap: TimeInterval = 0.23
 
+  /// Each sample builds a NEW host with an explicit override, so this reaches neither live
+  /// system-setting delivery nor a mounted `TimelineView` being removed and restored.
   private static func lipSamples(reduceMotion: Bool) throws -> [Data] {
     var out: [Data] = []
     for index in 0..<3 {
@@ -236,7 +246,7 @@ struct OverlayReduceMotionTests {
       "the capsule reported \(targets.count) glow decisions across the toggle, not two")
     #expect(
       targets.last == 0.3,
-      "last glow decision \(String(describing: targets.last)), not the dim endpoint: still looping")
+      "last glow decision \(String(describing: targets.last)), not the dim endpoint")
   }
 
   @Test("turning Reduce Motion off re-arms the interruption pill without remounting it")
@@ -254,18 +264,50 @@ struct OverlayReduceMotionTests {
     #expect(targets.count == 2, "\(targets.count) glow decisions across the toggle, not two")
     #expect(
       targets.last == 0.3,
-      "last glow decision \(String(describing: targets.last)), not the dim endpoint: still looping")
+      "last glow decision \(String(describing: targets.last)), not the dim endpoint")
+  }
+
+  // MARK: - What Reduce Motion must NOT change
+
+  /// The lips are the pill's "I can hear you" signal. `OverlayMotion` records that stilling them
+  /// would leave a Reduce Motion user with a muted microphone nothing to distinguish a working
+  /// take from a silent one, so this is a row about what the change must NOT have done.
+  @Test("the ordinary lips still react to the voice under Reduce Motion")
+  func ordinaryLipsStayAudioReactive() throws {
+    let box = CGSize(width: 24, height: 24)
+    let silent = try Self.pixels(
+      RainbowLipsIcon(size: 24, audioLevel: 0), reduceMotion: true, size: box)
+    let speaking = try Self.pixels(
+      RainbowLipsIcon(size: 24, audioLevel: 1), reduceMotion: true, size: box)
+    #expect(silent != speaking, "the lips painted the same silent and loud, so they went deaf")
+
+    let speakingUnreduced = try Self.pixels(
+      RainbowLipsIcon(size: 24, audioLevel: 1), reduceMotion: false, size: box)
+    #expect(
+      speaking == speakingUnreduced,
+      "Reduce Motion changed how loud lips are drawn, and it is meant to change nothing here")
+  }
+
+  /// #2201 and #2435 already chose two ways for a hairline to hold still, and neither is about
+  /// Reduce Motion. A pill that was still for one of those reasons must paint identically with
+  /// the setting on or off, or this change has quietly taken over their decision.
+  @Test("the hairlines that already held still are unmoved by the setting")
+  func existingStillChoicesAreUnaffected() throws {
+    let previewPill = OverlayCapsuleBackground(cornerStyle: .rounded, animatesGlow: true)
+    let frozenCapsule = OverlayCapsuleBackground(cornerStyle: .capsule, animatesGlow: false)
+    for still in [AnyView(previewPill), AnyView(frozenCapsule)] {
+      let off = try Self.pixels(still, reduceMotion: false)
+      let on = try Self.pixels(still, reduceMotion: true)
+      #expect(off == on, "a hairline that was already still changed when Reduce Motion came on")
+    }
   }
 
   // MARK: - The policy, and the seam that lets these rows exist
 
-  @Test("an ambient loop runs only while Reduce Motion is off")
-  func ambientLoopFollowsTheSetting() {
-    #expect(OverlayMotion.showsAmbientLoop(reduceMotion: false))
-    #expect(OverlayMotion.showsAmbientLoop(reduceMotion: true) == false)
-  }
-
-  @Test("a discrete state change keeps its animation off, and becomes instant on")
+  /// `showsAmbientLoop` needs no row of its own: every pixel and target row above reaches it
+  /// through a real view, in both directions. `stateChange` does, because nothing else here
+  /// constructs `RecordingOverlayView` — see the coverage note in this suite's header.
+  @Test("the state-change helper returns an animation off, and nil on")
   func stateChangeFollowsTheSetting() {
     #expect(OverlayMotion.stateChange(.easeInOut(duration: 0.3), reduceMotion: false) != nil)
     #expect(OverlayMotion.stateChange(.easeInOut(duration: 0.3), reduceMotion: true) == nil)
@@ -280,23 +322,34 @@ struct OverlayReduceMotionTests {
   func theOverrideIsInertInTheShippedApp() throws {
     let sources = RepoRoot.url.appending(path: "Sources")
     let files = FileManager.default.enumerator(at: sources, includingPropertiesForKeys: nil)
-    var setters: [String] = []
+    var unexpected: [String] = []
     var scanned = 0
+    var declarations = 0
     while let url = files?.nextObject() as? URL {
       guard url.pathExtension == "swift" else { continue }
       scanned += 1
       let text = try String(contentsOf: url, encoding: .utf8)
       guard text.contains("overlayReduceMotionOverride") else { continue }
-      // The declaration itself is the one legitimate mention.
-      if url.lastPathComponent == "OverlayMotion.swift" { continue }
       for line in text.split(separator: "\n") where line.contains("overlayReduceMotionOverride") {
         let mention = line.trimmingCharacters(in: .whitespaces)
-        // Reading it is what every pill does. Only a WRITE breaks the property.
+        // Prose about the key cannot set it.
+        if mention.hasPrefix("///") || mention.hasPrefix("//") { continue }
+        // Reading it is what every pill does. Only a WRITE would break the property.
         if mention.hasPrefix("@Environment(") { continue }
-        setters.append("\(url.lastPathComponent): \(mention)")
+        // The declaration itself, and only in its own file. Skipping the WHOLE file — which an
+        // earlier version of this row did — means a writer added beside the declaration passes,
+        // which is exactly where somebody wiring this to a debug menu would put it.
+        if url.lastPathComponent == "OverlayMotion.swift",
+          mention == "var overlayReduceMotionOverride: Bool? {"
+        {
+          declarations += 1
+          continue
+        }
+        unexpected.append("\(url.lastPathComponent): \(mention)")
       }
     }
     #expect(scanned > 0, "the sweep read no Swift files, so its silence means nothing")
-    #expect(setters.isEmpty, "shipped code writes the override: \(setters)")
+    #expect(declarations == 1, "expected exactly one declaration, found \(declarations)")
+    #expect(unexpected.isEmpty, "shipped code mentions the override unexpectedly: \(unexpected)")
   }
 }


### PR DESCRIPTION
## What a person gets

Turn on Reduce Motion in macOS System Settings and the recording pill stops breathing, the red interruption pill stops flashing, and the warning lips stop pulsing. The colours stay, so a warning still reads as a warning. The lips still react to the voice, because that is the only thing on screen that distinguishes a working take from a muted microphone.

The crash-recovery pill, the menu-bar icon and every Settings surface already honoured this setting. The pill a person looks at during every dictation did not.

## The three halves, each a decision

**Suppressed — self-running loops that carry nothing.** The rainbow hairline's two-second breathe and the distress hairline's red pulse. Each holds at the mid-point of its own loop, so a still line is no dimmer on average than the moving one. The rainbow's still value already existed for #2201 and #2435; the two added here follow it. The distress hairline's still value is now chosen in the body rather than assigned in `onAppear`, so it lands on the first frame.

**Made instant — discrete state changes.** The lock transition and the notice cross-fade. A nil animation applies a change INSTANTLY rather than skipping it; that is correct for both, and `RailMotion` records the case where it is not (a countdown rail would jump to full and tell a Reduce Motion user their three seconds were already gone).

**Kept, deliberately.** The audio level's easing: the level is repolled every 50 ms, so removing the easing makes the pill jump twenty times a second — strictly more movement. The lips reacting to the voice: each pill header carries exactly one "I can hear you" signal, `RainbowLipsIcon` on the `mark` header and `RainbowLevelMeter` on the `meterStrip` one.

## The test seam, and why it exists

`EnvironmentValues.accessibilityReduceMotion` is **get-only**. Measured against the SDK rather than assumed — `SwiftUICore.swiftinterface:18070` declares `get` and nothing else, beside a writable underscored twin this deliberately does not touch. So `.environment(...)` cannot hand a test a pretend value, and without an injection point the strongest claim any test could make is that the code READS a flag, never that the flag reaches a pixel.

`overlayReduceMotionOverride` is that point. It is inert in the shipped app because nothing sets it, and that is asserted against the source rather than promised in a comment.

## Evidence

Nine rows reading PIXELS, because `RenderedPillHarness` records that `fittingSize` is blind to colour and opacity. Every comparison is a RELATION between renders taken in one process, never a frozen absolute, and each difference row is paired with a control proving the instrument is deterministic.

**Falsified before being trusted.** With `showsAmbientLoop` forced to `true`:

```
✘ the recording pill's hairline is painted differently once Reduce Motion is on
✔ the same capsule painted twice is identical
✘ the interruption pill's red hairline is painted differently once Reduce Motion is on
✔ the same interruption capsule painted twice is identical
✔ the warning lips pulse over time while Reduce Motion is off
✘ the warning lips hold still once Reduce Motion is on
✘ an ambient loop runs only while Reduce Motion is off
✔ a discrete state change keeps its animation off, and becomes instant on
✔ no shipped code sets the override
```

4 of 9 red, and the ones that stayed green are exactly the instrument controls and the moving arm — the pattern a real gate produces rather than a suite that fails wholesale.

- Full Debug lane: **7,651 tests, all accepted**.
- Dev configuration builds (`xcodebuild -scheme EnviousWispr-Dev -configuration Dev`): **BUILD SUCCEEDED**.
- Local `codex review --base origin/main`: clean, no actionable regressions.

## Scope, stated rather than implied

**Other surfaces still ignore the setting.** Frozen here rather than in a source comment, because a roster in a comment goes stale the moment somebody adds a loop without touching that file. At `e16d81b8a4ba868bb975c8ad7198ed0617dad3d6`, `/usr/bin/grep -rn "repeatForever\|TimelineView(" Sources/` returns these hits in views that resolve no Reduce Motion value at all:

| file | line |
|---|---|
| `Sources/EnviousWisprAppKit/App/Brand/SpectrumWheelIcon.swift` | 59 |
| `Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift` | 244 |
| `Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift` | 1438, 2088, 2139 |
| `Sources/EnviousWisprAppKit/Views/Onboarding/RainbowLipsView.swift` | 161, 197, 207 |

`SpectrumWheelIcon`'s rotation is out of scope rather than decided, and the obvious reason for keeping it was checked and is wrong: it is NOT the only sign that work is happening. `PolishingOverlayView.swift:22` and `ColdStartNoticeView.swift:38` each draw a text label beside it. Whether a custom progress spinner should freeze under Reduce Motion is a real question this change does not answer.

## Not closed by this

Part of #2303. The remaining half is a dedicated in-app plain-appearance setting for someone who wants this WITHOUT turning on system-wide Reduce Motion. That waits on the reporter's reply and is a founder call. The issue's triage says to do the accessibility half regardless, because an app that respects an accessibility setting on some of its surfaces and not others is not respecting it.
