### PR TITLE
feat(itn): spoken addresses convert in nine languages' own words

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -716,15 +716,145 @@ public struct InverseTextNormalizer: Sendable {
 
   // MARK: - Lexical passes (email / url / decimals)
 
+  /// NO already-dotted pass exists, and that is a measured conclusion rather than a gap (#2770).
+  ///
+  /// Parakeet often emits `anna.schmidt at gmail.com` — it converts the spoken dots itself and
+  /// leaves "at" as a word — so a pass matching `<name> at <host>.<tld>` would catch the shape
+  /// that actually arrives. Three licences for such a pass were built and each was falsified by
+  /// running ordinary sentences through `normalize`, 2026-09-10:
+  ///
+  /// 1. A property of the CANDIDATE (punctuation in the local part, or a context word within four
+  ///    tokens) converted `download report.pdf at example.com` and `read the email online at
+  ///    example.com`. `report.pdf` and `anna.schmidt` are the same shape, so no property of the
+  ///    token can separate them.
+  /// 2. A property of the SENTENCE (an English introducer or noun-plus-copula immediately before)
+  ///    converted seven more, including `You need to register at example.com`, `Contact us at
+  ///    example.com for details` and `my email address is listed at example.com`.
+  /// 3. A NON-ENGLISH cue within two tokens, with or without a punctuated local part, converted
+  ///    `Read about Mir online at wikipedia.org`, `Check the IST check-in at example.com`,
+  ///    `Open dir user-guide.pdf at example.com` and `Send the Mich. tax-free at example.com` —
+  ///    English proper nouns and abbreviations lowercase onto German cues.
+  ///
+  /// The root is a property of the language, not of any word list: English spells a website
+  /// `<verb> at <host>` and an address `<name> at <host>`, so the marker is the same word in both
+  /// and no amount of surrounding context decides it. The set of English words that may precede a
+  /// website is not bounded by anything, and neither is the set of proper nouns.
+  ///
+  /// The language would decide it, and is not available here: `InverseTextNormalizationStep`
+  /// SKIPS this engine outright for an explicitly non-English take, so a German dictation reaches
+  /// this code only when the language is unknown — exactly the case a language gate cannot serve.
+  ///
+  /// What ships instead is the pass below, which is self-limiting because the speaker must SAY
+  /// the dot. Reopening this needs an admission condition that is unambiguous, not a longer list.
+
+  /// What speakers actually say for `@` and for `.`, in the languages we cover.
+  ///
+  /// German has no localised at-word here and that is the measured point, not an omission: German
+  /// borrowed the English word and says "at". `klammeraffe` and `affenschwanz` appear only
+  /// because Apple's German voice renders a written `@` as those words, so they turn up in
+  /// synthesised audio even though speakers do not use them.
+  ///
+  /// These words are only ever read INSIDE the address frame, never as standalone rewrites, which
+  /// is what keeps an ordinary `chiocciola` (snail), `собака` (dog), `malpa` (monkey) or `punto`
+  /// (full stop) safe in prose.
+  ///
+  /// Native spellings checked against dictionaries, 2026-09-10, one word at a time rather than by
+  /// eye: `małpa` is the only ASCII-looking entry whose standard spelling is not ASCII (Polish
+  /// Academy dictionary), and the ASCII `malpa` is kept beside it because a recognizer may drop
+  /// the diacritic. A missing native spelling is SILENT — the conversion simply never fires —
+  /// and an ASCII-only test row hides it, which is how `małpa` was missed.
+  ///
+  /// A language needs BOTH halves or it converts nothing. Belarusian shipped with `малпа` and no
+  /// `кропка` and was dead on arrival; the Latin `kropka` beside it is the POLISH word. That is
+  /// why the two halves live in ONE table below and the regex alternations are GENERATED from it.
+  /// Completed 2026-09-10 with sources: Belarusian `сабака`/`кропка`, Ukrainian
+  /// `собачка`/`равлик`/`крапка`, Finnish `ät`/`miuku`/`miukumauku`/`kissanhäntä` beside the
+  /// existing `piste`, Norwegian `krøllalfa`, and `punktum` for Norwegian and Danish, which had
+  /// `snabel-a` and no dot-word at all.
+  ///
+  /// NOT COVERED, recorded rather than implied: Czech (`zavináč`/`tečka`), Estonian, Bulgarian,
+  /// Macedonian, Catalan and Afrikaans. `prikk` is kept for Norwegian but its use for reciting an
+  /// address is NOT VERIFIED — Norway's language council uses `punktum`, which is why that was
+  /// added rather than substituted. `.no` and `.by` stay excluded from `countryCodeTLDs` under the
+  /// existing English-word policy, so a Norwegian or Belarusian address at its own national
+  /// domain still does not convert.
+  ///
+  /// WHERE THIS RUNS (#2783). `InverseTextNormalizationStep.skipReason` skips this engine
+  /// outright for a take resolved as explicitly non-English, so these words reach a take whose
+  /// language is UNKNOWN (Parakeet reports none) or resolved as English. They are not, by
+  /// themselves, support for dictating in those languages. Both halves are pinned in
+  /// `InverseTextNormalizationStepTests`, which is the only suite that sees the gate — the
+  /// direct-formatter suite calls `normalize` and cannot.
+  ///
+  /// THE LICENCE: the at-word and dot-word a language ACTUALLY uses together, keyed by at-word.
+  /// A table, not a judgement about which words are English. Three review rounds falsified the judgement version, each with a measured sentence:
+  ///
+  /// - `We left because at one point me and John got tired.` -> `We left because@one.me`.
+  ///   `point` is an English word in the dot slot beside the English `at`.
+  /// - `look at the punto de vista` -> `look@the.de vista`. `punto` is NOT an English word, and
+  ///   English prose carries borrowed phrases anyway, with `de` a valid TLD.
+  /// - `Can the arroba example point me to the setting?` -> `Can the@example.me to the setting?`.
+  ///   An English sentence ABOUT the `arroba` symbol, with English `point` in the dot slot.
+  ///
+  /// "Can this word appear in an English sentence" has no bound and returned a new counterexample
+  /// every round. "Which pair does this language use" is a finite table, and the third sentence
+  /// above is refused by it because Spanish says `punto`, never `point`.
+  ///
+  /// English and German share the `at` key: German borrowed the English word (measured on a
+  /// native teaching recording and on four of the founder's own dictations, 2026-09-10) and pairs
+  /// it with `punkt`, English with `dot`.
+  ///
+  /// RESIDUAL RISK, stated rather than implied. French pairs `arobase` with `point`, which IS an
+  /// English word, so an English sentence ABOUT the `arobase` symbol in this exact frame still
+  /// converts. That is the same shape as the third sentence above and it is not closed — it is
+  /// narrower, because it needs the reader to be discussing the French term by name. Dropping
+  /// `point` would remove French entirely, since `point` is the French word for the dot.
+  /// #2781 tracks the equivalent hole in the shipped `at`/`dot` pair.
+  static let addressWordPairs: [String: Set<String>] = [
+    "at": ["dot", "punkt"],                          // English, and German which borrowed "at"
+    "klammeraffe": ["punkt"], "affenschwanz": ["punkt"],  // German
+    "arroba": ["punto", "ponto"],                    // Spanish, Portuguese
+    "chiocciola": ["punto"],                         // Italian
+    "apenstaartje": ["punt"], "apestaartje": ["punt"],    // Dutch
+    "malpa": ["kropka"], "małpa": ["kropka"],        // Polish
+    "sobaka": ["точка"], "собака": ["точка"],        // Russian
+    "сабака": ["кропка"], "малпа": ["кропка"],       // Belarusian
+    "собачка": ["крапка"], "равлик": ["крапка"],     // Ukrainian
+    "snabel-a": ["punkt", "punktum"], "snabela": ["punkt", "punktum"],  // Swedish, Danish
+    "krøllalfa": ["punktum", "prikk"],               // Norwegian
+    "kukac": ["pont"],                               // Hungarian
+    "arobase": ["point"],                            // French
+    "ät": ["piste"], "miuku": ["piste"], "miukumauku": ["piste"], "kissanhäntä": ["piste"],  // Finnish
+  ]
+
+  /// Both halves of the table as regex alternations. Generated FROM the table, never written out
+  /// again beside it — a second hand-written list is how a word ends up in one and not the other,
+  /// which is exactly what made Belarusian dead on arrival.
+  static let addressAtAlt = alt(Array(addressWordPairs.keys))
+  static let addressDotAlt = alt(Array(Set(addressWordPairs.values.flatMap { $0 })))
+
+  /// Does this at-word and this dot-word belong to one language?
+  static func isPairedAddressWording(_ atWord: String, _ dotWord: String) -> Bool {
+    guard let dots = addressWordPairs[atWord.lowercased()] else { return false }
+    return dots.contains(dotWord.lowercased())
+  }
+
   private func emails(_ t: String) -> String {
+    // Fully spoken: "name <at-word> domain <dot-word> tld", where the at-word and the dot-word
+    // must belong to ONE language. The pair is checked in the closure rather than by running a
+    // frame per language, so this stays a single pass — `emails` runs on every dictation and the
+    // engine has a 0.5 s deadline (#2770).
     let pat =
-      #"\b(?<name>[a-z][a-z0-9_]*)\s+at\s+(?<dom>[a-z][a-z0-9-]*)\s+dot\s+"#
+      #"\b(?<name>[a-z][a-z0-9_]*)\s+(?<atw>"# + Self.addressAtAlt + #")\s+"#
+      + #"(?<dom>[a-z][a-z0-9-]*)\s+(?<dotw>"# + Self.addressDotAlt + #")\s+"#
       + #"(?<tld>"# + Self.emailTLDAlt + #")\b"#
     return reSub(pat, t) { m in
+      guard Self.isPairedAddressWording(m.g("atw") ?? "", m.g("dotw") ?? "") else { return nil }
       let name = (m.g("name") ?? "").replacingOccurrences(of: " ", with: "")
       return "\(name)@\(m.g("dom") ?? "").\(m.g("tld") ?? "")"
     }
   }
+
 
   /// Two independent passes over two different recognizer shapes for the same spoken
   /// URL (#2257, #2049/#2050 — Parakeet v3 sometimes leaves "dot"/"slash" as literal

--- a/Tests/EnviousWisprTests/Pipeline/InverseTextNormalizationStepTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/InverseTextNormalizationStepTests.swift
@@ -49,6 +49,34 @@ import Testing
     #expect(step.lastRun?.skipReason == "lid_backend_nil")
   }
 
