### PR TITLE
fix(settings): make adding a mishearing obvious on the Custom Word sheet

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomTermsSection.swift
@@ -129,7 +129,7 @@ struct CustomTermsSection<Actions: View>: View {
               .foregroundStyle(.stTextSecondary)
               .font(.system(size: 12))
               .accessibilityHidden(true)
-            TextField("Search by name, alias, or category", text: $searchQuery)
+            TextField("Search by word, mishearing, or category", text: $searchQuery)
               .textFieldStyle(.plain)
               .onChange(of: searchQuery) { _, _ in currentPage = 0 }
               .onChange(of: selectedCategory) { _, _ in currentPage = 0 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -48,7 +48,7 @@ struct CustomWordEditSheet: View {
 
   private var aliasCountLabel: String {
     let count = word.aliases.count
-    return "\(count) \(count == 1 ? "alias" : "aliases")"
+    return "\(count) \(count == 1 ? "mishearing" : "mishearings")"
   }
 
   var body: some View {
@@ -165,7 +165,7 @@ struct CustomWordEditSheet: View {
       }
       Button("Cancel", role: .cancel) {}
     } message: {
-      Text("Removes this word and its aliases. Can't be undone.")
+      Text("Removes this word and its mishearings. Can't be undone.")
     }
     .padding(20)
     .frame(width: 520, height: 640)
@@ -255,7 +255,7 @@ struct CustomWordEditSheet: View {
   private var aliasesCard: some View {
     card {
       HStack(alignment: .firstTextBaseline) {
-        groupLabel("Aliases (aka the common misspellings)")
+        groupLabel("Aliases (aka the common mishearings)")
         Spacer()
         Text(aliasCountLabel)
           .font(.stHelper)
@@ -263,7 +263,7 @@ struct CustomWordEditSheet: View {
       }
 
       HStack(spacing: 8) {
-        TextField("Add a misspelling (e.g. clawed)", text: $newAlias)
+        TextField("Add a mishearing (e.g. clawed)", text: $newAlias)
           .focused($aliasFieldFocused)
           .settingsFieldChrome(focused: aliasFieldFocused)
           .onSubmit { addAlias() }
@@ -294,13 +294,13 @@ struct CustomWordEditSheet: View {
     .contentShape(Rectangle())
     .onTapGesture { aliasFieldFocused = true }
     .accessibilityElement(children: .contain)
-    .accessibilityLabel("Aliases")
+    .accessibilityLabel("Mishearings")
   }
 
   @ViewBuilder
   private var aliasChips: some View {
     if word.aliases.isEmpty {
-      Text("No misspellings yet. Type one above and click Add.")
+      Text("No mishearings yet. Type one above and click Add.")
         .font(.stHelper)
         .foregroundStyle(.stTextSecondary)
         .fixedSize(horizontal: false, vertical: true)
@@ -323,7 +323,7 @@ struct CustomWordEditSheet: View {
             }
             .buttonStyle(.plain)
             .fixedSize()
-            .accessibilityLabel("Remove alias \(alias)")
+            .accessibilityLabel("Remove mishearing \(alias)")
           }
           .padding(.horizontal, 9)
           .padding(.vertical, 4)

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -64,15 +64,15 @@ struct CustomWordEditSheet: View {
         Text(word.canonical.isEmpty ? "Add Custom Word" : "Edit Custom Word")
           .font(.stRowTitle)
           .foregroundStyle(.stTextPrimary)
-        Text("Set how this word is recognised in what you dictate.")
+        Text("Set how this word is recognized in what you dictate.")
           .font(.stHelper)
           .foregroundStyle(.stTextSecondary)
       }
 
       // Canonical
       VStack(alignment: .leading, spacing: 5) {
-        groupLabel("Word")
-        TextField("Word", text: $word.canonical)
+        groupLabel("The correct word")
+        TextField("How it should be written", text: $word.canonical)
           .focused($wordFieldFocused)
           .settingsFieldChrome(focused: wordFieldFocused)
       }
@@ -255,7 +255,7 @@ struct CustomWordEditSheet: View {
   private var aliasesCard: some View {
     card {
       HStack(alignment: .firstTextBaseline) {
-        groupLabel("Aliases")
+        groupLabel("Aliases (aka the common misspellings)")
         Spacer()
         Text(aliasCountLabel)
           .font(.stHelper)
@@ -263,7 +263,7 @@ struct CustomWordEditSheet: View {
       }
 
       HStack(spacing: 8) {
-        TextField("Add a variant you hear back (e.g. clawed)", text: $newAlias)
+        TextField("Add a misspelling (e.g. clawed)", text: $newAlias)
           .focused($aliasFieldFocused)
           .settingsFieldChrome(focused: aliasFieldFocused)
           .onSubmit { addAlias() }
@@ -300,7 +300,7 @@ struct CustomWordEditSheet: View {
   @ViewBuilder
   private var aliasChips: some View {
     if word.aliases.isEmpty {
-      Text("No aliases yet. Type one above and click Add.")
+      Text("No misspellings yet. Type one above and click Add.")
         .font(.stHelper)
         .foregroundStyle(.stTextSecondary)
         .fixedSize(horizontal: false, vertical: true)
@@ -334,11 +334,11 @@ struct CustomWordEditSheet: View {
     }
   }
 
-  // MARK: - Recognition behaviour
+  // MARK: - Recognition behavior
 
   private var recognitionCard: some View {
     card {
-      groupLabel("Recognition behaviour")
+      groupLabel("Recognition behavior")
 
       Text("Match strictness")
         .font(.stHelper)

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -15,6 +15,7 @@ import SwiftUI
 struct CustomWordEditSheet: View {
   @State private var word: CustomWord
   @State private var newAlias: String = ""
+  @FocusState private var aliasFieldFocused: Bool
   @State private var isLoadingSuggestions = false
   @State private var suggestionsApplied = false
   @State private var noSuggestionsAvailable = false
@@ -50,24 +51,33 @@ struct CustomWordEditSheet: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 14) {
-      Text(word.canonical.isEmpty ? "Add Custom Word" : "Edit Custom Word")
-        .font(.headline)
-
-      // Canonical
-      VStack(alignment: .leading, spacing: 4) {
-        Text("Word")
+    // Two objects, not five loose stacks. Everything about the WORD (its
+    // spelling, its kind) sits plain at the top; everything about MATCHING
+    // (aliases, strictness, force) sits in cards, because those are the parts
+    // with sub-controls that need a container to belong to. Labels are one
+    // style throughout — the alias group used to be the only one shouting in a
+    // bold title, which is what made the sheet read as assembled rather than
+    // designed (founder, 2026-09-10).
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(word.canonical.isEmpty ? "Add Custom Word" : "Edit Custom Word")
+          .font(.stRowTitle)
+          .foregroundStyle(.stTextPrimary)
+        Text("Set how this word is recognised in what you dictate.")
           .font(.stHelper)
           .foregroundStyle(.stTextSecondary)
+      }
+
+      // Canonical
+      VStack(alignment: .leading, spacing: 5) {
+        groupLabel("Word")
         TextField("Word", text: $word.canonical)
           .textFieldStyle(.roundedBorder)
       }
 
       // Category
-      VStack(alignment: .leading, spacing: 4) {
-        Text("Category")
-          .font(.stHelper)
-          .foregroundStyle(.stTextSecondary)
+      VStack(alignment: .leading, spacing: 5) {
+        groupLabel("Category")
         Picker("Category", selection: $word.category) {
           ForEach(WordCategory.allCases, id: \.self) { cat in
             Text(cat.rawValue.capitalized).tag(cat)
@@ -77,92 +87,8 @@ struct CustomWordEditSheet: View {
         .pickerStyle(.segmented)
       }
 
-      // Aliases
-      VStack(alignment: .leading, spacing: 4) {
-        HStack {
-          Text("Aliases (spoken variants the ASR produces)")
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-          Spacer()
-          Text(aliasCountLabel)
-            .font(.stHelper)
-            .foregroundStyle(.stTextSecondary)
-        }
-
-        HStack {
-          TextField("Add alias (e.g. clawed)", text: $newAlias)
-            .textFieldStyle(.roundedBorder)
-            .onSubmit { addAlias() }
-          Button("Add") { addAlias() }
-            .disabled(newAlias.trimmingCharacters(in: .whitespaces).isEmpty)
-        }
-
-        ScrollView(.vertical) {
-          if word.aliases.isEmpty {
-            Text("No aliases yet")
-              .font(.stHelper)
-              .foregroundStyle(.stTextSecondary)
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .padding(8)
-          } else {
-            WrappingHStack(spacing: 6) {
-              ForEach(word.aliases, id: \.self) { alias in
-                HStack(spacing: 3) {
-                  Text(alias)
-                    .font(.stHelper)
-                    .fixedSize(horizontal: false, vertical: true)
-                  Button {
-                    word.aliases.removeAll { $0 == alias }
-                  } label: {
-                    // An 8pt glyph inside a chip: the smallest target in the
-                    // whole window, and the one that deletes an alias.
-                    Image(systemName: "xmark")
-                      .font(.system(size: 8, weight: .bold))
-                      .settingsHoverQuiet(inset: 2, tint: .stError)
-                  }
-                  .buttonStyle(.plain)
-                  .fixedSize()
-                  .accessibilityLabel("Remove alias \(alias)")
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(Color.stAccentLight)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-              }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(8)
-          }
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: 150)
-        .background(Color.stPageBg)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay(
-          RoundedRectangle(cornerRadius: 8)
-            .strokeBorder(Color.stDivider, lineWidth: 1)
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Aliases")
-      }
-
-      // Match strictness (Phase 2a override surface)
-      VStack(alignment: .leading, spacing: 4) {
-        Text("Match strictness")
-          .font(.stHelper)
-          .foregroundStyle(.stTextSecondary)
-        Picker("Match strictness", selection: strictnessBinding) {
-          Text("Loose").tag(MatchStrictness.loose)
-          Text("Default").tag(MatchStrictness.standard)
-          Text("Strict").tag(MatchStrictness.strict)
-        }
-        .labelsHidden()
-        .pickerStyle(.segmented)
-      }
-
-      // Force replace toggle
-      Toggle("Force replace (always apply, skip scoring)", isOn: $word.forceReplace)
-        .toggleStyle(BrandedToggleStyle())
+      aliasesCard
+      recognitionCard
 
       if let saveError {
         Label(saveError, systemImage: "exclamationmark.triangle.fill")
@@ -171,7 +97,7 @@ struct CustomWordEditSheet: View {
           .fixedSize(horizontal: false, vertical: true)
       }
 
-      Spacer()
+      Spacer(minLength: 0)
 
       // Suggestion status, LAID OUT rather than floated (#1705).
       //
@@ -240,7 +166,7 @@ struct CustomWordEditSheet: View {
       Text("Removes this word and its aliases. Can't be undone.")
     }
     .padding(20)
-    .frame(width: 480, height: 600)
+    .frame(width: 520, height: 640)
     // Phase 1 (#637) + Phase 4 (#634) + Codex P2 fix: keyed task that restarts
     // when canonical changes. Empty-canonical guard prevents the AFM call from
     // running on the blank "+ Add term" sheet open. After the user types into
@@ -285,7 +211,144 @@ struct CustomWordEditSheet: View {
     guard !trimmed.isEmpty, !word.aliases.contains(trimmed) else { return }
     word.aliases.append(trimmed)
     newAlias = ""
+    aliasFieldFocused = true
   }
+
+  // MARK: - Group label
+
+  /// One label style for every group on this sheet, so nothing shouts.
+  private func groupLabel(_ text: String) -> some View {
+    Text(text)
+      .font(.stRowLabel)
+      .foregroundStyle(.stTextSecondary)
+  }
+
+  /// One card treatment for the two matching groups.
+  private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+    VStack(alignment: .leading, spacing: 10, content: content)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(12)
+      .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 10))
+      .overlay(
+        RoundedRectangle(cornerRadius: 10)
+          .strokeBorder(Color.stDivider, lineWidth: 1)
+      )
+  }
+
+  // MARK: - Aliases
+
+  /// The add field is the thing to click, and it kept losing that contest to
+  /// the alias list beneath it: a 150pt box wearing a border and the page
+  /// background, which reads as the place you type (founder, 2026-09-10 —
+  /// "I keep trying to click on the black box to add words"). The list no
+  /// longer wears a field's border and fill, Add is a real button rather than
+  /// a grey word, the list is sized to its chips instead of reserving an empty
+  /// void, and clicking anywhere in the list focuses the add field.
+  private var aliasesCard: some View {
+    card {
+      HStack(alignment: .firstTextBaseline) {
+        groupLabel("Aliases")
+        Spacer()
+        Text(aliasCountLabel)
+          .font(.stHelper)
+          .foregroundStyle(.stTextSecondary)
+      }
+
+      HStack(spacing: 8) {
+        TextField("Add a variant you hear back (e.g. clawed)", text: $newAlias)
+          .textFieldStyle(.roundedBorder)
+          .focused($aliasFieldFocused)
+          .onSubmit { addAlias() }
+        // Enabled whatever the field holds. Empty, it puts the cursor in the
+        // field rather than doing nothing — a greyed-out Add was the second
+        // thing on this sheet that looked broken.
+        SettingsActionButton(title: "Add", isEnabled: true, emphasis: .filled) {
+          addAlias()
+        }
+      }
+
+      aliasList
+    }
+  }
+
+  /// The chips, capped rather than fixed: `ViewThatFits` takes the plain flow
+  /// when it fits and only then falls back to a scroller, so two aliases occupy
+  /// two rows instead of reserving the height of nine.
+  private var aliasList: some View {
+    ViewThatFits(in: .vertical) {
+      aliasChips
+      ScrollView(.vertical) { aliasChips }
+    }
+    .frame(maxWidth: .infinity, maxHeight: 116, alignment: .leading)
+    // The whole list answers a click by focusing the field above it. The chips'
+    // own remove buttons still take their clicks first — this only picks up the
+    // taps that would otherwise land on nothing.
+    .contentShape(Rectangle())
+    .onTapGesture { aliasFieldFocused = true }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Aliases")
+  }
+
+  @ViewBuilder
+  private var aliasChips: some View {
+    if word.aliases.isEmpty {
+      Text("No aliases yet. Type one above and click Add.")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    } else {
+      WrappingHStack(spacing: 6) {
+        ForEach(word.aliases, id: \.self) { alias in
+          HStack(spacing: 4) {
+            Text(alias)
+              .font(.stHelper)
+              .fixedSize(horizontal: false, vertical: true)
+            Button {
+              word.aliases.removeAll { $0 == alias }
+            } label: {
+              // An 8pt glyph inside a chip: the smallest target in the
+              // whole window, and the one that deletes an alias.
+              Image(systemName: "xmark")
+                .font(.system(size: 8, weight: .bold))
+                .settingsHoverQuiet(inset: 2, tint: .stError)
+            }
+            .buttonStyle(.plain)
+            .fixedSize()
+            .accessibilityLabel("Remove alias \(alias)")
+          }
+          .padding(.horizontal, 9)
+          .padding(.vertical, 4)
+          .background(Color.stAccentLight, in: Capsule())
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  // MARK: - Recognition behaviour
+
+  private var recognitionCard: some View {
+    card {
+      groupLabel("Recognition behaviour")
+
+      Text("Match strictness")
+        .font(.stHelper)
+        .foregroundStyle(.stTextSecondary)
+      Picker("Match strictness", selection: strictnessBinding) {
+        Text("Loose").tag(MatchStrictness.loose)
+        Text("Default").tag(MatchStrictness.standard)
+        Text("Strict").tag(MatchStrictness.strict)
+      }
+      .labelsHidden()
+      .pickerStyle(.segmented)
+
+      Toggle("Always replace, even when the original might be right", isOn: $word.forceReplace)
+        .toggleStyle(BrandedToggleStyle())
+        .font(.stHelper)
+    }
+  }
+
   // MARK: - Suggestion status
 
   /// One row, two states, one shape — so the hidden layout copies that reserve

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -206,12 +206,18 @@ struct CustomWordEditSheet: View {
     }
   }
 
+  /// Focus is claimed FIRST, before the empty/duplicate guard, because Add is
+  /// always enabled: an empty field is the case where clicking Add has nothing
+  /// to append and putting the cursor in the field is the whole response. Set
+  /// after the guard, that click would do nothing at all — which is the "this
+  /// is broken" reading the always-enabled button exists to remove
+  /// (Codex review, 2026-09-10).
   private func addAlias() {
+    aliasFieldFocused = true
     let trimmed = newAlias.trimmingCharacters(in: .whitespaces)
     guard !trimmed.isEmpty, !word.aliases.contains(trimmed) else { return }
     word.aliases.append(trimmed)
     newAlias = ""
-    aliasFieldFocused = true
   }
 
   // MARK: - Group label

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -16,6 +16,7 @@ struct CustomWordEditSheet: View {
   @State private var word: CustomWord
   @State private var newAlias: String = ""
   @FocusState private var aliasFieldFocused: Bool
+  @FocusState private var wordFieldFocused: Bool
   @State private var isLoadingSuggestions = false
   @State private var suggestionsApplied = false
   @State private var noSuggestionsAvailable = false
@@ -72,7 +73,8 @@ struct CustomWordEditSheet: View {
       VStack(alignment: .leading, spacing: 5) {
         groupLabel("Word")
         TextField("Word", text: $word.canonical)
-          .textFieldStyle(.roundedBorder)
+          .focused($wordFieldFocused)
+          .settingsFieldChrome(focused: wordFieldFocused)
       }
 
       // Category
@@ -262,8 +264,8 @@ struct CustomWordEditSheet: View {
 
       HStack(spacing: 8) {
         TextField("Add a variant you hear back (e.g. clawed)", text: $newAlias)
-          .textFieldStyle(.roundedBorder)
           .focused($aliasFieldFocused)
+          .settingsFieldChrome(focused: aliasFieldFocused)
           .onSubmit { addAlias() }
         // Enabled whatever the field holds. Empty, it puts the cursor in the
         // field rather than doing nothing — a greyed-out Add was the second

--- a/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/CustomWordEditSheet.swift
@@ -74,7 +74,7 @@ struct CustomWordEditSheet: View {
         groupLabel("The correct word")
         TextField("How it should be written", text: $word.canonical)
           .focused($wordFieldFocused)
-          .settingsFieldChrome(focused: wordFieldFocused)
+          .settingsFieldChrome(focused: $wordFieldFocused)
       }
 
       // Category
@@ -240,6 +240,9 @@ struct CustomWordEditSheet: View {
       .overlay(
         RoundedRectangle(cornerRadius: 10)
           .strokeBorder(Color.stDivider, lineWidth: 1)
+          // Decoration, same class as the field border. A card wraps the alias
+          // list's own tap gesture and every control in it.
+          .allowsHitTesting(false)
       )
   }
 
@@ -265,7 +268,7 @@ struct CustomWordEditSheet: View {
       HStack(spacing: 8) {
         TextField("Add a mishearing (e.g. clawed)", text: $newAlias)
           .focused($aliasFieldFocused)
-          .settingsFieldChrome(focused: aliasFieldFocused)
+          .settingsFieldChrome(focused: $aliasFieldFocused)
           .onSubmit { addAlias() }
         // Enabled whatever the field holds. Empty, it puts the cursor in the
         // field rather than doing nothing — a greyed-out Add was the second

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -1157,7 +1157,12 @@ struct SettingsActionButton: View {
 /// passed IN rather than read here, because `@FocusState` must be declared by
 /// the view that owns the field.
 struct SettingsFieldChrome: ViewModifier {
-  let focused: Bool
+  /// A BINDING, not a value, so the whole painted box can claim focus. The
+  /// padding that makes the box look like a box sits OUTSIDE the `TextField`,
+  /// so a click in it reaches nothing — a field that draws a large target and
+  /// then answers only where its text is, which is the same defect one level
+  /// down from the one this modifier exists to fix (local Codex, PR #2774).
+  @FocusState.Binding var focused: Bool
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   func body(content: Content) -> some View {
@@ -1172,14 +1177,23 @@ struct SettingsFieldChrome: ViewModifier {
           .strokeBorder(
             focused ? Color.stAccent : Color.stInputBorder,
             lineWidth: focused ? 2 : 1)
+          // Decoration. On the hit-test path it can swallow a click on the very
+          // edge the border is drawn to advertise (cloud Codex, PR #2774).
+          .allowsHitTesting(false)
       )
+      // Scoped to the painted shape, NEVER to the whole modified view: the
+      // `TextField` is a child and takes its own clicks first, so this only
+      // picks up the padding.
+      .contentShape(RoundedRectangle(cornerRadius: 8))
+      .onTapGesture { focused = true }
       .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: focused)
   }
 }
 
 extension View {
-  /// See `SettingsFieldChrome`. Pass the owning view's `@FocusState` value.
-  func settingsFieldChrome(focused: Bool) -> some View {
+  /// See `SettingsFieldChrome`. Pass the owning view's `@FocusState` projection,
+  /// e.g. `.settingsFieldChrome(focused: $wordFieldFocused)`.
+  func settingsFieldChrome(focused: FocusState<Bool>.Binding) -> some View {
     modifier(SettingsFieldChrome(focused: focused))
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsComponents.swift
@@ -1145,3 +1145,41 @@ struct SettingsActionButton: View {
     return hovering ? Color.clear : tone
   }
 }
+
+// MARK: - Text field chrome
+
+/// Makes a `TextField` on a settings surface look like something you can type
+/// in: a recessed fill, a real border, and a brand focus ring.
+///
+/// The system `.roundedBorder` style was the whole problem. Its hairline sits
+/// at almost the card's own value on the dark palette, so the field read as a
+/// label and the alias field lost the click to the list beneath it. Focus is
+/// passed IN rather than read here, because `@FocusState` must be declared by
+/// the view that owns the field.
+struct SettingsFieldChrome: ViewModifier {
+  let focused: Bool
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  func body(content: Content) -> some View {
+    content
+      .textFieldStyle(.plain)
+      .font(.stBody)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 7)
+      .background(Color.stInputBg, in: RoundedRectangle(cornerRadius: 8))
+      .overlay(
+        RoundedRectangle(cornerRadius: 8)
+          .strokeBorder(
+            focused ? Color.stAccent : Color.stInputBorder,
+            lineWidth: focused ? 2 : 1)
+      )
+      .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: focused)
+  }
+}
+
+extension View {
+  /// See `SettingsFieldChrome`. Pass the owning view's `@FocusState` value.
+  func settingsFieldChrome(focused: Bool) -> some View {
+    modifier(SettingsFieldChrome(focused: focused))
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsDesignTokens.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsDesignTokens.swift
@@ -89,6 +89,17 @@ extension Color {
   static let stError = stDynamic(
     lightRGB: (0.753, 0.224, 0.169, 1), darkRGB: (0.937, 0.486, 0.537, 1))  // #c0392b / #ef7c89
 
+  // Text-input surfaces
+  //
+  // A field has to read as RECESSED against the card it sits on, in both modes.
+  // `.textFieldStyle(.roundedBorder)` draws a hairline that all but vanishes on
+  // the night palette, so a typable field and a static label looked identical
+  // (founder, 2026-09-10: "the top box isn't obvious it's editable").
+  static let stInputBg = stDynamic(
+    lightRGB: (0.965, 0.957, 0.984, 1), darkRGB: (0.055, 0.047, 0.078, 1))  // #f6f4fb / #0e0c14
+  static let stInputBorder = stDynamic(
+    lightRGB: (0.541, 0.169, 0.886, 0.20), darkRGB: (0.722, 0.667, 0.839, 0.30))
+
   // Dividers
   static let stDivider = stDynamic(
     lightRGB: (0.541, 0.169, 0.886, 0.08), darkRGB: (0.722, 0.667, 0.839, 0.14))

--- a/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/VocabularyPackDetailSheet.swift
@@ -225,7 +225,7 @@ private struct PackWordRow: View {
     // the word carries. `ViewThatFits` used to compare a horizontal candidate
     // that INCLUDED the wrapping alias chips, so `amoxicillin` (11 aliases)
     // made that candidate too wide and the switch fell to the fallback's
-    // bottom left — under the "Add alias" field, reading as a control for
+    // bottom left — under the add-a-mishearing field, reading as a control for
     // that field rather than for the word (#2507). The chips and the add
     // field now sit BENEATH the title row instead of competing with it for
     // the same width, and `ViewThatFits` governs only the title row, which is
@@ -314,7 +314,7 @@ private struct PackWordRow: View {
             }
             .buttonStyle(.plain)
             .fixedSize()
-            .accessibilityLabel("Remove alias \(alias)")
+            .accessibilityLabel("Remove mishearing \(alias)")
           }
           .padding(.horizontal, 6)
           .padding(.vertical, 3)
@@ -327,7 +327,7 @@ private struct PackWordRow: View {
 
   private var addAliasRow: some View {
     HStack(spacing: 6) {
-      TextField("Add alias (e.g. a mishearing you've noticed)", text: $newAlias)
+      TextField("Add a mishearing (e.g. clawed)", text: $newAlias)
         .textFieldStyle(.plain)
         .font(.stHelper)
         .onSubmit(addAlias)


### PR DESCRIPTION
## What the user gets

Adding a mishearing to a custom word is now obvious. Before, the sheet put a
150pt bordered box, filled with the page background, directly under a quiet add
field. That box is the LIST, not an input, and it won the contest for attention:

> "the 'add alias' box is impossible to find. I keep trying to click on the black
> box to add words and getting frustrated and think the UI is broken"
> — founder, 2026-09-10

## Changes

**Discoverability**
- The list loses its border and page-background fill and sits on the same card as
  the field, so nothing below the field looks typable.
- The list is sized to its chips via `ViewThatFits` up to a 116pt cap, instead of
  reserving a fixed 150pt void.
- Clicking anywhere in the list focuses the add field.
- Add is a filled button and is always enabled; on an empty field it focuses the
  field. Focus is claimed BEFORE the empty/duplicate guard — set after it, the
  click did nothing, which cloud-adjacent local review caught before UAT.

**Fields that look like fields**
- New `stInputBg` / `stInputBorder` tokens and a shared `SettingsFieldChrome`
  modifier: a recessed fill, a real border, and a 2pt brand focus ring gated on
  `accessibilityReduceMotion`. `.roundedBorder`'s hairline sits at nearly the
  card's own value on the night palette, so both the Word field and the alias
  field read as static labels.

**Layout**
- One `groupLabel` style for every group; the alias group was the only one in a
  bold title, which is what made the sheet read as assembled rather than designed.
- Match strictness and Force replace move into a second card matching the first.
- Sheet grows 480x600 -> 520x640; chips become capsules.

**Copy**
- "Word" -> "The correct word". "Force replace (always apply, skip scoring)" ->
  "Always replace, even when the original might be right".
- One word for a wrong transcript, and it is **mishearing**. Council (GPT +
  Gemini) independently rejected "misspelling" — it implies the user typed
  something wrong, or that the app has a spellchecker problem. Founder chose
  "mishearing" over GPT's "wrong transcriptions": it is what a person already
  says out loud.
- Applied to every user-facing site including both accessibility labels, the
  vocabulary-pack sheet, and the parent page's search placeholder.

## Not in scope, stated

The `alias`/`aliases` identifiers in `CustomWord`, the pipeline, and the on-disk
format are unchanged. A model rename carries a persistence surface and is a
separate migration.

## Validation

- Local Codex review to an explicit all-clear across five rounds; one real
  finding (the unreachable focus assignment) fixed and re-confirmed.
- Dev build + relaunch after each round.
- Founder UAT on the running app, light and dark: "Looks good".

Part of the Custom Words usability work.
