### PR TITLE
feat(dictation): a stuck transcription can be escaped, keeps its audio, and names its stage next launch (#2787)

### DIFF
--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -64,6 +64,8 @@ public final class ASRManager: ASRManagerInterface {
   /// against the first; there is no "which one is newer" question left to
   /// get wrong.
   private var streamingStartInFlight = false
+  /// #2787: is a vendor decode call running right now, whoever is waiting.
+  public let vendorDecodeOccupancy = VendorDecodeOccupancy()
   /// This attempt's identity, supplied by the caller (`ParakeetEngineAdapter`
   /// mints a fresh one per `beginSession()`) rather than an internal counter,
   /// so `cancelInFlightStreamingStart(attemptID:)` can name exactly the
@@ -454,7 +456,12 @@ public final class ASRManager: ASRManagerInterface {
     async throws -> ASRResult
   {
     guard let activeBackend else { throw ASRManagerNotOwnedError(backend: activeBackendType) }
-    return try await activeBackend.transcribe(audioSamples: audioSamples, options: options)
+    // #2787: counted for the whole vendor call, so a session that stops
+    // waiting (cancel during transcribing) leaves the engine visibly BUSY
+    // until Core ML actually returns.
+    return try await vendorDecodeOccupancy.track {
+      try await activeBackend.transcribe(audioSamples: audioSamples, options: options)
+    }
   }
 
   // MARK: - Streaming ASR
@@ -559,7 +566,10 @@ public final class ASRManager: ASRManagerInterface {
     // by the time this returns).
     let attemptID = streamingStartID
     do {
-      let result = try await activeBackend.finalizeStreaming()
+      // #2787: see `transcribe` — the streaming finalize is a vendor decode too.
+      let result = try await vendorDecodeOccupancy.track {
+        try await activeBackend.finalizeStreaming()
+      }
       // Identity-checked, not unconditional: a reclaim task or a newer
       // start's own admission could have moved `streamingStartID` on during
       // this suspension (round 9/10's lesson, applied here too).

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -468,9 +468,17 @@ public final class ASRManager: ASRManagerInterface {
     // idle engine and release the lease under a decode about to start. The
     // backend forwards reports only while its own `transcribe` runs, so the
     // observer needs no clearing here.
+    //
+    // A decode must not START in a task the kernel has already cancelled
+    // (second-pass review): the session terminal drains its task bag, so a
+    // finalize suspended before this call — the streaming batch rescue awaits
+    // a log line first — resumes cancelled AFTER the lease was released on an
+    // idle count, and its decode would then run under a new take's session.
+    try Task.checkCancellation()
     let chunkObserver = onVendorDecodeChunkScheduled
     return try await vendorDecodeOccupancy.track {
       await activeBackend.setDecodeChunkObserver { Task { @MainActor in chunkObserver?() } }
+      try Task.checkCancellation()
       return try await activeBackend.transcribe(audioSamples: audioSamples, options: options)
     }
   }

--- a/Sources/EnviousWisprASR/ASRManager.swift
+++ b/Sources/EnviousWisprASR/ASRManager.swift
@@ -66,6 +66,10 @@ public final class ASRManager: ASRManagerInterface {
   private var streamingStartInFlight = false
   /// #2787: is a vendor decode call running right now, whoever is waiting.
   public let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  /// #2787: observation only — fired once per vendor chunk the active backend
+  /// reports as scheduled during a batch `transcribe`. The adapter turns it
+  /// into an `.observation` finalize tick for the kernel's checkpoint.
+  public var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   /// This attempt's identity, supplied by the caller (`ParakeetEngineAdapter`
   /// mints a fresh one per `beginSession()`) rather than an internal counter,
   /// so `cancelInFlightStreamingStart(attemptID:)` can name exactly the
@@ -458,9 +462,16 @@ public final class ASRManager: ASRManagerInterface {
     guard let activeBackend else { throw ASRManagerNotOwnedError(backend: activeBackendType) }
     // #2787: counted for the whole vendor call, so a session that stops
     // waiting (cancel during transcribing) leaves the engine visibly BUSY
-    // until Core ML actually returns.
+    // until Core ML actually returns. The observation-only chunk observer is
+    // installed INSIDE the tracked region: installing it first would open a
+    // suspension before occupancy begins, during which a cancel could see an
+    // idle engine and release the lease under a decode about to start. The
+    // backend forwards reports only while its own `transcribe` runs, so the
+    // observer needs no clearing here.
+    let chunkObserver = onVendorDecodeChunkScheduled
     return try await vendorDecodeOccupancy.track {
-      try await activeBackend.transcribe(audioSamples: audioSamples, options: options)
+      await activeBackend.setDecodeChunkObserver { Task { @MainActor in chunkObserver?() } }
+      return try await activeBackend.transcribe(audioSamples: audioSamples, options: options)
     }
   }
 

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -175,6 +175,9 @@ public protocol ASRManagerInterface: AnyObject {
   /// that never returned, which is the exact state this exists to expose.
   var vendorDecodeOccupancy: VendorDecodeOccupancy { get }
 
+  /// #2787: observation only — see `ASRManager.onVendorDecodeChunkScheduled`.
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)? { get set }
+
   // Streaming transcription
   /// Create a fresh `attemptID` before scheduling the call and its deadline —
   /// `cancelInFlightStreamingStart(attemptID:)` needs it to name exactly

--- a/Sources/EnviousWisprASR/ASRManagerInterface.swift
+++ b/Sources/EnviousWisprASR/ASRManagerInterface.swift
@@ -168,6 +168,13 @@ public protocol ASRManagerInterface: AnyObject {
   // Batch transcription
   func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
 
+  /// #2787: whether a vendor decode (`transcribe` / `finalizeStreaming`) is
+  /// still running, independent of whether any session is still waiting for
+  /// it. No protocol default on purpose: a conformer that answered "idle"
+  /// by omission would let a record press mint a session on top of a decode
+  /// that never returned, which is the exact state this exists to expose.
+  var vendorDecodeOccupancy: VendorDecodeOccupancy { get }
+
   // Streaming transcription
   /// Create a fresh `attemptID` before scheduling the call and its deadline —
   /// `cancelInFlightStreamingStart(attemptID:)` needs it to name exactly

--- a/Sources/EnviousWisprASR/ASRProtocol.swift
+++ b/Sources/EnviousWisprASR/ASRProtocol.swift
@@ -26,6 +26,11 @@ public protocol ASRBackend: Actor {
   /// Batch transcription from raw Float32 samples (16kHz mono).
   func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult
 
+  /// #2787: observation only — see the extension default below. A PROTOCOL
+  /// requirement, not only an extension member, so a call through the
+  /// existential dispatches to the backend's own implementation.
+  func setDecodeChunkObserver(_ observer: (@Sendable () -> Void)?) async
+
   /// Release model resources.
   func unload() async
 
@@ -50,6 +55,13 @@ public protocol ASRBackend: Actor {
 /// Default implementations for optional protocol members.
 extension ASRBackend {
   public var supportsStreaming: Bool { false }
+
+  /// #2787: observation only. A backend whose vendor reports chunk scheduling
+  /// (Parakeet, for audio longer than one model window) forwards each report
+  /// to `observer` for the duration of the next `transcribe`. Default: no
+  /// signal (WhisperKit has none), which is honest — the checkpoint simply
+  /// carries no chunk count for that engine.
+  public func setDecodeChunkObserver(_ observer: (@Sendable () -> Void)?) async {}
 
   public func startStreaming(options _: TranscriptionOptions) async throws {
     throw ASRError.streamingNotSupported

--- a/Sources/EnviousWisprASR/ParakeetBackend.swift
+++ b/Sources/EnviousWisprASR/ParakeetBackend.swift
@@ -17,6 +17,12 @@ public actor ParakeetBackend: ASRBackend {
   public private(set) var isReady = false
 
   private var fluidAsrManager: AsrManager?
+  /// #2787: see `setDecodeChunkObserver`.
+  private var decodeChunkObserver: (@Sendable () -> Void)?
+
+  public func setDecodeChunkObserver(_ observer: (@Sendable () -> Void)?) async {
+    decodeChunkObserver = observer
+  }
   private var fluidModels: AsrModels?
 
   // Streaming ASR state
@@ -293,6 +299,32 @@ public actor ParakeetBackend: ASRBackend {
     -> ASRResult
   {
     guard isReady, let manager = fluidAsrManager else { throw ASRError.notReady }
+
+    // #2787: forward the fork's per-chunk progress to the observer for exactly
+    // this call. Observation only. Three facts from the pinned fork shape this:
+    // the array path emits only for audio longer than one model window
+    // (240,000 samples), so a shorter call must NOT touch the emitter — its
+    // session is never finished for short calls, and a cancelled consumer
+    // would poison the next long call's stream; the emitter yields synthetic
+    // 0.0 and 1.0 that are not chunk reports, so only 0 < p < 1 counts; and
+    // the stream is acquired BEFORE `transcribe` is awaited so a fast decode
+    // cannot finish the emitter before the subscription exists. The count is
+    // therefore "observed non-final chunk-scheduling reports", not chunks.
+    var chunkForwarder: Task<Void, Never>?
+    if audioSamples.count > 240_000, let observer = decodeChunkObserver {
+      let stream = await manager.transcriptionProgressStream
+      chunkForwarder = Task {
+        do {
+          for try await progress in stream {
+            guard !Task.isCancelled else { return }
+            if progress > 0, progress < 1 { observer() }
+          }
+        } catch {
+          // Observation failure does not change transcription.
+        }
+      }
+    }
+    defer { chunkForwarder?.cancel() }
 
     let startTime = CFAbsoluteTimeGetCurrent()
     // Vendor API: the caller owns decoder state (fresh per one-shot batch decode;

--- a/Sources/EnviousWisprASR/VendorDecodeOccupancy.swift
+++ b/Sources/EnviousWisprASR/VendorDecodeOccupancy.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// #2787 — whether a vendor decode call (`transcribe` / `finalizeStreaming`)
+/// is still RUNNING, independent of whether anyone is still waiting for it.
+///
+/// A recording session can conclude `.cancelled` while its decode is in
+/// flight: the kernel honours a cancel during `.delivering(.transcribing)` and
+/// returns to idle, but the vendor call it was awaiting keeps running until
+/// Core ML returns — which, on the machine that motivated this, was never.
+/// Nothing above the manager could see that. `isStreaming`,
+/// `streamingStartInFlight` and the session generation all answer "is anyone
+/// waiting"; this answers "is the engine busy", which is the question a
+/// record press, a crash-recovery replay and an engine unload all need.
+///
+/// The count is incremented immediately before the backend call is issued and
+/// decremented on every exit, thrown or returned. Cancellation of the awaiting
+/// task is NOT an exit: `Task.cancel()` sets a flag the vendor call may ignore,
+/// so the only release evidence is the call returning
+/// (`swift-concurrency-patterns.md`, and the escape-recovery reasoning at
+/// `RecordingSessionKernel.cancel`).
+///
+/// `awaitIdle()` resumes every waiter when the count reaches zero. It never
+/// times out: a caller that needs a bound races it with its own deadline, and
+/// the one production caller (`AbandonedDecodeHold`) deliberately does not —
+/// the engine is held until it is actually free, and the user is told so.
+@MainActor
+public final class VendorDecodeOccupancy {
+  public private(set) var inFlight: Int = 0
+  private var idleWaiters: [CheckedContinuation<Void, Never>] = []
+
+  public init() {}
+
+  public var isIdle: Bool { inFlight == 0 }
+
+  /// Run one vendor decode call under occupancy accounting.
+  public func track<T: Sendable>(_ operation: () async throws -> T) async rethrows -> T {
+    inFlight += 1
+    defer { end() }
+    return try await operation()
+  }
+
+  private func end() {
+    inFlight -= 1
+    guard inFlight == 0 else { return }
+    let waiters = idleWaiters
+    idleWaiters.removeAll()
+    for waiter in waiters { waiter.resume() }
+  }
+
+  /// Suspends until no vendor decode is in flight. Returns immediately when
+  /// already idle.
+  public func awaitIdle() async {
+    guard inFlight > 0 else { return }
+    await withCheckedContinuation { continuation in
+      idleWaiters.append(continuation)
+    }
+  }
+}

--- a/Sources/EnviousWisprASR/WhisperKitBackend.swift
+++ b/Sources/EnviousWisprASR/WhisperKitBackend.swift
@@ -569,9 +569,9 @@ public actor WhisperKitBackend: ASRBackend {
   // in the base options (the session sets `clipTimestamps = [lastConfirmedSec]` and
   // keeps `.none` per cycle; it must NEVER inherit the `>30s -> .vad` branch that
   // would re-chunk the whole growing buffer, F2).
-  package func makeStreamingSession(options: TranscriptionOptions)
-    async -> (any WhisperKitIncrementalSession)?
-  {
+  package func makeStreamingSession(
+    options: TranscriptionOptions, vendorDecodeOccupancy: VendorDecodeOccupancy
+  ) async -> (any WhisperKitIncrementalSession)? {
     guard let kit = await readyKitAfterWarmupDrain() else { return nil }
     var opts = makeDecodeOptions(from: options, sampleCount: 0)
     // LocalAgreement-2 confirmation is word-level — word timings are required
@@ -588,8 +588,10 @@ public actor WhisperKitBackend: ASRBackend {
     // (large-v3-turbo CoreML), a `<|startofprev|>` prompt makes the decoder
     // intermittently EOT whole speech-filled windows empty (WhisperKit trace,
     // investigation log 2026-07-04) — the buffer shape alone is the winner.
+    // #2787: every decode this session issues is counted (see the decorator).
     return WhisperKitStreamingSession(
-      whisperKit: kit, decodingOptions: opts,
+      whisperKit: OccupiedWhisperKitDecoder(base: kit, occupancy: vendorDecodeOccupancy),
+      decodingOptions: opts,
       conditionOnPriorText: false, localAgreement: true)
   }
 

--- a/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
+++ b/Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift
@@ -92,6 +92,35 @@ package protocol WhisperKitTranscribing: Sendable {
   func encodeText(_ text: String) -> [Int]
 }
 
+/// #2787: counts every decode the streaming session issues against the shared
+/// `VendorDecodeOccupancy`, so a session that stops waiting mid-stream leaves
+/// the engine visibly busy until WhisperKit actually returns. Wraps the
+/// decoder INTERFACE rather than each call site: the streaming loop and both
+/// flush branches go through one `transcribe`, and any future call the
+/// session adds is counted by construction.
+package struct OccupiedWhisperKitDecoder: WhisperKitTranscribing {
+  let base: any WhisperKitTranscribing
+  let occupancy: VendorDecodeOccupancy
+
+  package init(base: any WhisperKitTranscribing, occupancy: VendorDecodeOccupancy) {
+    self.base = base
+    self.occupancy = occupancy
+  }
+
+  package func transcribe(
+    audioArray: [Float], decodeOptions: DecodingOptions?,
+    shouldContinueDecoding: (@Sendable () -> Bool)?
+  ) async throws -> [TranscriptionResult] {
+    try await occupancy.track {
+      try await base.transcribe(
+        audioArray: audioArray, decodeOptions: decodeOptions,
+        shouldContinueDecoding: shouldContinueDecoding)
+    }
+  }
+
+  package func encodeText(_ text: String) -> [Int] { base.encodeText(text) }
+}
+
 // Retroactive @unchecked Sendable: WhisperKit (upstream, @preconcurrency-imported)
 // has mutable stored properties so it cannot auto-synthesize Sendable, but every
 // caller of the shared instance in this package already goes through actor

--- a/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/AppLifecycleCoordinator.swift
@@ -5,6 +5,7 @@ import EnviousWisprCore
 import EnviousWisprLLM
 import EnviousWisprPipeline
 import EnviousWisprServices
+import EnviousWisprStorage
 import Foundation
 
 // Issue #574: `EnviousWisprAudio` and `EnviousWisprASR` are needed in release
@@ -76,6 +77,10 @@ final class AppLifecycleCoordinator {
   /// growth, and this is one genuinely new capability adding exactly one
   /// dependency.
   private let batchDecodeFaultController: BatchDecodeFaultController?
+  /// #2787: the persisted stage checkpoint. Read once at launch for the
+  /// previous process's interrupted take, and mirrored into every telemetry
+  /// flush as `last_stage` / `stage_age_ms`.
+  private let transcriptionCheckpointStore: TranscriptionCheckpointStore
 
   /// #2455 C3: required and non-defaulted. The one call this type makes moves the
   /// app to accessory at launch, which a unit test must never do to the real app.
@@ -105,6 +110,7 @@ final class AppLifecycleCoordinator {
     // #1176: captured in the onboarding-dismiss closure below (NOT stored — keeps
     // this coordinator's stored-property ceiling clean).
     onboardingProgress: OnboardingProgress,
+    transcriptionCheckpointStore: TranscriptionCheckpointStore,
     batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
     self.application = application
@@ -128,6 +134,7 @@ final class AppLifecycleCoordinator {
     self.applicationRelocationCoordinator = applicationRelocationCoordinator
     self.bluetoothAwarenessPresenter = bluetoothAwarenessPresenter
     self.batchDecodeFaultController = batchDecodeFaultController
+    self.transcriptionCheckpointStore = transcriptionCheckpointStore
     // Icon-refresh seam: the window coordinator's two onboarding-dismiss
     // callsites route through this closure. Was wired in `AppDelegate.attach`
     // before PR-B.4.
@@ -220,9 +227,19 @@ final class AppLifecycleCoordinator {
     // any flush path can fire, so the provider is never nil in production.
     TelemetryService.shared.flushContextProvider = { [weak self] in
       let phase = self?.liveRecordingState.pipelineState ?? .idle
+      // #2787: the stage the take in flight last reached, if any, so a graceful
+      // quit during `transcribing` names the step and not just the phase.
+      let checkpoint = self?.transcriptionCheckpointStore.current
       return TelemetryService.FlushContext(
-        activeRecording: phase.isActive, appPhase: phase.telemetryLabel)
+        activeRecording: phase.isActive, appPhase: phase.telemetryLabel,
+        lastStage: checkpoint?.stage.rawValue,
+        stageAgeMs: checkpoint.map { max(0, Int(Date().timeIntervalSince($0.stageEnteredAt) * 1000)) })
     }
+
+    // #2787: report the take the PREVIOUS process died in the middle of, once.
+    // Before the recovery scan can replay its audio, so the two signals — "it
+    // stuck at stage X" and "its audio replayed fine" — arrive in that order.
+    TranscriptionInterruptionReporter.reportOrphanIfAny(from: transcriptionCheckpointStore)
 
     // Run Apple Intelligence diagnostics via coordinator.
     // Handles: Sentry context, PostHog event, persistence, first-launch re-check.

--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -196,6 +196,12 @@ enum DictationNarrator {
         return "Finishing an earlier take. Try again soon."
       case .dictation:
         return "Already recording."
+      case .abandonedDecode:
+        // #2787: the decode the user stopped waiting for still owns the engine.
+        // Say what will actually work, not "try again soon" — on the machine
+        // this was written for, soon never came.
+        // 45 characters: the pill truncates at 46 (DictationNarratorTests).
+        return "Previous take still running. Restart the app."
       }
     }
   }

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/AbandonedDecodeHold.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/AbandonedDecodeHold.swift
@@ -1,0 +1,93 @@
+import EnviousWisprASR
+import EnviousWisprPipeline
+import EnviousWisprServices
+import Foundation
+
+/// #2787 — keeps the shared engine claimed while a vendor decode that nobody
+/// is waiting for any more is still running.
+///
+/// The dictation lifecycle hands its `EngineLease` token back on the kernel's
+/// accepted terminal. That is the right moment for every ending EXCEPT one:
+/// a session that concluded while its `transcribe` / `finalizeStreaming`
+/// call was still inside Core ML. The kernel is idle, the pill is gone, the
+/// user is free — and the engine is not. Releasing the lease there let the
+/// next record press mint a session on top of a decode that, on the machine
+/// this was written for, never returned.
+///
+/// So the release goes THROUGH here. If `VendorDecodeOccupancy` says the
+/// engine is still busy, the dictation token is released and the lease is
+/// immediately re-claimed as `.abandonedDecode`. Every participant that
+/// competes for the engine (a record press, crash-recovery replay, file
+/// import) is refused by the lease it already consults, and the refusal names
+/// this holder so `DictationNarrator` can say "restart the app". The claim is
+/// released the moment the vendor call actually returns or throws — never on
+/// a timer, never on task cancellation (`VendorDecodeOccupancy`).
+///
+/// `onSettled` fires once per hold when the decode returns, carrying how long
+/// the engine stayed held. It is how the recovery cleanup learns that a
+/// stop-waiting take's audio can now be deleted (its rescue — a restart and a
+/// launch replay — is no longer needed) and how the fleet counts these.
+///
+/// Sits beside `RecordingFinalizer` and `RecordingStarter` rather than inside
+/// `DictationLifecycleCoordinator`, which is at its collaborator cap and
+/// sequences a dictation; this holds the engine AFTER the dictation ended.
+@MainActor
+final class AbandonedDecodeHold {
+  private let lease: EngineLease
+  private let occupancy: VendorDecodeOccupancy
+  private var heldToken: EngineLease.Token?
+  private var heldSince: ContinuousClock.Instant?
+  /// Fired when a hold ends because the decode returned. `seconds` is the
+  /// wall-clock the engine stayed held past the session's end.
+  var onSettled: (@MainActor (_ seconds: Double) -> Void)?
+
+  init(lease: EngineLease, occupancy: VendorDecodeOccupancy) {
+    self.lease = lease
+    self.occupancy = occupancy
+  }
+
+  /// Whether the engine is currently held on behalf of a decode nobody is
+  /// waiting for.
+  var isHolding: Bool { heldToken != nil }
+
+  /// The dictation lifecycle's release path. Releases `token`; then, if a
+  /// vendor decode is still running, re-claims the lease as `.abandonedDecode`
+  /// until it returns.
+  func releaseFromDictation(_ token: EngineLease.Token) {
+    lease.release(token)
+    guard !occupancy.isIdle, heldToken == nil else { return }
+    guard case .granted(let hold) = lease.admit(.abandonedDecode) else {
+      // Unreachable in practice: `release` and `admit` are both synchronous,
+      // non-suspending MainActor calls with no callbacks between them, so
+      // nothing can claim the lease in the gap. Kept as a guard rather than a
+      // force-unwrap because the lease API returns an enum.
+      return
+    }
+    heldToken = hold
+    heldSince = ContinuousClock.now
+    SentryBreadcrumb.add(
+      stage: "asr", message: "Engine held after session end: vendor decode still running",
+      data: ["in_flight": occupancy.inFlight])
+    TelemetryService.shared.abandonedDecodeHoldStarted(inFlight: occupancy.inFlight)
+    Task { @MainActor [weak self] in
+      await self?.occupancy.awaitIdle()
+      self?.settle()
+    }
+  }
+
+  private func settle() {
+    guard let hold = heldToken else { return }
+    heldToken = nil
+    let seconds =
+      heldSince.map { ContinuousClock.now - $0 }.map {
+        Double($0.components.seconds) + Double($0.components.attoseconds) / 1e18
+      } ?? 0
+    heldSince = nil
+    lease.release(hold)
+    SentryBreadcrumb.add(
+      stage: "asr", message: "Engine released: abandoned vendor decode returned",
+      data: ["held_seconds": seconds])
+    TelemetryService.shared.abandonedDecodeHoldSettled(seconds: seconds)
+    onSettled?(seconds)
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/CancelAffordancePolicy.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/CancelAffordancePolicy.swift
@@ -28,24 +28,18 @@ enum CancelAffordancePolicy {
 
   /// Whether the cancel shortcut should be armed for this state.
   ///
-  /// `.transcribing` is the only state whose answer depends on anything beyond
-  /// the state itself. During an ordinary transcription there is nothing a
-  /// cancel could do — the audio is already captured and the decode is not
-  /// interruptible — so the shortcut stays down, exactly as today. During an
-  /// Escape Recovery the same keypress means something new: discard the text
-  /// this recovery is producing.
-  ///
-  /// `isEscapeRecoveryTranscribing` is false for every take the setting is off
-  /// for, which is the default, so those takes get today's answers unchanged.
-  static func isShortcutEnabled(
-    state: PipelineState,
-    isEscapeRecoveryTranscribing: Bool
-  ) -> Bool {
+  /// `.transcribing` is armed for EVERY take (#2787). The audio is already
+  /// captured and the decode itself is not interruptible, but a cancel here
+  /// still does two things the user needs: it ends their wait (the kernel
+  /// honours a cancel in `.delivering(.transcribing)` and concludes
+  /// `.cancelled`), and — while the engine is still inside a decode that will
+  /// not return — it keeps the audio for a launch replay. During an Escape
+  /// Recovery the same keypress means "discard the text this recovery is
+  /// producing" (`isAbandonment` below); the finalizer routes the two.
+  static func isShortcutEnabled(state: PipelineState) -> Bool {
     switch state {
-    case .recording:
+    case .recording, .transcribing:
       return true
-    case .transcribing:
-      return isEscapeRecoveryTranscribing
     case .loadingModel, .polishing, .error, .idle, .complete, .advisory:
       // Every other state disarms, including all four terminals. Enumerated
       // rather than defaulted so a future `PipelineState` case is a compile
@@ -59,9 +53,10 @@ enum CancelAffordancePolicy {
   ///
   /// Lives here because it is the other half of `isShortcutEnabled`, and the
   /// two must agree or the shortcut is armed against a finalizer that refuses
-  /// it: `RecordingFinalizer.cancel` admits only `.recording` and
-  /// `.loadingModel`, so a key left live through `.transcribing` would be armed
-  /// and inert — a user pressing Escape and nothing happening at all.
+  /// it. `RecordingFinalizer.cancel` admits `.recording`, `.loadingModel` and
+  /// (#2787) `.transcribing`; before #2787 it refused `.transcribing`, so an
+  /// armed key there was inert — a user pressing Escape and nothing happening
+  /// at all, which is exactly what the customer's four force-quits were.
   ///
   /// An abandonment must ALSO skip that method's teardown. The session is still
   /// running until its decode returns, so hiding its overlay and clearing its

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/DictationLifecycleCoordinator.swift
@@ -367,9 +367,7 @@ final class DictationLifecycleCoordinator {
     // deferred-setting work — those are genuinely per-state and are not an
     // affordance question.
     hotkeyService.setCancelHotkeyEnabled(
-      CancelAffordancePolicy.isShortcutEnabled(
-        state: newState,
-        isEscapeRecoveryTranscribing: kernelDriver.isEscapeRecoveryTranscribing))
+      CancelAffordancePolicy.isShortcutEnabled(state: newState))
     switch newState {
     case .recording:
       // PR7 of #763 — clear the prior recording's polish error on every new
@@ -436,9 +434,7 @@ final class DictationLifecycleCoordinator {
       enabled: settings.playRecordingSounds, selectedPairing: settings.recordingSoundPairing)
     // #2087: see `handleParakeet` — one affordance decision, both backends.
     hotkeyService.setCancelHotkeyEnabled(
-      CancelAffordancePolicy.isShortcutEnabled(
-        state: newState,
-        isEscapeRecoveryTranscribing: whisperKitKernelDriver.isEscapeRecoveryTranscribing))
+      CancelAffordancePolicy.isShortcutEnabled(state: newState))
     switch newState {
     case .recording:
       lastRecordingResult.polishError = nil

--- a/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationRuntime/RecordingFinalizer.swift
@@ -117,7 +117,12 @@ final class RecordingFinalizer {
       active.requestEscapeRecoveryAbandonment()
       return true
     }
-    guard active.state == .recording || active.state == .loadingModel else { return false }
+    // #2787: `.transcribing` admitted. The kernel concludes `.cancelled` from
+    // `.delivering(.transcribing)`; the decode keeps running, and the engine
+    // hold (`AbandonedDecodeHold`) keeps the engine claimed until it returns.
+    guard active.state == .recording || active.state == .loadingModel
+      || active.state == .transcribing
+    else { return false }
     languageSuggestionPresenter?.clearCurrentChip()
     languageSuggestionPresenter?.clearBuffer()
     recordingOverlay.dismissCurrent(.silent)

--- a/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/RecoveryCoordinator.swift
@@ -369,6 +369,9 @@ final class RecoveryCoordinator {
     /// completed (crash, or the delete itself failed). No replay is ever
     /// attempted for this case; this is a cleanup retry, not a fresh decision.
     case markedForDiscard = "marked_for_discard"
+    /// #2787: a spool retained by `.stoppedWaitingForDecode` whose decode then
+    /// returned in this launch — the restart-and-replay rescue is moot.
+    case abandonedDecodeReturned = "abandoned_decode_returned"
   }
 
   /// #1755 chunk 4 test seams (internal; nil in production — the real spool
@@ -503,7 +506,8 @@ final class RecoveryCoordinator {
         TelemetryService.shared.recoveryCleanup(
           source: source.rawValue, component: component, succeeded: succeeded)
       }
-    case .durableSave, .liveEnding, .preStartAbort, .historyDedup, .userDiscard:
+    case .durableSave, .liveEnding, .preStartAbort, .historyDedup, .userDiscard,
+      .abandonedDecodeReturned:
       // Not a spent recovery attempt — no cleanup-coverage question to answer.
       break
     }
@@ -848,7 +852,51 @@ final class RecoveryCoordinator {
       // #1755: flipped — every producer is app-alive by construction (an
       // app-gone event cannot publish any ending; it leaves an orphan).
       return true
+    case .stoppedWaitingForDecode:
+      // #2787: the ONE live ending that retains. The user got no outcome —
+      // the decode they stopped waiting for is still inside the vendor and
+      // may never return — and the exit the app tells them to take is a
+      // restart, where the launch replay recovers this audio (measured on the
+      // customer's Mac Studio: three replays, all recovered). If the decode
+      // does return in this launch, `handleAbandonedDecodeReturned` destroys
+      // the spool then, so a normal cancel never produces a surprise replay.
+      return false
     }
+  }
+
+  /// #2787: the spools retained by `.stoppedWaitingForDecode` in this launch,
+  /// awaiting either a restart (launch replay) or the decode's late return.
+  private var stoppedWaitingSpoolIDs: Set<String> = []
+
+  /// #2787: the abandoned vendor decode returned in this launch. The user's
+  /// rescue is no longer a replay — they can simply dictate again — so every
+  /// spool retained by `.stoppedWaitingForDecode` is destroyed now, before the
+  /// next launch could replay it as a surprise.
+  /// Returns the per-spool destroy work so a test can await it; production
+  /// callers discard it.
+  @discardableResult
+  func handleAbandonedDecodeReturned() -> [Task<Void, Never>] {
+    let ids = stoppedWaitingSpoolIDs
+    stoppedWaitingSpoolIDs.removeAll()
+    var work: [Task<Void, Never>] = []
+    for id in ids {
+      RecoveryLog.line("abandoned decode returned — deleting the spool retained for it: \(id)")
+      // The vendor returning does not prove the WRITER has finished with the
+      // spool: the retain disposition settles only on writer quiescence, in its
+      // own Task. Join that settlement (an already-retired entry returns at
+      // once), start the durable discard marker now, and destroy only after.
+      let settled = requestDisposal(recoverySessionID: id, disposition: .retain)
+      let marker = beginDiscardMarkerPersistence(
+        recoverySessionID: id, source: .abandonedDecodeReturned)
+      work.append(
+        Task { @MainActor [self] in
+          await settled.value
+          await destroySpoolAndKey(
+            id: id, source: .abandonedDecodeReturned, markerPersistence: marker
+          ).value
+        })
+    }
+    return work
   }
 
   /// Delete-versus-retain after a launch replay attempt (#1464; #1740 cutover).
@@ -971,6 +1019,8 @@ final class RecoveryCoordinator {
         RecoveryLog.line("live ending (\(ending)) — keeping the spool for a future launch")
       }
       nextLaunchOnlyRecoveryIDs.insert(id)
+      // #2787: remember it, so the decode's late return can destroy it.
+      if case .stoppedWaitingForDecode = ending { stoppedWaitingSpoolIDs.insert(id) }
       // #1807 (§C): retain still joins the writer-quiescence contract — the
       // entry stays protected until the writer confirms it will never touch
       // this spool again, exactly like the delete branch below. Only then is

--- a/Sources/EnviousWisprAppKit/App/TranscriptionInterruptionReporter.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptionInterruptionReporter.swift
@@ -1,0 +1,70 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+
+/// #2787 — on launch, reports the take the PREVIOUS process died in the
+/// middle of, from the checkpoint it left on disk.
+///
+/// The customer's four stuck takes each ended in a quit while the app was
+/// still "transcribing", and every one of them reached us as
+/// `telemetry.flush_requested app_phase=transcribing` and nothing more: no
+/// stage, no Sentry event, no breadcrumbs. A force-quit does not even send
+/// that. This turns the persisted `TranscriptionCheckpoint` into ONE Sentry
+/// error (fingerprinted by stage, so the fleet groups by where it stuck) and
+/// one PostHog event, then consumes the checkpoint so the report can never
+/// repeat. Metadata only: stage names, counts, the backend, a version.
+///
+/// It reports an INTERRUPTION, not a proven hang: a user who quit two seconds
+/// into a healthy long decode leaves the same checkpoint. `stage_age_ms` is
+/// wall-clock elapsed from the last checkpoint to THIS launch, including the
+/// time the app was closed. It is not a measured hang duration — the dying
+/// process cannot write its own death time — and a clock change weakens even
+/// that reading.
+enum TranscriptionInterruptionReporter {
+
+  struct InterruptedTranscriptionError: Error, CustomStringConvertible {
+    let stage: TranscriptionStage
+    var description: String { "transcription interrupted by process exit at \(stage.rawValue)" }
+  }
+
+  /// Reads and consumes the orphaned checkpoint, if any, and reports it.
+  /// Returns the checkpoint it reported, for tests; nil when there was none.
+  @discardableResult
+  @MainActor
+  static func reportOrphanIfAny(
+    from store: TranscriptionCheckpointStore, now: Date = Date()
+  ) -> TranscriptionCheckpoint? {
+    guard let checkpoint = store.takeOrphan() else { return nil }
+    let ageMs = max(0, Int(now.timeIntervalSince(checkpoint.stageEnteredAt) * 1000))
+    SentryBreadcrumb.captureError(
+      InterruptedTranscriptionError(stage: checkpoint.stage),
+      category: .transcriptionInterrupted,
+      stage: "asr",
+      extra: [
+        "stage": checkpoint.stage.rawValue,
+        "asr_backend": checkpoint.backend,
+        "chunks_scheduled": checkpoint.chunksScheduled,
+        "stage_age_ms": ageMs,
+        "checkpoint_app_version": checkpoint.appVersion,
+        "take_id": checkpoint.takeID,
+      ],
+      tags: ["transcription.stage": checkpoint.stage.rawValue])
+    TelemetryService.shared.transcriptionInterruptedAtQuit(
+      stage: checkpoint.stage.rawValue, backend: checkpoint.backend,
+      chunksScheduled: checkpoint.chunksScheduled, stageAgeMs: ageMs,
+      checkpointAppVersion: checkpoint.appVersion)
+    return checkpoint
+  }
+}
+
+// MARK: - Sentry identity
+
+/// Pinned once shipped. The stage is part of the descriptor so each stage is
+/// its own Sentry issue: "stuck after capture stopped" and "stuck inside the
+/// decode" are different bugs with different owners.
+extension TranscriptionInterruptionReporter.InterruptedTranscriptionError: StableSentryErrorIdentity
+{
+  var sentryFingerprintDescriptor: String { "TranscriptionInterrupted#\(stage.rawValue)" }
+  var sentrySemanticID: String { "transcription.interrupted.\(stage.rawValue)" }
+}

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1164,6 +1164,9 @@ package final class WisprBootstrapper {
     // that deferred work while the engine was held — a pending engine switch
     // and a deferred crash-recovery pass.
     abandonedDecodeHold.onSettled = { [weak engineCoordinator, weak recoveryCoordinator] _ in
+      // Order matters: destroy the retained stop-waiting spool BEFORE the
+      // recovery recheck, or the recheck could replay it in this launch.
+      recoveryCoordinator?.handleAbandonedDecodeReturned()
       engineCoordinator?.poke(.driverStateChanged)
       recoveryCoordinator?.requestRecoveryRecheck()
     }

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -260,7 +260,13 @@ package final class WisprBootstrapper {
     // several chunks. A consumer not yet migrated stays on its existing
     // per-consumer closure wiring below until its own chunk lands.
     let engineMutationScope = EngineMutationScope.live(
-      tryBegin: { [engineRecoveryGate] in engineRecoveryGate.tryBeginMutation() },
+      // #2787: no warm-up, unload, download or migration while an abandoned
+      // vendor decode still owns the engine — the hold is the one holder the
+      // recovery gate cannot see, because it is not a recovery.
+      tryBegin: { [engineRecoveryGate, engineLease] in
+        guard engineLease.currentHolder != .abandonedDecode else { return false }
+        return engineRecoveryGate.tryBeginMutation()
+      },
       end: { [engineRecoveryGate] in engineRecoveryGate.endMutation() },
       wake: { recoveryCoordinatorForEngineMutationScope?.requestRecoveryRecheck() },
       onRefused: { site in TelemetryService.shared.recoveryEngineActionDeferred(site: site) })
@@ -271,6 +277,9 @@ package final class WisprBootstrapper {
     // out from under an idle dictation. The `useXPCASRService` selector and
     // its `defaults write` escape hatch are retired along with it.
     let asrManager: any ASRManagerInterface = ASRManager(engineMutationScope: engineMutationScope)
+    // #2787: owns the engine AFTER a session ends with its decode still running.
+    let abandonedDecodeHold = AbandonedDecodeHold(
+      lease: engineLease, occupancy: asrManager.vendorDecodeOccupancy)
 
     let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 
@@ -534,6 +543,7 @@ package final class WisprBootstrapper {
         captureTelemetry: captureTelemetry,
         pasteCompletionRegistry: pasteCompletionRegistry,
         engineMutationScope: engineMutationScope,
+        vendorDecodeOccupancy: asrManager.vendorDecodeOccupancy,
         outputClassifierHolder: outputClassifierHolder,
         dictationAudioArchiveOptInProvider: { settings.isDictationAudioArchiveEnabled },
         microphonePermissionIsDenied: { permissions.microphonePermissionIsDenied },
@@ -1052,8 +1062,11 @@ package final class WisprBootstrapper {
         readiness: { [kernelDriver, whisperKitKernelDriver] backend in
           (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver).engineReadiness
         },
-        isEngineActive: { [kernelDriver, whisperKitKernelDriver] backend in
-          (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver).state.isActive
+        // #2787: an engine whose abandoned decode is still running is ACTIVE
+        // for switching purposes, whatever the pipeline state says.
+        isEngineActive: { [kernelDriver, whisperKitKernelDriver, engineLease] backend in
+          engineLease.currentHolder == .abandonedDecode
+            || (backend == .whisperKit ? whisperKitKernelDriver : kernelDriver).state.isActive
         },
         isRecovering: { [weak recoveryCoordinator] in recoveryCoordinator?.isRecovering ?? false },
         // `isEngineHeld`, not `isRunning`: Stop flips the visible state at the
@@ -1147,6 +1160,13 @@ package final class WisprBootstrapper {
       get: { liveRecordingState.isRecordingLocked },
       set: { locked in liveRecordingState.isRecordingLocked = locked }
     )
+    // #2787: when the abandoned decode finally returns, wake the two consumers
+    // that deferred work while the engine was held — a pending engine switch
+    // and a deferred crash-recovery pass.
+    abandonedDecodeHold.onSettled = { [weak engineCoordinator, weak recoveryCoordinator] _ in
+      engineCoordinator?.poke(.driverStateChanged)
+      recoveryCoordinator?.requestRecoveryRecheck()
+    }
     let dictationLifecycleCoordinator = DictationLifecycleCoordinator(
       application: presentationEffects.application,
       kernelDriver: kernelDriver,
@@ -1162,8 +1182,11 @@ package final class WisprBootstrapper {
       recordingLockedAccess: recordingLockedAccess,
       // #2648 — the running session's claim comes back here, on the session's
       // terminal transition, because both start methods return while the
-      // recording is still running.
-      releaseEngineClaim: { [engineLease] token in engineLease.release(token) }
+      // recording is still running. #2787: through the hold, which keeps the
+      // engine claimed if the session's vendor decode is still running.
+      releaseEngineClaim: { [abandonedDecodeHold] token in
+        abandonedDecodeHold.releaseFromDictation(token)
+      }
     )
     dictationLifecycleCoordinator.install()
     // #1171 — every pipeline state change pokes the coordinator: non-terminal

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -280,6 +280,11 @@ package final class WisprBootstrapper {
     // #2787: owns the engine AFTER a session ends with its decode still running.
     let abandonedDecodeHold = AbandonedDecodeHold(
       lease: engineLease, occupancy: asrManager.vendorDecodeOccupancy)
+    // #2787: the persisted per-take stage checkpoint (see `TranscriptionCheckpointStore`).
+    let transcriptionCheckpointStore = TranscriptionCheckpointStore()
+    let transcriptionCheckpoint: @MainActor (TranscriptionCheckpointEvent) -> Void = {
+      [transcriptionCheckpointStore] event in transcriptionCheckpointStore.apply(event)
+    }
 
     let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 
@@ -496,7 +501,8 @@ package final class WisprBootstrapper {
         s1MiniRuntime: s1MiniRuntime,
         parakeetDelivery: modelDelivery.parakeetHandle,
         batchDecodeFaultController: batchDecodeFaultController,
-        escapeRecovery: EscapeRecoveryWiring.wire(transcriptCoordinator)
+        escapeRecovery: EscapeRecoveryWiring.wire(transcriptCoordinator),
+        transcriptionCheckpoint: transcriptionCheckpoint
       ))
 
     // W6: language-flip telemetry wired via a closure so `EnviousWisprASR`
@@ -550,7 +556,8 @@ package final class WisprBootstrapper {
         egOneRuntime: egOneRuntime,
         s1MiniRuntime: s1MiniRuntime,
         batchDecodeFaultController: batchDecodeFaultController,
-        escapeRecovery: EscapeRecoveryWiring.wire(transcriptCoordinator)
+        escapeRecovery: EscapeRecoveryWiring.wire(transcriptCoordinator),
+        transcriptionCheckpoint: transcriptionCheckpoint
       ))
 
     // Phase F (#501) — `SetupCoordinator` needs `asrManager` + the WhisperKit
@@ -1347,6 +1354,7 @@ package final class WisprBootstrapper {
       applicationRelocationCoordinator: applicationRelocationCoordinator,
       bluetoothAwarenessPresenter: bluetoothAwarenessPresenter,
       onboardingProgress: onboardingProgress,
+      transcriptionCheckpointStore: transcriptionCheckpointStore,
       batchDecodeFaultController: batchDecodeFaultController
     )
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -946,6 +946,10 @@ struct TranscribeFileView: View {
       return "That transcription engine isn't downloaded yet. Get it in Transcription settings."
     case .engineNotReady: return "The transcription engine didn't start. Try again."
     case .engineBusy(.fileImport): return "Another file is being transcribed right now."
+    // #2787: a dictation ended but its transcription never returned; the engine
+    // is not free until the app restarts.
+    case .engineBusy(.abandonedDecode):
+      return "The last dictation is still transcribing. Restart the app, then try again."
     case .failed: return "Something went wrong reading that file. Try a different one."
     }
   }

--- a/Sources/EnviousWisprCore/TranscriptionCheckpoint.swift
+++ b/Sources/EnviousWisprCore/TranscriptionCheckpoint.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// #2787 — the stages a take walks between "stop pressed" and "text in hand".
+///
+/// A live decode that never returns leaves the app parked in "transcribing"
+/// with nothing to say about WHICH step stopped. The kernel records each of
+/// these as it enters it; the checkpoint store persists the latest one per
+/// take so a launch after a quit, a crash or a force-quit can report where the
+/// previous take was when the process died. Bounded set, string-backed: the
+/// Sentry fingerprint groups on the stage name, so a new member is a new group.
+public enum TranscriptionStage: String, Codable, Sendable, CaseIterable, Equatable {
+  /// The audio engine returned from `stopCapture`.
+  case captureStopped = "capture_stopped"
+  /// The VAD conditioning pass over the whole buffer finished.
+  case vadConditioned = "vad_conditioned"
+  /// The tail-preserve decision was made; the batch buffer is final.
+  case tailChecked = "tail_checked"
+  /// The adapter's `finalize` (the vendor decode) was called.
+  case decodeStarted = "decode_started"
+  /// The vendor scheduled another chunk of a long decode (observation only;
+  /// `chunksScheduled` on the checkpoint carries the count).
+  case decodeChunkScheduled = "decode_chunk_scheduled"
+  /// The vendor decode returned, with or without text.
+  case decodeReturned = "decode_returned"
+}
+
+/// #2787 — metadata about one take's last observed transcription stage.
+/// Never text, never audio, never a path: the privacy boundary is unchanged.
+public struct TranscriptionCheckpoint: Codable, Sendable, Equatable {
+  public let takeID: String
+  public let backend: String
+  public let stage: TranscriptionStage
+  public let stageEnteredAt: Date
+  public let chunksScheduled: Int
+  public let appVersion: String
+
+  public init(
+    takeID: String, backend: String, stage: TranscriptionStage, stageEnteredAt: Date,
+    chunksScheduled: Int, appVersion: String
+  ) {
+    self.takeID = takeID
+    self.backend = backend
+    self.stage = stage
+    self.stageEnteredAt = stageEnteredAt
+    self.chunksScheduled = chunksScheduled
+    self.appVersion = appVersion
+  }
+}
+
+/// #2787 — what the kernel tells the checkpoint store. One closure-shaped sink,
+/// defaulted to a no-op in every test construction site, wired to the real
+/// store by the composition root.
+public enum TranscriptionCheckpointEvent: Sendable, Equatable {
+  /// The take entered `stage`. `chunksScheduled` is the running count of vendor
+  /// chunks scheduled so far (0 until the decode reports any).
+  case mark(takeID: String, backend: String, stage: TranscriptionStage, chunksScheduled: Int)
+  /// The take reached a terminal while the app was alive: nothing to report later.
+  case clear
+}

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -357,6 +357,13 @@ package protocol ASREngineAdapter: AnyObject, Sendable {
   /// `loadProgress`.
   var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { get }
 
+  /// #2787: whether a vendor decode this adapter issued is still running,
+  /// whoever is waiting for it. Read by the driver at a `.cancelled` terminal
+  /// to decide whether the take's audio must survive for a launch replay
+  /// (`RecordingRecoveryEnding.stoppedWaitingForDecode`). Backed by the one
+  /// `VendorDecodeOccupancy` the composition root owns, never by session state.
+  var isVendorDecodeInFlight: Bool { get }
+
   /// #1707 Phase 2 — a second, bounded decode attempt over audio a PRIOR
   /// `finalize()` call already failed to decode. Distinct from calling
   /// `finalize()` again: both `ParakeetEngineAdapter` and

--- a/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ASREngineAdapter.swift
@@ -190,11 +190,25 @@ public struct ASRLoadProgressTick: Sendable {
 /// A wedge-detection progress tick emitted during `finalize()` (PR-1 §B.1.7,
 /// §B.2.1). Same cadence-watching semantics as `ASRLoadProgressTick`.
 public struct ASRFinalizeProgressTick: Sendable {
+  /// #2787: what a tick is allowed to DO in the kernel.
+  public enum Kind: Sendable, Equatable {
+    /// A liveness signal: the first arms `detectFinalizeWedge`, and a long
+    /// silence after it is a wedge the kernel tears down (PR-1 §B.1.7).
+    case progress
+    /// An observation only: recorded on the take's checkpoint
+    /// (`decode_chunk_scheduled`) and nothing else. Never arms the detector —
+    /// the vendor reports a chunk when it is SCHEDULED, not finished, so
+    /// silence between these is not evidence of anything.
+    case observation
+  }
+
   /// Monotonic progress marker.
   public let marker: UInt64
+  public let kind: Kind
 
-  public init(marker: UInt64) {
+  public init(marker: UInt64, kind: Kind = .progress) {
     self.marker = marker
+    self.kind = kind
   }
 }
 

--- a/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelAdapterFactory.swift
@@ -50,6 +50,7 @@ package enum KernelAdapterFactory {
     languageDetector: LanguageDetector,
     audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64,
     engineMutationScope: EngineMutationScope,
+    vendorDecodeOccupancy: VendorDecodeOccupancy,
     batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) -> any ASREngineAdapter {
     WhisperKitEngineAdapter(
@@ -57,6 +58,7 @@ package enum KernelAdapterFactory {
       engineMutationScope: engineMutationScope,
       languageDetector: languageDetector,
       audioCaptureSessionIDSource: audioCaptureSessionIDSource,
+      vendorDecodeOccupancy: vendorDecodeOccupancy,
       batchDecodeFaultController: batchDecodeFaultController)
   }
 }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriver.swift
@@ -1558,7 +1558,13 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
   /// sessions ending at the same terminal still each fire (intervening states
   /// change the latch). `.completed` is never a signal here (its durable-save
   /// callback owns cleanup); `.idle` and the transient states map to nil.
-  private func fireSessionEndedWithoutSaveIfNeeded() {
+  /// `package`, not `private` (#2787): ALSO called from the factory's terminal
+  /// relay, synchronously on the accepted terminal and BEFORE
+  /// `onSessionTerminalAccepted` hands the engine claim to `AbandonedDecodeHold`,
+  /// so spool retention is registered before the hold exists and no suspension
+  /// sits between the two. The observer-Task call below stays; the session-ID
+  /// latch makes the second call a no-op.
+  package func fireSessionEndedWithoutSaveIfNeeded() {
     // A concluded session carries its ending on `recordingOutcome`; fire once
     // per concluded session, deduped by `currentSessionID` (NOT by state — two
     // sessions may publish an outcome with idle between them, r1 Q1.1). #1548 D1.
@@ -1581,7 +1587,15 @@ public final class KernelDictationDriver: HeartPathTelemetryTarget {
       //
       // Both origins delete under #1755 — the disposition decision lives solely
       // in the coordinator's predicate; the driver only projects the origin.
-      ending = .cancelled(kernel.lastCancelOrigin)
+      // #2787: EXCEPT when the vendor decode this session was awaiting was still
+      // running AT THE TERMINAL — the user stopped waiting, not the engine.
+      // Read from the kernel's terminal-time snapshot, never from the live
+      // occupancy: this fires from the observer Task, by which time another
+      // workload could have claimed the engine and made "busy" true for a
+      // decode that is not this session's.
+      ending =
+        kernel.lastTerminalStoppedWaitingForDecode
+        ? .stoppedWaitingForDecode : .cancelled(kernel.lastCancelOrigin)
     } else {
       ending = Self.recoveryEnding(for: outcome, retryOutcome: kernel.asrRetryOutcome)
     }

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -835,6 +835,10 @@ public enum KernelDictationDriverFactory {
     // own contract.
     telemetryRelay.sessionTerminal = { [lifecycleSink, weak driver] snapshot in
       lifecycleSink.emitTerminal(snapshot)
+      // #2787: the recovery ending BEFORE the engine claim is handed back, in
+      // the same synchronous turn, so a `.stoppedWaitingForDecode` retention is
+      // registered before `AbandonedDecodeHold` can exist to settle it.
+      driver?.fireSessionEndedWithoutSaveIfNeeded()
       driver?.onSessionTerminalAccepted?(snapshot.takeID)
     }
 

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -249,6 +249,12 @@ public enum KernelDictationDriverFactory {
     /// the composition root, threaded into the driver, kernel, and
     /// `WhisperKitEngineAdapter` this factory builds. Required — no default.
     package let engineMutationScope: EngineMutationScope
+    /// #2787: the ONE occupancy counter the composition root owns
+    /// (`ASRManager.vendorDecodeOccupancy`). WhisperKit's live batch decode
+    /// does not go through `ASRManager.transcribe`, so the adapter counts its
+    /// own vendor call against this. Required — no default — so the production
+    /// site cannot leave WhisperKit invisible to the engine hold.
+    package let vendorDecodeOccupancy: VendorDecodeOccupancy
     /// #2087: writes the crash-provenance marker that tells the next launch this
     /// spool was a cancelled-but-kept dictation. Defaults to "cannot prepare", so
     /// a call site that never wires it gets today's destructive cancel rather
@@ -273,6 +279,7 @@ public enum KernelDictationDriverFactory {
       captureTelemetry: CaptureTelemetryState,
       pasteCompletionRegistry: PasteCompletionRegistry,
       engineMutationScope: EngineMutationScope,
+      vendorDecodeOccupancy: VendorDecodeOccupancy,
       captureErrorSink: @escaping HeartPathCaptureErrorSink = defaultCaptureErrorSink,
       outputClassifierHolder: OutputClassifierHolder? = nil,
       dictationAudioArchiveOptInProvider: @escaping @MainActor () -> Bool = { false },
@@ -284,6 +291,7 @@ public enum KernelDictationDriverFactory {
     ) {
       self.audioCapture = audioCapture
       self.whisperKitBackend = whisperKitBackend
+      self.vendorDecodeOccupancy = vendorDecodeOccupancy
       self.languageDetector = languageDetector
       self.vadSignalSource = vadSignalSource
       self.transcriptStore = transcriptStore
@@ -418,6 +426,7 @@ public enum KernelDictationDriverFactory {
       languageDetector: inputs.languageDetector,
       audioCaptureSessionIDSource: { captureSource.currentCaptureSessionID },
       engineMutationScope: inputs.engineMutationScope,
+      vendorDecodeOccupancy: inputs.vendorDecodeOccupancy,
       batchDecodeFaultController: inputs.batchDecodeFaultController)
     return assembleDriver(
       adapter: adapter,

--- a/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
+++ b/Sources/EnviousWisprPipeline/KernelDictationDriverFactory.swift
@@ -166,6 +166,11 @@ public enum KernelDictationDriverFactory {
     /// than a spool with no provenance.
     package let escapeRecovery: PrepareEscapeRecovery
 
+    /// #2787: the persisted stage checkpoint sink. Defaulted to a no-op so
+    /// every test construction site is untouched; the composition root wires
+    /// the real `TranscriptionCheckpointStore`.
+    package let transcriptionCheckpoint: @MainActor (TranscriptionCheckpointEvent) -> Void
+
     /// Explicit package init: Swift's synthesized memberwise init is `internal`
     /// and would prevent App callers from constructing this struct. `@MainActor`
     /// because `captureErrorSink`'s default is a main-actor-isolated value;
@@ -189,7 +194,8 @@ public enum KernelDictationDriverFactory {
       s1MiniRuntime: (any EGOneEndpointProviding)? = nil,
       parakeetDelivery: ParakeetDeliveryHandle? = nil,
       batchDecodeFaultController: BatchDecodeFaultController? = nil,
-      escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false }
+      escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false },
+      transcriptionCheckpoint: @escaping @MainActor (TranscriptionCheckpointEvent) -> Void = { _ in }
     ) {
       self.audioCapture = audioCapture
       self.asrManager = asrManager
@@ -208,6 +214,7 @@ public enum KernelDictationDriverFactory {
       self.parakeetDelivery = parakeetDelivery
       self.batchDecodeFaultController = batchDecodeFaultController
       self.escapeRecovery = escapeRecovery
+      self.transcriptionCheckpoint = transcriptionCheckpoint
     }
   }
 
@@ -261,6 +268,11 @@ public enum KernelDictationDriverFactory {
     /// than a spool with no provenance.
     package let escapeRecovery: PrepareEscapeRecovery
 
+    /// #2787: the persisted stage checkpoint sink. Defaulted to a no-op so
+    /// every test construction site is untouched; the composition root wires
+    /// the real `TranscriptionCheckpointStore`.
+    package let transcriptionCheckpoint: @MainActor (TranscriptionCheckpointEvent) -> Void
+
     /// Explicit package init — same reasoning as `ParakeetInputs.init`.
     /// `languageDetector` is intentionally non-optional (no default) so the
     /// production caller in Rung 5 must explicitly pass the `LanguageDetector`
@@ -287,7 +299,8 @@ public enum KernelDictationDriverFactory {
       egOneRuntime: (any EGOneEndpointProviding)? = nil,
       s1MiniRuntime: (any EGOneEndpointProviding)? = nil,
       batchDecodeFaultController: BatchDecodeFaultController? = nil,
-      escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false }
+      escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false },
+      transcriptionCheckpoint: @escaping @MainActor (TranscriptionCheckpointEvent) -> Void = { _ in }
     ) {
       self.audioCapture = audioCapture
       self.whisperKitBackend = whisperKitBackend
@@ -307,6 +320,7 @@ public enum KernelDictationDriverFactory {
       self.s1MiniRuntime = s1MiniRuntime
       self.batchDecodeFaultController = batchDecodeFaultController
       self.escapeRecovery = escapeRecovery
+      self.transcriptionCheckpoint = transcriptionCheckpoint
     }
   }
 
@@ -395,7 +409,8 @@ public enum KernelDictationDriverFactory {
       egOneRuntime: inputs.egOneRuntime,
       s1MiniRuntime: inputs.s1MiniRuntime,
       batchDecodeFaultController: inputs.batchDecodeFaultController,
-      escapeRecovery: inputs.escapeRecovery)
+      escapeRecovery: inputs.escapeRecovery,
+      transcriptionCheckpoint: inputs.transcriptionCheckpoint)
   }
 
   /// Build the driver stack for the WhisperKit engine. PR-5 Rung 5 flips the
@@ -444,7 +459,8 @@ public enum KernelDictationDriverFactory {
       egOneRuntime: inputs.egOneRuntime,
       s1MiniRuntime: inputs.s1MiniRuntime,
       batchDecodeFaultController: inputs.batchDecodeFaultController,
-      escapeRecovery: inputs.escapeRecovery)
+      escapeRecovery: inputs.escapeRecovery,
+      transcriptionCheckpoint: inputs.transcriptionCheckpoint)
   }
 
   /// Engine-agnostic assembler. The two package entry points construct their
@@ -468,7 +484,8 @@ public enum KernelDictationDriverFactory {
     egOneRuntime: (any EGOneEndpointProviding)? = nil,
     s1MiniRuntime: (any EGOneEndpointProviding)? = nil,
     batchDecodeFaultController: BatchDecodeFaultController? = nil,
-    escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false }
+    escapeRecovery: @escaping PrepareEscapeRecovery = { _, _, _ in false },
+    transcriptionCheckpoint: @escaping @MainActor (TranscriptionCheckpointEvent) -> Void = { _ in }
   ) -> KernelDictationDriver {
     // #1803: prepare the English word oracle off the heart path. Its one-time
     // setup measures 105.6 ms cold — language resolution plus a tag-scheme
@@ -664,6 +681,7 @@ public enum KernelDictationDriverFactory {
           callerResumeMs: callerResumeMs, acceptedAfterCutoff: acceptedAfterCutoff)
       },
       engineMutationScope: engineMutationScope,
+      transcriptionCheckpoint: transcriptionCheckpoint,
       // Production wedge-stall window — `RecordingSessionKernel` defaults
       // to 2 ticks (test-only value); with the wiring's 100ms tick clock
       // that would cancel cold model loads after ~200ms instead of the

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -793,13 +793,41 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     return outcome
   }
 
-  /// No finalize progress stream for Parakeet in this revision. The fork does
-  /// expose per-chunk progress for audio longer than ~15 s, but it reports a
-  /// chunk when it is SCHEDULED, not finished, and the kernel's consumer of
-  /// this stream arms an automatic teardown on the first tick — connecting it
-  /// would auto-abort a slow long decode (#2787 plan, piece 3: observation
-  /// only, deferred until the customer's process sample locates the hang).
-  var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { nil }
+  /// #2787: OBSERVATION-only finalize ticks. The fork reports a chunk when
+  /// it is SCHEDULED (not finished) for audio longer than one model window;
+  /// each report becomes an `.observation` tick, which the kernel records on
+  /// the take's checkpoint (`decode_chunk_scheduled`) and never uses to arm
+  /// the finalize-wedge detector — a `.progress` tick would auto-abort a slow
+  /// long decode, which is exactly what the founder ruled out. A fresh stream
+  /// per read, so each `finalize` consumes only the ticks of its own decode.
+  var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? {
+    let (stream, continuation) = AsyncStream.makeStream(of: ASRFinalizeProgressTick.self)
+    observationContinuation?.finish()
+    observationContinuation = continuation
+    // The callback captures THIS stream's continuation: a report that arrives
+    // late, after a later read replaced the stream, lands on the finished old
+    // one (dropped) rather than on whichever stream is current by then.
+    let marker = ObservationMarker()
+    asrManager.onVendorDecodeChunkScheduled = {
+      continuation.yield(
+        ASRFinalizeProgressTick(marker: marker.next(), kind: .observation))
+    }
+    return stream
+  }
+  private var observationContinuation: AsyncStream<ASRFinalizeProgressTick>.Continuation?
+
+  /// Monotonic per-stream marker; a class so the `@Sendable` callback can
+  /// advance it without capturing the adapter.
+  private final class ObservationMarker: @unchecked Sendable {
+    private var value: UInt64 = 0
+    private let lock = NSLock()
+    func next() -> UInt64 {
+      lock.withLock {
+        value &+= 1
+        return value
+      }
+    }
+  }
 
   /// #2787: the manager's occupancy, which counts this adapter's own
   /// `transcribe` / `finalizeStreaming` calls.

--- a/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift
@@ -793,11 +793,17 @@ final class ParakeetEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     return outcome
   }
 
-  /// Parakeet/ASRManager expose completion-only `finalizeStreaming()` and
-  /// `transcribe(...)` calls. There is no decoder-step, partial-result, queue,
-  /// or file-mtime signal to feed the kernel's signal-based wedge detector.
-  // TODO(#NNN): finalize-wedge watchdog needs Parakeet progress signal.
+  /// No finalize progress stream for Parakeet in this revision. The fork does
+  /// expose per-chunk progress for audio longer than ~15 s, but it reports a
+  /// chunk when it is SCHEDULED, not finished, and the kernel's consumer of
+  /// this stream arms an automatic teardown on the first tick — connecting it
+  /// would auto-abort a slow long decode (#2787 plan, piece 3: observation
+  /// only, deferred until the customer's process sample locates the hang).
   var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { nil }
+
+  /// #2787: the manager's occupancy, which counts this adapter's own
+  /// `transcribe` / `finalizeStreaming` calls.
+  var isVendorDecodeInFlight: Bool { !asrManager.vendorDecodeOccupancy.isIdle }
 
   /// The cheap, model-preserving teardown shared by `cancel()` and
   /// `recoverFromWedge()`: cancel streaming, clear per-session state. Touches

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -58,6 +58,11 @@ public enum SharedEngineHolder: String, Sendable, Equatable, CaseIterable {
   case dictation
   case crashRecovery
   case fileImport
+  /// #2787: a dictation ended (the user stopped waiting, or the session was
+  /// torn down) while its vendor decode was still running. The engine is not
+  /// free until that call returns, and on the machine that motivated this it
+  /// never did — so the honest answer to the next record press is "restart".
+  case abandonedDecode
 }
 
 /// #1567 (heartpath E3): a typed fact explaining a post-completion or advisory

--- a/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
+++ b/Sources/EnviousWisprPipeline/PipelineVocabulary.swift
@@ -356,6 +356,14 @@ public enum RecordingRecoveryEnding: Equatable, Sendable {
   case asrInterrupted
   case noTransport
   case cancelled(RecordingCancelOrigin)
+  /// #2787: the user cancelled while the vendor decode was still running, and
+  /// it is STILL running at the terminal. Unlike every other live ending the
+  /// user did NOT witness an outcome — the decode may never return (the
+  /// customer's Mac Studio on macOS 27 RC) — and the prescribed exit is a
+  /// restart, at which the launch replay delivers the text. So this one
+  /// retains its spool, and the coordinator destroys it later if the decode
+  /// does return in this launch (`handleAbandonedDecodeReturned`).
+  case stoppedWaitingForDecode
   /// #1920: audio was arriving, the engine ran clean, and it produced no words.
   /// Kept distinct from `.noSpeech` because it asserts nothing about whether
   /// speech occurred. Deletes like every other concluded live ending (#1755) —

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -1174,6 +1174,15 @@ final class RecordingSessionKernel {
   private(set) var lastCancelOrigin: RecordingCancelOrigin = .systemOrFault
   private var cancelOriginLatched = false
 
+  /// #2787: frozen INSIDE `finishTerminal`, in the same synchronous turn as
+  /// `recordingOutcome`, so the recovery projection and the engine hold read
+  /// one terminal-time fact rather than two later reads of a shared counter
+  /// that another workload could have moved. True only for a `.cancelled`
+  /// accepted from `.delivering(.transcribing)` while THIS session's vendor
+  /// decode was still running — never for a cancel during recording, where a
+  /// live streaming decode is the normal state and the audio is discarded.
+  package private(set) var lastTerminalStoppedWaitingForDecode = false
+
   /// What the session that is finishing IS (#2087). See `FinalizationDisposition`
   /// for why this is kernel-owned rather than read at delivery.
   ///
@@ -4257,6 +4266,11 @@ final class RecordingSessionKernel {
     }
     let terminal = outcome  // local alias for the existing telemetry logs below
     recordingOutcome = outcome
+    lastTerminalStoppedWaitingForDecode =
+      outcome == .cancelled
+      && state == .delivering
+      && deliveringPhase == .transcribing
+      && adapter.isVendorDecodeInFlight
     // #1846: stamp the concluded take INSIDE the set-once barrier, so it is
     // first-wins under the same condition as the outcome itself and can only ever
     // name the session this terminal actually accepted (`audit-all-terminal-paths-
@@ -4461,6 +4475,7 @@ final class RecordingSessionKernel {
     // must clear with it — otherwise the first session's provenance would win
     // forever and every later take would read as that one's cancel.
     lastCancelOrigin = .systemOrFault
+    lastTerminalStoppedWaitingForDecode = false
     cancelOriginLatched = false
     // #2087: the disposition describes THIS take. Leaking it forward would make
     // the next session inherit an abandonment the user never requested, and the

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -985,6 +985,10 @@ final class RecordingSessionKernel {
       String, String, Int, ASRRetryDeadlineResolution, ASRRetryDeadlineDisposition, Int?, Int, Bool
     ) -> Void = { _, _, _, _, _, _, _, _ in },
     engineMutationScope: EngineMutationScope,
+    // #2787: persisted stage checkpoint for the take in flight. Defaulted to a
+    // no-op so every test construction site is untouched; the factory wires the
+    // real store. Observation only — it never gates the heart path.
+    transcriptionCheckpoint: @escaping @MainActor (TranscriptionCheckpointEvent) -> Void = { _ in },
     wedgeStallTicks: Int = 2,
     minimumRecordingTicks: Int = 5,
     zombieZeroPeakTelemetry: @escaping @MainActor (ZeroPeakContext) -> Void = { _ in },
@@ -1034,6 +1038,7 @@ final class RecordingSessionKernel {
     self.asrRetryDeadlineStartedTelemetry = asrRetryDeadlineStartedTelemetry
     self.asrRetryDeadlineResolvedTelemetry = asrRetryDeadlineResolvedTelemetry
     self.engineMutationScope = engineMutationScope
+    self.transcriptionCheckpoint = transcriptionCheckpoint
     self.wedgeStallTicks = wedgeStallTicks
     self.minimumRecordingTicks = minimumRecordingTicks
     self.zombieZeroPeakTelemetry = zombieZeroPeakTelemetry
@@ -1182,6 +1187,20 @@ final class RecordingSessionKernel {
   /// decode was still running — never for a cancel during recording, where a
   /// live streaming decode is the normal state and the audio is discarded.
   package private(set) var lastTerminalStoppedWaitingForDecode = false
+
+  /// #2787: see the init parameter. Called with `.mark` at each stop→decode
+  /// stage and `.clear` at every accepted terminal.
+  private let transcriptionCheckpoint: @MainActor (TranscriptionCheckpointEvent) -> Void
+  /// #2787: vendor chunks scheduled so far in this take's decode (chunk 4 feeds it).
+  private var decodeChunksScheduled = 0
+
+  private func markStage(_ stage: TranscriptionStage) {
+    transcriptionCheckpoint(
+      .mark(
+        takeID: currentSessionID.raw.uuidString,
+        backend: adapter.engineIdentity.backendType.rawValue,
+        stage: stage, chunksScheduled: decodeChunksScheduled))
+  }
 
   /// What the session that is finishing IS (#2087). See `FinalizationDisposition`
   /// for why this is kernel-owned rather than read at delivery.
@@ -1980,6 +1999,10 @@ final class RecordingSessionKernel {
     captureLifecycle = .stopped
     resourcesReleased = true
     guard recordingOutcome == nil else { return }
+    // #2787: AFTER the outcome guard — a cancel accepted while `stopCapture`
+    // was suspended already cleared the checkpoint, and a mark here would
+    // recreate it as a false "interrupted" report at the next launch.
+    markStage(.captureStopped)
     // Heartpath 5b (#1520): capture the session-ownership token NOW, while THIS
     // take's source is still current, so a stale finish after the awaits below
     // can only retire the source it actually captured, never a newer take's.
@@ -2391,6 +2414,7 @@ final class RecordingSessionKernel {
     // "post-isCapturing audio only"; preserving it.
     let conditioned = CapturedAudioConditioner.condition(
       rawSamples: captureResult.samples, vadSegments: vadSegments)
+    markStage(.vadConditioned)
     let vadSpeechDurationMs = Self.speechDurationMs(vadSegments)
 
     // #1707 GitHub Codex code-diff r16: an ASR-interruption recovery always
@@ -2445,6 +2469,7 @@ final class RecordingSessionKernel {
       droppedTailSamples: droppedTailSamples,
       droppedTailMs: tailDroppedMs ?? 0,
       voicedFraction: tailFraction)
+    markStage(.tailChecked)
     let asrSamples: [Float]
     var recoveredTailMs: Int? = nil
     // nil when ineligible (engine/streaming); a real Bool on the eligible path so
@@ -2929,6 +2954,7 @@ final class RecordingSessionKernel {
       // synchronously, so a clock started before it charges the instrument's own
       // cost to the decode and can report an on-time retry as late.
       let retryEntry = ContinuousClock.now
+      markStage(.decodeStarted)  // #2787: the Phase-2 retry is a decode too
       let retryOutcome = await withMainActorOrderedDeadline(
         seconds: retryBudgetSec,  // measured, length-aware — see §11.1
         // `@MainActor` so the return stamp is taken on the SAME actor the decode
@@ -2999,6 +3025,9 @@ final class RecordingSessionKernel {
         emitRetryDeadlineObservation(.stale)
         return
       }
+      // #2787: only a RETURNED retry marks the decode returned — a deadline
+      // winning is not evidence the vendor came back.
+      if retryOutcome != nil { markStage(.decodeReturned) }
       // #2087: before `markASRTimingEnd()`, for the same reason the primary
       // decode's check is — the retry's latency belongs to work the user asked
       // to discard, and the `.failed(.asrFailed)` branch just below would
@@ -3458,11 +3487,17 @@ final class RecordingSessionKernel {
       }
     }
 
+    // #2787: marked HERE, in the shared helper, so the salvage re-finalize is
+    // covered as well as the primary decode — a hang in either reads as
+    // `decode_started`, never as a stale `decode_returned` from the first.
+    guard isCurrent(sid), recordingOutcome == nil else { return .cancelled }
+    markStage(.decodeStarted)
     let outcome = await adapter.finalize(batchSamples: batchSamples)
     // Guard BEFORE touching kernel state — a `finalize()` unblocked after a
     // cancel, with a new session already started, must not clear the new
     // session's flags (Codex P2-round4 stale-completion guard).
     guard isCurrent(sid) else { return .cancelled }
+    if recordingOutcome == nil { markStage(.decodeReturned) }
     finalizeCompleted = true
     // `finalize()` is the adapter's own session-terminal hook — the open
     // session is now closed, so a later `finishTerminal` must NOT also call
@@ -4271,6 +4306,8 @@ final class RecordingSessionKernel {
       && state == .delivering
       && deliveringPhase == .transcribing
       && adapter.isVendorDecodeInFlight
+    // #2787: the app lived to see this terminal; nothing for the next launch to report.
+    transcriptionCheckpoint(.clear)
     // #1846: stamp the concluded take INSIDE the set-once barrier, so it is
     // first-wins under the same condition as the outcome itself and can only ever
     // name the session this terminal actually accepted (`audit-all-terminal-paths-
@@ -4476,6 +4513,7 @@ final class RecordingSessionKernel {
     // forever and every later take would read as that one's cancel.
     lastCancelOrigin = .systemOrFault
     lastTerminalStoppedWaitingForDecode = false
+    decodeChunksScheduled = 0
     cancelOriginLatched = false
     // #2087: the disposition describes THIS take. Leaking it forward would make
     // the next session inherit an abandonment the user never requested, and the
@@ -4969,6 +5007,7 @@ final class RecordingSessionKernel {
     /// Bypasses `isLegalConclusion` so a test can stage any outcome directly.
     func testForceConclude(_ outcome: RecordingOutcome) {
       recordingOutcome = outcome
+      transcriptionCheckpoint(.clear)  // #2787: a forced conclusion is a terminal too
       state = .idle
       bump()
     }

--- a/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
+++ b/Sources/EnviousWisprPipeline/RecordingSessionKernel.swift
@@ -2964,7 +2964,10 @@ final class RecordingSessionKernel {
         // `retryDecode` is already `@MainActor`, so this removes a hop rather
         // than adding an actor requirement.
         operation: { @MainActor [adapter] in
-          let decoded = await adapter.retryDecode(inputSamples: retryInput)
+          // #2787: the retry is a decode attempt with its own progress identity.
+          let decoded = await self.withDecodeProgress(sid) {
+            await adapter.retryDecode(inputSamples: retryInput)
+          }
           retryOperationReturn.withLock { $0 = ContinuousClock.now - retryEntry }
           return decoded
         },
@@ -3466,15 +3469,35 @@ final class RecordingSessionKernel {
 
   // MARK: Finalize + wedge detection
 
-  private func finalize(_ sid: SessionID, batchSamples: [Float]?) async -> ASREngineOutcome {
-    finalizeWedgeDetected = false
-    finalizeCompleted = false
-    finalizeTickCount = 0
+  /// #2787: identity of the decode attempt whose progress ticks are live.
+  /// The primary finalize, the salvage re-finalize and the Phase-2 retry each
+  /// read a fresh stream; a tick buffered on an OLDER stream for the SAME
+  /// session must not be counted against a later attempt, and `isCurrent`
+  /// cannot tell them apart. Nil outside a decode.
+  private var observedDecodeID: UUID?
+
+  /// #2787: runs one decode attempt with its progress stream consumed for
+  /// exactly that attempt. `.observation` ticks record vendor chunk scheduling
+  /// on the checkpoint and nothing else; `.progress` ticks arm the wedge
+  /// detector as before (PR-1 §B.1.7).
+  private func withDecodeProgress(
+    _ sid: SessionID, operation: @MainActor () async -> ASREngineOutcome
+  ) async -> ASREngineOutcome {
+    let id = UUID()
+    observedDecodeID = id
+    defer { if observedDecodeID == id { observedDecodeID = nil } }
 
     if let stream = adapter.finalizeProgress {
       spawn(sid) { [weak self] in
-        for await _ in stream {
-          guard let self, self.isCurrent(sid) else { return }
+        for await tick in stream {
+          guard let self, self.isCurrent(sid), self.observedDecodeID == id,
+            self.recordingOutcome == nil
+          else { return }
+          if tick.kind == .observation {
+            self.decodeChunksScheduled += 1
+            self.markStage(.decodeChunkScheduled)
+            continue
+          }
           self.finalizeTickCount += 1
           self.lastFinalizeTickAt = self.currentTick()
           self.bump()
@@ -3486,13 +3509,22 @@ final class RecordingSessionKernel {
         }
       }
     }
+    return await operation()
+  }
+
+  private func finalize(_ sid: SessionID, batchSamples: [Float]?) async -> ASREngineOutcome {
+    finalizeWedgeDetected = false
+    finalizeCompleted = false
+    finalizeTickCount = 0
 
     // #2787: marked HERE, in the shared helper, so the salvage re-finalize is
     // covered as well as the primary decode — a hang in either reads as
     // `decode_started`, never as a stale `decode_returned` from the first.
     guard isCurrent(sid), recordingOutcome == nil else { return .cancelled }
     markStage(.decodeStarted)
-    let outcome = await adapter.finalize(batchSamples: batchSamples)
+    let outcome = await withDecodeProgress(sid) {
+      await adapter.finalize(batchSamples: batchSamples)
+    }
     // Guard BEFORE touching kernel state — a `finalize()` unblocked after a
     // cancel, with a new session already started, must not clear the new
     // session's flags (Codex P2-round4 stale-completion guard).

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -966,6 +966,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// progress signal. Same `nil` semantics as `loadProgress`.
   var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { nil }
 
+  /// #2787: the shared occupancy this adapter's batch decode and its streaming
+  /// session's decodes are counted against.
+  var isVendorDecodeInFlight: Bool { !vendorDecodeOccupancy.isIdle }
+
   /// Reset every per-session audio buffer at a terminal/cancel boundary. One
   /// place so a future buffer field added to the session lifecycle can't be
   /// silently missed at a cleanup site (#827 — the bug that caused this fix

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -77,6 +77,11 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// #1707 Phase 2: DEBUG fault-injection oracle (§11.1) — `nil` in every
   /// production/test path that doesn't explicitly construct one.
   private let batchDecodeFaultController: BatchDecodeFaultController?
+  /// #2787: counts this adapter's vendor decode against the shared occupancy.
+  /// Production passes `ASRManager.vendorDecodeOccupancy` through the factory
+  /// (required there); the init default is a private counter nothing reads,
+  /// so the 77 test construction sites stay untouched and cannot affect a hold.
+  private let vendorDecodeOccupancy: VendorDecodeOccupancy
 
   // MARK: Engine-session bookkeeping (NOT FSM state — §3.11 adapter-shape check)
 
@@ -284,11 +289,13 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     languageDetector: LanguageDetector = LanguageDetector(),
     audioCaptureSessionIDSource: @escaping @MainActor () -> UInt64 = { 0 },
     wedgeRecoveryUnloadDeadlineSec: Double = 2.0,
+    vendorDecodeOccupancy: VendorDecodeOccupancy = VendorDecodeOccupancy(),
     // #1707 Phase 2: DEBUG fault-injection oracle (§11.1). Defaulted `nil`
     // so every existing test construction site is unaffected.
     batchDecodeFaultController: BatchDecodeFaultController? = nil
   ) {
     self.backend = backend
+    self.vendorDecodeOccupancy = vendorDecodeOccupancy
     self.engineMutationScope = engineMutationScope
     self.languageDetector = languageDetector
     self.audioCaptureSessionIDSource = audioCaptureSessionIDSource
@@ -505,7 +512,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
   /// model-not-ready vend (`nil`) the adapter stays in batch mode — `finalize`
   /// then runs the clean batch fallback (fail-open, heart stays alive).
   private func startStreamingSession(_ id: SessionID, options: TranscriptionOptions) async {
-    guard let session = await backend.makeStreamingSession(options: options) else {
+    guard
+      let session = await backend.makeStreamingSession(
+        options: options, vendorDecodeOccupancy: vendorDecodeOccupancy)
+    else {
       // Stale guard (cloud r2): a cancel + beginSession(B) during the vend
       // await must not overwrite B's per-session telemetry state.
       if sessionID == id, !isCancelled {
@@ -1420,8 +1430,11 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
       return .failed(ASREngineError.decodeFailed)
     }
     do {
-      let result = try await backend.transcribe(
-        audioSamples: samples, options: decodeOptions)
+      // #2787: counted for the whole vendor call, so a session that stops
+      // waiting leaves the engine visibly busy until WhisperKit returns.
+      let result = try await vendorDecodeOccupancy.track {
+        try await backend.transcribe(audioSamples: samples, options: decodeOptions)
+      }
       return .success(result)
     } catch is CancellationError {
       return .cancelled
@@ -1612,8 +1625,9 @@ package protocol WhisperKitBackendDriving: Actor {
   // #1276 Step 2 (PR-2): vend the authoritative streaming session
   // (locked-language Live-transcription path). Nil when the model is not
   // loaded (the adapter stays in batch mode, fail-open).
-  func makeStreamingSession(options: TranscriptionOptions) async
-    -> (any WhisperKitIncrementalSession)?
+  func makeStreamingSession(
+    options: TranscriptionOptions, vendorDecodeOccupancy: VendorDecodeOccupancy
+  ) async -> (any WhisperKitIncrementalSession)?
   func unload() async
 }
 

--- a/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
+++ b/Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift
@@ -728,12 +728,20 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
     let backendForObserver = backend
     let observerSamples = lidSamples
     let lidWindowCountForObserver = lidWindowCount
+    let occupancyForObserver = vendorDecodeOccupancy
     let lidResult = await languageDetector.detect(
       samples: lidSamples,
       voicedDuration: voicedDurationSec,
       observerFn: {
-        await backendForObserver.observeLID(
-          samples: observerSamples, maxWindows: lidWindowCountForObserver)
+        // #2787 (second-pass review): language detection is a real WhisperKit
+        // model call that runs BEFORE the decode, so it is counted too. Left
+        // uncounted, an Escape during it read the engine as idle, released
+        // the lease and deleted the spool while the model was still working,
+        // and the next record press could enter WhisperKit under it.
+        await occupancyForObserver.track {
+          await backendForObserver.observeLID(
+            samples: observerSamples, maxWindows: lidWindowCountForObserver)
+        }
       },
       mode: mode
     )
@@ -1437,7 +1445,10 @@ final class WhisperKitEngineAdapter: ASREngineAdapter, @unchecked Sendable {
       // #2787: counted for the whole vendor call, so a session that stops
       // waiting leaves the engine visibly busy until WhisperKit returns.
       let result = try await vendorDecodeOccupancy.track {
-        try await backend.transcribe(audioSamples: samples, options: decodeOptions)
+        // Twin of `ASRManager.transcribe`: never START a decode in a task the
+        // session terminal already cancelled (second-pass review, #2787).
+        try Task.checkCancellation()
+        return try await backend.transcribe(audioSamples: samples, options: decodeOptions)
       }
       return .success(result)
     } catch is CancellationError {

--- a/Sources/EnviousWisprServices/SentryBreadcrumb.swift
+++ b/Sources/EnviousWisprServices/SentryBreadcrumb.swift
@@ -431,6 +431,11 @@ public enum SentryBreadcrumb {
     /// Do not add a failure sentence here or a failure case to `OverlayIntent`
     /// without reopening that decision.
     case recoveryDecryptFailed = "recovery_decrypt_failed"
+    /// #2787: the previous process died (quit, crash or force-quit) while a
+    /// take was between "stop" and "text in hand". Reported once on the NEXT
+    /// launch from the persisted `TranscriptionCheckpoint`; the fingerprint
+    /// carries the bounded stage name so the fleet groups by WHERE it stuck.
+    case transcriptionInterrupted = "transcription_interrupted"
     /// #1063 PR2: transcribing a recovered spool THREW. Non-crash limb (one
     /// attempt) — the orphan is deleted, and see `recoveryDecryptFailed` above
     /// for what the user is (not) shown.

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1998,6 +1998,38 @@ public final class TelemetryService {
       "recovery.press_blocked", properties: ["asr_backend": asrBackend])
   }
 
+  /// #2787 — a dictation session ended while its vendor decode was still
+  /// running, so the shared engine stays claimed as `abandonedDecode` until
+  /// that call returns. One event per hold. Pairs with
+  /// `abandonedDecodeHoldSettled`; a hold with no settle is a decode that
+  /// never returned before the app quit — the fleet-level count of the #2787
+  /// hang. `in_flight` is how many vendor calls were running at the time.
+  public func abandonedDecodeHoldStarted(inFlight: Int) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "engine.abandoned_decode_hold_started", stringProps: [:],
+          intProps: ["in_flight": inFlight]))
+    #endif
+    PostHogSDK.shared.capture(
+      "engine.abandoned_decode_hold_started", properties: ["in_flight": inFlight])
+  }
+
+  /// #2787 — the abandoned decode returned and the engine was released.
+  /// `seconds` is how long it stayed held past the session's end; `$value`
+  /// mirrors it in seconds (RULE: value-slot-carries-seconds-for-durations).
+  public func abandonedDecodeHoldSettled(seconds: Double) {
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "engine.abandoned_decode_hold_settled", stringProps: [:], intProps: [:],
+          doubleProps: ["held_seconds": seconds]))
+    #endif
+    PostHogSDK.shared.capture(
+      "engine.abandoned_decode_hold_settled",
+      properties: ["held_seconds": seconds, "$value": seconds])
+  }
+
   /// #1707 Phase 3 — pairs with `recoveryPressBlocked`: a press that was
   /// previously blocked went on to mint an active session. `waitSeconds` is
   /// the measured gap between the block and this later successful start,

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2015,6 +2015,31 @@ public final class TelemetryService {
       "engine.abandoned_decode_hold_started", properties: ["in_flight": inFlight])
   }
 
+  /// #2787 — the previous process died between "stop" and "text in hand".
+  /// One event per orphaned checkpoint, on the launch that found it; the
+  /// Sentry twin (`transcription_interrupted`) carries the same stage. `stage`
+  /// is the bounded `TranscriptionStage` raw value; `stage_age_ms` is
+  /// wall-clock elapsed from the last checkpoint to this launch, including
+  /// downtime. It is not a measured hang duration.
+  public func transcriptionInterruptedAtQuit(
+    stage: String, backend: String, chunksScheduled: Int, stageAgeMs: Int, checkpointAppVersion: String
+  ) {
+    let props: [String: Any] = [
+      "stage": stage, "asr_backend": backend, "chunks_scheduled": chunksScheduled,
+      "stage_age_ms": stageAgeMs, "checkpoint_app_version": checkpointAppVersion,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "transcription.interrupted_at_quit",
+          stringProps: [
+            "stage": stage, "asr_backend": backend, "checkpoint_app_version": checkpointAppVersion,
+          ],
+          intProps: ["chunks_scheduled": chunksScheduled, "stage_age_ms": stageAgeMs]))
+    #endif
+    PostHogSDK.shared.capture("transcription.interrupted_at_quit", properties: props)
+  }
+
   /// #2787 — the abandoned decode returned and the engine was released.
   /// `seconds` is how long it stayed held past the session's end; `$value`
   /// mirrors it in seconds (RULE: value-slot-carries-seconds-for-durations).
@@ -3550,9 +3575,19 @@ public final class TelemetryService {
   public struct FlushContext: Sendable {
     public let activeRecording: Bool
     public let appPhase: String
-    public init(activeRecording: Bool, appPhase: String) {
+    /// #2787: the last transcription stage the take in flight reached, and how
+    /// long ago (ms). Nil when no take is between stop and text. A graceful quit
+    /// during `transcribing` then says WHICH step it was on; a force-quit cannot
+    /// reach here at all, which is what the persisted checkpoint is for.
+    public let lastStage: String?
+    public let stageAgeMs: Int?
+    public init(
+      activeRecording: Bool, appPhase: String, lastStage: String? = nil, stageAgeMs: Int? = nil
+    ) {
       self.activeRecording = activeRecording
       self.appPhase = appPhase
+      self.lastStage = lastStage
+      self.stageAgeMs = stageAgeMs
     }
   }
 
@@ -3602,20 +3637,30 @@ public final class TelemetryService {
       #endif
     }
 
+    var properties: [String: Any] = [
+      "reason": reason.rawValue,
+      "active_recording": context.activeRecording,
+      "app_phase": context.appPhase,
+    ]
+    var stringProps = ["reason": reason.rawValue, "app_phase": context.appPhase]
+    var intProps: [String: Int] = [:]
+    // #2787: omit-when-nil, so absence means "no take between stop and text".
+    if let lastStage = context.lastStage {
+      properties["last_stage"] = lastStage
+      stringProps["last_stage"] = lastStage
+    }
+    if let stageAgeMs = context.stageAgeMs {
+      properties["stage_age_ms"] = stageAgeMs
+      intProps["stage_age_ms"] = stageAgeMs
+    }
     #if DEBUG
       testEventHook?(
         CapturedTelemetryEvent(
           name: "telemetry.flush_requested",
-          stringProps: ["reason": reason.rawValue, "app_phase": context.appPhase],
+          stringProps: stringProps, intProps: intProps,
           boolProps: ["active_recording": context.activeRecording]))
     #endif
-    PostHogSDK.shared.capture(
-      "telemetry.flush_requested",
-      properties: [
-        "reason": reason.rawValue,
-        "active_recording": context.activeRecording,
-        "app_phase": context.appPhase,
-      ])
+    PostHogSDK.shared.capture("telemetry.flush_requested", properties: properties)
     PostHogSDK.shared.flush()
   }
 

--- a/Sources/EnviousWisprStorage/TranscriptionCheckpointStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptionCheckpointStore.swift
@@ -1,0 +1,95 @@
+import EnviousWisprCore
+import Foundation
+
+/// #2787 — persists the latest `TranscriptionCheckpoint` for the take in
+/// flight, so the NEXT launch can report where a take was when this process
+/// died. Metadata only (`TranscriptionCheckpoint`); one file; overwritten per
+/// stage; deleted on every terminal the app lives to see.
+///
+/// Why disk and not a Sentry event at quit: a Force Quit is SIGKILL and no
+/// code in the dying process runs, so anything worth reporting has to be on
+/// disk BEFORE the step that might never return. The write is a few hundred
+/// bytes via temp file + rename, at most six times per take.
+///
+/// `current` is the in-memory mirror for the graceful-quit path
+/// (`TelemetryService.FlushContext`), where the process is still alive.
+public final class TranscriptionCheckpointStore: @unchecked Sendable {
+  public static let fileName = "transcription_checkpoint.json"
+
+  private let fileURL: URL
+  private let lock = NSLock()
+  private var mirror: TranscriptionCheckpoint?
+
+  /// The production store, in the app's support directory.
+  public convenience init() {
+    self.init(directory: AppConstants.appSupportURL)
+  }
+
+  /// Tests inject a private directory.
+  public init(directory: URL) {
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    fileURL = directory.appendingPathComponent(Self.fileName)
+  }
+
+  /// The checkpoint most recently written in THIS process, or nil.
+  public var current: TranscriptionCheckpoint? {
+    lock.withLock { mirror }
+  }
+
+  /// Applies one kernel event: `.mark` writes (or overwrites) the checkpoint,
+  /// `.clear` removes it. Best-effort: a write failure is logged by the caller
+  /// only through the absence of a later report, never surfaced to the user.
+  public func apply(_ event: TranscriptionCheckpointEvent, now: Date = Date()) {
+    switch event {
+    case .mark(let takeID, let backend, let stage, let chunksScheduled):
+      let checkpoint = TranscriptionCheckpoint(
+        takeID: takeID, backend: backend, stage: stage, stageEnteredAt: now,
+        chunksScheduled: chunksScheduled, appVersion: AppConstants.appVersion)
+      lock.withLock { mirror = checkpoint }
+      write(checkpoint)
+    case .clear:
+      lock.withLock { mirror = nil }
+      try? FileManager.default.removeItem(at: fileURL)
+    }
+  }
+
+  /// A checkpoint left by a PREVIOUS process, consumed exactly once: the file
+  /// is deleted BEFORE the read is returned, so a report can never repeat
+  /// across launches. Returns nil when there is none, when deletion fails
+  /// (nothing may be reported that could be reported again), or when the file
+  /// cannot be decoded (a corrupt or foreign file is deleted too).
+  public func takeOrphan() -> TranscriptionCheckpoint? {
+    guard let data = try? Data(contentsOf: fileURL) else { return nil }
+    // Consume FIRST: a checkpoint whose deletion failed must not be reported,
+    // or the same orphan is reported again at every launch until it succeeds.
+    do {
+      try FileManager.default.removeItem(at: fileURL)
+    } catch {
+      return nil
+    }
+    return try? Self.decoder.decode(TranscriptionCheckpoint.self, from: data)
+  }
+
+  private func write(_ checkpoint: TranscriptionCheckpoint) {
+    guard let data = try? Self.encoder.encode(checkpoint) else { return }
+    let tmp = fileURL.appendingPathExtension("tmp-\(UUID().uuidString)")
+    do {
+      try data.write(to: tmp, options: [.atomic])
+      _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tmp)
+    } catch {
+      try? FileManager.default.removeItem(at: tmp)
+    }
+  }
+
+  private static let encoder: JSONEncoder = {
+    let e = JSONEncoder()
+    e.dateEncodingStrategy = .iso8601
+    return e
+  }()
+
+  private static let decoder: JSONDecoder = {
+    let d = JSONDecoder()
+    d.dateDecodingStrategy = .iso8601
+    return d
+  }()
+}

--- a/Sources/EnviousWisprStorage/TranscriptionCheckpointStore.swift
+++ b/Sources/EnviousWisprStorage/TranscriptionCheckpointStore.swift
@@ -16,19 +16,33 @@ import Foundation
 public final class TranscriptionCheckpointStore: @unchecked Sendable {
   public static let fileName = "transcription_checkpoint.json"
 
+  /// The production file name is scoped by bundle id, because
+  /// `AppConstants.appSupportURL` is ONE directory shared by the shipped app
+  /// and the dev build (measured: `custom-words.json` and `audio_recovery/`
+  /// already live there for both). An unscoped file would let a dev take's
+  /// checkpoint be reported as an interruption by the shipped app's next
+  /// launch, and vice versa. Spools avoid this by carrying a session id per
+  /// file; this single file carries the bundle id in its name instead.
+  public static func fileName(forBundleID bundleID: String?) -> String {
+    guard let bundleID, !bundleID.isEmpty else { return fileName }
+    return "transcription_checkpoint.\(bundleID).json"
+  }
+
   private let fileURL: URL
   private let lock = NSLock()
   private var mirror: TranscriptionCheckpoint?
 
-  /// The production store, in the app's support directory.
+  /// The production store, in the app's support directory, scoped to this bundle.
   public convenience init() {
-    self.init(directory: AppConstants.appSupportURL)
+    self.init(
+      directory: AppConstants.appSupportURL,
+      fileName: Self.fileName(forBundleID: Bundle.main.bundleIdentifier))
   }
 
-  /// Tests inject a private directory.
-  public init(directory: URL) {
+  /// Tests inject a private directory (and may keep the unscoped name).
+  public init(directory: URL, fileName: String = TranscriptionCheckpointStore.fileName) {
     try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-    fileURL = directory.appendingPathComponent(Self.fileName)
+    fileURL = directory.appendingPathComponent(fileName)
   }
 
   /// The checkpoint most recently written in THIS process, or nil.

--- a/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
+++ b/Tests/EnviousWisprASRTests/ASRManagerBackendInjectionTests.swift
@@ -367,6 +367,42 @@ final actor FakeASRBackend: ASRBackend {
     for c in parked { c.resume() }
   }
 
+  /// #2787: when set, `transcribe` parks after its readiness guard until
+  /// `releaseTranscribeGate()` — the shape of a vendor decode that does not
+  /// return. Separate from the `prepare()` gate so a test can hold the decode
+  /// with the model loaded normally.
+  private var transcribeGated = false
+  private var transcribeGateContinuations: [CheckedContinuation<Void, Never>] = []
+
+  func gateTranscribe() { transcribeGated = true }
+
+  private var parkedWaiters: [(id: UUID, continuation: CheckedContinuation<Bool, Never>)] = []
+
+  /// Resolves `true` once a gated `transcribe` is parked, `false` after the
+  /// deadline — a signal wait, bounded so a test never hangs on it.
+  func transcribeParked() async -> Bool {
+    if !transcribeGateContinuations.isEmpty { return true }
+    return await withCheckedContinuation { (c: CheckedContinuation<Bool, Never>) in
+      let id = UUID()
+      parkedWaiters.append((id, c))
+      Task {
+        try? await Task.sleep(for: .seconds(5))  // deadline-fallback: bounds the signal wait
+        await self.expireParkedWaiter(id)
+      }
+    }
+  }
+
+  private func expireParkedWaiter(_ id: UUID) {
+    guard let index = parkedWaiters.firstIndex(where: { $0.id == id }) else { return }
+    parkedWaiters.remove(at: index).continuation.resume(returning: false)
+  }
+
+  func releaseTranscribeGate() {
+    let parked = transcribeGateContinuations
+    transcribeGateContinuations.removeAll()
+    for c in parked { c.resume() }
+  }
+
   func transcribe(audioSamples: [Float], options: TranscriptionOptions)
     async throws -> ASRResult
   {
@@ -374,6 +410,14 @@ final actor FakeASRBackend: ASRBackend {
     // (`guard isReady ... else { throw ASRError.notReady }`). A double must
     // refuse what the real tool refuses, or a test proves nothing about it.
     guard ready else { throw ASRError.notReady }
+    if transcribeGated {
+      await withCheckedContinuation { c in
+        transcribeGateContinuations.append(c)
+        let waiters = parkedWaiters
+        parkedWaiters.removeAll()
+        for waiter in waiters { waiter.continuation.resume(returning: true) }
+      }
+    }
     return ASRResult(
       text: "ok", language: nil, duration: 0, processingTime: 0, backendType: .parakeet)
   }

--- a/Tests/EnviousWisprASRTests/VendorDecodeOccupancyTests.swift
+++ b/Tests/EnviousWisprASRTests/VendorDecodeOccupancyTests.swift
@@ -1,0 +1,258 @@
+import Foundation
+import Testing
+import WhisperKit
+
+@testable import EnviousWisprASR
+
+/// #2787 — the engine stays visibly BUSY for exactly as long as a vendor
+/// decode is running, whoever is still waiting for it.
+///
+/// **When this fails, the user sees one of two wrong things:** a second
+/// recording minted on top of a decode that never returned (the engine reads
+/// idle while Core ML still owns it), or "restart the app" after the decode
+/// has in fact returned (the engine reads busy after the call unwound). The
+/// customer's Mac Studio on the macOS 27 RC produced the first; this is the
+/// instrument the hold reads to prevent both.
+@Suite(.tags(.productOutcome))
+@MainActor
+struct VendorDecodeOccupancyTests {
+
+  /// Parks a tracked operation until the test releases it, and announces the
+  /// moment it is parked so the test waits on a signal rather than a guess.
+  private final class Gate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parked: CheckedContinuation<Void, Never>?
+    private var enteredWaiters: [(id: UUID, continuation: CheckedContinuation<Bool, Never>)] = []
+    private var hasEntered = false
+
+    func park() async {
+      await withCheckedContinuation { c in
+        let waiters = lock.withLock { () -> [(id: UUID, continuation: CheckedContinuation<Bool, Never>)] in
+          parked = c
+          hasEntered = true
+          let ws = enteredWaiters
+          enteredWaiters.removeAll()
+          return ws
+        }
+        for waiter in waiters { waiter.continuation.resume(returning: true) }
+      }
+    }
+
+    /// Resolves `true` once `park()` has been reached, `false` after the
+    /// deadline. Bounded so a subject that never reaches the gate fails the
+    /// test instead of hanging the suite.
+    func entered() async -> Bool {
+      await withCheckedContinuation { (c: CheckedContinuation<Bool, Never>) in
+        let id = UUID()
+        // Check and register under ONE lock hold: a producer finishing between
+        // a separate check and the registration would strand the waiter.
+        let alreadyEntered = lock.withLock {
+          if hasEntered { return true }
+          enteredWaiters.append((id, c))
+          return false
+        }
+        if alreadyEntered {
+          c.resume(returning: true)
+          return
+        }
+        Task {
+          try? await Task.sleep(for: .seconds(5))  // deadline-fallback: bounds the signal wait
+          self.expireEnteredWaiter(id)
+        }
+      }
+    }
+
+    private func expireEnteredWaiter(_ id: UUID) {
+      let waiter = lock.withLock { () -> CheckedContinuation<Bool, Never>? in
+        guard let index = enteredWaiters.firstIndex(where: { $0.id == id }) else { return nil }
+        return enteredWaiters.remove(at: index).continuation
+      }
+      waiter?.resume(returning: false)
+    }
+
+    func open() {
+      let c = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+        let p = parked
+        parked = nil
+        return p
+      }
+      c?.resume()
+    }
+  }
+
+  @Test("idle before, busy during, idle after a decode that returns")
+  func countsOneDecode() async {
+    let occupancy = VendorDecodeOccupancy()
+    let gate = Gate()
+    #expect(occupancy.isIdle)
+    let decode = Task { @MainActor in
+      await occupancy.track {
+        await gate.park()
+        return "text"
+      }
+    }
+    #expect(await gate.entered())
+    #expect(occupancy.inFlight == 1)
+    #expect(occupancy.isIdle == false)
+    gate.open()
+    _ = await decode.value
+    #expect(occupancy.isIdle)
+  }
+
+  @Test("a decode that throws still releases the count")
+  func throwingDecodeReleases() async {
+    let occupancy = VendorDecodeOccupancy()
+    struct Boom: Error {}
+    await #expect(throws: Boom.self) {
+      try await occupancy.track { () throws -> Void in throw Boom() }
+    }
+    #expect(occupancy.isIdle)
+  }
+
+  @Test("awaitIdle returns at once when nothing is running")
+  func awaitIdleImmediate() async {
+    let occupancy = VendorDecodeOccupancy()
+    await occupancy.awaitIdle()
+    #expect(occupancy.isIdle)
+  }
+
+  @Test("awaitIdle resumes only when the decode returns, not when its awaiting task is cancelled")
+  func awaitIdleWaitsForTheVendorCallNotTheWaiter() async {
+    let occupancy = VendorDecodeOccupancy()
+    let gate = Gate()
+    // The session's own await: cancelled by the user long before the decode returns.
+    let sessionWait = Task { @MainActor in
+      await occupancy.track { await gate.park() }
+    }
+    #expect(await gate.entered())
+    sessionWait.cancel()
+    let resumed = Resumed()
+    let waiterA = Task { @MainActor in
+      await occupancy.awaitIdle()
+      resumed.mark("a")
+    }
+    let waiterB = Task { @MainActor in
+      await occupancy.awaitIdle()
+      resumed.mark("b")
+    }
+    // A NEGATIVE has no signal to park on: the waiters' whole job here is to
+    // stay silent. Yielding gives them the opportunity they must decline; it is
+    // weaker than the signal waits around it (swift-testing-patterns.md
+    // a-test-that-proves-a-NEGATIVE-has-no-signal-to-park-on). The binding
+    // precondition is the count, asserted on the same line.
+    for _ in 0..<20 { await Task.yield() }
+    #expect(occupancy.inFlight == 1)
+    #expect(resumed.names.isEmpty, "a cancelled waiter is not a returned decode")
+    gate.open()
+    _ = await sessionWait.value
+    _ = await waiterA.value
+    _ = await waiterB.value
+    #expect(resumed.names.sorted() == ["a", "b"])
+    #expect(occupancy.isIdle)
+  }
+
+  @Test("two overlapping decodes: idle only after both return")
+  func overlappingDecodes() async {
+    let occupancy = VendorDecodeOccupancy()
+    let first = Gate()
+    let second = Gate()
+    let a = Task { @MainActor in await occupancy.track { await first.park() } }
+    let b = Task { @MainActor in await occupancy.track { await second.park() } }
+    #expect(await first.entered())
+    #expect(await second.entered())
+    #expect(occupancy.inFlight == 2)
+    first.open()
+    _ = await a.value
+    #expect(occupancy.inFlight == 1)
+    #expect(occupancy.isIdle == false)
+    second.open()
+    _ = await b.value
+    #expect(occupancy.isIdle)
+  }
+
+  /// The real seam: `ASRManager.transcribe` counts the backend call it issues.
+  /// A parked fake backend is the shape of a vendor decode that does not
+  /// return; the manager's occupancy must read busy for as long as it is
+  /// parked, and idle the moment it returns.
+  @Test("ASRManager.transcribe is counted for the whole vendor call")
+  func managerTranscribeIsCounted() async throws {
+    let parakeet = FakeASRBackend(initiallyReady: true)
+    await parakeet.gateTranscribe()
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting, parakeetBackendFactory: { parakeet })
+    manager.setInitialBackendType(.parakeet)
+    try await manager.loadModel()
+    #expect(manager.vendorDecodeOccupancy.isIdle)
+    let decode = Task { @MainActor in
+      try await manager.transcribe(audioSamples: [0.0], options: .default)
+    }
+    #expect(await parakeet.transcribeParked(), "the fake never reached its gate")
+    #expect(manager.vendorDecodeOccupancy.inFlight == 1)
+    await parakeet.releaseTranscribeGate()
+    let result = try await decode.value
+    #expect(result.text == "ok")
+    #expect(manager.vendorDecodeOccupancy.isIdle)
+  }
+
+  /// The WhisperKit STREAMING path never touches `ASRManager.transcribe`; its
+  /// session decodes through the decoder interface. The decorator counts every
+  /// one of those decodes, so a stream stopped mid-decode reads busy until the
+  /// vendor call actually returns.
+  @Test("the streaming decoder decorator counts each vendor decode for its whole duration")
+  func streamingDecoderIsCounted() async throws {
+    let occupancy = VendorDecodeOccupancy()
+    let gate = Gate()
+    let decoder = OccupiedWhisperKitDecoder(
+      base: ParkedDecoder(gate: gate), occupancy: occupancy)
+    let decode = Task { @MainActor in
+      try await decoder.transcribe(audioArray: [0.0], decodeOptions: nil, shouldContinueDecoding: nil)
+    }
+    #expect(await gate.entered())
+    #expect(occupancy.inFlight == 1)
+    gate.open()
+    let results = try await decode.value
+    #expect(results.isEmpty)
+    #expect(occupancy.isIdle)
+    #expect(decoder.encodeText("x") == [7], "pass-through must reach the base decoder")
+  }
+
+  /// A decoder that parks inside `transcribe` until the gate opens.
+  private struct ParkedDecoder: WhisperKitTranscribing {
+    let gate: Gate
+    func transcribe(
+      audioArray: [Float], decodeOptions: DecodingOptions?,
+      shouldContinueDecoding: (@Sendable () -> Bool)?
+    ) async throws -> [TranscriptionResult] {
+      await gate.park()
+      return []
+    }
+    func encodeText(_ text: String) -> [Int] { [7] }
+  }
+
+  @Test("a refused transcribe (backend not owned) never touches the count")
+  func refusedTranscribeNotCounted() async {
+    let manager = ASRManager(
+      engineMutationScope: .alwaysAllowedForTesting,
+      parakeetBackendFactory: { FakeASRBackend(initiallyReady: true) })
+    manager.setInitialBackendType(.whisperKit)
+    await #expect(throws: ASRManagerNotOwnedError(backend: .whisperKit)) {
+      _ = try await manager.transcribe(audioSamples: [0.0], options: .default)
+    }
+    #expect(manager.vendorDecodeOccupancy.isIdle)
+  }
+
+  private final class Resumed: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String] = []
+    var names: [String] {
+      lock.lock()
+      defer { lock.unlock() }
+      return stored
+    }
+    func mark(_ name: String) {
+      lock.lock()
+      stored.append(name)
+      lock.unlock()
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/App/AbandonedDecodeHoldTests.swift
+++ b/Tests/EnviousWisprTests/App/AbandonedDecodeHoldTests.swift
@@ -1,0 +1,263 @@
+import EnviousWisprServices
+import Foundation
+import Testing
+
+@testable import EnviousWisprASR
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprPipeline
+
+/// #2787 — after a session ends while its vendor decode is still running, the
+/// shared engine stays claimed until that decode returns.
+///
+/// **When this fails, the user sees a second recording start on top of a decode
+/// that never returned** — the state the customer's Mac Studio was in four
+/// times on macOS 27 RC day — or, in the other direction, "Restart the app"
+/// after the engine is in fact free.
+@Suite(.tags(.productOutcome))
+@MainActor
+struct AbandonedDecodeHoldTests {
+
+  /// A vendor decode the test controls: parked inside `track` until opened.
+  private final class Decode: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parked: CheckedContinuation<Void, Never>?
+    private var enteredWaiters: [(id: UUID, continuation: CheckedContinuation<Bool, Never>)] = []
+    private var hasEntered = false
+
+    func run(under occupancy: VendorDecodeOccupancy) -> Task<Void, Never> {
+      Task { @MainActor in
+        await occupancy.track { await self.park() }
+      }
+    }
+
+    private func park() async {
+      await withCheckedContinuation { c in
+        let waiters = lock.withLock { () -> [(id: UUID, continuation: CheckedContinuation<Bool, Never>)] in
+          parked = c
+          hasEntered = true
+          let ws = enteredWaiters
+          enteredWaiters.removeAll()
+          return ws
+        }
+        for waiter in waiters { waiter.continuation.resume(returning: true) }
+      }
+    }
+
+    /// `true` once the decode is parked inside the occupancy; bounded.
+    func entered() async -> Bool {
+      await withCheckedContinuation { (c: CheckedContinuation<Bool, Never>) in
+        let id = UUID()
+        // Check and register under ONE lock hold: a producer finishing between
+        // a separate check and the registration would strand the waiter.
+        let alreadyEntered = lock.withLock {
+          if hasEntered { return true }
+          enteredWaiters.append((id, c))
+          return false
+        }
+        if alreadyEntered {
+          c.resume(returning: true)
+          return
+        }
+        Task {
+          try? await Task.sleep(for: .seconds(5))  // deadline-fallback: bounds the signal wait
+          self.expireEnteredWaiter(id)
+        }
+      }
+    }
+
+    private func expireEnteredWaiter(_ id: UUID) {
+      let waiter = lock.withLock { () -> CheckedContinuation<Bool, Never>? in
+        guard let index = enteredWaiters.firstIndex(where: { $0.id == id }) else { return nil }
+        return enteredWaiters.remove(at: index).continuation
+      }
+      waiter?.resume(returning: false)
+    }
+
+    func finish() {
+      let c = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+        let p = parked
+        parked = nil
+        return p
+      }
+      c?.resume()
+    }
+  }
+
+  /// Resolves when `onSettled` fires, or `false` at the deadline.
+  private final class Settled: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seconds: Double?
+    private var waiters: [(id: UUID, continuation: CheckedContinuation<Double?, Never>)] = []
+
+    func fire(_ s: Double) {
+      let ws = lock.withLock { () -> [(id: UUID, continuation: CheckedContinuation<Double?, Never>)] in
+        seconds = s
+        let w = waiters
+        waiters.removeAll()
+        return w
+      }
+      for w in ws { w.continuation.resume(returning: s) }
+    }
+
+    func value() async -> Double? {
+      await withCheckedContinuation { (c: CheckedContinuation<Double?, Never>) in
+        let id = UUID()
+        let known = lock.withLock { () -> Double? in
+          if let seconds { return seconds }
+          waiters.append((id, c))
+          return nil
+        }
+        if let known {
+          c.resume(returning: known)
+          return
+        }
+        Task {
+          try? await Task.sleep(for: .seconds(5))  // deadline-fallback: bounds the signal wait
+          self.expireWaiter(id)
+        }
+      }
+    }
+
+    private func expireWaiter(_ id: UUID) {
+      let waiter = lock.withLock { () -> CheckedContinuation<Double?, Never>? in
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return nil }
+        return waiters.remove(at: index).continuation
+      }
+      waiter?.resume(returning: nil)
+    }
+  }
+
+  private func dictationToken(_ lease: EngineLease) throws -> EngineLease.Token {
+    guard case .granted(let token) = lease.admit(.dictation) else {
+      throw TestFailure("dictation could not claim a free lease")
+    }
+    return token
+  }
+
+  private struct TestFailure: Error {
+    let message: String
+    init(_ message: String) { self.message = message }
+  }
+
+  @Test("a session that ends with the engine idle hands the lease straight back")
+  func idleEngineReleasesNormally() throws {
+    let lease = EngineLease()
+    let hold = AbandonedDecodeHold(lease: lease, occupancy: VendorDecodeOccupancy())
+    let token = try dictationToken(lease)
+    hold.releaseFromDictation(token)
+    #expect(lease.isBusy == false)
+    #expect(hold.isHolding == false)
+    // The next press claims cleanly.
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("the lease was not free after a normal release")
+      return
+    }
+  }
+
+  @Test(
+    "a session that ends mid-decode keeps the engine claimed as abandonedDecode until the decode returns"
+  )
+  func busyEngineIsHeldUntilTheDecodeReturns() async throws {
+    let lease = EngineLease()
+    let occupancy = VendorDecodeOccupancy()
+    let hold = AbandonedDecodeHold(lease: lease, occupancy: occupancy)
+    let settled = Settled()
+    hold.onSettled = { settled.fire($0) }
+    let token = try dictationToken(lease)
+
+    let decode = Decode()
+    let vendorCall = decode.run(under: occupancy)
+    #expect(await decode.entered())
+
+    // The user stopped waiting: the session's terminal releases the dictation claim.
+    hold.releaseFromDictation(token)
+    #expect(hold.isHolding)
+    #expect(lease.currentHolder == .abandonedDecode)
+    // A record press, a replay, an import: all refused, naming the abandoned decode.
+    for holder in [SharedEngineHolder.dictation, .crashRecovery, .fileImport] {
+      guard case .refused(let by) = lease.admit(holder) else {
+        Issue.record("\(holder) claimed the engine while a decode was still running")
+        continue
+      }
+      #expect(by == .abandonedDecode)
+    }
+
+    // The decode finally returns: the hold settles and the lease is free.
+    decode.finish()
+    _ = await vendorCall.value
+    let seconds = await settled.value()
+    #expect(seconds != nil, "onSettled never fired after the decode returned")
+    #expect(hold.isHolding == false)
+    #expect(lease.isBusy == false)
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("the lease was not free after the decode returned")
+      return
+    }
+  }
+
+  @Test("a hold that never settles keeps refusing: the honest state is 'restart the app'")
+  func unreturnedDecodeKeepsRefusing() async throws {
+    let lease = EngineLease()
+    let occupancy = VendorDecodeOccupancy()
+    let hold = AbandonedDecodeHold(lease: lease, occupancy: occupancy)
+    let token = try dictationToken(lease)
+    let decode = Decode()
+    let vendorCall = decode.run(under: occupancy)
+    #expect(await decode.entered())
+    hold.releaseFromDictation(token)
+    // A NEGATIVE: nothing must free the lease while the decode is parked.
+    // Yield is the honest instrument (a-test-that-proves-a-NEGATIVE-has-no-
+    // signal-to-park-on); the binding precondition is the in-flight count.
+    for _ in 0..<20 { await Task.yield() }
+    #expect(occupancy.inFlight == 1)
+    #expect(lease.currentHolder == .abandonedDecode)
+    #expect(
+      DictationNarrator.copy(for: .sharedEngineBusy(holder: .abandonedDecode))
+        == "Previous take still running. Restart the app.")
+    decode.finish()
+    _ = await vendorCall.value
+  }
+
+  #if DEBUG
+    @Test("the hold reports one started and one settled event, in that order")
+    func telemetryPair() async throws {
+      let lease = EngineLease()
+      let occupancy = VendorDecodeOccupancy()
+      let hold = AbandonedDecodeHold(lease: lease, occupancy: occupancy)
+      let settled = Settled()
+      hold.onSettled = { settled.fire($0) }
+      let names = Names()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name.hasPrefix("engine.abandoned_decode_hold") { names.add(event.name) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+      let token = try dictationToken(lease)
+      let decode = Decode()
+      let vendorCall = decode.run(under: occupancy)
+      #expect(await decode.entered())
+      hold.releaseFromDictation(token)
+      decode.finish()
+      _ = await vendorCall.value
+      _ = await settled.value()
+      #expect(
+        names.all == [
+          "engine.abandoned_decode_hold_started", "engine.abandoned_decode_hold_settled",
+        ])
+    }
+
+    private final class Names: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [String] = []
+      var all: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+      }
+      func add(_ n: String) {
+        lock.lock()
+        stored.append(n)
+        lock.unlock()
+      }
+    }
+  #endif
+}

--- a/Tests/EnviousWisprTests/App/CancelAffordancePolicyTests.swift
+++ b/Tests/EnviousWisprTests/App/CancelAffordancePolicyTests.swift
@@ -17,69 +17,52 @@ import Testing
 @Suite("Cancel affordance policy (#2087)", .tags(.productOutcome))
 struct CancelAffordancePolicyTests {
 
-  /// Every state, both capability values. The pairs are written out rather than
-  /// generated so the expected answer is visible next to its input — a table
-  /// that computes its own expectations agrees with itself by construction.
-  private static let cases: [(state: PipelineState, recovery: Bool, armed: Bool)] = [
-    (.recording, false, true),
-    (.recording, true, true),
-    (.transcribing, false, false),
-    (.transcribing, true, true),
-    (.loadingModel, false, false),
-    (.loadingModel, true, false),
-    (.polishing, false, false),
-    (.polishing, true, false),
-    (.idle, false, false),
-    (.idle, true, false),
-    (.complete, false, false),
-    (.complete, true, false),
-    (.error(.asrFailed), false, false),
-    (.error(.asrFailed), true, false),
-    (.advisory(.zeroSignal), false, false),
-    (.advisory(.zeroSignal), true, false),
+  /// Every state. The pairs are written out rather than generated so the
+  /// expected answer is visible next to its input — a table that computes its
+  /// own expectations agrees with itself by construction.
+  ///
+  /// #2787 made `.transcribing` armed for every take, so the capability that
+  /// used to split it (`isEscapeRecoveryTranscribing`) no longer reaches this
+  /// half of the policy; it still decides `isAbandonment` below.
+  private static let cases: [(state: PipelineState, armed: Bool)] = [
+    (.recording, true),
+    (.transcribing, true),
+    (.loadingModel, false),
+    (.polishing, false),
+    (.idle, false),
+    (.complete, false),
+    (.error(.asrFailed), false),
+    (.advisory(.zeroSignal), false),
   ]
 
-  @Test("the affordance table holds for every state and both capability values")
+  @Test("the affordance table holds for every state")
   func truthTable() {
     for c in Self.cases {
       #expect(
-        CancelAffordancePolicy.isShortcutEnabled(
-          state: c.state, isEscapeRecoveryTranscribing: c.recovery) == c.armed,
-        "state \(c.state) with recovery=\(c.recovery) must be armed=\(c.armed)")
+        CancelAffordancePolicy.isShortcutEnabled(state: c.state) == c.armed,
+        "state \(c.state) must be armed=\(c.armed)")
     }
   }
 
-  /// `.transcribing` is the ONLY state whose answer depends on the capability,
-  /// and that is the entire behavioural change this policy introduces. Asserted
-  /// directly so a future edit that made some other state capability-dependent
-  /// has to come here and say so.
-  @Test("transcribing is the only state the capability can change")
-  func onlyTranscribingIsCapabilityDependent() {
-    let states: [PipelineState] = [
-      .recording, .transcribing, .loadingModel, .polishing, .idle, .complete,
-      .error(.asrFailed), .advisory(.zeroSignal),
-    ]
-    let dependent = states.filter { state in
-      CancelAffordancePolicy.isShortcutEnabled(state: state, isEscapeRecoveryTranscribing: true)
-        != CancelAffordancePolicy.isShortcutEnabled(
-          state: state, isEscapeRecoveryTranscribing: false)
-    }
-    #expect(dependent == [.transcribing])
+  /// #2787: the key is live through an ORDINARY transcription. Before this,
+  /// Escape during a stuck decode did nothing at all, and the customer's only
+  /// exit was to quit the app four times.
+  @Test("an ordinary transcription keeps the cancel shortcut live")
+  func ordinaryTranscribingIsArmed() {
+    #expect(CancelAffordancePolicy.isShortcutEnabled(state: .transcribing))
   }
 
   /// The other half of the policy, and the reason both halves live together:
-  /// `RecordingFinalizer` admits only `.recording` and `.loadingModel`, so if
-  /// this ever answered false where `isShortcutEnabled(.transcribing, true)`
-  /// answers true, the key would be armed and inert — a user pressing Escape
-  /// and nothing happening at all.
+  /// the state the finalizer must admit is exactly the state the key stays live
+  /// for. If this ever answered false where `isShortcutEnabled(.transcribing)`
+  /// answers true, the key would be armed and inert.
   @Test("the two halves agree: a shortcut cancel during a live recovery is an abandonment")
   func halvesAgree() {
     #expect(
       CancelAffordancePolicy.isAbandonment(
         trigger: .shortcut, isEscapeRecoveryTranscribing: true))
     #expect(
-      CancelAffordancePolicy.isShortcutEnabled(
-        state: .transcribing, isEscapeRecoveryTranscribing: true),
+      CancelAffordancePolicy.isShortcutEnabled(state: .transcribing),
       "the state the finalizer must admit is exactly the state the key stays live for")
   }
 
@@ -94,19 +77,5 @@ struct CancelAffordancePolicyTests {
       CancelAffordancePolicy.isAbandonment(
         trigger: .shortcut, isEscapeRecoveryTranscribing: false) == false,
       "and a shortcut outside a recovery is an ordinary cancel")
-  }
-
-  /// The inert claim, checked rather than asserted in prose: with the capability
-  /// false — which is every take until chunk 12 ships the setting — the policy
-  /// returns exactly what the six register/unregister calls it replaced did.
-  /// Armed in `.recording`, down everywhere else.
-  @Test("with the capability off the policy reproduces today's behaviour exactly")
-  func inertWithoutTheCapability() {
-    for c in Self.cases where !c.recovery {
-      let expected = (c.state == .recording)
-      #expect(
-        CancelAffordancePolicy.isShortcutEnabled(
-          state: c.state, isEscapeRecoveryTranscribing: false) == expected)
-    }
   }
 }

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -181,6 +181,8 @@ import Testing
       .fileImport: "A file is being transcribed. Try again soon.",
       .crashRecovery: "Finishing an earlier take. Try again soon.",
       .dictation: "Already recording.",
+      // #2787: the decode the user stopped waiting for still owns the engine.
+      .abandonedDecode: "Previous take still running. Restart the app.",
     ]
     let sentence = DictationNarrator.copy(for: .sharedEngineBusy(holder: holder))
     #expect(sentence == expected[holder])

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -80,6 +80,7 @@ final class RouterTestASRManager: ASRManagerInterface {
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = false
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming: Bool = false
   var downloadProgress: Double = 0
   var downloadPhase: String = "idle"

--- a/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
+++ b/Tests/EnviousWisprTests/App/DictationRuntimeTestSupport.swift
@@ -79,6 +79,7 @@ final class RouterTestASRManager: ASRManagerInterface {
   var parakeetModelDirectory: URL?
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = false
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming: Bool = false
   var downloadProgress: Double = 0
   var downloadPhase: String = "idle"
@@ -176,7 +177,8 @@ enum DictationRuntimeFixtures {
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry(),
-        engineMutationScope: .alwaysAllowedForTesting
+        engineMutationScope: .alwaysAllowedForTesting,
+        vendorDecodeOccupancy: VendorDecodeOccupancy()
       ))
   }
 

--- a/Tests/EnviousWisprTests/App/DictationSessionConfigFactoryTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationSessionConfigFactoryTests.swift
@@ -283,6 +283,7 @@ private final class FactoryFakeASRManager: ASRManagerInterface {
   init(backend: ASRBackendType) { self.activeBackendType = backend }
 
   var isModelLoaded: Bool { true }
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming: Bool { false }
   var downloadProgress: Double { 1 }
   var downloadPhase: String { "ready" }

--- a/Tests/EnviousWisprTests/App/DictationSessionConfigFactoryTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationSessionConfigFactoryTests.swift
@@ -284,6 +284,7 @@ private final class FactoryFakeASRManager: ASRManagerInterface {
 
   var isModelLoaded: Bool { true }
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming: Bool { false }
   var downloadProgress: Double { 1 }
   var downloadPhase: String { "ready" }

--- a/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
+++ b/Tests/EnviousWisprTests/App/RecordingFinalizerCancelPathTests.swift
@@ -159,6 +159,26 @@
         #expect(obs.dispatchRan)  // the state guard passed and the dispatch was reached
         #expect(obs.stampAtEntry != nil)  // the timestamp was already set at dispatch entry
       }
+      /// #2787: a shortcut cancel during an ORDINARY transcription reaches the
+      /// dispatch. Before this the state guard refused `.transcribing`, so the
+      /// key was inert exactly when a stuck decode made it the only exit.
+      @Test("a cancel during an ordinary transcription is dispatched, not refused")
+      func cancelDuringOrdinaryTranscribingIsDispatched() async {
+        let fx = Self.makeFixture()
+        fx.asr.activeBackendType = .parakeet
+        let kernel = fx.kernelDriver.kernelForTesting
+        kernel.start(config: .testDefault())
+        kernel.testForceState(.delivering)
+        kernel.testSetDeliveringPhase(.transcribing)
+        #expect(fx.kernelDriver.state == .transcribing, "fixture must be transcribing")
+        #expect(fx.kernelDriver.isEscapeRecoveryTranscribing == false, "ordinary, not a recovery")
+        let obs = DispatchObservation()
+        fx.finalizer.cancelRecordingDispatch = { _, _ in obs.dispatchRan = true }
+        let abandoned = await fx.finalizer.cancel(trigger: .shortcut)
+        #expect(abandoned == false, "an ordinary cancel is not an abandonment")
+        #expect(obs.dispatchRan, "the state guard must admit .transcribing")
+      }
+
       /// #2087: the trigger must survive the whole chain, not merely be accepted.
       ///
       /// The earlier version of the dispatch-seam test ignored both closure

--- a/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/AppLifecycleCoordinatorCeilingsTests.swift
@@ -83,6 +83,7 @@ import Testing
     "applicationRelocationCoordinator",
     "bluetoothAwarenessPresenter",
     "batchDecodeFaultController",
+    "transcriptionCheckpointStore",  // #2787
     "accessibilityWarmupObserver",
   ]
 
@@ -125,10 +126,13 @@ import Testing
     // `RouterCeilingParser.imports` surfaces every anchored `import` line,
     // including inside `#if DEBUG` — so `EnviousWisprPipeline` (imported only
     // for `DebugFaultEndpoint` in debug builds) is on the allowlist.
+    // #2787: `EnviousWisprStorage` for `TranscriptionCheckpointStore` — the
+    // launch-time "the previous process died mid-transcription" report is a
+    // launch responsibility, and the store is the persisted record it reads.
     let allowed: Set<String> = [
       "AppKit", "EnviousWisprASR", "EnviousWisprAudio", "EnviousWisprCore",
       "EnviousWisprLLM", "EnviousWisprPipeline", "EnviousWisprServices",
-      "Foundation",
+      "EnviousWisprStorage", "Foundation",
     ]
     let extras = actual.subtracting(allowed)
     #expect(

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -962,7 +962,7 @@ import Testing
     // unawaited cancellation races recovery's gate opening.
     CallSite(
       file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "transcribe",
-      text: "try await backend.transcribe(audioSamples: samples, options: decodeOptions)",
+      text: "return try await backend.transcribe(audioSamples: samples, options: decodeOptions)",
       classification: .knownGap(
         issue: 1749,
         reason:
@@ -2117,7 +2117,7 @@ import Testing
         text: "let results = try await whisperKit.transcribe("),
       SiteKey(
         file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "transcribe",
-        text: "try await backend.transcribe(audioSamples: samples, options: decodeOptions)"),
+        text: "return try await backend.transcribe(audioSamples: samples, options: decodeOptions)"),
       SiteKey(
         file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "transcribe",
         text: "let result = try await asrManager.transcribe("),

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -941,7 +941,7 @@ import Testing
     CallSite(
       file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift",
       matcher: "makeStreamingSession",
-      text: "guard let session = await backend.makeStreamingSession(options: options) else {",
+      text: "let session = await backend.makeStreamingSession(",
       classification: .structurallySafe),
     // Language-ID observation inside the adapter's own finalize/decode flow —
     // session-scoped, an `ASREngineLanguageIdentifying`-adjacent read that
@@ -962,7 +962,7 @@ import Testing
     // unawaited cancellation races recovery's gate opening.
     CallSite(
       file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "transcribe",
-      text: "let result = try await backend.transcribe(",
+      text: "try await backend.transcribe(audioSamples: samples, options: decodeOptions)",
       classification: .knownGap(
         issue: 1749,
         reason:
@@ -978,8 +978,7 @@ import Testing
     // review named, not cascaded through every deeper forwarding layer.
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "transcribe",
-      text:
-        "return try await activeBackend.transcribe(audioSamples: audioSamples, options: options)",
+      text: "try await activeBackend.transcribe(audioSamples: audioSamples, options: options)",
       classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "feedAudio",
@@ -1008,7 +1007,7 @@ import Testing
     // discarding whatever is current IS the intent.
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "finalizeStreaming",
-      text: "let result = try await activeBackend.finalizeStreaming()",
+      text: "try await activeBackend.finalizeStreaming()",
       classification: .transitivelyCoveredByCaller),
 
     // MARK: ParakeetBackend — new Chunk 11 entry, same inherited coverage as
@@ -1063,6 +1062,13 @@ import Testing
     // `transcribe` calls below are internal decode-loop steps; #1749 —
     // "ordinary-session operations that can remain in flight" per Codex's
     // grounded review: not guaranteed to stop before recovery's gate opens.
+    // #2787: the occupancy decorator every streaming decode passes through. It
+    // adds no vendor call of its own — it forwards the session's — so it
+    // inherits the caller's safety exactly as the sites above do.
+    CallSite(
+      file: "Sources/EnviousWisprASR/WhisperKitIncrementalSession.swift", matcher: "transcribe",
+      text: "try await base.transcribe(",
+      classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASR/WhisperKitStreamingSession.swift", matcher: "transcribe",
       text: "let results = try await whisperKit.transcribe(",
@@ -2111,7 +2117,7 @@ import Testing
         text: "let results = try await whisperKit.transcribe("),
       SiteKey(
         file: "Sources/EnviousWisprPipeline/WhisperKitEngineAdapter.swift", matcher: "transcribe",
-        text: "let result = try await backend.transcribe("),
+        text: "try await backend.transcribe(audioSamples: samples, options: decodeOptions)"),
       SiteKey(
         file: "Sources/EnviousWisprPipeline/ParakeetEngineAdapter.swift", matcher: "transcribe",
         text: "let result = try await asrManager.transcribe("),

--- a/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineMutationInventoryFreezeTests.swift
@@ -811,7 +811,7 @@ import Testing
       file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "retryDecode",
       // #1946 chunk 2 re-spelled the operation closure so it can stamp the
       // decode's own return time. Same call, same session-scoped safety.
-      text: "let decoded = await adapter.retryDecode(inputSamples: retryInput)",
+      text: "await adapter.retryDecode(inputSamples: retryInput)",
       classification: .structurallySafe),
     // Row 22 — "confirmed already safe, no code change" per this file's own
     // doc comment at the site.
@@ -978,7 +978,7 @@ import Testing
     // review named, not cascaded through every deeper forwarding layer.
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "transcribe",
-      text: "try await activeBackend.transcribe(audioSamples: audioSamples, options: options)",
+      text: "return try await activeBackend.transcribe(audioSamples: audioSamples, options: options)",
       classification: .transitivelyCoveredByCaller),
     CallSite(
       file: "Sources/EnviousWisprASR/ASRManager.swift", matcher: "feedAudio",
@@ -1105,7 +1105,7 @@ import Testing
     // The real adapter-facing finalize call.
     CallSite(
       file: "Sources/EnviousWisprPipeline/RecordingSessionKernel.swift", matcher: "finalize",
-      text: "let outcome = await adapter.finalize(batchSamples: batchSamples)",
+      text: "await adapter.finalize(batchSamples: batchSamples)",
       classification: .structurallySafe),
     // The kernel's own private `finalize(sid:batchSamples:)` called
     // recursively during ASR-interruption salvage and the empty-result retry

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -428,6 +428,10 @@ import Testing
         ),
         MemberSignature(condition: nil, signature: "func unload() async"),
         MemberSignature(condition: nil, signature: "var supportsStreaming: Bool { get }"),
+        // #2787: a requirement, so the existential call reaches Parakeet's implementation.
+        MemberSignature(
+          condition: nil,
+          signature: "func setDecodeChunkObserver(_ observer: (@Sendable () -> Void)?) async"),
         MemberSignature(
           condition: nil,
           signature: "func startStreaming(options: TranscriptionOptions) async throws"
@@ -440,6 +444,10 @@ import Testing
         // Extension defaults (`extension ASRBackend { ... }`) — part of what
         // the protocol actually promises to a non-overriding conformer.
         MemberSignature(condition: nil, signature: "public var supportsStreaming: Bool { false }"),
+        // #2787: observation-only chunk reports; default is no signal.
+        MemberSignature(
+          condition: nil,
+          signature: "public func setDecodeChunkObserver(_ observer: (@Sendable () -> Void)?) async"),
         MemberSignature(
           condition: nil,
           signature: "public func startStreaming(options _: TranscriptionOptions) async throws"),
@@ -483,6 +491,10 @@ import Testing
         // #2787: the engine-busy authority a record press, replay and unload consult.
         MemberSignature(
           condition: nil, signature: "var vendorDecodeOccupancy: VendorDecodeOccupancy { get }"),
+        // #2787: observation-only chunk reports from the active backend.
+        MemberSignature(
+          condition: nil,
+          signature: "var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)? { get set }"),
         MemberSignature(
           condition: nil,
           signature:

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -480,6 +480,9 @@ import Testing
           signature:
             "func transcribe(audioSamples: [Float], options: TranscriptionOptions) async throws -> ASRResult"
         ),
+        // #2787: the engine-busy authority a record press, replay and unload consult.
+        MemberSignature(
+          condition: nil, signature: "var vendorDecodeOccupancy: VendorDecodeOccupancy { get }"),
         MemberSignature(
           condition: nil,
           signature:
@@ -650,7 +653,7 @@ import Testing
         MemberSignature(
           condition: nil,
           signature:
-            "func makeStreamingSession(options: TranscriptionOptions) async\n    -> (any WhisperKitIncrementalSession)?"
+            "func makeStreamingSession(\n    options: TranscriptionOptions, vendorDecodeOccupancy: VendorDecodeOccupancy\n  ) async -> (any WhisperKitIncrementalSession)?"
         ),
         MemberSignature(condition: nil, signature: "func unload() async"),
       ]),

--- a/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/EngineProtocolSurfaceFreezeTests.swift
@@ -577,6 +577,8 @@ import Testing
         MemberSignature(
           condition: nil,
           signature: "var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? { get }"),
+        // #2787: read at a `.cancelled` terminal to decide spool retention.
+        MemberSignature(condition: nil, signature: "var isVendorDecodeInFlight: Bool { get }"),
         MemberSignature(
           condition: nil,
           signature: "func retryDecode(inputSamples: [Float]) async -> ASREngineOutcome"),

--- a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
@@ -378,6 +378,7 @@ private final class FakeASRManager: ASRManagerInterface {
 
   var isModelLoaded: Bool { false }
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming: Bool { false }
   var downloadProgress: Double { 0 }
   var downloadPhase: String { "" }

--- a/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Architecture/SetupCoordinatorTests.swift
@@ -377,6 +377,7 @@ private final class FakeASRManager: ASRManagerInterface {
   init(backend: ASRBackendType) { self.backendType = backend }
 
   var isModelLoaded: Bool { false }
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming: Bool { false }
   var downloadProgress: Double { 0 }
   var downloadPhase: String { "" }

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -686,6 +686,7 @@ internal final class MockASRManager: ASRManagerInterface {
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = true
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming: Bool = false
   var downloadProgress: Double = 1
   var downloadPhase: String = "ready"

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathIntegrationTests.swift
@@ -685,6 +685,7 @@ internal final class MockASRManager: ASRManagerInterface {
 
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = true
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming: Bool = false
   var downloadProgress: Double = 1
   var downloadPhase: String = "ready"

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -622,6 +622,7 @@ private final class NoOpASRManager: ASRManagerInterface {
   var parakeetModelDirectory: URL?
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = false
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming: Bool = false
   var downloadProgress: Double = 0
   var downloadPhase: String = "idle"

--- a/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/HeartPathTelemetryWiringTests.swift
@@ -623,6 +623,7 @@ private final class NoOpASRManager: ASRManagerInterface {
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = false
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming: Bool = false
   var downloadProgress: Double = 0
   var downloadPhase: String = "idle"

--- a/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
@@ -37,7 +37,8 @@ import Testing
       backend: WhisperKitBackend(admittedModelFolder: { nil }),
       languageDetector: LanguageDetector(),
       audioCaptureSessionIDSource: { 0 },
-      engineMutationScope: .alwaysAllowedForTesting)
+      engineMutationScope: .alwaysAllowedForTesting,
+      vendorDecodeOccupancy: VendorDecodeOccupancy())
     #expect(adapter.engineIdentity.backendType == .whisperKit)
   }
 }
@@ -54,6 +55,7 @@ private final class MinimalASRManager: ASRManagerInterface {
   var parakeetModelDirectory: URL?
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded = false
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming = false
   var downloadProgress: Double = 0
   var downloadPhase = ""

--- a/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelAdapterFactoryTests.swift
@@ -56,6 +56,7 @@ private final class MinimalASRManager: ASRManagerInterface {
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded = false
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming = false
   var downloadProgress: Double = 0
   var downloadPhase = ""

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverBridgeMatrixTests.swift
@@ -38,6 +38,8 @@ import Testing
     private struct Fixture {
       let driver: KernelDictationDriver
       let kernel: RecordingSessionKernel
+      /// #2787: the fake engine, so a test can end a session with its decode "still running".
+      let engine: FakeEngine
     }
 
     private func makeFixture() -> Fixture {
@@ -71,7 +73,7 @@ import Testing
         context: context, steps: steps, adapter: adapter,
         engineMutationScope: .alwaysAllowedForTesting)
       driver.start()
-      return Fixture(driver: driver, kernel: kernel)
+      return Fixture(driver: driver, kernel: kernel, engine: adapter)
     }
 
     private func drain() async {
@@ -317,6 +319,66 @@ import Testing
           box.value == .cancelled(.user(trigger)),
           "a later system cancel must not alter the already-emitted ending")
       }
+    }
+    /// #2787: a cancel during `.delivering(.transcribing)` projects to
+    /// `.stoppedWaitingForDecode` when the engine's vendor decode is still
+    /// running, and to the ordinary `.cancelled(origin)` when it is not. The
+    /// coordinator keys spool retention on exactly this projection, so a wrong
+    /// value here either deletes the audio the customer needs for a launch
+    /// replay, or retains a normal cancel's audio for a surprise replay.
+    @Test("a cancel while the decode is still running projects stoppedWaitingForDecode")
+    func cancelWithDecodeInFlightProjectsStopWaiting() async {
+      for inFlight in [true, false] {
+        let fx = makeFixture()
+        await place(fx.kernel, in: .deliveringTranscribing)
+        fx.engine.isVendorDecodeInFlight = inFlight
+        let box = EndingBox()
+        fx.driver.onSessionEndedWithoutSave = { _, ending in box.value = ending }
+
+        await fx.driver.cancelRecording(disposition: .user(.shortcut))
+        await drain()
+
+        #expect(
+          box.value == (inFlight ? .stoppedWaitingForDecode : .cancelled(.user(.shortcut))),
+          "inFlight=\(inFlight) must project \(inFlight ? "stoppedWaitingForDecode" : "cancelled")")
+      }
+    }
+
+    /// #2787 (Codex chunk-2 P1): the projection is a TERMINAL-TIME snapshot.
+    /// The ending is delivered from an observer Task, by which time another
+    /// workload could have moved the shared occupancy. Flipping the fake's
+    /// answer between the cancel and the delivery must change nothing.
+    @Test("the stop-waiting projection is frozen at the terminal, not read at delivery")
+    func stopWaitingProjectionIsFrozenAtTheTerminal() async {
+      for (atTerminal, atDelivery) in [(true, false), (false, true)] {
+        let fx = makeFixture()
+        await place(fx.kernel, in: .deliveringTranscribing)
+        fx.engine.isVendorDecodeInFlight = atTerminal
+        let box = EndingBox()
+        fx.driver.onSessionEndedWithoutSave = { _, ending in box.value = ending }
+        // `cancel` concludes synchronously; the observer Task has not run yet.
+        fx.kernel.cancel(origin: .user(.shortcut))
+        fx.engine.isVendorDecodeInFlight = atDelivery
+        await drain()
+        #expect(
+          box.value == (atTerminal ? .stoppedWaitingForDecode : .cancelled(.user(.shortcut))),
+          "terminal=\(atTerminal) delivery=\(atDelivery): only the terminal-time value may count")
+      }
+    }
+
+    /// #2787 (Codex chunk-2 P1): a cancel DURING RECORDING never projects
+    /// stop-waiting, even with a decode in flight — a live WhisperKit streaming
+    /// decode is the normal state there, and that audio is discarded (#1755).
+    @Test("a cancel before transcribing projects the ordinary cancelled ending even with a decode in flight")
+    func cancelBeforeTranscribingIsNeverStopWaiting() async {
+      let fx = makeFixture()
+      await place(fx.kernel, in: .stopping)
+      fx.engine.isVendorDecodeInFlight = true
+      let box = EndingBox()
+      fx.driver.onSessionEndedWithoutSave = { _, ending in box.value = ending }
+      await fx.driver.cancelRecording(disposition: .user(.shortcut))
+      await drain()
+      #expect(box.value == .cancelled(.user(.shortcut)))
     }
   }
 

--- a/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverFactoryWhisperKitTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/KernelDictationDriverFactoryWhisperKitTests.swift
@@ -61,7 +61,8 @@ import Testing
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry(),
-        engineMutationScope: .alwaysAllowedForTesting)
+        engineMutationScope: .alwaysAllowedForTesting,
+        vendorDecodeOccupancy: VendorDecodeOccupancy())
       return KernelDictationDriverFactory.makeForWhisperKit(inputs: inputs)
     }
 
@@ -95,7 +96,8 @@ import Testing
         keychainManager: KeychainManager(),
         captureTelemetry: CaptureTelemetryState(),
         pasteCompletionRegistry: PasteCompletionRegistry(),
-        engineMutationScope: .alwaysAllowedForTesting)
+        engineMutationScope: .alwaysAllowedForTesting,
+        vendorDecodeOccupancy: VendorDecodeOccupancy())
       _ = KernelDictationDriverFactory.makeForWhisperKit(inputs: inputs)
       // Factory construction is synchronous and pure — no warm-up dispatch.
       // Backend's `isReady` flips to true only after `prepare()` completes.

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -15,6 +15,26 @@ import Testing
 @MainActor
 @Suite struct ParakeetEngineAdapterTests {
 
+  /// #2787 chunk 4: the manager's "vendor chunk scheduled" callback becomes an
+  /// `.observation` tick on the adapter's finalize stream — the non-destructive
+  /// mode the kernel records without arming its wedge detector. Each read of
+  /// `finalizeProgress` is a fresh stream, so a tick lands only on the current one.
+  @Test("a vendor chunk report becomes an observation tick on the current finalize stream")
+  func vendorChunkReportBecomesObservationTick() async throws {
+    let manager = StubParakeetASRManager()
+    let adapter = ParakeetEngineAdapter(asrManager: manager)
+    let stream = try #require(adapter.finalizeProgress)
+    var iterator = stream.makeAsyncIterator()
+    manager.onVendorDecodeChunkScheduled?()
+    manager.onVendorDecodeChunkScheduled?()
+    let first = try #require(await iterator.next())
+    let second = try #require(await iterator.next())
+    #expect(first.kind == .observation)
+    #expect(second.kind == .observation)
+    #expect(second.marker > first.marker, "markers are monotonic")
+  }
+
+
   // MARK: Identity (PR-5 Rung 1)
 
   @Test("engineIdentity: Parakeet declares .parakeet backend")
@@ -880,6 +900,7 @@ final class StubParakeetASRManager: ASRManagerInterface {
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded = false
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming = false
   var downloadProgress: Double = 0
   var downloadPhase = "idle"

--- a/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/ParakeetEngineAdapterTests.swift
@@ -879,6 +879,7 @@ final class StubParakeetASRManager: ASRManagerInterface {
   var parakeetModelDirectory: URL?
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded = false
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming = false
   var downloadProgress: Double = 0
   var downloadPhase = "idle"

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -343,6 +343,10 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
     finalizeProgressAbsent ? nil : finalizeStream
   }
 
+  /// #2787: settable so a scenario can end a session with the fake's decode
+  /// "still running" and assert the driver projects `.stoppedWaitingForDecode`.
+  var isVendorDecodeInFlight: Bool = false
+
   // MARK: Wedge continuations
 
   private var loadWedgeContinuation: CheckedContinuation<Void, Never>?

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/FakeEngine.swift
@@ -321,8 +321,13 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
 
   private let loadStream: AsyncStream<ASRLoadProgressTick>
   private let loadContinuation: AsyncStream<ASRLoadProgressTick>.Continuation
-  private let finalizeStream: AsyncStream<ASRFinalizeProgressTick>
-  private let finalizeContinuation: AsyncStream<ASRFinalizeProgressTick>.Continuation
+  /// #2787: a FRESH stream per read, mirroring `ParakeetEngineAdapter` — the
+  /// kernel reads once per decode attempt, and a tick yielded on an older
+  /// stream must not be counted against a later attempt. `emitFinalizeTick` /
+  /// `emitObservationTick` yield on the LATEST; `emitObservationTickOnPreviousStream`
+  /// deliberately targets the one before it.
+  private var finalizeContinuation: AsyncStream<ASRFinalizeProgressTick>.Continuation
+  private var previousFinalizeContinuation: AsyncStream<ASRFinalizeProgressTick>.Continuation?
   private var loadMarker: UInt64 = 0
   private var finalizeMarker: UInt64 = 0
 
@@ -340,7 +345,11 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
 
   /// `nil` when the engine exposes no finalize-progress stream.
   var finalizeProgress: AsyncStream<ASRFinalizeProgressTick>? {
-    finalizeProgressAbsent ? nil : finalizeStream
+    guard !finalizeProgressAbsent else { return nil }
+    let (stream, continuation) = AsyncStream.makeStream(of: ASRFinalizeProgressTick.self)
+    previousFinalizeContinuation = finalizeContinuation
+    finalizeContinuation = continuation
+    return stream
   }
 
   /// #2787: settable so a scenario can end a session with the fake's decode
@@ -363,8 +372,7 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
     self.loadProgressAbsent = loadProgressAbsent
     self.finalizeProgressAbsent = finalizeProgressAbsent
     (loadStream, loadContinuation) = AsyncStream.makeStream(of: ASRLoadProgressTick.self)
-    (finalizeStream, finalizeContinuation) = AsyncStream.makeStream(
-      of: ASRFinalizeProgressTick.self)
+    (_, finalizeContinuation) = AsyncStream.makeStream(of: ASRFinalizeProgressTick.self)
   }
 
   // MARK: Warm-up
@@ -544,6 +552,23 @@ final class FakeEngine: ASREngineAdapter, @unchecked Sendable {
   func emitFinalizeTick() {
     finalizeMarker += 1
     finalizeContinuation.yield(ASRFinalizeProgressTick(marker: finalizeMarker))
+  }
+
+  /// #2787: emit one OBSERVATION tick — the shape Parakeet's adapter produces
+  /// from a vendor "chunk scheduled" report. Must reach the checkpoint and
+  /// must NOT arm the finalize-wedge detector.
+  func emitObservationTick() {
+    finalizeMarker += 1
+    finalizeContinuation.yield(
+      ASRFinalizeProgressTick(marker: finalizeMarker, kind: .observation))
+  }
+
+  /// #2787: a LATE report from a previous decode attempt (the stream the kernel
+  /// read before the current one). Must never reach the current attempt's count.
+  func emitObservationTickOnPreviousStream() {
+    finalizeMarker += 1
+    previousFinalizeContinuation?.yield(
+      ASRFinalizeProgressTick(marker: finalizeMarker, kind: .observation))
   }
 
   func cancel() async {

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/RecordingSessionDriving.swift
@@ -175,6 +175,13 @@ final class StopTimeZeroSignalTelemetryLog {
   var fired: [CaptureStallContext] = []
 }
 
+/// #2787: records every `TranscriptionCheckpointEvent` the kernel emits, in
+/// order, so a scenario can assert the stop→decode stage sequence and the
+/// terminal clear without a real store. Same pre-`self` capture shape as above.
+final class TranscriptionCheckpointLog {
+  var events: [TranscriptionCheckpointEvent] = []
+}
+
 /// Heartpath 5b (#1520): records the kernel's dead-mic telemetry closures so a
 /// test can assert what fired without a real emitter. Reference type for the
 /// same pre-`self` capture constraint as `StopTimeZeroSignalTelemetryLog`.
@@ -223,6 +230,11 @@ final class KernelRecordingSession: RecordingSessionDriving {
   var asrTimingEndCount: Int { asrTimingLog.count }
 
   private let stopTimeTelemetryLog = StopTimeZeroSignalTelemetryLog()
+  private let transcriptionCheckpointLog = TranscriptionCheckpointLog()
+  /// #2787: the kernel's checkpoint events, in fire order.
+  var transcriptionCheckpointEvents: [TranscriptionCheckpointEvent] {
+    transcriptionCheckpointLog.events
+  }
   /// #1317: `CaptureStallContext`s the kernel's STOP-time classification
   /// submitted via `stopTimeZeroSignalTelemetry`, in fire order. Lets a test
   /// assert exactly one classified event fired (dedup) without a real
@@ -292,6 +304,7 @@ final class KernelRecordingSession: RecordingSessionDriving {
     let limb = self.limb
     let telemetryState = self.telemetryState
     let stopTimeTelemetryLog = self.stopTimeTelemetryLog
+    let transcriptionCheckpointLog = self.transcriptionCheckpointLog
     let storeLog = self.storeLog
     let captureTelemetry = self.captureTelemetry
     let deadMicLog = self.deadMicLog
@@ -344,6 +357,9 @@ final class KernelRecordingSession: RecordingSessionDriving {
       asrRetryDeadlineStartedTelemetry: onRetryDeadlineStarted,
       asrRetryDeadlineResolvedTelemetry: onRetryDeadlineResolved,
       engineMutationScope: .alwaysAllowedForTesting,
+      transcriptionCheckpoint: { [transcriptionCheckpointLog] event in
+        transcriptionCheckpointLog.events.append(event)
+      },
       minimumRecordingTicks: minimumRecordingTicks,
       captureTelemetry: captureTelemetry,
       deadMicRetireAttemptTelemetry: { [deadMicLog] ctx in

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/Scenario.swift
@@ -28,6 +28,11 @@ enum EngineDirective: Sendable {
   case emitLoadTick
   /// Emit one finalize-progress tick (when the engine exposes a finalize stream).
   case emitFinalizeTick
+  /// #2787: emit one OBSERVATION tick on the finalize stream — recorded on the
+  /// checkpoint, never arms the wedge detector.
+  case emitObservationTick
+  /// #2787: a late observation tick on the PREVIOUS decode attempt's stream.
+  case emitObservationTickOnPreviousStream
   /// Model the engine exposing NO load-progress stream — `loadProgress` becomes
   /// `nil` (the documented signal-free warm-up path, PR-1 §B.2.2; A19).
   case setLoadProgressAbsent(Bool)

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunner.swift
@@ -128,6 +128,10 @@ struct ScenarioRunner {
         context.engine.emitLoadTick()
       case .emitFinalizeTick:
         context.engine.emitFinalizeTick()
+      case .emitObservationTick:
+        context.engine.emitObservationTick()
+      case .emitObservationTickOnPreviousStream:
+        context.engine.emitObservationTickOnPreviousStream()
       case .setLoadProgressAbsent(let absent):
         context.engine.loadProgressAbsent = absent
       case .setFinalizeProgressAbsent(let absent):

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/TranscriptionCheckpointStagesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/TranscriptionCheckpointStagesTests.swift
@@ -90,6 +90,80 @@ struct TranscriptionCheckpointStagesTests {
     #expect(events.last == .clear, "the app lived to see the cancel; nothing to report later")
   }
 
+  /// #2787 chunk 4: an OBSERVATION tick lands on the checkpoint as
+  /// `decode_chunk_scheduled` with a running count, and does NOT arm the
+  /// finalize-wedge detector. The discriminator: the kernel's test wedge window
+  /// is 2 ticks and `slowFinalize` dwells 3, so an armed detector would tear the
+  /// decode down (`.failed(.wedged)`) before it returned. `.completed` proves
+  /// the tick was observed and nothing more.
+  @Test("observation ticks are recorded with a count and never arm the wedge detector")
+  func observationTicksAreRecordedAndNeverArmTheDetector() async {
+    let (context, wrapper) = makeContext()
+    let scenario = Scenario(
+      id: "CK5", name: "observation ticks during a dwelling decode",
+      steps: [
+        .engine(.setBehavior(.slowFinalize(ticksToFinal: 3, text: "long take"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .engine(.emitObservationTick), .engine(.emitObservationTick),
+        .advanceClock(ticks: 3),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .exact("long take")))
+    let result = await ScenarioRunner().run(scenario, context: context)
+    #expect(result.passed, "\(result.failures)")
+    let events = wrapper.transcriptionCheckpointEvents
+    let chunkMarks = events.compactMap { event -> Int? in
+      if case .mark(_, _, .decodeChunkScheduled, let chunks) = event { return chunks }
+      return nil
+    }
+    #expect(chunkMarks == [1, 2], "each observation tick carries the running chunk count")
+    #expect(stages(events).last == .decodeReturned)
+    #expect(events.last == .clear)
+  }
+
+  /// #2787 chunk 4 (Codex P1): a tick that arrives on a PREVIOUS decode
+  /// attempt's stream — the failed first decode, after the retry has started
+  /// — must not count against the retry. `crashOnFinalize` fails the first
+  /// decode synchronously and the retry (`slow` is not needed: the fake's
+  /// retry returns immediately) reads a fresh stream; the late tick is yielded
+  /// on the OLD stream after that, and the count must stay at zero.
+  @Test("a late tick from a previous decode attempt is not counted against the retry")
+  func lateTickFromPreviousAttemptIsRejected() async throws {
+    let (context, wrapper) = makeContext()
+    context.engine.behavior = .crashOnFinalize
+    // The retry must be ACTIVE when the stale tick lands, or `recordingOutcome`
+    // rejects it on its own and the attempt-identity guard is untested.
+    context.engine.retryDecodeDelayTicks = 3
+
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+    context.capture.deliverBuffer(frameCount: 16_000, amplitude: 0.5)
+    await wrapper.apply(.stop)
+    await wrapper.drainReadyWork()
+
+    try #require(context.engine.retryDecodeCallCount == 1, "the retry must be in flight")
+    try #require(wrapper.testKernel.recordingOutcome == nil)
+
+    // Stale tick on the failed first attempt's stream, then a genuine one on
+    // the retry's stream: the positive control. Removing the identity guard
+    // would admit both.
+    context.engine.emitObservationTickOnPreviousStream()
+    context.engine.emitObservationTick()
+    await wrapper.drainReadyWork()
+
+    let counts = wrapper.transcriptionCheckpointEvents.compactMap { event -> Int? in
+      if case .mark(_, _, .decodeChunkScheduled, let count) = event { return count }
+      return nil
+    }
+    #expect(counts == [1], "only the current attempt's tick may count: \(counts)")
+
+    context.clock.advance(by: 3)
+    await wrapper.drainUntilConcluded()
+    #expect(wrapper.testKernel.recordingOutcome == .completed)
+  }
+
   /// Codex chunk-3 P1: the Phase-2 retry is a decode too. A hang INSIDE the
   /// retry must read `decode_started`, never a stale `decode_returned` left by
   /// the first (failed) decode — so the marks go started/returned/started/returned.

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/TranscriptionCheckpointStagesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/TranscriptionCheckpointStagesTests.swift
@@ -1,0 +1,155 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #2787 — the kernel marks every stop→decode stage, in order, and clears the
+/// checkpoint at the terminal.
+///
+/// **Observability contract:** when this fails, the launch-time report names
+/// the wrong stage (or none) for a take the app died in the middle of, and the
+/// fleet groups a hang under the wrong step. The customer's four takes reached
+/// us as `app_phase=transcribing` with no stage at all; these marks are what
+/// would have said "stuck inside the decode" versus "stuck stopping capture".
+@MainActor
+@Suite("Transcription checkpoint stages (#2787)", .tags(.observabilityContract))
+struct TranscriptionCheckpointStagesTests {
+
+  private func makeContext() -> (SimulatorContext, KernelRecordingSession) {
+    let clock = FakeClock()
+    let engine = FakeEngine(behavior: .batchSuccess(text: "hello"), clock: clock)
+    let capture = FakeAudioCapture()
+    let vad = FakeVADSignalSource()
+    let paste = FakePasteTarget()
+    let wrapper = KernelRecordingSession(
+      engine: engine, capture: capture, vad: vad, clock: clock, paste: paste)
+    return (
+      SimulatorContext(
+        sut: wrapper, engine: engine, capture: capture, vad: vad, clock: clock, paste: paste),
+      wrapper
+    )
+  }
+
+  private func stages(_ events: [TranscriptionCheckpointEvent]) -> [TranscriptionStage] {
+    events.compactMap {
+      if case .mark(_, _, let stage, _) = $0 { return stage }
+      return nil
+    }
+  }
+
+  @Test("a successful batch take marks the five stages in order and then clears")
+  func happyPathMarksAllStagesThenClears() async {
+    let (context, wrapper) = makeContext()
+    let scenario = Scenario(
+      id: "CK1", name: "checkpoint stages on a batch success",
+      steps: [
+        .engine(.setBehavior(.batchSuccess(text: "hello world"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .expectState(.completed),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted, transcript: .nonEmpty))
+    let result = await ScenarioRunner().run(scenario, context: context)
+    #expect(result.passed, "\(result.failures)")
+
+    let events = wrapper.transcriptionCheckpointEvents
+    #expect(
+      stages(events) == [
+        .captureStopped, .vadConditioned, .tailChecked, .decodeStarted, .decodeReturned,
+      ])
+    #expect(events.last == .clear, "the terminal must clear the checkpoint")
+    // Every mark names the take and the engine, never text.
+    for event in events {
+      if case .mark(let takeID, let backend, _, let chunks) = event {
+        #expect(UUID(uuidString: takeID) != nil, "take id must be the session UUID")
+        #expect(backend == "parakeet")
+        #expect(chunks == 0, "no vendor chunk progress is wired in this revision")
+      }
+    }
+  }
+
+  @Test("a cancel during the decode leaves decodeStarted as the last mark before the clear")
+  func cancelDuringDecodeLeavesDecodeStartedAsLastMark() async {
+    let (context, wrapper) = makeContext()
+    // A decode that dwells (inventory A8's shape): the cancel lands inside
+    // `transcribing`, with the finalize genuinely in flight.
+    let scenario = Scenario(
+      id: "CK2", name: "checkpoint stages when the decode is abandoned",
+      steps: [
+        .engine(.setBehavior(.slowFinalize(ticksToFinal: 3, text: "in flight"))),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+        .trigger(.cancel), .expectState(.cancelled),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .cancelled, pasteCount: 0, pasteOutcome: .none, transcript: .none))
+    let result = await ScenarioRunner().run(scenario, context: context)
+    #expect(result.passed, "\(result.failures)")
+    let events = wrapper.transcriptionCheckpointEvents
+    #expect(stages(events).last == .decodeStarted, "the decode never returned")
+    #expect(events.last == .clear, "the app lived to see the cancel; nothing to report later")
+  }
+
+  /// Codex chunk-3 P1: the Phase-2 retry is a decode too. A hang INSIDE the
+  /// retry must read `decode_started`, never a stale `decode_returned` left by
+  /// the first (failed) decode — so the marks go started/returned/started/returned.
+  @Test("a failed decode rescued by the Phase-2 retry marks both decodes")
+  func retryMarksBothDecodes() async {
+    let (context, wrapper) = makeContext()
+    let scenario = Scenario(
+      id: "CK3", name: "checkpoint stages across a Phase-2 retry",
+      steps: [
+        .engine(.setBehavior(.crashOnFinalize)),
+        .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
+      ],
+      expected: ExpectedOutcome(
+        terminalState: .completed, pasteCount: 1, pasteOutcome: .pasted,
+        transcript: .exact("retried transcript")))
+    let result = await ScenarioRunner().run(scenario, context: context)
+    #expect(result.passed, "\(result.failures)")
+    let events = wrapper.transcriptionCheckpointEvents
+    #expect(
+      stages(events) == [
+        .captureStopped, .vadConditioned, .tailChecked,
+        .decodeStarted, .decodeReturned,  // the first decode, which failed
+        .decodeStarted, .decodeReturned,  // the retry, which returned text
+      ])
+    #expect(events.last == .clear)
+  }
+
+  /// Codex chunk-3 P1: a cancel accepted while `stopCapture` is suspended has
+  /// already cleared the checkpoint; the late stop return must not recreate
+  /// it, or the next launch reports a false interruption. The fake capture's
+  /// stop gate parks the first `stopCapture` so the cancel lands INSIDE the
+  /// suspension, with the same session still current when the stop returns —
+  /// the exact precondition the repaired guard exists for.
+  @Test("a late stop return cannot recreate a cleared checkpoint")
+  func nothingAfterTheClear() async throws {
+    let (context, wrapper) = makeContext()
+    context.capture.gateStopCaptureCall = 1
+
+    await wrapper.apply(.start)
+    await wrapper.drainReadyWork()
+    try #require(wrapper.testKernel.state == .live)
+
+    context.capture.deliverBuffer(frameCount: 16_000, amplitude: 0.5)
+    await wrapper.apply(.stop)
+    // Signal-based: resume only once the stop has genuinely parked.
+    await context.capture.awaitStopCaptureGateReached()
+    try #require(wrapper.testKernel.state == .stopping)
+
+    await wrapper.apply(.cancel)
+    try #require(wrapper.testKernel.recordingOutcome == .cancelled)
+    try #require(wrapper.transcriptionCheckpointEvents.last == .clear)
+    let terminalEvents = wrapper.transcriptionCheckpointEvents
+
+    // The suspended stop now returns for the cancelled session.
+    context.capture.releaseStopCaptureGate()
+    await wrapper.drainReadyWork()
+
+    #expect(wrapper.effects.resourcesReleased, "the late stop return did run")
+    #expect(
+      wrapper.transcriptionCheckpointEvents == terminalEvents,
+      "a mark after the clear would be a false report next launch: \(wrapper.transcriptionCheckpointEvents)")
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/TranscriptionCheckpointStagesTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/TranscriptionCheckpointStagesTests.swift
@@ -105,7 +105,13 @@ struct TranscriptionCheckpointStagesTests {
         .engine(.setBehavior(.slowFinalize(ticksToFinal: 3, text: "long take"))),
         .trigger(.start), .capture(.deliverBuffer), .trigger(.stop),
         .engine(.emitObservationTick), .engine(.emitObservationTick),
-        .advanceClock(ticks: 3),
+        // The wedge detector's stall window is 2 ticks (`wedgeStallTicks`);
+        // the decode dwells 3. Advancing 3 at once lets a wrongly armed
+        // detector and the decode race (second-pass review), so the window is
+        // supplied first and the session must STILL be transcribing.
+        .advanceClock(ticks: 2),
+        .expectState(.transcribing),
+        .advanceClock(ticks: 1),
         .expectState(.completed),
       ],
       expected: ExpectedOutcome(

--- a/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
+++ b/Tests/EnviousWisprTests/Pipeline/StubWhisperKitBackend.swift
@@ -119,9 +119,9 @@ actor StubWhisperKitBackend: WhisperKitBackendDriving {
     return observeLIDResult
   }
 
-  func makeStreamingSession(options: TranscriptionOptions) async
-    -> (any WhisperKitIncrementalSession)?
-  {
+  func makeStreamingSession(
+    options: TranscriptionOptions, vendorDecodeOccupancy: VendorDecodeOccupancy
+  ) async -> (any WhisperKitIncrementalSession)? {
     makeStreamingSessionCount += 1
     return streamingSessionFactory?()
   }

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -231,6 +231,7 @@ private final class NoOpASRManagerV2: ASRManagerInterface {
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = false
   let vendorDecodeOccupancy = VendorDecodeOccupancy()
+  var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
   var isStreaming: Bool = false
   var downloadProgress: Double = 0
   var downloadPhase: String = "idle"

--- a/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/V2/DedupSurvivesStallTests.swift
@@ -230,6 +230,7 @@ private final class NoOpASRManagerV2: ASRManagerInterface {
   var parakeetModelDirectory: URL?
   var activeBackendType: ASRBackendType = .parakeet
   var isModelLoaded: Bool = false
+  let vendorDecodeOccupancy = VendorDecodeOccupancy()
   var isStreaming: Bool = false
   var downloadProgress: Double = 0
   var downloadPhase: String = "idle"

--- a/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoveryCoordinatorTests.swift
@@ -207,6 +207,58 @@ struct RecoveryCoordinatorTests {
     #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
   }
 
+  // MARK: - #2787 stop-waiting: retain, then destroy only after the writer is done
+
+  /// #2787: a `.stoppedWaitingForDecode` ending keeps its spool (the user's
+  /// rescue is a restart and a launch replay). If the abandoned decode then
+  /// returns in this launch, the spool is destroyed — but only after the
+  /// writer has confirmed it will never touch the file again. Here the vendor
+  /// "returns" BEFORE the writer acknowledges, which is the ordering that
+  /// would delete beneath an unfinished writer if destruction were direct.
+  @Test("stop-waiting retains; a late decode return destroys only after writer quiescence")
+  func stopWaitingRetainsThenDestroysAfterWriterAck() async throws {
+    let h = Self.makeHarness()
+    let id = try await Self.armRealSession(h)
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+
+    // The live ending: retained, and excluded from same-launch replay.
+    let retain = h.coordinator.handleRecordingEndedWithoutDurableSave(
+      recoverySessionID: id, ending: .stoppedWaitingForDecode)
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    await h.coordinator.scanAndRecover()
+    #expect(h.replayer.replayedIDs.isEmpty, "a retained stop-waiting spool is next-launch only")
+
+    // The vendor returns while the writer has NOT yet acknowledged.
+    let destroys = h.coordinator.handleAbandonedDecodeReturned()
+    #expect(destroys.count == 1)
+    // A NEGATIVE: destruction must not have happened yet. Yield gives it the
+    // opportunity it must decline (a-test-that-proves-a-NEGATIVE-has-no-signal-to-park-on).
+    for _ in 0..<20 { await Task.yield() }
+    #expect(
+      FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path),
+      "the spool must survive until the writer is quiescent")
+
+    // The writer finishes: the retain settles, and the deferred destroy runs.
+    h.coordinator.acknowledgeWriterQuiescent(recoverySessionID: id)
+    await retain?.value
+    for task in destroys { await task.value }
+    #expect(!FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect(throws: RecoveryKeyStoreError.notFound) { try h.keyStore.retrieve(for: id) }
+  }
+
+  /// Two-way control: a decode return with NOTHING retained destroys nothing.
+  @Test("a decode return with no retained stop-waiting spool is inert")
+  func decodeReturnWithNothingRetainedIsInert() async throws {
+    let h = Self.makeHarness()
+    let id = "healthy-\(UUID().uuidString)"
+    try Self.writeSpool(h.spoolStore, id)
+    try h.keyStore.store(keyData: RecoveryKeyStore.makeKey(), for: id)
+    #expect(h.coordinator.handleAbandonedDecodeReturned().isEmpty)
+    #expect(FileManager.default.fileExists(atPath: h.spoolStore.spoolURL(for: id).path))
+    #expect((try? h.keyStore.retrieve(for: id)) != nil)
+  }
+
   // MARK: - #1740 live History-save failure destroys instead of deferring
 
   @Test("live History-save failure destroys the spool AND the key")
@@ -533,7 +585,7 @@ struct RecoveryCoordinatorTests {
 
   // MARK: - #1464 delete/retain predicates (adversarial: every case in both classes)
 
-  @Test("shouldDeleteOnLiveEnding: all nine ending cells delete (#1755 founder discard doctrine)")
+  @Test("shouldDeleteOnLiveEnding: nine ending cells delete (#1755), stop-waiting retains (#2787)")
   func liveEndingPredicate() {
     // Unchanged cells (already deleted before #1755):
     #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.discarded), "unchanged")
@@ -564,6 +616,12 @@ struct RecoveryCoordinatorTests {
     // #1755: plain `.failed` (no retry consulted) ALSO deletes now — the
     // negative half of this same adversarial pair.
     #expect(RecoveryCoordinator.shouldDeleteOnLiveEnding(.asrRetryExhausted), "unchanged")
+    // #2787: the ONE retaining cell. The user stopped waiting for a decode that
+    // is still inside the vendor; their rescue is a restart and a launch
+    // replay, so the audio must survive to that launch.
+    #expect(
+      RecoveryCoordinator.shouldDeleteOnLiveEnding(.stoppedWaitingForDecode) == false,
+      "#2787: stop-waiting retains, because the user saw no outcome and the exit is a restart")
   }
 
   /// #1740: EVERY spent attempt deletes; only outcomes where ASR never ran

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -36,6 +36,7 @@ struct RecoverySpoolReplayerTests {
     var parakeetModelDirectory: URL?
     var activeBackendType: ASRBackendType = .parakeet
     var isModelLoaded = false
+    let vendorDecodeOccupancy = VendorDecodeOccupancy()
     var isStreaming = false
     var downloadProgress: Double = 0
     var downloadPhase = "idle"

--- a/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/RecoverySpoolReplayerTests.swift
@@ -37,6 +37,7 @@ struct RecoverySpoolReplayerTests {
     var activeBackendType: ASRBackendType = .parakeet
     var isModelLoaded = false
     let vendorDecodeOccupancy = VendorDecodeOccupancy()
+    var onVendorDecodeChunkScheduled: (@MainActor @Sendable () -> Void)?
     var isStreaming = false
     var downloadProgress: Double = 0
     var downloadPhase = "idle"

--- a/Tests/EnviousWisprTests/Recovery/TranscriptionCheckpointStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/TranscriptionCheckpointStoreTests.swift
@@ -58,6 +58,25 @@ struct TranscriptionCheckpointStoreTests {
     #expect(TranscriptionCheckpointStore(directory: dir).takeOrphan() == nil)
   }
 
+  /// The production file is scoped by bundle id because the support directory
+  /// is shared by the shipped app and the dev build; a dev take must never be
+  /// reported by the shipped app's next launch.
+  @Test("two bundles in one support directory never see each other's checkpoint")
+  func bundleScopedFileNames() throws {
+    let dir = Self.tempDir()
+    let dev = TranscriptionCheckpointStore(
+      directory: dir, fileName: TranscriptionCheckpointStore.fileName(forBundleID: "com.x.dev"))
+    let prod = TranscriptionCheckpointStore(
+      directory: dir, fileName: TranscriptionCheckpointStore.fileName(forBundleID: "com.x"))
+    dev.apply(
+      .mark(takeID: Self.takeID, backend: "parakeet", stage: .decodeStarted, chunksScheduled: 0))
+    #expect(prod.takeOrphan() == nil, "the shipped app must not consume the dev build's checkpoint")
+    #expect(dev.takeOrphan()?.stage == .decodeStarted)
+    #expect(
+      TranscriptionCheckpointStore.fileName(forBundleID: nil)
+        == TranscriptionCheckpointStore.fileName, "no bundle id falls back to the plain name")
+  }
+
   @Test("a corrupt checkpoint file is consumed silently, never reported")
   func corruptFileIsConsumed() throws {
     let dir = Self.tempDir()

--- a/Tests/EnviousWisprTests/Recovery/TranscriptionCheckpointStoreTests.swift
+++ b/Tests/EnviousWisprTests/Recovery/TranscriptionCheckpointStoreTests.swift
@@ -1,0 +1,179 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import EnviousWisprStorage
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2787 — the persisted per-take stage checkpoint and its launch-time report.
+///
+/// **Observability contract:** when this fails, a take the app died in the
+/// middle of either reports nothing next launch, reports twice, or reports
+/// text it must never carry. The customer's Mac Studio produced four takes
+/// that ended in a quit during `transcribing` and left no stage behind; this
+/// is the instrument that would have named the step.
+@Suite("Transcription checkpoint store + launch report (#2787)", .tags(.observabilityContract))
+struct TranscriptionCheckpointStoreTests {
+
+  private static func tempDir() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-checkpoint-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private static let takeID = "5D5D6BD1-3D5E-4F2A-9E8C-000000000001"
+
+  @Test("mark writes the checkpoint, overwrites on the next stage, and clear removes it")
+  func markOverwriteClear() throws {
+    let dir = Self.tempDir()
+    let store = TranscriptionCheckpointStore(directory: dir)
+    let file = dir.appendingPathComponent(TranscriptionCheckpointStore.fileName)
+    #expect(store.current == nil)
+    #expect(!FileManager.default.fileExists(atPath: file.path))
+
+    store.apply(
+      .mark(takeID: Self.takeID, backend: "parakeet", stage: .captureStopped, chunksScheduled: 0))
+    #expect(store.current?.stage == .captureStopped)
+    #expect(FileManager.default.fileExists(atPath: file.path))
+
+    store.apply(
+      .mark(takeID: Self.takeID, backend: "parakeet", stage: .decodeStarted, chunksScheduled: 2))
+    let reread = TranscriptionCheckpointStore(directory: dir)
+    let orphan = try #require(reread.takeOrphan())
+    #expect(orphan.stage == .decodeStarted)
+    #expect(orphan.chunksScheduled == 2)
+    #expect(orphan.takeID == Self.takeID)
+    #expect(orphan.backend == "parakeet")
+    // Consumed exactly once.
+    #expect(reread.takeOrphan() == nil)
+    #expect(!FileManager.default.fileExists(atPath: file.path))
+
+    store.apply(
+      .mark(takeID: Self.takeID, backend: "parakeet", stage: .decodeReturned, chunksScheduled: 2))
+    store.apply(.clear)
+    #expect(store.current == nil)
+    #expect(!FileManager.default.fileExists(atPath: file.path))
+    #expect(TranscriptionCheckpointStore(directory: dir).takeOrphan() == nil)
+  }
+
+  @Test("a corrupt checkpoint file is consumed silently, never reported")
+  func corruptFileIsConsumed() throws {
+    let dir = Self.tempDir()
+    let file = dir.appendingPathComponent(TranscriptionCheckpointStore.fileName)
+    try Data("not json".utf8).write(to: file)
+    let store = TranscriptionCheckpointStore(directory: dir)
+    #expect(store.takeOrphan() == nil)
+    #expect(!FileManager.default.fileExists(atPath: file.path), "consumed, not left to re-fail")
+  }
+
+  /// Codex chunk-3 P2: consume-once means the report is issued only when the
+  /// file is actually gone. A checkpoint whose deletion fails is NOT returned,
+  /// or it would be reported at every launch until the delete succeeds.
+  @Test("an orphan whose deletion fails is not reported")
+  func undeletableOrphanIsNotReported() throws {
+    let dir = Self.tempDir()
+    let writer = TranscriptionCheckpointStore(directory: dir)
+    writer.apply(
+      .mark(takeID: Self.takeID, backend: "parakeet", stage: .decodeStarted, chunksScheduled: 0))
+    // Deleting a file needs write permission on its directory.
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+    defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path) }
+    let reader = TranscriptionCheckpointStore(directory: dir)
+    #expect(reader.takeOrphan() == nil, "a checkpoint that cannot be consumed must not be reported")
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    // Two-way control: once deletable, the same orphan is reported exactly once.
+    #expect(reader.takeOrphan()?.stage == .decodeStarted)
+    #expect(reader.takeOrphan() == nil)
+  }
+
+  @Test("the checkpoint carries metadata only")
+  func metadataOnly() throws {
+    let dir = Self.tempDir()
+    let store = TranscriptionCheckpointStore(directory: dir)
+    store.apply(
+      .mark(takeID: Self.takeID, backend: "whisperKit", stage: .tailChecked, chunksScheduled: 0))
+    let file = dir.appendingPathComponent(TranscriptionCheckpointStore.fileName)
+    let json = try #require(
+      try JSONSerialization.jsonObject(with: Data(contentsOf: file)) as? [String: Any])
+    #expect(
+      Set(json.keys) == [
+        "takeID", "backend", "stage", "stageEnteredAt", "chunksScheduled", "appVersion",
+      ])
+  }
+
+  #if DEBUG
+    @Test("the launch report fires one PostHog event per orphan and consumes it")
+    @MainActor
+    func launchReportFiresOnceAndConsumes() async throws {
+      let dir = Self.tempDir()
+      let writer = TranscriptionCheckpointStore(directory: dir)
+      let then = Date(timeIntervalSinceNow: -12.5)
+      writer.apply(
+        .mark(takeID: Self.takeID, backend: "parakeet", stage: .decodeStarted, chunksScheduled: 3),
+        now: then)
+
+      let seen = Seen()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "transcription.interrupted_at_quit" { seen.add(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      let reader = TranscriptionCheckpointStore(directory: dir)
+      let reported = TranscriptionInterruptionReporter.reportOrphanIfAny(from: reader, now: Date())
+      #expect(reported?.stage == .decodeStarted)
+      #expect(seen.events.count == 1)
+      let event = try #require(seen.events.first)
+      #expect(event.stringProps["stage"] == "decode_started")
+      #expect(event.stringProps["asr_backend"] == "parakeet")
+      #expect(event.intProps["chunks_scheduled"] == 3)
+      // ~12.5 s old; bounded below by what we wrote and above by test wall-clock.
+      let age = try #require(event.intProps["stage_age_ms"])
+      #expect(age >= 12_000 && age < 60_000, "stage_age_ms=\(age)")
+
+      // A second launch finds nothing: the report can never repeat.
+      #expect(TranscriptionInterruptionReporter.reportOrphanIfAny(from: reader) == nil)
+      #expect(seen.events.count == 1)
+    }
+
+    @Test("no orphan, no report")
+    @MainActor
+    func noOrphanNoReport() {
+      let seen = Seen()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        if event.name == "transcription.interrupted_at_quit" { seen.add(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+      let store = TranscriptionCheckpointStore(directory: Self.tempDir())
+      #expect(TranscriptionInterruptionReporter.reportOrphanIfAny(from: store) == nil)
+      #expect(seen.events.isEmpty)
+    }
+
+    private final class Seen: @unchecked Sendable {
+      private let lock = NSLock()
+      private var stored: [CapturedTelemetryEvent] = []
+      var events: [CapturedTelemetryEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+      }
+      func add(_ e: CapturedTelemetryEvent) {
+        lock.lock()
+        stored.append(e)
+        lock.unlock()
+      }
+    }
+  #endif
+
+  /// The Sentry fingerprint carries the stage, so each stage is its own issue.
+  @Test("each stage groups as its own Sentry issue")
+  func fingerprintPerStage() {
+    let descriptors = Set(
+      TranscriptionStage.allCases.map {
+        TranscriptionInterruptionReporter.InterruptedTranscriptionError(stage: $0)
+          .sentryFingerprintDescriptor
+      })
+    #expect(descriptors.count == TranscriptionStage.allCases.count)
+  }
+}

--- a/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
+++ b/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
@@ -29,6 +29,6 @@ A pause shorter than your chosen duration is ignored. At the half-second setting
 
 When the app appears unresponsive after you stop speaking, the recording has already ended. EnviousWispr is turning your speech into text and applying any polish you have chosen. That takes a moment, especially on the first dictation after opening the app. Give it a few seconds before starting a new one.
 
-If the bar keeps spinning long after that, press **Escape**. The bar goes away and nothing is pasted. EnviousWispr stops waiting for that dictation but keeps the audio. If the engine does finish the take later, its text is dropped, because you asked to stop waiting.
+If the bar stays on **transcribing** long after that, press **Escape**. The bar goes away and nothing is pasted. EnviousWispr stops waiting for that dictation. If the engine does finish the take later, its text is dropped, because you asked to stop waiting. Escape does not interrupt AI polish; polish has its own time limit and finishes on its own.
 
-If your next press of the record key shows **Previous take still running. Restart the app.**, the engine never came back from that take. Quit EnviousWispr and open it again. On the next launch it transcribes the audio it kept and saves the text to your History, the same way it [recovers a recording after a crash](/help/app-crashes-or-asr-engine-crashes/).
+If your next press of the record key shows **Previous take still running. Restart the app.**, the engine never came back from that take. Quit EnviousWispr and open it again. With crash recovery on (the default), the next launch transcribes the audio it kept from that take and saves the text to your History, the same way it [recovers a recording after a crash](/help/app-crashes-or-asr-engine-crashes/).

--- a/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
+++ b/website/src/content/help/recording-won-t-stop-or-seems-stuck.md
@@ -4,10 +4,10 @@ description: "What to do when a recording seems to hang."
 category: "troubleshooting"
 section: "Recording Issues"
 order: 7
-keywords: ["wont stop", "stuck", "keeps recording", "frozen", "hung", "still recording", "cant stop", "spinning"]
-related: ["canceling-a-recording"]
+keywords: ["wont stop", "stuck", "keeps recording", "frozen", "hung", "still recording", "cant stop", "spinning", "transcribing", "previous take still running", "restart"]
+related: ["canceling-a-recording", "app-crashes-or-asr-engine-crashes"]
 seeAlso: "mac-dictation-keeps-stopping"
-updated: 2026-09-01
+updated: 2026-09-10
 ---
 If a recording will not stop, press **Escape**. This ends any recording in progress, in every recording mode. The on-screen bar disappears, which confirms it worked.
 
@@ -27,4 +27,8 @@ A pause shorter than your chosen duration is ignored. At the half-second setting
 
 ### If it seems stuck after you stop talking
 
-When the app appears unresponsive after you stop speaking, the recording has already ended. EnviousWispr is turning your speech into text and applying any polish you have chosen. That takes a moment, especially on the first dictation after opening the app. Because the Escape key only cancels a recording that is still running, pressing it now has no effect. Wait for the current dictation to finish before starting a new one.
+When the app appears unresponsive after you stop speaking, the recording has already ended. EnviousWispr is turning your speech into text and applying any polish you have chosen. That takes a moment, especially on the first dictation after opening the app. Give it a few seconds before starting a new one.
+
+If the bar keeps spinning long after that, press **Escape**. The bar goes away and nothing is pasted. EnviousWispr stops waiting for that dictation but keeps the audio. If the engine does finish the take later, its text is dropped, because you asked to stop waiting.
+
+If your next press of the record key shows **Previous take still running. Restart the app.**, the engine never came back from that take. Quit EnviousWispr and open it again. On the next launch it transcribes the audio it kept and saves the text to your History, the same way it [recovers a recording after a crash](/help/app-crashes-or-asr-engine-crashes/).

--- a/workers/reporting/sentry-section.js
+++ b/workers/reporting/sentry-section.js
@@ -120,6 +120,14 @@ export const ERROR_CATEGORIES = Object.freeze({
   // marker is an unindexed EXTRA, so no aggregate field can split them.
   model_load_wedged: { group: LOST, deliveryProven: false, emitted: true, label: "speech model load got stuck" },
 
+  // #2787: reported on the NEXT launch from a persisted per-take checkpoint —
+  // the previous process left an unfinished one. It may have exited during
+  // processing OR during delivery (the checkpoint is cleared only at the
+  // terminal, after paste), so delivery is not proven either way. Not proof of
+  // a hang: a user quitting two seconds into a healthy long decode leaves the
+  // same record.
+  transcription_interrupted: { group: LOST, deliveryProven: false, emitted: true, label: "app exited before a dictation's completion was recorded" },
+
   // Conservative: covers both a failed dispatch and a nil collaborator, and
   // delivery is not decidable from the category alone.
   pipeline_dispatch_failed: { group: LOST, deliveryProven: false, emitted: true, label: "dictation could not start processing" },


### PR DESCRIPTION
Part of #2787. #2787 stays open for the customer's diagnostic report; this PR is the safety net, not the root cause of the one-machine Parakeet hang.

**Tier: MEDIUM | Lane: Code | mixed_pr: true (one help-centre page, one Worker label) | Test: required (Pipeline, ASR, AppKit) | Live UAT: Y**

## What a user gets

A transcription that never comes back no longer parks the app in "transcribing" until they quit.

1. **Escape ends the wait and keeps the audio.** The cancel shortcut now stays armed through transcription. If the engine is still inside its decode when the user presses it, the take ends as `stoppedWaitingForDecode`, the on-screen bar goes away, and the encrypted spool is KEPT. If the decode does return later, its text is dropped and the spool is destroyed (#1755 doctrine: the user asked to stop waiting). If it never returns, the next launch replays the spool into History like a crash.
2. **The engine is honest about being busy.** While the abandoned decode is still running, the engine lease is held as `abandonedDecode`: a new record press shows "Previous take still running. Restart the app.", file import says "The last dictation is still transcribing. Restart the app, then try again.", and warm-up / unload / engine switch / model download are refused through the same mutation gate. No wall-clock timer anywhere (founder 2026-09-10: a timer was a risk factor, not a safety net).
3. **The next launch says where the previous take died.** Each take writes a tiny metadata-only checkpoint (`capture_stopped` → `vad_conditioned` → `tail_checked` → `decode_started` → `decode_chunk_scheduled`×n → `decode_returned`), cleared at every terminal. A checkpoint that survives the process is reported ONCE at the next launch as `transcription.interrupted_at_quit` (PostHog) and `transcription_interrupted` (Sentry, one issue per stage), and a graceful quit carries `last_stage` on `telemetry.flush_requested`. Parakeet's per-chunk progress from the pinned FluidAudio fork is recorded as an observation and never arms the wedge detector.

No pill hint (founder at Gate 2: users press Escape on their own).

## Retired reason, refuted (`workflow-process.md` RULE: move-recorded-reasons-before-simplifying)

`CancelAffordancePolicy` and `RecordingFinalizer.cancel` refused `.transcribing` on the recorded reason "there is nothing a cancel could do — the audio is already captured and the decode is not interruptible". Reproduced and refuted on the customer's telemetry (four takes, 2026-09-10): the decode is indeed not interruptible, but the kernel already concludes `.cancelled` from `.delivering(.transcribing)`, which frees the user; and the audio can be kept for a launch replay, which is the exit that worked for the customer three times. Their only exit was to quit the app, four times. The comment is deleted; its replacements carry this issue number.

## Review

- Plan `docs/feature-requests/issue-2787-2026-09-10-transcription-hang-safety-net.md`: council + Codex coverage, grounded review to PROCEED-AS-PLANNED, Gate 2 approved 2026-09-10.
- Built in four chunks under one Codex orchestrator session, each to CHUNK-CLEAN (round summaries in the commit bodies).
- Second-pass behavioural review (`.claude/prompts/second-pass-review.md`): five findings, three adopted (WhisperKit language detection now counted as busy; no decode may START in a cancelled take, at both the manager funnel and WhisperKit's own batch entry; one test isolated from a clock race), one help-text narrowing adopted, one withdrawn by the reviewer after measurement. Confirming round CLEAN. Commit `2ac469ca` carries the detail.

## Validation

- Debug suite: 7592 tests after the second-pass fixes, green except `RenderedPillFreezeTests` (#2792, red on untouched main since the macOS 27.0 upgrade, identical failure set).
- Release lane: 6933 tests, same single pre-existing suite red; compiles.
- Live UAT on the dev build with `EW_FAULT_INJECTION=1` (receipt `.validation/runs/2787-live-uat/live-uat.json`, gitignored): held Parakeet decode → cancel → spool retained → engine held (`engine.abandoned_decode_hold_started` / `_settled` in PostHog dev) → release → spool destroyed → fresh take completes (repeated on the rebuilt final head); graceful quit mid-decode → `telemetry.flush_requested{last_stage=decode_started}` + `transcription.interrupted_at_quit` + Sentry `transcription_interrupted` on relaunch, checkpoint consumed; force-kill mid-decode → same launch report; Escape then restart → launch replay "recovered 42 chars, saved to History"; a 21.9 s take marked `decode_chunk_scheduled` count 1. Not staged: a real Escape keypress (synthetic Escape cannot reach the Carbon hotkey; the kernel entry it reaches was driven directly) and the pill pixels (screen was locked; the sentence is pinned by `DictationNarratorTests`).
- `test-hardening`: #2793 carries the 8-row mutation recipe (validated 8/8 runnable).
- Help centre: `check-help-content.mjs` 58 articles, 0 errors.

## Blast radius

Cancellation retention (one new live ending that retains), engine admission (one new lease holder), progress observation (a new tick kind on the existing contract), launch diagnostics (one new file in Application Support, bundle-scoped). Paste delivery unchanged. Rollback is this one PR; an older build ignores a leftover checkpoint file because it never reads that file name; the next build with the reader consumes it once.