+  // MARK: Where the localised address words actually reach a user (#2770)
+
+  /// The direct-formatter suite calls `InverseTextNormalizer.normalize` and so cannot see this
+  /// gate. These two rows are the ones that say where the localised at-words and dot-words reach
+  /// a real dictation, and where they do not.
+  @Test("a spoken address in the speaker's own words converts on a no-language take")
+  func localisedAddressConvertsOnNilLanguageTake() async throws {
+    let step = InverseTextNormalizationStep()
+    step.backendSupportsLID = false
+    let out = try await step.process(ctx("mandalo a marco arroba esempio punto com"))
+    #expect(out.text.contains("marco@esempio.com"))
+    #expect(step.lastRun?.ran == true)
+  }
+
+  /// The limit, as a test rather than a comment: a take the app KNOWS is Spanish skips this
+  /// engine entirely, so the Spanish words never run on it. The localised words serve a take
+  /// whose language is unknown (Parakeet reports none) or resolved as English. Routing them for
+  /// a resolved non-English take is tracked separately.
+  @Test("the same address does NOT convert on a take resolved as Spanish")
+  func localisedAddressSkippedOnResolvedNonEnglishTake() async throws {
+    let step = InverseTextNormalizationStep()
+    step.backendSupportsLID = true
+    let input = "mandalo a marco arroba esempio punto com"
+    let out = try await step.process(ctx(input, language: "es"))
+    #expect(out.text == input)
+    #expect(step.lastRun?.skipReason == "non_english")
+  }
+
   @Test("explicit non-English language → skips (non_english)")
   func skipsForNonEnglishLanguage() async throws {
     let step = InverseTextNormalizationStep()

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerDottedEmailTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerDottedEmailTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// What each language's own words for `@` and `.` do, and what the ALREADY-DOTTED shape
+/// deliberately does not do.
+///
+/// Measured on the founder's own dictation, 2026-09-10. Parakeet emitted
+/// `anna.schmidt at gmail.com` and `Sorb at Gmail.de`: it had already turned the spoken "punkt"
+/// into a dot and left "at" as a word, so no spoken "dot" was left to match. A pass for that
+/// shape was built three times and falsified three times, and the refusals below are what
+/// falsified it. `emails(_:)` carries the full record and the reason the class is closed.
+///
+/// **These refusals pass trivially today, and that is their job.** Nothing converts the
+/// already-dotted shape, so every row is green by construction. They exist as the falsification
+/// condition for the next person who adds such a pass: 24 ordinary sentences that a licence wide
+/// enough to catch a real address also catches. Every one was MEASURED converting under a real
+/// implementation, not imagined.
+@Suite("Spoken email addresses and the already-dotted shape (#2770)", .tags(.productOutcome))
+struct InverseTextNormalizerDottedEmailTests {
+
+  private static let itn = InverseTextNormalizer()
+  private static func run(_ s: String) -> String {
+    itn.normalize(s, spokenPunctuation: false)
+  }
+
+  /// Real addresses, left as spoken. This is the cost of having no already-dotted pass, recorded
+  /// rather than hidden: a user who dictates an address without saying "punkt" or "dot" keeps
+  /// readable text instead of an address. Saying the dot works in every language, and AI polish
+  /// still sees the sentence.
+  @Test(
+    "a real address in the already-dotted shape is left as spoken",
+    arguments: [
+      "schreib mir an anna.schmidt at gmail.com",
+      "du erreichst mich unter thomas.mueller at beispiel.de",
+      "stuur het naar jan_jansen at voorbeeld.nl",
+      "escribeme a maria.lopez at ejemplo.es",
+      "meine E-Mail ist sorb at gmail.de",
+      "my email is tom at example.com",
+      "send it to bob at example.com",
+    ])
+  func alreadyDottedShapeIsLeftAlone(input: String) {
+    #expect(!Self.run(input).contains("@"))
+  }
+
+  /// Website prose carrying an email cue or punctuation. Each one converted under licence 1 —
+  /// a property of the CANDIDATE. `report.pdf` and `anna.schmidt` are the same shape, so no
+  /// property of the token alone separates them.
+  @Test(
+    "website prose remains prose despite email cues or punctuation",
+    arguments: [
+      "read the email online at example.com",
+      "shop tax-free at example.com",
+      "download report.pdf at example.com",
+      "send feedback about check-in at example.com",
+      "Please email me the chiocciola example.com sells.",
+    ])
+  func refusesWebsiteProseWithLicences(input: String) {
+    #expect(Self.run(input) == input)
+  }
+
+  /// Ordinary sentences whose words land in the `<word> at <host>.<tld>` frame. Rows 8-14
+  /// converted under licence 2 — an English introducer or noun-plus-copula immediately before.
+  /// Rows 2-7 converted under licence 3 — a non-English cue within two tokens — because `Mir`,
+  /// `IST`, `dir` and `Mich.` are English proper nouns and abbreviations that lowercase onto a
+  /// German cue. All measured 2026-09-10.
+  @Test(
+    "an ordinary sentence about a website is not an address",
+    arguments: [
+      "read it at bbc.co.uk",
+      "Check the IST check-in at example.com.",
+      "Read the Mir report.pdf at example.com.",
+      "Open dir user-guide.pdf at example.com.",
+      "Send the Mich. tax-free at example.com.",
+      "Read about Mir online at wikipedia.org.",
+      "Check the IST schedule at example.com.",
+      "You need to register at example.com.",
+      "Contact us at example.com for details.",
+      "reach us at example.com",
+      "the email is available at example.com",
+      "there is an update at example.com",
+      "send an invite at example.com",
+      "my email address is listed at example.com",
+      "the docs are available at github.com",
+      "we found it at example.com",
+      "you can watch it at youtube.com later",
+      "the source is hosted at gitlab.com",
+      "look at wikipedia.org for the details",
+    ])
+  func refusesOrdinaryProse(input: String) {
+    #expect(!Self.run(input).contains("@"))
+  }
+
+  /// An English at-word beside an English DOT-word is ordinary prose, not an address, and the
+  /// frame must not take it. Measured 2026-09-10: `point` paired with `at` turned
+  /// `We left because at one point me and John got tired.` into `We left because@one.me` —
+  /// `because` read as the name, `one` as the host, `point` as the dot and `me` as the TLD.
+  /// `punt`, `pont` and `piste` are the same shape. Each is safe beside a non-English at-word,
+  /// which `localisedSymbolWordsConvert` covers, and refused here.
+  @Test(
+    "a dot-word not paired with the English at-word is refused",
+    arguments: [
+      // English words in the dot slot.
+      "We left because at one point me and John got tired.",
+      "he kicked it at the punt me and walked away",
+      "we skied at the piste me and then ate",
+      "she looked at the pont me and smiled",
+      // Borrowed foreign phrases in an English transcript. Not English words, and they corrupt
+      // anyway, which is why the licence is a pairing rather than a judgement about English.
+      "look at the punto de vista",
+      "we discussed it at the ponto de vista",
+      // An English sentence ABOUT a foreign at-word. The at-word alone was treated as proof the
+      // sentence was not English prose; it is not. Spanish says `punto`, never `point`, so the
+      // pair is what refuses this.
+      "Can the arroba example point me to the setting?",
+      "Does the chiocciola example point me anywhere?",
+      "The klammeraffe example point me at nothing.",
+      // The cost, pinned: the English at-word mixed with a speaker's own dot-word.
+      "wyslij na jan at przyklad kropka pl",
+      "send til anna at eksempel punktum dk",
+    ])
+  func unpairedDotWordIsRefused(input: String) {
+    #expect(!Self.run(input).contains("@"))
+  }
+
+  /// The spoken-form pass is the one that ships, and it is self-limiting: the speaker has to SAY
+  /// the dot, which prose does not do.
+  @Test(
+    "the fully spoken form still converts",
+    arguments: [
+      ("send it to thomas at example dot com", "thomas@example.com"),
+      ("write to anna at beispiel dot de", "anna@beispiel.de"),
+    ] as [(input: String, expected: String)])
+  func spokenFormUnaffected(input: String, expected: String) {
+    #expect(Self.run(input).contains(expected))
+  }
+
+  /// The three raw-ASR strings the founder's own dictation actually produced, 2026-09-10, pinned
+  /// verbatim. They are the only cases in this file not constructed by me, and all three are
+  /// recorded MISSES.
+  ///
+  /// Takes 1 and 3 are the already-dotted shape, and the suite doc says why nothing converts it.
+  /// Take 2 misses for a second, independent reason: Parakeet heard "thomas punkt müller" as the
+  /// single token `punktmüller`, and the local-part pattern is ASCII, so the umlaut stops the
+  /// match. Converting it would produce `punktmüller@gmail.com`, which is not the speaker's
+  /// address either — the name was already lost in the recognizer. Widening to Unicode letters
+  /// would buy a wrong address, not a right one.
+  ///
+  /// All three convert today if the speaker says "punkt", which `spokenFormUnaffected` covers.
+  @Test("the founder's real dictation, verbatim")
+  func realDictationStrings() {
+    // Take 3 — already-dotted shape, no spoken dot to match.
+    #expect(
+      !Self.run(
+        "Du kannst mich unter anna ad web.de oder unter anna.schmidt at gmail.com erreichen."
+      ).contains("@"))
+    // Take 1 — already-dotted shape.
+    #expect(!Self.run("Meine E-Mail ist Sorb at Gmail.de.").contains("@"))
+    // Take 2 — already-dotted shape AND an umlaut in the local part.
+    #expect(!Self.run("Schreib mir an Thomas punktmüller at gmail.com.").contains("@"))
+  }
+
+  /// `anna ad web.de` in take 3 must stay untouched: "ad" is a MISHEARING of "at", and accepting
+  /// near-misses would convert ordinary prose containing "ad", "and" or "add".
+  @Test("a misheard at-word is not accepted")
+  func misheardAtIsRefused() {
+    #expect(!Self.run("du kannst mich unter anna ad web.de erreichen").contains("anna@web.de"))
+  }
+
+  /// Each language's own word for `@` and `.`, inside the address frame.
+  ///
+  /// German is absent on purpose: it borrowed the English "at", which the cases above already
+  /// cover. `klammeraffe` is included because Apple's German voice renders a written `@` as that
+  /// word, so it turns up in synthesised audio even though speakers do not say it.
+  @Test(
+    "a spoken address in the speaker's own words converts",
+    arguments: [
+      ("mandalo a marco arroba esempio punto com", "marco@esempio.com"),
+      ("mandalo a marco chiocciola esempio punto com", "marco@esempio.com"),
+      ("mandalo a maria arroba ejemplo punto es", "maria@ejemplo.es"),
+      ("stuur het naar jan apenstaartje voorbeeld punt nl", "jan@voorbeeld.nl"),
+      ("wyslij na jan malpa przyklad kropka pl", "jan@przyklad.pl"),
+      // The spelling a Polish speaker's transcript actually carries. The ASCII row above passed
+      // while this one failed, which is why an ASCII-only row is not evidence for a language
+      // whose word is not ASCII.
+      ("wyslij na jan małpa przyklad kropka pl", "jan@przyklad.pl"),
+      // Each language needs BOTH its at-word and its dot-word. Belarusian shipped with `малпа`
+      // and no `кропка` and converted nothing; the Latin `kropka` beside it is the POLISH word.
+      ("dashli na ivan малпа primer кропка com", "ivan@primer.com"),
+      ("nadishly na ivan собачка pryklad крапка ua", "ivan@pryklad.ua"),
+      ("ivan равлик pryklad крапка ua", "ivan@pryklad.ua"),
+      ("laheta matti ät esimerkki piste fi", "matti@esimerkki.fi"),
+      ("laheta matti miuku esimerkki piste fi", "matti@esimerkki.fi"),
+      ("send til anna krøllalfa eksempel punktum com", "anna@eksempel.com"),
+      ("send til anna snabel-a eksempel punktum dk", "anna@eksempel.dk"),
+      ("envoie a marie arobase exemple point fr", "marie@exemple.fr"),
+      ("envia para joao arroba exemplo ponto pt", "joao@exemplo.pt"),
+      ("kuldd el a kovacs kukac pelda pont hu", "kovacs@pelda.hu"),
+      ("skicka till anna snabel-a exempel punkt se", "anna@exempel.se"),
+      ("schick das an thomas at beispiel punkt de", "thomas@beispiel.de"),
+      ("schick das an thomas klammeraffe beispiel punkt de", "thomas@beispiel.de"),
+    ] as [(input: String, expected: String)])
+  func localisedSymbolWordsConvert(input: String, expected: String) {
+    #expect(Self.run(input).contains(expected))
+  }
+
+  /// Italy's own domain cannot convert, and that is the trade-off #2764 shipped rather than a
+  /// gap here: `it` is an ordinary English word, so admitting it to the TLD list turns "he
+  /// pointed at the dot it made" into an address. So an Italian speaker gets the `@` on a
+  /// generic domain and nothing on `.it`. Recorded so the cost is visible, and so that anyone
+  /// who later finds a safe way to admit `.it` sees this test go green rather than having to
+  /// rediscover why it was excluded.
+  @Test("Italy's own domain is a known, deliberate miss")
+  func italianDomainIsAKnownMiss() {
+    #expect(Self.run("mandalo a marco chiocciola esempio punto com").contains("marco@esempio.com"))
+    #expect(!Self.run("mandalo a marco chiocciola esempio punto it").contains("@"))
+  }
+
+  /// The words are only ever read INSIDE the address frame. Standing alone in ordinary prose —
+  /// and every one of these is an ordinary word in its language — they must do nothing.
+  /// `chiocciola` is a snail, `собака` is a dog, `malpa` is a monkey, `punto` is a full stop.
+  @Test(
+    "the same words in ordinary prose do nothing",
+    arguments: [
+      "ho visto una chiocciola nel giardino",
+      "questo e un punto importante per noi",
+      "mala widzialem malpa w zoo wczoraj",
+      "das ist ein wichtiger punkt fuer uns",
+      "el punto de partida es importante",
+      "we saw a snail at the garden centre",
+    ])
+  func symbolWordsInProseDoNothing(input: String) {
+    #expect(!Self.run(input).contains("@"))
+  }
+
+  /// An address the recognizer already completed must survive untouched — this pass must never
+  /// double-convert or re-wrap one.
+  @Test(
+    "an already-complete address is left alone",
+    arguments: [
+      "meine E-Mail ist anna.schmidt@gmail.com",
+      "write to thomas.mueller@beispiel.de please",
+    ])
+  func alreadyCompleteAddressUnchanged(input: String) {
+    #expect(Self.run(input) == input)
+  }
+}


