### PR TITLE
feat(asr): FluidAudio fork catch-up to upstream v0.15.7, streaming seams fixed, batch byte-identical (#2788, release held)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b3664c13dfe1f09cf94dbd8988d3f80b62d0f2cfbad8c681364b3191fec86a5a",
+  "originHash" : "84dfc64018bc5e42ede3cd7ca5ba30ce62be0a4123f8a7c2aa881004ed8ea6c6",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/saurabhav88/FluidAudio.git",
       "state" : {
-        "revision" : "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d"
+        "revision" : "b29591ada1f70510c12c13b50ffae02052ff75c3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", from: "1.0.0"),
     .package(
       url: "https://github.com/saurabhav88/FluidAudio.git",
-      revision: "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d"),
+      revision: "b29591ada1f70510c12c13b50ffae02052ff75c3"),
     .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.8.0"),

--- a/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
+++ b/Sources/EnviousWispr/Resources/parakeet-delivery-manifest.json
@@ -5,7 +5,7 @@
     "name": "parakeet-tdt-0.6b-v3-coreml",
     "revision": "aed02740059203c4a87495924f685de3722ae9ce",
     "variant": "int8",
-    "runtimeABI": "fluidAudio-bf9fe27f"
+    "runtimeABI": "fluidAudio-b29591ad"
   },
   "runtimeCompatibility": {
     "minAppVersion": "2.4.0"
@@ -172,5 +172,5 @@
     "diskHeadroomFactor": "2.2",
     "evictPreviousRevisions": false
   },
-  "manifestDigest": "bc1aae28fe94f2bff66b47f85a395188c88e01e4f59b23d9aaba92d6739217fb"
+  "manifestDigest": "ed66a393964e8901e1502b5acde82033a5902b112db2b1057b1fbd1b10d69e23"
 }

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -230,7 +230,14 @@ public actor ParakeetBackend: ASRBackend {
       }
       self.fluidModels = loadedModels
 
-      let manager = AsrManager(config: .default)
+      // #2788: pin the mel-context long-form path explicitly. Upstream #869 flipped
+      // the v3 default (`melChunkContextOverride == nil` → no-mel, silence-aligned
+      // starts). On the 500-recording corpus that default changed 15 long recordings,
+      // about as many worse as better; `melChunkContext: true` is byte-identical to the
+      // previous pin on all 500. Evaluating the new path is #2769's harness work, not a
+      // silent default flip. The label is the supported initializer parameter; only
+      // the computed `melChunkContext` property is deprecated upstream.
+      let manager = AsrManager(config: ASRConfig(melChunkContext: true))
       // Vendor API: models load via loadModels(_:) after construction.
       try await manager.loadModels(loadedModels)
       self.fluidAsrManager = manager