### PR DESCRIPTION
Lane: `Code` · Tier: SMALL · Modules: PostProcessing, Pipeline · Test: required (PostProcessing, Pipeline)

## What a user gets

A spoken email address converts when the speaker uses their own language's words for `@` and
for the dot.

```
mandalo a marco arroba esempio punto com          -> marco@esempio.com
mandalo a marco chiocciola esempio punto com      -> marco@esempio.com
stuur het naar jan apenstaartje voorbeeld punt nl -> jan@voorbeeld.nl
wyslij na jan małpa przyklad kropka pl            -> jan@przyklad.pl
envoie a marie arobase exemple point fr           -> marie@exemple.fr
skicka till anna snabel-a exempel punkt se        -> anna@exempel.se
kuldd el a kovacs kukac pelda pont hu             -> kovacs@pelda.hu
dashli na ivan малпа primer кропка com            -> ivan@primer.com
laheta matti ät esimerkki piste fi                -> matti@esimerkki.fi
send til anna krøllalfa eksempel punktum com      -> anna@eksempel.com
schick das an thomas at beispiel punkt de         -> thomas@beispiel.de
```

## The licence is a pairing table, not a judgement about which words are English

`addressWordPairs` maps each at-word to the dot-words its own language uses. `emails(_:)`
matches the frame once and refuses any unpaired combination in the closure, so this stays a
single pass under the engine's 0.5 s deadline.

Three review rounds falsified the judgement version, each with a sentence measured through
`normalize`:

```
We left because at one point me and John got tired. -> because@one.me
look at the punto de vista                          -> look@the.de vista
Can the arroba example point me to the setting?     -> Can the@example.me
```

The first is an English word in the dot slot. The second is **not** an English word, and
English prose carries borrowed phrases anyway, with `de` a valid TLD. The third is an English
sentence **about** the Spanish symbol, so a foreign at-word is not proof the sentence is
foreign either.

"Can this word appear in an English sentence" has no bound and returned a new counterexample
every round. "Which pair does this language use" is a finite table. Spanish says `punto`,
never `point`, which is what refuses the third sentence. Eleven sentences are pinned as
refusals.

Both regex alternations are **generated** from that one table. A second hand-written list is
exactly how Belarusian shipped with an at-word and no dot-word.

## Native spellings and pairing, checked one at a time

All words checked against dictionaries with sources. `małpa` is the only ASCII-looking entry
whose standard spelling is not ASCII (Polish Academy dictionary); the ASCII `malpa` is kept
beside it in case a recognizer drops the diacritic.

A missing native spelling is silent — the conversion simply never fires — and the ASCII-only
Polish test row passed while the accented one failed, which is how it was missed. Both rows
are now pinned.