--- a/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
+++ b/Sources/EnviousWisprAppKit/Resources/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: bf9fe27f (fork saurabhav88/FluidAudio)
+  Version: b29591ad (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -257,7 +257,7 @@ The full text of the Apache License, Version 2.0 follows.
 
 --------------------------------------------------------------------------------
 FluidAudio
-  Version: bf9fe27f (fork saurabhav88/FluidAudio)
+  Version: b29591ad (fork saurabhav88/FluidAudio)
   License: Apache-2.0
   Source:  https://github.com/saurabhav88/FluidAudio
 --------------------------------------------------------------------------------

--- a/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
+++ b/Tests/EnviousWisprTests/ModelDelivery/DeliveryManifestTests.swift
@@ -432,7 +432,12 @@ enum ManifestFixture {
   // existing admission markers, so a clean writable install revalidates and re-admits
   // without downloading — re-admission still runs cleanup and rewrites the marker
   // (`CacheAdmission.promoteAndAdmit` 3 and 4), so a dirty or unwritable one can fetch.
-  static let goldenDigest = "bc1aae28fe94f2bff66b47f85a395188c88e01e4f59b23d9aaba92d6739217fb"
+  // Updated 2026-09-10 (#2788): `runtimeABI` advanced to fork pin b29591ad (upstream
+  // v0.15.7 + carries; the French-blocklist carry dropped for upstream's own, the
+  // chunk-text assembly half of the fresh-state carry retired). Identical model bytes
+  // (`identity.revision` unchanged) — the same re-admission-without-re-download case.
+  // Regenerated with `scripts/regen-delivery-manifest-digest.py --write`, control OK.
+  static let goldenDigest = "ed66a393964e8901e1502b5acde82033a5902b112db2b1057b1fbd1b10d69e23"
 
   @Test func shippedManifestLoadsAndMatchesGoldenDigest() throws {
     let data = try Data(contentsOf: Self.shippedManifestURL)

--- a/scripts/ci/gen-third-party-notices.sh
+++ b/scripts/ci/gen-third-party-notices.sh
@@ -37,7 +37,7 @@ COMPONENTS=(
   # text too, not just Argmax's MIT LICENSE (Codex audit 2026-07-10). Empty
   # identity — it is vendored inside argmax-oss-swift, not its own SwiftPM pin.
   "swift-transformers (incorporated into Argmax OSS)|n/a|Apache-2.0|argmax-oss-swift/NOTICES|https://github.com/huggingface/swift-transformers|"
-  "FluidAudio|bf9fe27f (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
+  "FluidAudio|b29591ad (fork saurabhav88/FluidAudio)|Apache-2.0|FluidAudio/LICENSE|https://github.com/saurabhav88/FluidAudio|fluidaudio"
   "PostHog iOS|3.68.2|MIT|posthog-ios/LICENSE|https://github.com/PostHog/posthog-ios|posthog-ios"
   "Sentry Cocoa|9.26.1|MIT|sentry-cocoa/LICENSE.md|https://github.com/getsentry/sentry-cocoa|sentry-cocoa"
   "Sparkle|2.9.6|MIT (with bundled BSD/MIT components)|Sparkle/LICENSE|https://github.com/sparkle-project/Sparkle|sparkle"

--- a/scripts/eval/build_parakeet_corpus.py
+++ b/scripts/eval/build_parakeet_corpus.py
@@ -40,11 +40,21 @@ import json
 import subprocess
 import sys
 import tempfile
+import wave
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CLI = ROOT / ".build/checkouts/FluidAudio/.build/arm64-apple-macosx/release/fluidaudiocli"
 PIN = "b29591ada1f70510c12c13b50ffae02052ff75c3"
+
+# #2788: the app pins `ASRConfig(melChunkContext: true)`; `fluidaudiocli
+# tts-asr-verify` constructs `AsrManager()` with the vendor default, which on this
+# pin is the no-mel long-form path. The two agree on any clip the engine decodes
+# in ONE window (`transcribe` takes the single-window branch when the sample count
+# is at or below `ASRConstants.maxModelSamples`, 15 s at 16 kHz) and can differ
+# beyond it. A synthesized clip longer than this is REFUSED rather than
+# transcribed off the shipped path; teaching the CLI the setting is #2769 work.
+LONGFORM_SECONDS = 15.0
 
 
 def check_engine() -> None:
@@ -89,18 +99,22 @@ def wer(ref: str, hyp: str) -> float:
     return d[len(r)][len(h)] / len(r)
 
 
-def run_batch(texts: list[str], voice: str) -> list[str] | None:
-    """Synthesize+transcribe a batch. Returns hypotheses in order, or None if
-    the batch aborted (caller then retries line by line)."""
+def run_batch(texts: list[str], voice: str) -> list[tuple[str, float]] | None:
+    """Synthesize+transcribe a batch. Returns (hypothesis, audio seconds) in
+    order, or None if the batch aborted (caller then retries line by line).
+    Audio seconds come from the WAV the tool wrote (`phrase_%03d.wav`), never
+    from the tool's own report, so the long-form refusal reads the artifact."""
     with tempfile.TemporaryDirectory() as td:
         tf = Path(td) / "phrases.txt"
         of = Path(td) / "out.json"
+        ad = Path(td) / "audio"
+        ad.mkdir()
         # '#' starts a comment in the tool's phrases file; no corpus line begins
         # with one (checked at load), so nothing is silently dropped.
         tf.write_text("\n".join(texts) + "\n")
         proc = subprocess.run(
             [str(CLI), "tts-asr-verify", "--texts-file", str(tf),
-             "--voice", voice, "--output-json", str(of)],
+             "--voice", voice, "--output-json", str(of), "--audio-dir", str(ad)],
             capture_output=True, text=True,
         )
         if proc.returncode != 0 or not of.exists():
@@ -109,7 +123,15 @@ def run_batch(texts: list[str], voice: str) -> list[str] | None:
         phrases = sorted(data["phrases"], key=lambda p: p["index"])
         if len(phrases) != len(texts):
             return None
-        return [p["hypothesis"].strip() for p in phrases]
+        out = []
+        for p in phrases:
+            wav_path = ad / f"phrase_{p['index']:03d}.wav"
+            if not wav_path.exists():
+                return None  # the artifact the refusal reads is missing: abort loudly
+            with wave.open(str(wav_path)) as w:
+                seconds = w.getnframes() / w.getframerate()
+            out.append((p["hypothesis"].strip(), seconds))
+        return out
 
 
 def main() -> int:
@@ -144,6 +166,7 @@ def main() -> int:
     print(f"corpus   : {args.corpus.name} ({len(cases)} cases), voice={args.voice}", file=sys.stderr)
 
     hyps: dict[str, str | None] = {}
+    refused_longform: list[tuple[str, float]] = []
     for start in range(0, len(cases), args.batch_size):
         chunk = cases[start : start + args.batch_size]
         got = run_batch([t for _, _, t in chunk], args.voice)
@@ -158,7 +181,17 @@ def main() -> int:
                     got.append(None)
                 else:
                     got.append(one[0])
-        for (d, _, _), h in zip(chunk, got):
+        for (d, _, _), item in zip(chunk, got):
+            if item is None:
+                hyps[d["id"]] = None
+                continue
+            h, seconds = item
+            if seconds > LONGFORM_SECONDS:
+                print(f"    REFUSED {d['id']}: {seconds:.1f}s > {LONGFORM_SECONDS:.0f}s, "
+                      f"long-form path differs from the app (#2788, #2769)", file=sys.stderr)
+                refused_longform.append((d["id"], round(seconds, 2)))
+                hyps[d["id"]] = None
+                continue
             hyps[d["id"]] = h
         print(f"  {min(start + args.batch_size, len(cases))}/{len(cases)}", file=sys.stderr)
 
@@ -186,16 +219,19 @@ def main() -> int:
     report = {
         "engine_pin": PIN, "voice": args.voice, "max_wer": args.max_wer,
         "total": len(cases), "kept": len(kept),
-        "rejected_wer": len(rejected), "tts_failed": len(failed),
+        "rejected_wer": len(rejected), "tts_failed": len(failed) - len(refused_longform),
+        "refused_longform": len(refused_longform),
         "rejected": [{"id": i, "orig": o, "parakeet": h, "wer": w} for i, o, h, w in rejected],
-        "tts_failed_ids": [i for i, _, _ in failed],
+        "tts_failed_ids": [i for i, _, _ in failed if i not in {r for r, _ in refused_longform}],
+        "refused_longform_ids": [{"id": i, "seconds": s} for i, s in refused_longform],
     }
     (args.out_dir / "roundtrip_report.json").write_text(json.dumps(report, indent=2))
 
     n = len(cases)
     print(f"\nkept (words identical)  : {len(kept)}/{n} ({100*len(kept)/n:.1f}%)", file=sys.stderr)
     print(f"rejected (words changed): {len(rejected)}/{n} ({100*len(rejected)/n:.1f}%)", file=sys.stderr)
-    print(f"TTS failed              : {len(failed)}/{n}", file=sys.stderr)
+    print(f"TTS failed              : {len(failed) - len(refused_longform)}/{n}", file=sys.stderr)
+    print(f"refused (>{LONGFORM_SECONDS:.0f}s long-form): {len(refused_longform)}/{n}", file=sys.stderr)
     print(f"\n-> {out_path}\n-> {args.out_dir / 'roundtrip_report.json'}", file=sys.stderr)
     return 0
 

--- a/scripts/eval/build_parakeet_corpus.py
+++ b/scripts/eval/build_parakeet_corpus.py
@@ -8,7 +8,7 @@ score we hold was therefore measured on an input form the shipped ASR does not
 produce. This rebuilds the inputs through the ASR we actually ship.
 
 Engine fidelity: drives `fluidaudiocli tts-asr-verify` from the PINNED FluidAudio
-checkout (`.build/checkouts/FluidAudio`, revision bf9fe27f per Package.resolved),
+checkout (`.build/checkouts/FluidAudio`, revision b29591ad per Package.resolved),
 NOT `~/Developer/EnviousLabs/FluidAudio*` — a local checkout's HEAD floats, so
 it can silently measure a different engine; the pinned checkout cannot.
 
@@ -44,7 +44,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CLI = ROOT / ".build/checkouts/FluidAudio/.build/arm64-apple-macosx/release/fluidaudiocli"
-PIN = "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d"
+PIN = "b29591ada1f70510c12c13b50ffae02052ff75c3"
 
 
 def check_engine() -> None:

--- a/scripts/eval/parakeet_runner/Package.swift
+++ b/scripts/eval/parakeet_runner/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // and reloads the model each time, which is unusable for 1,890 cases.
 //
 // Depends on the SAME git URL + exact immutable revision the app pins in the
-// root Package.swift (saurabhav88/FluidAudio @ bf9fe27f) rather than a local
+// root Package.swift (saurabhav88/FluidAudio @ b29591ad) rather than a local
 // path, so this provably runs the same pinned engine the app resolves. Do not
 // repoint at a local checkout — a path dependency floats with whatever that
 // checkout happens to hold, while this remote revision cannot drift.
@@ -16,7 +16,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/saurabhav88/FluidAudio.git",
-      revision: "bf9fe27f837c86ee786a3f0ddb9966eeeeb4915d")
+      revision: "b29591ada1f70510c12c13b50ffae02052ff75c3")
   ],
   targets: [
     .executableTarget(name: "ParakeetRunner", dependencies: ["FluidAudio"])

--- a/scripts/eval/parakeet_runner/Sources/ParakeetRunner/main.swift
+++ b/scripts/eval/parakeet_runner/Sources/ParakeetRunner/main.swift
@@ -10,7 +10,7 @@ import Foundation
 ///     the app's ModelDelivery path OWNS model setup and admission; this
 ///     benchmark only consumes the cache it populated, and must never mutate
 ///     the model bytes it measures (#1981)
-///   - `AsrManager(config: .default)` + `loadModels(_:)`
+///   - `AsrManager(config: ASRConfig(melChunkContext: true))` (#2788, matches the app) + `loadModels(_:)`
 ///   - a FRESH `TdtDecoderState` per file, sized by `manager.decoderLayerCount`
 ///     (the app makes one per one-shot batch decode; reusing state across files
 ///     would leak decoder context between unrelated utterances)
@@ -71,7 +71,9 @@ do {
 } catch {
   fail("Open EnviousWispr and complete Parakeet model setup once, then rerun.")
 }
-let manager = AsrManager(config: .default)
+// #2788: same explicit long-form path as the app (ParakeetBackend), so this measures
+// what ships rather than upstream's new v3 default.
+let manager = AsrManager(config: ASRConfig(melChunkContext: true))
 try await manager.loadModels(models)
 let layers = await manager.decoderLayerCount
 FileHandle.standardError.write(


### PR DESCRIPTION
Part of #2788. **Release HELD: merge to main, no tag until macOS 27 is public and the founder lifts the hold on #2788** (recorded on the issue, in `session-log.md`, and at the top of the release checklist).

## What changes

Fork pin `saurabhav88/FluidAudio` `bf9fe27f` → `b29591ad` = upstream `ec07aabf` (v0.15.7 + #904, 53 commits since our base) plus four carries: CTC/rescorer constants, fresh decoder state per sliding window, punctuation-only last-chunk finalization, alpha-2.8 rationale.

- **Dropped carry:** the French-only English-blocklist scope. Upstream `cefd05af` (#847) owns it (`englishBlocklistApplies(to:)`), with a broader test.
- **Retired half of a carry:** the `finish()`-time chunk-text assembly (`chunkTexts`, `assembleChunkTexts`). Its recorded reason (fresh state re-decodes the previous window's tail, so overlapping text must be removed at boundaries) was reproduced and falsified on this base: upstream's temporal dedup (#788) and final-window seam reconciliation (#903/#904) remove that overlap on `accumulatedTokens`, which the chunk-text path bypassed. With it intact the fork failed upstream's real-recording fixture (`code and an analyzing`); without it the fixture passes and the corpus is strictly better. Fork commit `b29591ad` carries the refutation; the source comment was deleted and replaced with the #2788 ownership sentence.
- **Batch path pinned:** `ParakeetBackend` and the eval runner pass `ASRConfig(melChunkContext: true)`. Upstream #869 flipped the v3 long-form default to the no-mel path; on our corpus that default changed 15 long recordings, about as many worse as better. The explicit setting is byte-identical to the previous pin on 500/500. Evaluating the new path is #2769 work, not a silent default flip.
- **Corpus generator fail-closed (second commit):** `build_parakeet_corpus.py` drives `fluidaudiocli tts-asr-verify`, which constructs `AsrManager()` with the vendor default (no-mel long-form). The two paths agree on any clip decoded in one window (at or below `ASRConstants.maxModelSamples`, 15 s) and can differ beyond it, so the generator now reads each synthesized WAV's duration and REFUSES clips over 15 s with a per-id reason and a `refused_longform` report bucket. Found by the whole-diff review (P2). Not executed end to end (needs the Kokoro TTS models and a root-checkout CLI build); `py_compile` passes.
- Delivery manifest `runtimeABI` → `fluidAudio-b29591ad`, digest regenerated with the baseline control, Parakeet golden updated. `identity.revision` and every file hash unchanged: clean, writable existing caches revalidate and re-admit without downloading; dirty or unwritable caches can fetch. Notices regenerated (16 components, `--check` clean). Eval pins and the corpus pin guard moved.

## Measured (500 frozen `fed.wav` recordings, SHA-256 manifest, 2,580 s, 28 at or above 13 s)

Six arms, each a runner built against a detached fork worktree with its HEAD sha recorded; comparator fails closed on missing rows, error rows or duplicate revisions and reported a planted change; the old pin, the chosen arm and the final pin were each stream-run twice, texts byte-identical 500/500.

| arm | batch identical to old | stream distance to batch proxy | closer / farther than old |
|---|---|---|---|
| old pin `bf9fe27f` | — | 92 | — |
| stock upstream `ec07aabf` | 483/500 | 105 | 8 / 6 |
| rebased, carry 1 intact | 485/500 | 77 | 4 / 0 |
| **rebased, chunk-text assembly retired (shipped)** | 485/500 (default) · **500/500 with `melChunkContext: true`** | **74** | **7 / 0** |

Stock upstream without the carries is worse than today on 6 recordings (fabricated completions `that's a good thing` / `these things are.` that carry 2 suppresses; 9 and 16 words lost on a 58 s and a 135 s recording that carry 1's fresh state keeps). Seam artifacts the old assembly left (`con vert`, `ch anged`, `properly. correctly.`, `box ,`) are gone.

Final pin re-run: batch (mel-context) identical to old 500/500; stream identical to the chosen arm 500/500; pass 2 identical.

## Receipts

- Fork: `swift test` on `b29591ad`: 2,396 tests, 45 skipped, 0 failures; `SlidingWindowFinalWindowRegressionTests`, `TokenDeduplicationRegressionTests`, `TdtFinalizationPunctuationTests`, `EnglishBlocklistTests` pass by name.
- GATE 0: `ParakeetShippedManifestTests` 3/3 including `shippedManifestLoadsAndMatchesGoldenDigest` and `shippedManifestMatchesWorkerSeed`.
- App: Debug and Release suites, 7,568 tests in 674 suites each; neither full run is green, and the three failing suites are all outside the engine, delivery and notices areas. Classification, with the controls that support it: `RenderedPillFreezeTests` (4 rows, +1 pt height) fails identically on unchanged `main` on the same Mac, so it is pre-existing relative to this PR; the host cause (macOS 27.0 metrics) is the test's own named hypothesis, tracked as #2790, unproven here. `FileImportCoordinatorTests` "stop keeps what already finished" (Release only) matches the open flake report #2779 and passed on a re-run against `main`; consistent with the flake, not proof of it. `PasteServiceActivationTimeoutTests` (Debug only, `.neverRegistered`) passed when run alone on both `main` and this branch; the one failure coincided with two full suites and corpus arms running concurrently, which is a hypothesis, not a proven cause. Nothing in this diff touches those three areas.
- Side packages build: `scripts/eval/parakeet_runner`, gitignored `scripts/asr-preview/preview_runner` (both resolve `b29591ad`).
- Reviews: coverage (10 findings folded in), grounded r1–r3 → PROCEED-AS-PLANNED, behavioural second pass CLEAN, build orchestrator: chunks 1-2 CHUNK-CLEAN, chunk 3 CHUNK-FINDINGS on receipt and commit-message wording, corrected, confirming round CHUNK-CLEAN; whole-diff `codex review` r1 one P2 (the generator gap above, fixed), r2 clean ("No actionable bugs found").
- Eval-harness lane: the polish `acceptance_gate.py` run is NOT performed. Founder exception on #2788 (no eval gate may require a cloud model; polish is unrelated to transcription). The lane rule is now scoped to polish-scoring changes; #2789 retires or localizes the gate.
- Live UAT on macOS 27.0 `26A428`: all seven items on the rebuilt Dev bundle (`build/EnviousWispr Local.app` from this worktree, pid verified by executable path), verdicts from `app.log`:
  1. Live mode (`useStreamingASR` on), 26.4 s English dictation crossing seams and ending mid-sentence: `mode=streaming`, tail kept to the last word, target word found, ASR 0.441 s. Two seam glitches in the transcript (`test tested`, `pineapple in the`) decode IDENTICALLY on the old pin from the same `raw.wav` (old stream = final stream, byte for byte), so they are pre-existing (#897 finding 2, open upstream), not introduced here; normal-mode decode of the same audio is clean on both pins. VERIFIED.
  2. Live mode, German 17.6 s (macOS `say -v Anna`, not Azure: the harness has no Azure path; recorded as the deviation): complete transcript, target word found, ASR 0.448 s. VERIFIED.
  3. Normal mode, 4.8 s: complete, ASR 0.356 s. VERIFIED.
  4. Admission after the pin move: one validation pass, `adopted_in_place` from the legacy shared copy (cloned, 483 MB, no fetch); later launches `marker_fast_path`. VERIFIED.
  5. Neural Engine on 27.0: evidenced by timing only (ASR 0.36-0.45 s for 5-38 s of audio, the #2787 probe band; the vendor's compute-unit log line does not reach the unified log at default privacy). VERIFIED by timing, placement line not observed.
  6. Normal mode, 38.0 s (over the 30 s mark): complete, target word found, ASR 0.413 s, and the app's `RAW ASR` text is byte-identical to the final-pin runner (`melChunkContext: true`) on the same saved `fed.wav`. VERIFIED.
  7. First-time setup: every local copy of the model moved aside (app install dir, both legacy shared dirs, admission markers); the app fetched 469 MB from our mirror (`attempt started resumed=false` → `admitted duration=under_1m bytes=200mb_600mb sources=1 final_source=our_copy`, 8 s), so the vendor's changed download code (#853/#864) is not on our first-run path. One dictation on the fresh model completed; its capture was clipped (both old and final runners decode that `fed.wav` to the same truncated text, so the clip, not the engine, was short), and the same sentence on the restored model came through complete. Originals restored byte-for-byte by rename, fresh download kept aside, re-admitted `marker_fast_path`. VERIFIED.
  The live-transcription switch is shared with the shipped app (`unifiedDefaultsKeys`): it was off, turned on for items 1-2, restored to off.
- Previous-OS coverage gap: no 26.x machine available; corpus arms are OS-independent text comparisons; CI's hosted runner runs the Debug suite on its own image; no dictation was driven on 26.x.
- `LiveTranscriptionCopy` figures (2.0% / 3.7%, 17 / 51) retained: measured at the old pin; batch is byte-identical and streaming strictly closer, so the comparison still holds in the same direction. Re-measure is #2769 work.

Rollback: revert this one squash commit (pins, explicit config, corpus guard, manifest and golden, notices travel together), then restore the gitignored companions (preview runner pin, knowledge files) from the values recorded on #2788.