The pairing check found four more half-wired languages, not the one cloud review named.
Completed with sources: Belarusian `сабака`/`кропка`, Ukrainian `собачка`/`равлик`/`крапка`,
Finnish `ät`/`miuku`/`miukumauku`/`kissanhäntä` beside the existing `piste`, Norwegian
`krøllalfa`, and `punktum` for Norwegian and Danish, which had `snabel-a` and no dot-word.

German is deliberately absent from the localised at-list: German borrowed the English "at" and
says that, confirmed on a native teaching recording and on four of the founder's own
dictations. `klammeraffe` is included only because Apple's German voice renders a written `@`
as that word, so it turns up in synthesised audio.

## Where this runs, and the tests that say so

The direct-formatter suite calls `normalize` and cannot see
`InverseTextNormalizationStep.skipReason`, which no-ops the whole engine for a take resolved as
explicitly non-English. Two step-level rows pin both halves:

- The Italian address **converts** on a no-language take (Parakeet, the measured case).
- It **does not** convert on a take resolved as Spanish.

So these words serve a take whose language is unknown or resolved as English. They are not, by
themselves, support for dictating in those languages — the same posture #2764 already recorded
for the country-code domains.

## Costs and limits, recorded rather than implied

- A speaker who mixes the English "at" with their own dot-word — `jan at przyklad kropka pl` —
  does not convert. Their own at-word does, and so does saying "dot". Both sides are pinned.
- French pairs `arobase` with `point`, which **is** an English word, so an English sentence
  about the `arobase` symbol in this exact frame still converts. Dropping `point` would remove
  French entirely, since `point` is the French word for the dot.
- Not covered at all: Czech (`zavináč`/`tečka`), Estonian, Bulgarian, Macedonian, Catalan,
  Afrikaans.
- `prikk` is kept for Norwegian but its use for reciting an address is **not verified** —
  Norway's language council uses `punktum`, which is why that was added rather than
  substituted.
- `.no` and `.by` stay excluded from `countryCodeTLDs` under the existing English-word policy,
  so a Norwegian or Belarusian address at its own national domain still does not convert.
- Recorded misses: the founder's three takes are the already-dotted shape and none converts;
  take 2 also carries an umlaut in the local part (`punktmüller`), where the recognizer had
  already lost the name. All three convert if the speaker says "punkt".
- `.it` stays excluded per #2764, because "it" is an English word.

## Two issues filed, both left open

- **#2781** — the shipped `at`/`dot` pair carries the same defect when the TLD is also an
  English word: `at one dot me` becomes `because@one.me`. Predates this change, so closing it
  alters a shipped path and needs its own measurement. The naive repair is wrong in an
  expensive direction: excluding `.me` would break `write to bob at example dot net`, because
  the true and false positives differ in the DOMAIN slot, not the TLD.
- **#2783** — routing the address pass for a take resolved as non-English, with what would have
  to be measured first.

## What does not ship, and why the reason is in the source

Parakeet often emits `anna.schmidt at gmail.com` — it converts the spoken dots itself and
leaves "at" as a word. A pass for that shape was built three times and each licence was
falsified by running ordinary sentences through `normalize`:

1. A property of the CANDIDATE (punctuation in the local part, or a context word within four
   tokens) converted `download report.pdf at example.com` and
   `read the email online at example.com`.
2. A property of the SENTENCE (an English introducer, or a noun plus copula, immediately
   before) converted seven more, including `You need to register at example.com`,
   `Contact us at example.com for details` and `my email address is listed at example.com`.
3. A NON-ENGLISH cue within two tokens, with and without a punctuated local part, converted
   `Read about Mir online at wikipedia.org`, `Check the IST check-in at example.com`,
   `Open dir user-guide.pdf at example.com` and `Send the Mich. tax-free at example.com` —
   English proper nouns and abbreviations lowercase onto German cues.

The root is a property of the language: English spells a website `<verb> at <host>` and an
address `<name> at <host>`, so the marker is the same word in both. Each round returned a new
MEMBER rather than a new axis, which is the signal that the set was being described instead of
enumerated. The language would decide it and is not available on exactly these takes.

Twenty-four ordinary sentences are pinned as refusals for that shape, plus 7 real addresses
recorded as the cost. They pass trivially today because nothing converts that shape, and that
is their purpose: they are the falsification condition for the next person who adds such a
pass. Every one was measured converting under a real implementation, not imagined.

## Validation

- `scripts/xcode-test.sh` Debug lane: 7568 tests in 674 suites pass, 0 fail, 3 pre-existing
  known issues.
- Local Codex diff review: clean, including all 29 address-word pairs and the 6,120 existing
  parity fixtures.
- Codex behavioural second pass: found the `małpa` gap, now fixed and pinned.
- Findings classified REPRODUCIBLE: every refusal row is a sentence a real user dictates, and
  each was measured through `normalize` before being pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCXKXAcwaQ9D37XJprGe4z
