### PR TITLE
Transcribe a File: show the cleanup as marked-up original words, with the counts (#2773)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -617,6 +617,8 @@ final class FileImportCoordinator {
     originalHistoryRow = nil
     documentView = .cleaned
     markedUpCache = nil
+    markedUpWorker?.task.cancel()
+    markedUpWorker = nil
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []
@@ -775,22 +777,24 @@ final class FileImportCoordinator {
   /// passage as REMOVED by a cleanup that never touched it. Found by Codex (chunk review).
   /// Comparison only; Copy, Save and Share still export `documentText`.
   var markedUpInput: MarkedUpInput {
-    MarkedUpInput(
-      raw: rawTranscript, cleanedParts: parts.map(\.text),
-      untouched: Array(pendingPieces.dropFirst(parts.count)))
+    // The split's pieces are the passages the cleanup ran on, in order; `parts[i]` is what
+    // it made of `pendingPieces[i]`. A piece past the last finished part was never reached.
+    // With no split in hand (nothing has run) the whole transcript is one untouched passage.
+    guard !pendingPieces.isEmpty else {
+      return MarkedUpInput(passages: [.init(original: rawTranscript, cleaned: nil)])
+    }
+    return MarkedUpInput(
+      passages: pendingPieces.enumerated().map { index, original in
+        .init(original: original, cleaned: index < parts.count ? parts[index].text : nil)
+      })
   }
 
-  /// The pieces, not the joined text: this is read on every redraw as the view's task id and
-  /// as the cache key, and joining a three-hour transcript on each read is an allocation
-  /// nobody asked for. The join happens once, inside `prepareMarkedUp`. Codex, round 2.
+  /// The passages, not a joined text: this is read on every redraw as the view's task id and
+  /// as the cache key, and the strings inside are the coordinator's own, shared not copied.
+  /// Passage by passage because that is how the cleanup ran; one joined block lost the
+  /// boundaries and could mark untouched waiting words as removed (second-pass review).
   struct MarkedUpInput: Equatable, Sendable {
-    let raw: String
-    let cleanedParts: [String]
-    let untouched: [String]
-
-    var cleaned: String {
-      cleanedParts.isEmpty ? raw : (cleanedParts + untouched).joined(separator: "\n\n")
-    }
+    let passages: [WordDiff.Passage]
   }
 
   /// The comparison, once `prepareMarkedUp` has run for the current input; nil while it is
@@ -812,12 +816,33 @@ final class FileImportCoordinator {
   func prepareMarkedUp() async {
     let input = markedUpInput
     guard markedUp == nil else { return }
-    let result = await Task.detached(priority: .userInitiated) {
-      WordDiff.compare(original: input.raw, cleaned: input.cleaned)
-    }.value
-    guard !Task.isCancelled, markedUpInput == input else { return }
+    // ONE comparison per input. Leaving the view cancels its task but not the detached work,
+    // and coming back before it finished used to start a second; switching back and forth on
+    // a large, heavily rewritten transcript piled them up. A worker for a different input is
+    // cancelled (its result is dropped; the algorithm itself runs to its end, bounded by the
+    // worst case noted on `WordDiff`), and a worker for THIS input is awaited, not repeated.
+    // Second-pass review.
+    if let inFlight = markedUpWorker, inFlight.input != input {
+      inFlight.task.cancel()
+      markedUpWorker = nil
+    }
+    let task: Task<WordDiff.Result, Never>
+    if let inFlight = markedUpWorker {
+      task = inFlight.task
+    } else {
+      task = Task.detached(priority: .userInitiated) {
+        WordDiff.compare(passages: input.passages)
+      }
+      markedUpWorker = (input, task)
+    }
+    let result = await task.value
+    guard markedUpInput == input else { return }
+    if markedUpWorker?.input == input { markedUpWorker = nil }
     markedUpCache = (input, result)
   }
+
+  @ObservationIgnored private var markedUpWorker:
+    (input: MarkedUpInput, task: Task<WordDiff.Result, Never>)?
 
   /// Whether the words on screen are the RAW ones: the user asked for them, or there is no
   /// cleaned part to show instead.
@@ -942,6 +967,8 @@ final class FileImportCoordinator {
     originalHistoryRow = nil
     documentView = .cleaned
     markedUpCache = nil
+    markedUpWorker?.task.cancel()
+    markedUpWorker = nil
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -781,7 +781,8 @@ final class FileImportCoordinator {
     // it made of `pendingPieces[i]`. A piece past the last finished part was never reached.
     // With no split in hand (nothing has run) the whole transcript is one untouched passage.
     guard !pendingPieces.isEmpty else {
-      return MarkedUpInput(passages: [.init(original: rawTranscript, cleaned: nil)])
+      return MarkedUpInput(
+        passages: [.init(original: rawTranscript, cleaned: nil)], language: engineReportedLanguage)
     }
     // Each passage's original is recovered FROM the transcript, not taken from the piece:
     // `TranscriptSplitter` slices from a word's start to a word's end and drops the
@@ -807,7 +808,7 @@ final class FileImportCoordinator {
       passages.append(.init(original: String(rawTranscript[cursor..<end]), cleaned: cleaned))
       cursor = end
     }
-    return MarkedUpInput(passages: passages)
+    return MarkedUpInput(passages: passages, language: engineReportedLanguage)
   }
 
   /// The passages, not a joined text: this is read on every redraw as the view's task id and
@@ -816,6 +817,9 @@ final class FileImportCoordinator {
   /// boundaries and could mark untouched waiting words as removed (second-pass review).
   struct MarkedUpInput: Equatable, Sendable {
     let passages: [WordDiff.Passage]
+    /// The engine's language code for the transcript, which decides the case fold (Turkish
+    /// has two I's). Part of the key so a re-transcription in another language recomputes.
+    let language: String?
   }
 
   /// The comparison, once `prepareMarkedUp` has run for the current input; nil while it is
@@ -852,7 +856,7 @@ final class FileImportCoordinator {
       task = inFlight.task
     } else {
       task = Task.detached(priority: .userInitiated) {
-        WordDiff.compare(passages: input.passages)
+        WordDiff.compare(passages: input.passages, language: input.language)
       }
       markedUpWorker = (input, task)
     }
@@ -890,7 +894,13 @@ final class FileImportCoordinator {
   /// hand over less than the screen shows. Found by the cloud review of PR #2799. On a
   /// finished run the two are the same text.
   var markedUpKeptText: String {
-    (parts.map(\.text) + Array(pendingPieces.dropFirst(parts.count))).joined(separator: "\n\n")
+    // The cleaned passages as `documentText` joins them, then the untouched passages as the
+    // TRANSCRIPT has them: each recovered original begins with the whitespace that preceded
+    // it, so nothing is invented between them. Joining the split's pieces with a blank line
+    // changed a single space or tab into a paragraph break. Found by the cloud review.
+    let cleaned = parts.map(\.text).joined(separator: "\n\n")
+    let untouched = markedUpInput.passages.dropFirst(parts.count).map(\.original).joined()
+    return cleaned + untouched
   }
 
   /// Whether Back is offered right now, so the button is absent rather than

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -775,24 +775,31 @@ final class FileImportCoordinator {
   /// passage as REMOVED by a cleanup that never touched it. Found by Codex (chunk review).
   /// Comparison only; Copy, Save and Share still export `documentText`.
   var markedUpInput: MarkedUpInput {
-    let cleaned: String
-    if parts.isEmpty {
-      cleaned = rawTranscript
-    } else {
-      cleaned = (parts.map(\.text) + Array(pendingPieces.dropFirst(parts.count)))
-        .joined(separator: "\n\n")
-    }
-    return MarkedUpInput(raw: rawTranscript, cleaned: cleaned)
+    MarkedUpInput(
+      raw: rawTranscript, cleanedParts: parts.map(\.text),
+      untouched: Array(pendingPieces.dropFirst(parts.count)))
   }
 
+  /// The pieces, not the joined text: this is read on every redraw as the view's task id and
+  /// as the cache key, and joining a three-hour transcript on each read is an allocation
+  /// nobody asked for. The join happens once, inside `prepareMarkedUp`. Codex, round 2.
   struct MarkedUpInput: Equatable, Sendable {
     let raw: String
-    let cleaned: String
+    let cleanedParts: [String]
+    let untouched: [String]
+
+    var cleaned: String {
+      cleanedParts.isEmpty ? raw : (cleanedParts + untouched).joined(separator: "\n\n")
+    }
   }
 
   /// The comparison, once `prepareMarkedUp` has run for the current input; nil while it is
   /// still being made or the input moved. Kept while the two texts it was made from stand.
-  @ObservationIgnored private var markedUpCache: (input: MarkedUpInput, result: WordDiff.Result)?
+  /// OBSERVED, deliberately: the write lands from `prepareMarkedUp` after an await, never
+  /// during a body evaluation, and it is the mutation that replaces the placeholder with the
+  /// result. Ignoring it left the view on "Comparing words" until an unrelated redraw. Codex,
+  /// round 2.
+  private var markedUpCache: (input: MarkedUpInput, result: WordDiff.Result)?
   var markedUp: WordDiff.Result? {
     guard let cached = markedUpCache, cached.input == markedUpInput else { return nil }
     return cached.result

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -786,11 +786,12 @@ final class FileImportCoordinator {
     // Each passage's original is recovered FROM the transcript, not taken from the piece:
     // `TranscriptSplitter` slices from a word's start to a word's end and drops the
     // whitespace between pieces, so the pieces concatenated rendered "alphaalpha" across a
-    // cut. Scanning forward for each piece and taking the text up to the next piece's start
-    // (the end of the transcript for the last) keeps every gap exactly as spoken. A piece
-    // the scan cannot place should not happen (the splitter yields ordered verbatim slices);
-    // if it did, the piece stands in for itself and the rendering loses that one gap rather
-    // than the app crashing. Codex, confirming round.
+    // cut. Each piece is found by scanning forward, and the passage is the text from the
+    // cursor to the piece's end, so the gap BEFORE a piece rides with it; the last passage
+    // runs to the transcript's end. Every gap renders exactly as spoken. A piece the scan
+    // cannot place should not happen (the splitter yields ordered verbatim slices); if it
+    // did, that piece is compared directly and exact reconstruction is not guaranteed on
+    // that path, which is preferred to crashing on a data invariant. Codex, confirming round.
     var cursor = rawTranscript.startIndex
     var passages: [WordDiff.Passage] = []
     for (index, piece) in pendingPieces.enumerated() {

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -615,6 +615,7 @@ final class FileImportCoordinator {
     forgetSaveOutcome()
     // Same rule as `startOver`: a different file is a different row (#2772).
     originalHistoryRow = nil
+    documentView = .cleaned
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []
@@ -754,7 +755,32 @@ final class FileImportCoordinator {
   /// landed, the raw transcript was in memory and unreachable — no view rendered
   /// it, and Copy and Save exported only the cleaned passages. A promise with no
   /// way to check it is a promise the product does not keep. Found by Codex.
-  var isShowingOriginal = false
+  var documentView: DocumentView = .cleaned
+
+  /// Which words the Done screen shows (#2773). Copy, Save and Share follow Cleaned and
+  /// Original; the marked-up view has no plain-text form, so it exports the CLEANED text.
+  enum DocumentView: Equatable, Sendable {
+    case cleaned
+    /// The original words with the cleanup marked on them: removed struck through, altered
+    /// highlighted, and the counts above. The founder's request: "people can quickly see
+    /// that it worked" instead of reading two blobs of prose.
+    case markedUp
+    case original
+  }
+
+  /// The comparison behind the marked-up view, computed on the first switch to it and kept
+  /// while the two texts it was made from stand. A hundred milliseconds on a three-hour file
+  /// once, not on every redraw.
+  @ObservationIgnored private var markedUpCache:
+    (raw: String, cleaned: String, result: WordDiff.Result)?
+  var markedUp: WordDiff.Result {
+    if let c = markedUpCache, c.raw == rawTranscript, c.cleaned == documentText {
+      return c.result
+    }
+    let result = WordDiff.compare(original: rawTranscript, cleaned: documentText)
+    markedUpCache = (rawTranscript, documentText, result)
+    return result
+  }
 
   /// Whether the words on screen are the RAW ones: the user asked for them, or there is no
   /// cleaned part to show instead.
@@ -766,7 +792,7 @@ final class FileImportCoordinator {
   /// the partial cleaned document and said it was not. Found by the cloud review of
   /// PR #2786, and the same shape as the credit it fixed earlier: a status about what was
   /// held rather than what was shown.
-  var screenShowsRawWords: Bool { isShowingOriginal || parts.isEmpty }
+  var screenShowsRawWords: Bool { documentView == .original || parts.isEmpty }
 
   /// What Copy and Save hand over, which is always what the screen is showing.
   var exportText: String { screenShowsRawWords ? rawTranscript : documentText }
@@ -877,6 +903,7 @@ final class FileImportCoordinator {
     // overwrite the last one's words, because the store names its file by id — which is the
     // same property that makes the raw-then-polished pair an update rather than a duplicate.
     originalHistoryRow = nil
+    documentView = .cleaned
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -878,7 +878,20 @@ final class FileImportCoordinator {
   var screenShowsRawWords: Bool { documentView == .original || parts.isEmpty }
 
   /// What Copy and Save hand over, which is always what the screen is showing.
-  var exportText: String { screenShowsRawWords ? rawTranscript : documentText }
+  var exportText: String {
+    if screenShowsRawWords { return rawTranscript }
+    if documentView == .markedUp { return markedUpKeptText }
+    return documentText
+  }
+
+  /// What the marked-up view presents as KEPT: the cleaned passages, then every passage the
+  /// cleanup never reached, unchanged. After a Stop that is more than `documentText`, which
+  /// holds only the finished passages, and an export that dropped the visible tail would
+  /// hand over less than the screen shows. Found by the cloud review of PR #2799. On a
+  /// finished run the two are the same text.
+  var markedUpKeptText: String {
+    (parts.map(\.text) + Array(pendingPieces.dropFirst(parts.count))).joined(separator: "\n\n")
+  }
 
   /// Whether Back is offered right now, so the button is absent rather than
   /// present and inert.

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -616,6 +616,7 @@ final class FileImportCoordinator {
     // Same rule as `startOver`: a different file is a different row (#2772).
     originalHistoryRow = nil
     documentView = .cleaned
+    markedUpCache = nil
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []
@@ -768,18 +769,47 @@ final class FileImportCoordinator {
     case original
   }
 
-  /// The comparison behind the marked-up view, computed on the first switch to it and kept
-  /// while the two texts it was made from stand. A hundred milliseconds on a three-hour file
-  /// once, not on every redraw.
-  @ObservationIgnored private var markedUpCache:
-    (raw: String, cleaned: String, result: WordDiff.Result)?
-  var markedUp: WordDiff.Result {
-    if let c = markedUpCache, c.raw == rawTranscript, c.cleaned == documentText {
-      return c.result
+  /// What the marked-up view compares the original against: the cleaned parts, then any
+  /// passage the cleanup never reached, unchanged. After a Stop, `documentText` holds only
+  /// the finished parts, and comparing the whole original against that marked every waiting
+  /// passage as REMOVED by a cleanup that never touched it. Found by Codex (chunk review).
+  /// Comparison only; Copy, Save and Share still export `documentText`.
+  var markedUpInput: MarkedUpInput {
+    let cleaned: String
+    if parts.isEmpty {
+      cleaned = rawTranscript
+    } else {
+      cleaned = (parts.map(\.text) + Array(pendingPieces.dropFirst(parts.count)))
+        .joined(separator: "\n\n")
     }
-    let result = WordDiff.compare(original: rawTranscript, cleaned: documentText)
-    markedUpCache = (rawTranscript, documentText, result)
-    return result
+    return MarkedUpInput(raw: rawTranscript, cleaned: cleaned)
+  }
+
+  struct MarkedUpInput: Equatable, Sendable {
+    let raw: String
+    let cleaned: String
+  }
+
+  /// The comparison, once `prepareMarkedUp` has run for the current input; nil while it is
+  /// still being made or the input moved. Kept while the two texts it was made from stand.
+  @ObservationIgnored private var markedUpCache: (input: MarkedUpInput, result: WordDiff.Result)?
+  var markedUp: WordDiff.Result? {
+    guard let cached = markedUpCache, cached.input == markedUpInput else { return nil }
+    return cached.result
+  }
+
+  /// Runs the comparison OFF the main actor. Cleanup-shaped inputs take milliseconds, but the
+  /// algorithm is linear in the edit distance too, and two transcripts with nothing in common
+  /// took three seconds at the three-hour size; done in a getter that froze the window.
+  /// Found by Codex (chunk review). A result for an input that moved while it ran is dropped.
+  func prepareMarkedUp() async {
+    let input = markedUpInput
+    guard markedUp == nil else { return }
+    let result = await Task.detached(priority: .userInitiated) {
+      WordDiff.compare(original: input.raw, cleaned: input.cleaned)
+    }.value
+    guard !Task.isCancelled, markedUpInput == input else { return }
+    markedUpCache = (input, result)
   }
 
   /// Whether the words on screen are the RAW ones: the user asked for them, or there is no
@@ -904,6 +934,7 @@ final class FileImportCoordinator {
     // same property that makes the raw-then-polished pair an update rather than a duplicate.
     originalHistoryRow = nil
     documentView = .cleaned
+    markedUpCache = nil
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -783,10 +783,30 @@ final class FileImportCoordinator {
     guard !pendingPieces.isEmpty else {
       return MarkedUpInput(passages: [.init(original: rawTranscript, cleaned: nil)])
     }
-    return MarkedUpInput(
-      passages: pendingPieces.enumerated().map { index, original in
-        .init(original: original, cleaned: index < parts.count ? parts[index].text : nil)
-      })
+    // Each passage's original is recovered FROM the transcript, not taken from the piece:
+    // `TranscriptSplitter` slices from a word's start to a word's end and drops the
+    // whitespace between pieces, so the pieces concatenated rendered "alphaalpha" across a
+    // cut. Scanning forward for each piece and taking the text up to the next piece's start
+    // (the end of the transcript for the last) keeps every gap exactly as spoken. A piece
+    // the scan cannot place should not happen (the splitter yields ordered verbatim slices);
+    // if it did, the piece stands in for itself and the rendering loses that one gap rather
+    // than the app crashing. Codex, confirming round.
+    var cursor = rawTranscript.startIndex
+    var passages: [WordDiff.Passage] = []
+    for (index, piece) in pendingPieces.enumerated() {
+      let cleaned = index < parts.count ? parts[index].text : nil
+      guard
+        let found = rawTranscript.range(
+          of: piece, options: .literal, range: cursor..<rawTranscript.endIndex)
+      else {
+        passages.append(.init(original: piece, cleaned: cleaned))
+        continue
+      }
+      let end = index == pendingPieces.count - 1 ? rawTranscript.endIndex : found.upperBound
+      passages.append(.init(original: String(rawTranscript[cursor..<end]), cleaned: cleaned))
+      cursor = end
+    }
+    return MarkedUpInput(passages: passages)
   }
 
   /// The passages, not a joined text: this is read on every redraw as the view's task id and

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1239,7 +1239,9 @@ struct TranscribeFileView: View {
       // The original/cleaned toggle belongs to DONE. On Working there is nothing to toggle
       // and honouring it there hid the finished parts during a re-polish.
       ForEach(
-        coordinator.step == .done && coordinator.screenShowsRawWords ? [] : coordinator.parts
+        coordinator.step == .done
+          && (coordinator.screenShowsRawWords || coordinator.documentView == .markedUp)
+          ? [] : coordinator.parts
       ) { part in
         VStack(alignment: .leading, spacing: 4) {
           Text(part.text)
@@ -1255,8 +1257,25 @@ struct TranscribeFileView: View {
           }
         }
       }
-      // DONE only. This is the "Show original words" view and the empty-document floor, and
-      // both belong to the finished screen; on Working the queue shows the raw words.
+      // DONE only, the marked-up view (#2773): the original words with the cleanup on them,
+      // and the counts that are the point. The marks are one attributed text so selection
+      // and copy behave like the other two views.
+      if coordinator.step == .done, coordinator.documentView == .markedUp,
+        !coordinator.parts.isEmpty
+      {
+        let markedUp = coordinator.markedUp
+        VStack(alignment: .leading, spacing: 8) {
+          Text(markedUp.legend)
+            .font(.stHelper)
+            .foregroundStyle(Color.stTextSecondary)
+            .accessibilityLabel("Cleanup summary: \(markedUp.legend)")
+          Text(Self.markedUpText(markedUp.segments))
+            .lineSpacing(6)
+            .textSelection(.enabled)
+        }
+      }
+      // DONE only. This is the "Original" view and the empty-document floor, and both belong
+      // to the finished screen; on Working the queue shows the raw words.
       if coordinator.step == .done,
         coordinator.screenShowsRawWords,
         !coordinator.rawTranscript.isEmpty
@@ -1408,13 +1427,23 @@ struct TranscribeFileView: View {
       savedToHistoryChip
       polishedByChip
       // The page promises the untouched words are kept. This is where the user reads them,
-      // and Copy, Save and Share all follow whichever is on screen.
+      // and Copy, Save and Share follow Cleaned and Original; Marked up exports Cleaned.
+      // Three states want one picker rather than two links (#2773).
       if !coordinator.parts.isEmpty {
-        Button(coordinator.isShowingOriginal ? "Show cleaned words" : "Show original words") {
-          coordinator.isShowingOriginal.toggle()
+        Picker(
+          "View",
+          selection: Binding(
+            get: { coordinator.documentView }, set: { coordinator.documentView = $0 })
+        ) {
+          Text("Cleaned").tag(FileImportCoordinator.DocumentView.cleaned)
+          Text("Marked up").tag(FileImportCoordinator.DocumentView.markedUp)
+          Text("Original").tag(FileImportCoordinator.DocumentView.original)
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(Color.stAccent)
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .controlSize(.small)
+        .fixedSize()
+        .accessibilityLabel("Which words to show")
       }
     }
   }
@@ -1520,6 +1549,32 @@ struct TranscribeFileView: View {
     formatter.dateFormat = "d MMMM yyyy"
     return formatter
   }()
+
+  /// The founder's two treatments, and a third for what the cleanup added (#2773). A removed
+  /// word is struck through, which reads without colour; an altered or added word is
+  /// highlighted AND heavier, so colour is never the only carrier. Both tints are the
+  /// existing semantic tokens, so light and dark are handled by what handles every other
+  /// surface. Static so `TranscribeFileMarkedUpTests` can read the attributes it sets.
+  static func markedUpText(_ segments: [WordDiff.Segment]) -> AttributedString {
+    var out = AttributedString()
+    for segment in segments {
+      var run = AttributedString(segment.text)
+      switch segment.kind {
+      case .same:
+        run.foregroundColor = Color.stTextBody
+      case .removed:
+        run.foregroundColor = Color.stTextSecondary
+        run.strikethroughStyle = .single
+      case .changed, .added:
+        run.foregroundColor = Color.stTextBody
+        run.backgroundColor = Color.stAccentLight
+        run.font = .body.weight(.semibold)
+      }
+      out.append(run)
+      out.append(AttributedString(segment.trailing.isEmpty ? " " : segment.trailing))
+    }
+    return out
+  }
 
   private func chip(_ text: String) -> some View {
     Text(text)

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1263,16 +1263,25 @@ struct TranscribeFileView: View {
       if coordinator.step == .done, coordinator.documentView == .markedUp,
         !coordinator.parts.isEmpty
       {
-        let markedUp = coordinator.markedUp
-        VStack(alignment: .leading, spacing: 8) {
-          Text(markedUp.legend)
-            .font(.stHelper)
-            .foregroundStyle(Color.stTextSecondary)
-            .accessibilityLabel("Cleanup summary: \(markedUp.legend)")
-          Text(Self.markedUpText(markedUp.segments))
-            .lineSpacing(6)
-            .textSelection(.enabled)
+        Group {
+          if let markedUp = coordinator.markedUp {
+            VStack(alignment: .leading, spacing: 8) {
+              Text(markedUp.legend)
+                .font(.stHelper)
+                .foregroundStyle(Color.stTextSecondary)
+                .accessibilityLabel("Cleanup summary: \(markedUp.legend)")
+              Text(Self.markedUpText(markedUp.segments))
+                .lineSpacing(6)
+                .textSelection(.enabled)
+                // The marks are visual; this is what a screen reader gets instead.
+                .accessibilityLabel(Self.markedUpAccessibilityText(markedUp.segments))
+            }
+          } else {
+            ProgressView("Comparing words")
+              .controlSize(.small)
+          }
         }
+        .task(id: coordinator.markedUpInput) { await coordinator.prepareMarkedUp() }
       }
       // DONE only. This is the "Original" view and the empty-document floor, and both belong
       // to the finished screen; on Working the queue shows the raw words.
@@ -1571,9 +1580,23 @@ struct TranscribeFileView: View {
         run.font = .body.weight(.semibold)
       }
       out.append(run)
-      out.append(AttributedString(segment.trailing.isEmpty ? " " : segment.trailing))
+      // The original's own whitespace, never an invented one: `WordDiff` already put a
+      // separator before an addition that needs it.
+      out.append(AttributedString(segment.trailing))
     }
     return out
+  }
+
+  /// The marks in words, for a screen reader: strikethrough and highlight say nothing aloud.
+  static func markedUpAccessibilityText(_ segments: [WordDiff.Segment]) -> String {
+    segments.map { segment in
+      switch segment.kind {
+      case .same: return segment.text + segment.trailing
+      case .removed: return "Removed: \(segment.text). "
+      case .changed: return "Changed: \(segment.text). "
+      case .added: return "Added: \(segment.text). "
+      }
+    }.joined()
   }
 
   private func chip(_ text: String) -> some View {

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -151,8 +151,13 @@ public enum WordDiff {
     let trimmed = word.trimmingCharacters(in: .punctuationCharacters.union(.symbols))
     // Unicode case FOLDING, not lowercasing: `lowercased()` leaves a Greek final sigma
     // ("ΟΣ" → "οσ" against "ος") and a German "STRASSE" against "straße" unequal, and the
-    // transcripts are multilingual. Found by the cloud review of PR #2799.
-    return (trimmed.isEmpty ? word : trimmed).folding(options: .caseInsensitive, locale: nil)
+    // transcripts are multilingual. Diacritic-insensitive as well, because the case fold of a
+    // Turkish capital dotted I ("İstanbul") is "i" plus a combining dot, which no lowercase
+    // spelling carries; folding the marks away makes it "istanbul", and it also means an
+    // accent the cleanup added or dropped ("cafe" → "café") is spelling, not a changed word,
+    // which is the count's meaning. Found by the cloud review of PR #2799, in two rounds.
+    return (trimmed.isEmpty ? word : trimmed)
+      .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
   }
 
   // MARK: - The comparison

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -159,23 +159,16 @@ public enum WordDiff {
   /// alignment could match the finished part's few words against the START of the original
   /// and mark the untouched waiting passages as removed, and a passage the splitter cut
   /// inside a run with no spaces read as two words against one. Each passage is compared
-  /// with its own original; a passage the cleanup never reached is all `.same`. The
-  /// original's own whitespace carries the layout between passages; the raw transcript is
-  /// the concatenation of its pieces, so nothing is inserted between them.
+  /// with its own original; a passage the cleanup never reached compares against itself,
+  /// which yields only `.same` and keeps its leading whitespace like any other. The caller
+  /// gives each passage's original WITH the whitespace that followed it in the source
+  /// transcript; the splitter's pieces alone do not carry inter-passage whitespace, and
+  /// concatenating them rendered "alphaalpha" across a cut (Codex, confirming round).
   public static func compare(passages: [Passage]) -> Result {
     var result = Result(segments: [], removedWords: 0, changedWords: 0)
     for passage in passages {
-      let piece: Result
-      if let cleaned = passage.cleaned {
-        piece = compare(original: passage.original, cleaned: cleaned)
-      } else {
-        piece = Result(
-          segments: tokenize(passage.original).map {
-            Segment(kind: .same, text: $0.text, trailing: $0.trailing)
-          },
-          removedWords: 0, changedWords: 0)
-      }
-      result = result.appending(piece)
+      result = result.appending(
+        compare(original: passage.original, cleaned: passage.cleaned ?? passage.original))
     }
     return result
   }

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -149,7 +149,10 @@ public enum WordDiff {
 
   static func key(for word: String) -> String {
     let trimmed = word.trimmingCharacters(in: .punctuationCharacters.union(.symbols))
-    return (trimmed.isEmpty ? word : trimmed).lowercased()
+    // Unicode case FOLDING, not lowercasing: `lowercased()` leaves a Greek final sigma
+    // ("ΟΣ" → "οσ" against "ος") and a German "STRASSE" against "straße" unequal, and the
+    // transcripts are multilingual. Found by the cloud review of PR #2799.
+    return (trimmed.isEmpty ? word : trimmed).folding(options: .caseInsensitive, locale: nil)
   }
 
   // MARK: - The comparison

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -149,15 +149,24 @@ public enum WordDiff {
 
   static func key(for word: String) -> String {
     let trimmed = word.trimmingCharacters(in: .punctuationCharacters.union(.symbols))
-    // Unicode case FOLDING, not lowercasing: `lowercased()` leaves a Greek final sigma
-    // ("ΟΣ" → "οσ" against "ος") and a German "STRASSE" against "straße" unequal, and the
-    // transcripts are multilingual. Diacritic-insensitive as well, because the case fold of a
-    // Turkish capital dotted I ("İstanbul") is "i" plus a combining dot, which no lowercase
-    // spelling carries; folding the marks away makes it "istanbul", and it also means an
-    // accent the cleanup added or dropped ("cafe" → "café") is spelling, not a changed word,
-    // which is the count's meaning. Found by the cloud review of PR #2799, in two rounds.
+    // WHICH spelling differences are the same word, decided once (three cloud-review rounds
+    // on PR #2799 each moved this a step; this is the closed rule, not the next step):
+    //
+    // - Case never counts, folded the Unicode way rather than with `lowercased()`, which
+    //   leaves a Greek final sigma ("ΟΣ" against "ος") and "STRASSE" against "straße" unequal.
+    // - A diacritic ALWAYS counts. "si" and "sí", "ou" and "où" are different words, and a
+    //   cleanup that adds or drops an accent changed the word; folding marks away would
+    //   report those as untouched.
+    // - The one artifact of case folding itself is undone: the fold of a Turkish capital
+    //   dotted I ("İstanbul") is "i" followed by a combining dot above (U+0307), a sequence no
+    //   lowercase spelling carries because a plain "i" already has its dot. That pair is
+    //   collapsed to "i". Nothing else is touched.
+    //
+    // What would reopen this: a case-only pair the fold leaves unequal that is not the
+    // dotted-I artifact.
     return (trimmed.isEmpty ? word : trimmed)
-      .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+      .folding(options: .caseInsensitive, locale: nil)
+      .replacingOccurrences(of: "i\u{0307}", with: "i")
   }
 
   // MARK: - The comparison

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -68,14 +68,38 @@ public enum WordDiff {
     }
 
     /// The legend above the text. Founder's example: "1,204 words removed · 318 changed".
-    public var legend: String {
-      let removed = Self.count(removedWords, "word", "words")
-      let changed = changedWords.formatted()
+    /// Numbers follow the locale: a German user reads "1.204".
+    public var legend: String { legend(locale: .current) }
+
+    public func legend(locale: Locale) -> String {
+      let removed = Self.count(removedWords, "word", "words", locale: locale)
+      let changed = changedWords.formatted(.number.locale(locale))
       return "\(removed) removed · \(changed) changed"
     }
 
-    private static func count(_ n: Int, _ singular: String, _ plural: String) -> String {
-      "\(n.formatted()) \(n == 1 ? singular : plural)"
+    private static func count(_ n: Int, _ singular: String, _ plural: String, locale: Locale)
+      -> String
+    {
+      "\(n.formatted(.number.locale(locale))) \(n == 1 ? singular : plural)"
+    }
+
+    /// Two results in reading order, as one. Counts add; the segments concatenate.
+    func appending(_ other: Result) -> Result {
+      Result(
+        segments: segments + other.segments, removedWords: removedWords + other.removedWords,
+        changedWords: changedWords + other.changedWords)
+    }
+  }
+
+  /// One passage of the original with what the cleanup made of it, or nil when the cleanup
+  /// never reached it.
+  public struct Passage: Equatable, Sendable {
+    public let original: String
+    public let cleaned: String?
+
+    public init(original: String, cleaned: String?) {
+      self.original = original
+      self.cleaned = cleaned
     }
   }
 
@@ -129,6 +153,32 @@ public enum WordDiff {
   }
 
   // MARK: - The comparison
+
+  /// Passage by passage, which is how the cleanup itself ran. Comparing the whole original
+  /// against the whole output as one block lost the boundaries: after a Stop, a global
+  /// alignment could match the finished part's few words against the START of the original
+  /// and mark the untouched waiting passages as removed, and a passage the splitter cut
+  /// inside a run with no spaces read as two words against one. Each passage is compared
+  /// with its own original; a passage the cleanup never reached is all `.same`. The
+  /// original's own whitespace carries the layout between passages; the raw transcript is
+  /// the concatenation of its pieces, so nothing is inserted between them.
+  public static func compare(passages: [Passage]) -> Result {
+    var result = Result(segments: [], removedWords: 0, changedWords: 0)
+    for passage in passages {
+      let piece: Result
+      if let cleaned = passage.cleaned {
+        piece = compare(original: passage.original, cleaned: cleaned)
+      } else {
+        piece = Result(
+          segments: tokenize(passage.original).map {
+            Segment(kind: .same, text: $0.text, trailing: $0.trailing)
+          },
+          removedWords: 0, changedWords: 0)
+      }
+      result = result.appending(piece)
+    }
+    return result
+  }
 
   public static func compare(original: String, cleaned: String) -> Result {
     let a = tokenize(original)

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -12,17 +12,21 @@ import Foundation
 /// observable in the diff; no category ("filler", "grammar") is inferred, because the
 /// polisher never says why it changed anything.
 ///
-/// **Words, not characters, and words by their letters.** Tokens are whitespace-separated
-/// runs; two tokens are the same word when they agree after lowercasing and stripping
-/// leading and trailing punctuation. So "hello" and "Hello," are one word: a comma or a
-/// capital is not the cleanup the count is about, and counting it would make every sentence
-/// look rewritten. The original's exact spelling and spacing are what get rendered.
+/// **Tokens, and what counts as the same one.** Counts are over whitespace-separated tokens.
+/// Two tokens compare equal after lowercasing and stripping LEADING and TRAILING punctuation
+/// and symbols from an otherwise non-empty token, so "hello" and "Hello," are one word: a
+/// comma or a capital is not the cleanup the count is about, and counting it would make every
+/// sentence look rewritten. Internal punctuation stays significant ("don't" and "dont"
+/// differ). A token that is only punctuation or only an emoji stays a token and can count.
+/// A replacement hunk counts its ORIGINAL tokens once; an insert-only hunk counts what it
+/// inserted. The original's exact spelling and spacing are what get rendered.
 ///
-/// **Myers' algorithm in linear space** (the middle-snake refinement), so an hour of speech
-/// costs tens of milliseconds and a three-hour file about a hundred, once, when the user
-/// switches to the view. Measured before choosing, on #2773: 1.8 ms at 2,000 words, 26 ms at
-/// 9,000, 107 ms at 27,000. The quadratic-memory form of the same algorithm would need half
-/// a gigabyte at the three-hour size.
+/// **Myers' algorithm in linear space** (the middle-snake refinement). The quadratic-memory
+/// form would need half a gigabyte at a three-hour transcript. Time is linear in the edit
+/// distance as well as the length: the cleanup-shaped inputs measured on #2773 took 1.8 ms
+/// at 2,000 words, 26 ms at 9,000 and 107 ms at 27,000 in Release, and two transcripts with
+/// nothing in common at 27,000 took about three seconds (Codex, chunk review). The
+/// coordinator therefore runs it off the main actor and the view shows a placeholder.
 public enum WordDiff {
 
   public enum Kind: Equatable, Sendable {
@@ -95,12 +99,11 @@ public enum WordDiff {
       word = ""
       space = ""
     }
-    for scalar in text.unicodeScalars {
-      let c = Character(scalar)
+    for c in text {
       if c.isWhitespace || c.isNewline {
         if word.isEmpty {
-          // Leading whitespace before any word: attach to the previous token's trailing run,
-          // or drop it at the very start.
+          // Whitespace before any word: attach to the previous token's trailing run. At the
+          // very start there is no token yet; `compare` keeps that run as its own segment.
           if var last = tokens.popLast() {
             last = Token(text: last.text, trailing: last.trailing + String(c), key: last.key)
             tokens.append(last)
@@ -131,7 +134,14 @@ public enum WordDiff {
     let a = tokenize(original)
     let b = tokenize(cleaned)
     let ops = edits(a.map(\.key), b.map(\.key))
-    return assemble(ops, original: a, cleaned: b)
+    let result = assemble(ops, original: a, cleaned: b)
+    // The original's leading whitespace is layout, not a word: kept as an unmarked segment
+    // so the rendering starts where the original did.
+    let leading = String(original.prefix { $0.isWhitespace })
+    guard !leading.isEmpty else { return result }
+    return Result(
+      segments: [Segment(kind: .same, text: leading, trailing: "")] + result.segments,
+      removedWords: result.removedWords, changedWords: result.changedWords)
   }
 
   enum Op: Equatable {
@@ -177,6 +187,12 @@ public enum WordDiff {
       }
       if deletes.isEmpty {
         for bi in inserts {
+          // An addition after the original's last word needs a separator the original
+          // never had; everywhere else the original's own whitespace does the job.
+          if let previous = segments.last, previous.trailing.isEmpty {
+            segments[segments.count - 1] = Segment(
+              kind: previous.kind, text: previous.text, trailing: " ")
+          }
           segments.append(Segment(kind: .added, text: b[bi].text, trailing: b[bi].trailing))
         }
         changed += inserts.count

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -1,0 +1,322 @@
+import Foundation
+
+/// A word-level comparison of the raw transcript against the cleaned document (#2773).
+///
+/// **What it answers:** the founder's question, "how much cleanup actually happened". Two
+/// blocks of prose side by side cannot say; this marks the ORIGINAL words with what the
+/// cleanup did to them and counts it: words removed, words changed.
+///
+/// **Two treatments, founder-specified.** A word the cleanup removed is struck through. A
+/// word it altered is highlighted. A word it ADDED has no original to mark, so it is shown
+/// highlighted in place: from the reader's side it is a change. Removed and altered are
+/// observable in the diff; no category ("filler", "grammar") is inferred, because the
+/// polisher never says why it changed anything.
+///
+/// **Words, not characters, and words by their letters.** Tokens are whitespace-separated
+/// runs; two tokens are the same word when they agree after lowercasing and stripping
+/// leading and trailing punctuation. So "hello" and "Hello," are one word: a comma or a
+/// capital is not the cleanup the count is about, and counting it would make every sentence
+/// look rewritten. The original's exact spelling and spacing are what get rendered.
+///
+/// **Myers' algorithm in linear space** (the middle-snake refinement), so an hour of speech
+/// costs tens of milliseconds and a three-hour file about a hundred, once, when the user
+/// switches to the view. Measured before choosing, on #2773: 1.8 ms at 2,000 words, 26 ms at
+/// 9,000, 107 ms at 27,000. The quadratic-memory form of the same algorithm would need half
+/// a gigabyte at the three-hour size.
+public enum WordDiff {
+
+  public enum Kind: Equatable, Sendable {
+    /// The cleanup kept this word.
+    case same
+    /// The cleanup dropped this word and put nothing in its place.
+    case removed
+    /// The cleanup replaced this word with something else.
+    case changed
+    /// The cleanup added this word; it has no original.
+    case added
+  }
+
+  /// One token of the marked-up text, in reading order, with the whitespace that followed
+  /// it in the original so the original's layout survives.
+  public struct Segment: Equatable, Sendable {
+    public let kind: Kind
+    public let text: String
+    public let trailing: String
+
+    public init(kind: Kind, text: String, trailing: String) {
+      self.kind = kind
+      self.text = text
+      self.trailing = trailing
+    }
+  }
+
+  public struct Result: Equatable, Sendable {
+    public let segments: [Segment]
+    /// Original words dropped with nothing in their place.
+    public let removedWords: Int
+    /// Original words replaced, plus words added with no original: what the highlight marks.
+    public let changedWords: Int
+
+    public init(segments: [Segment], removedWords: Int, changedWords: Int) {
+      self.segments = segments
+      self.removedWords = removedWords
+      self.changedWords = changedWords
+    }
+
+    /// The legend above the text. Founder's example: "1,204 words removed · 318 changed".
+    public var legend: String {
+      let removed = Self.count(removedWords, "word", "words")
+      let changed = changedWords.formatted()
+      return "\(removed) removed · \(changed) changed"
+    }
+
+    private static func count(_ n: Int, _ singular: String, _ plural: String) -> String {
+      "\(n.formatted()) \(n == 1 ? singular : plural)"
+    }
+  }
+
+  // MARK: - Tokens
+
+  struct Token: Equatable {
+    let text: String
+    let trailing: String
+    let key: String
+  }
+
+  /// Whitespace-separated runs, each carrying the whitespace that followed it, keyed by
+  /// their letters for comparison.
+  static func tokenize(_ text: String) -> [Token] {
+    var tokens: [Token] = []
+    var word = ""
+    var space = ""
+    func flush() {
+      guard !word.isEmpty else { return }
+      tokens.append(Token(text: word, trailing: space, key: key(for: word)))
+      word = ""
+      space = ""
+    }
+    for scalar in text.unicodeScalars {
+      let c = Character(scalar)
+      if c.isWhitespace || c.isNewline {
+        if word.isEmpty {
+          // Leading whitespace before any word: attach to the previous token's trailing run,
+          // or drop it at the very start.
+          if var last = tokens.popLast() {
+            last = Token(text: last.text, trailing: last.trailing + String(c), key: last.key)
+            tokens.append(last)
+          }
+        } else {
+          space.append(c)
+          // A run of whitespace ends the word once the next non-space arrives; keep
+          // accumulating until then.
+          continue
+        }
+      } else {
+        if !space.isEmpty { flush() }
+        word.append(c)
+      }
+    }
+    flush()
+    return tokens
+  }
+
+  static func key(for word: String) -> String {
+    let trimmed = word.trimmingCharacters(in: .punctuationCharacters.union(.symbols))
+    return (trimmed.isEmpty ? word : trimmed).lowercased()
+  }
+
+  // MARK: - The comparison
+
+  public static func compare(original: String, cleaned: String) -> Result {
+    let a = tokenize(original)
+    let b = tokenize(cleaned)
+    let ops = edits(a.map(\.key), b.map(\.key))
+    return assemble(ops, original: a, cleaned: b)
+  }
+
+  enum Op: Equatable {
+    case equal(Int, Int)  // a index, b index
+    case delete(Int)  // a index
+    case insert(Int)  // b index
+  }
+
+  /// Groups runs of deletes and inserts into hunks, which is where "removed" and "changed"
+  /// are decided: a hunk with deletes and no inserts removed words; a hunk with both changed
+  /// them; a hunk with inserts and no deletes added words, counted as changed.
+  static func assemble(_ ops: [Op], original a: [Token], cleaned b: [Token]) -> Result {
+    var segments: [Segment] = []
+    var removed = 0
+    var changed = 0
+    var i = 0
+    while i < ops.count {
+      if case .equal(let ai, _) = ops[i] {
+        segments.append(Segment(kind: .same, text: a[ai].text, trailing: a[ai].trailing))
+        i += 1
+        continue
+      }
+      // A hunk: consecutive deletes and inserts, in whatever order Myers emitted them.
+      var deletes: [Int] = []
+      var inserts: [Int] = []
+      while i < ops.count {
+        switch ops[i] {
+        case .equal: break
+        case .delete(let ai):
+          deletes.append(ai)
+          i += 1
+          continue
+        case .insert(let bi):
+          inserts.append(bi)
+          i += 1
+          continue
+        }
+        break
+      }
+      let kind: Kind = inserts.isEmpty ? .removed : .changed
+      for ai in deletes {
+        segments.append(Segment(kind: kind, text: a[ai].text, trailing: a[ai].trailing))
+      }
+      if deletes.isEmpty {
+        for bi in inserts {
+          segments.append(Segment(kind: .added, text: b[bi].text, trailing: b[bi].trailing))
+        }
+        changed += inserts.count
+      } else if inserts.isEmpty {
+        removed += deletes.count
+      } else {
+        changed += deletes.count
+      }
+    }
+    return Result(segments: segments, removedWords: removed, changedWords: changed)
+  }
+
+  // MARK: - Myers, linear space
+
+  static func edits(_ a: [String], _ b: [String]) -> [Op] {
+    var ops: [Op] = []
+    ops.reserveCapacity(a.count + b.count)
+    solve(a, b, 0, a.count, 0, b.count, &ops)
+    return ops
+  }
+
+  private static func solve(
+    _ a: [String], _ b: [String], _ a0: Int, _ a1: Int, _ b0: Int, _ b1: Int,
+    _ ops: inout [Op]
+  ) {
+    var a0 = a0
+    var b0 = b0
+    var a1 = a1
+    var b1 = b1
+    // Strip the common prefix and suffix first: cheap, and it keeps the recursion shallow on
+    // the shape a cleanup produces, which is long runs of untouched words.
+    while a0 < a1, b0 < b1, a[a0] == b[b0] {
+      ops.append(.equal(a0, b0))
+      a0 += 1
+      b0 += 1
+    }
+    var suffix: [Op] = []
+    while a0 < a1, b0 < b1, a[a1 - 1] == b[b1 - 1] {
+      suffix.append(.equal(a1 - 1, b1 - 1))
+      a1 -= 1
+      b1 -= 1
+    }
+    defer { ops.append(contentsOf: suffix.reversed()) }
+
+    if a0 == a1 {
+      for bi in b0..<b1 { ops.append(.insert(bi)) }
+      return
+    }
+    if b0 == b1 {
+      for ai in a0..<a1 { ops.append(.delete(ai)) }
+      return
+    }
+    let (x, y, u, v) = middleSnake(a, b, a0, a1, b0, b1)
+    // A snake that covers no ground would recurse on the same problem for ever. It cannot
+    // happen for non-empty inputs, and the fallback that makes that claim checkable is a
+    // plain replacement of the range, which is always a valid (if longer) edit.
+    guard (x, y, u, v) != (a0, b0, a0, b0) || (a1 - a0) + (b1 - b0) == 0 else {
+      for ai in a0..<a1 { ops.append(.delete(ai)) }
+      for bi in b0..<b1 { ops.append(.insert(bi)) }
+      return
+    }
+    solve(a, b, a0, x, b0, y, &ops)
+    var ai = x
+    var bi = y
+    while ai < u {
+      ops.append(.equal(ai, bi))
+      ai += 1
+      bi += 1
+    }
+    solve(a, b, u, a1, v, b1, &ops)
+  }
+
+  /// Myers 1986 §4b. Returns the middle snake's start and end in absolute indices.
+  private static func middleSnake(
+    _ a: [String], _ b: [String], _ a0: Int, _ a1: Int, _ b0: Int, _ b1: Int
+  ) -> (Int, Int, Int, Int) {
+    let n = a1 - a0
+    let m = b1 - b0
+    let max = (n + m + 1) / 2 + 1
+    let delta = n - m
+    let odd = delta & 1 == 1
+    let size = 2 * max + 2
+    var vf = [Int](repeating: 0, count: size)
+    var vb = [Int](repeating: 0, count: size)
+    @inline(__always) func idx(_ k: Int) -> Int { k + max + 1 }
+    vf[idx(1)] = 0
+    vb[idx(1)] = 0
+    for d in 0...max {
+      // Forward.
+      var k = -d
+      while k <= d {
+        var x: Int
+        if k == -d || (k != d && vf[idx(k - 1)] < vf[idx(k + 1)]) {
+          x = vf[idx(k + 1)]
+        } else {
+          x = vf[idx(k - 1)] + 1
+        }
+        var y = x - k
+        let sx = x
+        let sy = y
+        while x < n, y < m, a[a0 + x] == b[b0 + y] {
+          x += 1
+          y += 1
+        }
+        vf[idx(k)] = x
+        if odd, k >= delta - (d - 1), k <= delta + (d - 1) {
+          let c = delta - k
+          if c >= -(d - 1), c <= d - 1, vf[idx(k)] + vb[idx(c)] >= n {
+            return (a0 + sx, b0 + sy, a0 + x, b0 + y)
+          }
+        }
+        k += 2
+      }
+      // Backward.
+      k = -d
+      while k <= d {
+        var x: Int
+        if k == -d || (k != d && vb[idx(k - 1)] < vb[idx(k + 1)]) {
+          x = vb[idx(k + 1)]
+        } else {
+          x = vb[idx(k - 1)] + 1
+        }
+        var y = x - k
+        let ex = x
+        let ey = y
+        while x < n, y < m, a[a1 - 1 - x] == b[b1 - 1 - y] {
+          x += 1
+          y += 1
+        }
+        vb[idx(k)] = x
+        if !odd, k >= delta - d, k <= delta + d {
+          let c = delta - k
+          if c >= -d, c <= d, vf[idx(c)] + vb[idx(k)] >= n {
+            return (a1 - x, b1 - y, a1 - ex, b1 - ey)
+          }
+        }
+        k += 2
+      }
+    }
+    // Unreachable for non-empty inputs: the loop always finds a snake by d = max.
+    return (a0, b0, a0, b0)
+  }
+}

--- a/Sources/EnviousWisprCore/WordDiff.swift
+++ b/Sources/EnviousWisprCore/WordDiff.swift
@@ -113,13 +113,13 @@ public enum WordDiff {
 
   /// Whitespace-separated runs, each carrying the whitespace that followed it, keyed by
   /// their letters for comparison.
-  static func tokenize(_ text: String) -> [Token] {
+  static func tokenize(_ text: String, locale: Locale? = nil) -> [Token] {
     var tokens: [Token] = []
     var word = ""
     var space = ""
     func flush() {
       guard !word.isEmpty else { return }
-      tokens.append(Token(text: word, trailing: space, key: key(for: word)))
+      tokens.append(Token(text: word, trailing: space, key: key(for: word, locale: locale)))
       word = ""
       space = ""
     }
@@ -147,7 +147,7 @@ public enum WordDiff {
     return tokens
   }
 
-  static func key(for word: String) -> String {
+  static func key(for word: String, locale: Locale?) -> String {
     let trimmed = word.trimmingCharacters(in: .punctuationCharacters.union(.symbols))
     // WHICH spelling differences are the same word, decided once (three cloud-review rounds
     // on PR #2799 each moved this a step; this is the closed rule, not the next step):
@@ -157,15 +157,18 @@ public enum WordDiff {
     // - A diacritic ALWAYS counts. "si" and "sí", "ou" and "où" are different words, and a
     //   cleanup that adds or drops an accent changed the word; folding marks away would
     //   report those as untouched.
-    // - The one artifact of case folding itself is undone: the fold of a Turkish capital
-    //   dotted I ("İstanbul") is "i" followed by a combining dot above (U+0307), a sequence no
-    //   lowercase spelling carries because a plain "i" already has its dot. That pair is
-    //   collapsed to "i". Nothing else is touched.
+    // - The fold is done in the TRANSCRIPT's language when the engine reported one, because
+    //   Turkish has two I's and no locale-neutral fold gets both: neutral folding maps
+    //   "IŞIK" to "işik" against the lowercase "ışık", and "İstanbul" to "i" plus a
+    //   combining dot against "istanbul". With the Turkish locale both pairs fold equal.
+    //   With no language, the locale-neutral fold applies and the one artifact it leaves,
+    //   "i" plus combining dot above (U+0307), which no lowercase spelling carries, is
+    //   collapsed to "i".
     //
-    // What would reopen this: a case-only pair the fold leaves unequal that is not the
-    // dotted-I artifact.
+    // The known limit, stated: a Turkish transcript whose language the engine did not report
+    // compares its capital dotless I as a change.
     return (trimmed.isEmpty ? word : trimmed)
-      .folding(options: .caseInsensitive, locale: nil)
+      .folding(options: .caseInsensitive, locale: locale)
       .replacingOccurrences(of: "i\u{0307}", with: "i")
   }
 
@@ -181,18 +184,29 @@ public enum WordDiff {
   /// gives each passage's original WITH the whitespace that followed it in the source
   /// transcript; the splitter's pieces alone do not carry inter-passage whitespace, and
   /// concatenating them rendered "alphaalpha" across a cut (Codex, confirming round).
-  public static func compare(passages: [Passage]) -> Result {
+  /// `language` is the engine's code for the transcript ("tr", "en"); it decides the case
+  /// fold, see `key(for:locale:)`. Nil folds locale-neutrally.
+  public static func compare(passages: [Passage], language: String? = nil) -> Result {
+    let locale = language.map { Locale(identifier: $0) }
     var result = Result(segments: [], removedWords: 0, changedWords: 0)
     for passage in passages {
       result = result.appending(
-        compare(original: passage.original, cleaned: passage.cleaned ?? passage.original))
+        compare(
+          original: passage.original, cleaned: passage.cleaned ?? passage.original,
+          locale: locale))
     }
     return result
   }
 
-  public static func compare(original: String, cleaned: String) -> Result {
-    let a = tokenize(original)
-    let b = tokenize(cleaned)
+  public static func compare(original: String, cleaned: String, language: String? = nil)
+    -> Result
+  {
+    compare(original: original, cleaned: cleaned, locale: language.map { Locale(identifier: $0) })
+  }
+
+  static func compare(original: String, cleaned: String, locale: Locale?) -> Result {
+    let a = tokenize(original, locale: locale)
+    let b = tokenize(cleaned, locale: locale)
     let ops = edits(a.map(\.key), b.map(\.key))
     let result = assemble(ops, original: a, cleaned: b)
     // The original's leading whitespace is layout, not a word: kept as an unmarked segment

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -327,6 +327,14 @@ struct FileImportHistoryTests {
     c.documentView = .markedUp
     await c.prepareMarkedUp()
     let result = try #require(c.markedUp)
+    // EVERY word of every waiting passage is untouched, not only the distinctive one: the
+    // first passage's alphas may be removed, the waiting passages' alphas may not.
+    let firstPassageWords = c.pendingPieces[0].split(whereSeparator: \.isWhitespace).count
+    #expect(result.removedWords == firstPassageWords - 1, "\(result.removedWords) removed")
+    #expect(result.changedWords == 0)
+    let waitingWords = c.pendingPieces.dropFirst().joined(separator: " ")
+      .split(whereSeparator: \.isWhitespace).count
+    #expect(result.segments.suffix(waitingWords).allSatisfy { $0.kind == .same })
     let tail = try #require(result.segments.first { $0.text == "four" })
     #expect(tail.kind == .same, "an unfinished passage was marked \(tail.kind)")
   }

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -346,6 +346,11 @@ struct FileImportHistoryTests {
     // cloud review of PR #2799.
     #expect(c.exportText.contains("four five six"), "the marked-up export dropped the visible tail")
     #expect(c.exportText.hasPrefix("Alpha."))
+    // The untouched part of the export is the transcript's own text from the first piece's
+    // end, whitespace included: nothing invented between the pieces. Found by the cloud review.
+    let firstPiece = c.pendingPieces[0]
+    let tailStart = raw.range(of: firstPiece)!.upperBound
+    #expect(c.exportText == "Alpha." + String(raw[tailStart...]))
     c.documentView = .cleaned
     #expect(!c.exportText.contains("four"))
   }

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -341,6 +341,13 @@ struct FileImportHistoryTests {
     // splitter drops the whitespace between its pieces, and a version that concatenated them
     // rendered "alphaalpha" at every boundary. Codex, confirming round.
     #expect(result.segments.map { $0.text + $0.trailing }.joined() == raw)
+    // Copy, Save and Share follow the screen: the untouched tail the view shows is in the
+    // export, and the Cleaned view's export stays the finished prefix alone. Found by the
+    // cloud review of PR #2799.
+    #expect(c.exportText.contains("four five six"), "the marked-up export dropped the visible tail")
+    #expect(c.exportText.hasPrefix("Alpha."))
+    c.documentView = .cleaned
+    #expect(!c.exportText.contains("four"))
   }
 
   @MainActor

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -286,13 +286,39 @@ struct FileImportHistoryTests {
     #expect(!c.screenShowsRawWords)
     #expect(c.exportText == "One two three.")
     #expect(c.isSavedToHistory, "the cleaned document is what is saved and what exports")
+    // Nothing until the comparison has been made off the main actor.
+    #expect(c.markedUp == nil)
+    await c.prepareMarkedUp()
     // "um one two three" → "One two three.": one word removed, nothing changed.
-    #expect(c.markedUp.removedWords == 1)
-    #expect(c.markedUp.changedWords == 0)
-    #expect(c.markedUp.segments.map(\.kind) == [.removed, .same, .same, .same])
-    // A new file starts on Cleaned again.
+    #expect(c.markedUp?.removedWords == 1)
+    #expect(c.markedUp?.changedWords == 0)
+    #expect(c.markedUp?.segments.map(\.kind) == [.removed, .same, .same, .same])
+    // A new file starts on Cleaned again, with no comparison carried over.
     c.startOver()
     #expect(c.documentView == .cleaned)
+    #expect(c.markedUp == nil)
+  }
+
+  /// After a Stop, the passages the cleanup never reached are not "removed" (#2773). The
+  /// comparison runs against the finished parts plus the untouched tail; found by Codex.
+  @Test("a stopped import compares against the untouched tail, not against nothing")
+  func aStoppedImportDoesNotMarkTheTailRemoved() async {
+    let spy = HistorySpy()
+    let box = CoordinatorBox()
+    let raw = "um one two three\n\nfour five six"
+    let c = Self.coordinator(
+      spy: spy, raw: raw, cleaned: "One two three.",
+      onPart: { box.coordinator?.stop() })
+    box.coordinator = c
+    c.choose(url: Self.anyURL)
+    await settleUntil { if case .ready = c.state { return true } else { return false } }
+    c.start()
+    await settleUntil { c.state == .stopped }
+    guard !c.parts.isEmpty else { return }
+    c.documentView = .markedUp
+    await c.prepareMarkedUp()
+    let removed = c.markedUp?.segments.filter { $0.kind == .removed }.map(\.text) ?? []
+    #expect(!removed.contains("four"), "an unfinished passage was marked as removed: \(removed)")
   }
 
   /// **The ordering IS the feature.** The raw words must be durable before the slow half

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -337,6 +337,10 @@ struct FileImportHistoryTests {
     #expect(result.segments.suffix(waitingWords).allSatisfy { $0.kind == .same })
     let tail = try #require(result.segments.first { $0.text == "four" })
     #expect(tail.kind == .same, "an unfinished passage was marked \(tail.kind)")
+    // And the rendering rebuilds the transcript byte for byte across the passage cuts: the
+    // splitter drops the whitespace between its pieces, and a version that concatenated them
+    // rendered "alphaalpha" at every boundary. Codex, confirming round.
+    #expect(result.segments.map { $0.text + $0.trailing }.joined() == raw)
   }
 
   @MainActor

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -210,12 +210,12 @@ struct FileImportHistoryTests {
     #expect(!c.isSavedToHistory, "the cleaned document was refused and still reads as saved")
     #expect(c.exportText == "One two three.")
 
-    c.isShowingOriginal = true
+    c.documentView = .original
     #expect(c.isSavedToHistory, "the raw words are on screen and in History")
     #expect(c.exportText == "um one two three")
     #expect(c.historySaveNotice == nil)
 
-    c.isShowingOriginal = false
+    c.documentView = .cleaned
     #expect(!c.isSavedToHistory)
   }
 
@@ -243,7 +243,7 @@ struct FileImportHistoryTests {
     #expect(c.historyRowWasDeleted)
     #expect(c.historySaveNotice?.contains("You deleted this from History") == true)
     // With the original words showing, the answer is the same: those are gone too.
-    c.isShowingOriginal = true
+    c.documentView = .original
     #expect(!c.isSavedToHistory)
   }
 
@@ -273,6 +273,26 @@ struct FileImportHistoryTests {
   @MainActor
   private final class CoordinatorBox {
     var coordinator: FileImportCoordinator?
+  }
+
+  /// The marked-up view (#2773) exports the CLEANED text, because marks have no plain-text
+  /// form, and reports the cleanup's counts from the two texts the run holds.
+  @Test("the marked-up view exports cleaned words and counts what the cleanup did")
+  func theMarkedUpViewExportsCleanedAndCounts() async {
+    let spy = HistorySpy()
+    let c = Self.coordinator(spy: spy)
+    await run(c)
+    c.documentView = .markedUp
+    #expect(!c.screenShowsRawWords)
+    #expect(c.exportText == "One two three.")
+    #expect(c.isSavedToHistory, "the cleaned document is what is saved and what exports")
+    // "um one two three" → "One two three.": one word removed, nothing changed.
+    #expect(c.markedUp.removedWords == 1)
+    #expect(c.markedUp.changedWords == 0)
+    #expect(c.markedUp.segments.map(\.kind) == [.removed, .same, .same, .same])
+    // A new file starts on Cleaned again.
+    c.startOver()
+    #expect(c.documentView == .cleaned)
   }
 
   /// **The ordering IS the feature.** The raw words must be durable before the slow half

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -300,25 +300,40 @@ struct FileImportHistoryTests {
   }
 
   /// After a Stop, the passages the cleanup never reached are not "removed" (#2773). The
-  /// comparison runs against the finished parts plus the untouched tail; found by Codex.
+  /// comparison runs against the finished parts plus the untouched tail. Found by Codex; the
+  /// first version of this test stopped from the FIRST part, which lands nothing, and
+  /// guarded itself out. It now stops during the second, so one part is finished and at
+  /// least one piece is still waiting.
   @Test("a stopped import compares against the untouched tail, not against nothing")
-  func aStoppedImportDoesNotMarkTheTailRemoved() async {
+  func aStoppedImportDoesNotMarkTheTailRemoved() async throws {
     let spy = HistorySpy()
     let box = CoordinatorBox()
-    let raw = "um one two three\n\nfour five six"
+    let raw = Array(repeating: "alpha", count: 600).joined(separator: " ") + " four five six"
+    let calls = CallCounter()
     let c = Self.coordinator(
-      spy: spy, raw: raw, cleaned: "One two three.",
-      onPart: { box.coordinator?.stop() })
+      spy: spy, raw: raw, cleaned: "Alpha.",
+      onPart: {
+        calls.count += 1
+        if calls.count == 2 { box.coordinator?.stop() }
+      })
     box.coordinator = c
     c.choose(url: Self.anyURL)
-    await settleUntil { if case .ready = c.state { return true } else { return false } }
+    #expect(await settleUntil { if case .ready = c.state { return true } else { return false } })
     c.start()
-    await settleUntil { c.state == .stopped }
-    guard !c.parts.isEmpty else { return }
+    #expect(await settleUntil { c.state == .stopped })
+    try #require(c.parts.count == 1)
+    try #require(c.pendingPieces.count > 1)
+
     c.documentView = .markedUp
     await c.prepareMarkedUp()
-    let removed = c.markedUp?.segments.filter { $0.kind == .removed }.map(\.text) ?? []
-    #expect(!removed.contains("four"), "an unfinished passage was marked as removed: \(removed)")
+    let result = try #require(c.markedUp)
+    let tail = try #require(result.segments.first { $0.text == "four" })
+    #expect(tail.kind == .same, "an unfinished passage was marked \(tail.kind)")
+  }
+
+  @MainActor
+  private final class CallCounter {
+    var count = 0
   }
 
   /// **The ordering IS the feature.** The raw words must be durable before the slow half

--- a/Tests/EnviousWisprTests/Core/WordDiffTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordDiffTests.swift
@@ -77,6 +77,24 @@ struct WordDiffTests {
     #expect(r.segments.map(\.text) == ["first", "line", "second", "line"])
     #expect(r.segments[1].trailing == "\n")
     #expect(r.segments.allSatisfy { $0.kind == .same })
+    // Rebuilding the segments gives back the original byte for byte, leading run included.
+    let spaced = "  two  spaces\tand a tab\n"
+    let s = WordDiff.compare(original: spaced, cleaned: "Two spaces and a tab.")
+    #expect(s.segments.map { $0.text + $0.trailing }.joined() == spaced)
+    // An addition after the original's last word gets one separator; nothing else is added.
+    let added = WordDiff.compare(original: "call the doctor", cleaned: "Call the doctor tomorrow")
+    #expect(added.segments.map { $0.text + $0.trailing }.joined() == "call the doctor tomorrow")
+  }
+
+  /// The policy the doc comment states, pinned: internal punctuation counts, a lone
+  /// punctuation token counts, and a mixed hunk counts its original tokens once.
+  @Test("the count policy: internal punctuation and lone tokens count; a hunk counts once")
+  func countPolicy() {
+    #expect(WordDiff.compare(original: "dont go", cleaned: "don't go").changedWords == 1)
+    #expect(WordDiff.compare(original: "wait ...", cleaned: "wait !").changedWords == 1)
+    let hunk = WordDiff.compare(original: "x", cleaned: "a b c")
+    #expect(hunk.changedWords == 1, "a replacement hunk counts its original tokens, not its inserts")
+    #expect(hunk.segments.filter { $0.kind == .added }.isEmpty)
   }
 
   @Test("the legend reads like the founder's example")

--- a/Tests/EnviousWisprTests/Core/WordDiffTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordDiffTests.swift
@@ -53,6 +53,16 @@ struct WordDiffTests {
     #expect(r.changedWords == 0)
   }
 
+  @Test("case folds the Unicode way, not the ASCII way")
+  func caseFoldsUnicode() {
+    // A Greek word in capitals against its lowercase form with the final sigma.
+    let greek = WordDiff.compare(original: "ΟΣ", cleaned: "ος")
+    #expect(greek.segments.map(\.kind) == [.same], "\(greek.segments)")
+    // German sharp s against its capital spelling.
+    let german = WordDiff.compare(original: "STRASSE", cleaned: "Straße")
+    #expect(german.segments.map(\.kind) == [.same], "\(german.segments)")
+  }
+
   @Test("identical text is all the same, and an empty side is all one kind")
   func edges() {
     let same = WordDiff.compare(original: "one two three", cleaned: "one two three")

--- a/Tests/EnviousWisprTests/Core/WordDiffTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordDiffTests.swift
@@ -61,9 +61,15 @@ struct WordDiffTests {
     // German sharp s against its capital spelling.
     let german = WordDiff.compare(original: "STRASSE", cleaned: "Straße")
     #expect(german.segments.map(\.kind) == [.same], "\(german.segments)")
-    // Turkish capital dotted I, whose case fold carries a combining dot no lowercase has.
+    // Turkish capital dotted I, whose neutral case fold carries a combining dot no lowercase
+    // has; collapsed even with no language.
     let turkish = WordDiff.compare(original: "İstanbul", cleaned: "istanbul")
     #expect(turkish.segments.map(\.kind) == [.same], "\(turkish.segments)")
+    // Turkish capital dotless I needs the transcript's language, which the engine reports.
+    let dotless = WordDiff.compare(original: "IŞIK", cleaned: "ışık", language: "tr")
+    #expect(dotless.segments.map(\.kind) == [.same], "\(dotless.segments)")
+    // And the stated limit: without the language it counts as a change.
+    #expect(WordDiff.compare(original: "IŞIK", cleaned: "ışık").changedWords == 1)
     // A diacritic is a different word, and a cleanup that adds one changed the word.
     for (a, b) in [("si", "sí"), ("ou", "où"), ("cafe", "café")] {
       let r = WordDiff.compare(original: a, cleaned: b)

--- a/Tests/EnviousWisprTests/Core/WordDiffTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordDiffTests.swift
@@ -64,9 +64,12 @@ struct WordDiffTests {
     // Turkish capital dotted I, whose case fold carries a combining dot no lowercase has.
     let turkish = WordDiff.compare(original: "İstanbul", cleaned: "istanbul")
     #expect(turkish.segments.map(\.kind) == [.same], "\(turkish.segments)")
-    // An accent is spelling, not a changed word.
-    let accent = WordDiff.compare(original: "cafe", cleaned: "café")
-    #expect(accent.segments.map(\.kind) == [.same], "\(accent.segments)")
+    // A diacritic is a different word, and a cleanup that adds one changed the word.
+    for (a, b) in [("si", "sí"), ("ou", "où"), ("cafe", "café")] {
+      let r = WordDiff.compare(original: a, cleaned: b)
+      #expect(r.segments.map(\.kind) == [.changed], "\(a) → \(b): \(r.segments)")
+      #expect(r.changedWords == 1)
+    }
   }
 
   @Test("identical text is all the same, and an empty side is all one kind")

--- a/Tests/EnviousWisprTests/Core/WordDiffTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordDiffTests.swift
@@ -61,6 +61,12 @@ struct WordDiffTests {
     // German sharp s against its capital spelling.
     let german = WordDiff.compare(original: "STRASSE", cleaned: "Straße")
     #expect(german.segments.map(\.kind) == [.same], "\(german.segments)")
+    // Turkish capital dotted I, whose case fold carries a combining dot no lowercase has.
+    let turkish = WordDiff.compare(original: "İstanbul", cleaned: "istanbul")
+    #expect(turkish.segments.map(\.kind) == [.same], "\(turkish.segments)")
+    // An accent is spelling, not a changed word.
+    let accent = WordDiff.compare(original: "cafe", cleaned: "café")
+    #expect(accent.segments.map(\.kind) == [.same], "\(accent.segments)")
   }
 
   @Test("identical text is all the same, and an empty side is all one kind")

--- a/Tests/EnviousWisprTests/Core/WordDiffTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordDiffTests.swift
@@ -97,13 +97,40 @@ struct WordDiffTests {
     #expect(hunk.segments.filter { $0.kind == .added }.isEmpty)
   }
 
-  @Test("the legend reads like the founder's example")
+  @Test("the legend reads like the founder's example, in the reader's number format")
   func legend() {
     let r = WordDiff.Result(segments: [], removedWords: 1204, changedWords: 318)
-    #expect(r.legend == "1,204 words removed · 318 changed")
+    #expect(r.legend(locale: Locale(identifier: "en_US")) == "1,204 words removed · 318 changed")
+    #expect(r.legend(locale: Locale(identifier: "de_DE")) == "1.204 words removed · 318 changed")
     #expect(
-      WordDiff.Result(segments: [], removedWords: 1, changedWords: 0).legend
-        == "1 word removed · 0 changed")
+      WordDiff.Result(segments: [], removedWords: 1, changedWords: 0)
+        .legend(locale: Locale(identifier: "en_US")) == "1 word removed · 0 changed")
+  }
+
+  /// Passage by passage (#2773, second-pass review). A global alignment matched a finished
+  /// part's few words against the START of the original and marked the untouched waiting
+  /// passages as removed; and a passage the splitter cut inside a run with no spaces read as
+  /// two words against one.
+  @Test("passages are compared with their own originals; an unreached one is all the same")
+  func passagesAreComparedSeparately() {
+    let r = WordDiff.compare(passages: [
+      .init(original: "alpha alpha alpha alpha\n\n", cleaned: "Alpha."),
+      .init(original: "alpha alpha four five six", cleaned: nil),
+    ])
+    #expect(r.removedWords == 3, "three of the first passage's four; none of the waiting one")
+    #expect(r.changedWords == 0)
+    let waiting = r.segments.suffix(5)
+    #expect(waiting.allSatisfy { $0.kind == .same })
+    #expect(waiting.map(\.text) == ["alpha", "alpha", "four", "five", "six"])
+    // The original's whitespace between passages survives; nothing is inserted.
+    #expect(r.segments.map { $0.text + $0.trailing }.joined().hasPrefix("alpha alpha alpha alpha\n\nalpha"))
+
+    // A run with no spaces that the splitter cut in two, each half cleaned to itself.
+    let noSpaces = WordDiff.compare(passages: [
+      .init(original: String(repeating: "あ", count: 30), cleaned: String(repeating: "あ", count: 30)),
+      .init(original: String(repeating: "あ", count: 30), cleaned: String(repeating: "あ", count: 30)),
+    ])
+    #expect(noSpaces.removedWords == 0 && noSpaces.changedWords == 0)
   }
 
   // MARK: - The algorithm, against a reference

--- a/Tests/EnviousWisprTests/Core/WordDiffTests.swift
+++ b/Tests/EnviousWisprTests/Core/WordDiffTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// #2773: the marked-up view's engine. What fails when these fail is a person told the
+/// cleanup removed words it kept, or shown a mark on the wrong word.
+@Suite("WordDiff (#2773)", .tags(.productOutcome))
+struct WordDiffTests {
+
+  // MARK: - The founder's two treatments
+
+  @Test("a removed filler is struck through and counted as removed")
+  func aRemovedWordIsRemoved() {
+    let r = WordDiff.compare(
+      original: "so um the numbers are up", cleaned: "So the numbers are up.")
+    #expect(r.segments.map(\.kind) == [.same, .removed, .same, .same, .same, .same])
+    #expect(r.segments[1].text == "um")
+    #expect(r.removedWords == 1)
+    #expect(r.changedWords == 0)
+    // The ORIGINAL's spelling is what renders: "so", not the cleanup's "So".
+    #expect(r.segments[0].text == "so")
+  }
+
+  @Test("a replaced word is highlighted and counted as changed")
+  func aReplacedWordIsChanged() {
+    let r = WordDiff.compare(original: "we gonna ship it", cleaned: "We are going to ship it.")
+    #expect(r.segments.first?.kind == .same)
+    #expect(r.segments.filter { $0.kind == .changed }.map(\.text) == ["gonna"])
+    #expect(r.removedWords == 0)
+    #expect(r.changedWords >= 1)
+    #expect(r.segments.filter { $0.kind == .same }.map(\.text) == ["we", "ship", "it"])
+  }
+
+  @Test("a word the cleanup added is shown highlighted in place and counted as changed")
+  func anAddedWordIsShown() {
+    let r = WordDiff.compare(
+      original: "call the doctor tomorrow", cleaned: "Call the doctor tomorrow morning.")
+    #expect(r.segments.map(\.kind) == [.same, .same, .same, .same, .added])
+    #expect(r.segments.last?.text == "morning.")
+    #expect(r.removedWords == 0)
+    #expect(r.changedWords == 1)
+  }
+
+  // MARK: - What is NOT a change
+
+  @Test("capitalisation and punctuation are not changes; the count is about words")
+  func punctuationIsNotAChange() {
+    let r = WordDiff.compare(
+      original: "hello there how are you", cleaned: "Hello there, how are you?")
+    #expect(r.segments.allSatisfy { $0.kind == .same })
+    #expect(r.removedWords == 0)
+    #expect(r.changedWords == 0)
+  }
+
+  @Test("identical text is all the same, and an empty side is all one kind")
+  func edges() {
+    let same = WordDiff.compare(original: "one two three", cleaned: "one two three")
+    #expect(same.segments.allSatisfy { $0.kind == .same })
+    #expect(same.legend == "0 words removed · 0 changed")
+
+    let gone = WordDiff.compare(original: "one two three", cleaned: "")
+    #expect(gone.segments.map(\.kind) == [.removed, .removed, .removed])
+    #expect(gone.removedWords == 3)
+
+    let born = WordDiff.compare(original: "", cleaned: "one two")
+    #expect(born.segments.map(\.kind) == [.added, .added])
+    #expect(born.changedWords == 2)
+
+    #expect(WordDiff.compare(original: "", cleaned: "").segments.isEmpty)
+  }
+
+  @Test("the original's layout survives: newlines ride on the word before them")
+  func layoutSurvives() {
+    let r = WordDiff.compare(
+      original: "first line\nsecond line", cleaned: "First line.\nSecond line.")
+    #expect(r.segments.map(\.text) == ["first", "line", "second", "line"])
+    #expect(r.segments[1].trailing == "\n")
+    #expect(r.segments.allSatisfy { $0.kind == .same })
+  }
+
+  @Test("the legend reads like the founder's example")
+  func legend() {
+    let r = WordDiff.Result(segments: [], removedWords: 1204, changedWords: 318)
+    #expect(r.legend == "1,204 words removed · 318 changed")
+    #expect(
+      WordDiff.Result(segments: [], removedWords: 1, changedWords: 0).legend
+        == "1 word removed · 0 changed")
+  }
+
+  // MARK: - The algorithm, against a reference
+
+  /// Myers in linear space against a plain quadratic LCS, on random inputs: the edit
+  /// script must rebuild both sides exactly and be as short as the reference says it can be.
+  /// A wrong middle snake fails the length; a wrong split fails the rebuild.
+  @Test("the edit script rebuilds both sides and is minimal, on 300 random cases")
+  func agreesWithTheReference() {
+    var rng = SeededGenerator(seed: 2773)
+    let alphabet = ["a", "b", "c", "d", "e"]
+    for _ in 0..<300 {
+      let n = Int.random(in: 0...14, using: &rng)
+      let m = Int.random(in: 0...14, using: &rng)
+      let a = (0..<n).map { _ in alphabet.randomElement(using: &rng)! }
+      let b = (0..<m).map { _ in alphabet.randomElement(using: &rng)! }
+      let ops = WordDiff.edits(a, b)
+
+      var rebuiltA: [String] = []
+      var rebuiltB: [String] = []
+      var nonEqual = 0
+      for op in ops {
+        switch op {
+        case .equal(let i, let j):
+          #expect(a[i] == b[j])
+          rebuiltA.append(a[i])
+          rebuiltB.append(b[j])
+        case .delete(let i):
+          rebuiltA.append(a[i])
+          nonEqual += 1
+        case .insert(let j):
+          rebuiltB.append(b[j])
+          nonEqual += 1
+        }
+      }
+      #expect(rebuiltA == a, "a=\(a) b=\(b)")
+      #expect(rebuiltB == b, "a=\(a) b=\(b)")
+      #expect(nonEqual == n + m - 2 * Self.lcs(a, b), "not minimal for a=\(a) b=\(b)")
+    }
+  }
+
+  /// A three-hour transcript's worth of words, with a fifth of them touched, in well under
+  /// a second on any supported Mac. The bound is loose on purpose: this is a smoke test for
+  /// the linear-space claim, not a benchmark, and the measured figure lives on #2773.
+  @Test("27,000 words with a fifth touched completes in bounded time")
+  func scale() {
+    var rng = SeededGenerator(seed: 27)
+    let words = (0..<27_000).map { _ in "w\(Int.random(in: 0...3000, using: &rng))" }
+    var cleaned: [String] = []
+    for w in words {
+      let roll = Int.random(in: 0..<10, using: &rng)
+      if roll == 0 { continue }
+      if roll == 1 {
+        cleaned.append("x\(Int.random(in: 0...99, using: &rng))")
+        continue
+      }
+      cleaned.append(w)
+    }
+    let start = ContinuousClock.now
+    let r = WordDiff.compare(
+      original: words.joined(separator: " "), cleaned: cleaned.joined(separator: " "))
+    let elapsed = ContinuousClock.now - start
+    #expect(r.removedWords + r.changedWords > 0)
+    #expect(elapsed < .seconds(5), "\(elapsed)")
+  }
+
+  private static func lcs(_ a: [String], _ b: [String]) -> Int {
+    var dp = [[Int]](repeating: [Int](repeating: 0, count: b.count + 1), count: a.count + 1)
+    for i in 1...max(1, a.count) where i <= a.count {
+      for j in 1...max(1, b.count) where j <= b.count {
+        dp[i][j] = a[i - 1] == b[j - 1] ? dp[i - 1][j - 1] + 1 : max(dp[i - 1][j], dp[i][j - 1])
+      }
+    }
+    return dp[a.count][b.count]
+  }
+
+  struct SeededGenerator: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407 }
+    mutating func next() -> UInt64 {
+      state ^= state >> 12
+      state ^= state << 25
+      state ^= state >> 27
+      return state &* 2_685_821_657_736_338_717
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/Views/TranscribeFileDoneHeaderTests.swift
+++ b/Tests/EnviousWisprTests/Views/TranscribeFileDoneHeaderTests.swift
@@ -68,4 +68,26 @@ struct TranscribeFileDoneHeaderTests {
       #expect(!title.contains("\u{2014}") && !title.contains("\u{2013}"), "dash in \(title)")
     }
   }
+
+  /// The marks themselves (#2773): a removed word is struck through, which reads without
+  /// colour; an altered or added word carries a background AND weight. A version that used
+  /// colour alone would pass a "looks different" check and fail a colour-blind reader.
+  @Test("removed words are struck through; altered and added words are highlighted and heavier")
+  func markedUpTreatments() {
+    let text = TranscribeFileView.markedUpText([
+      .init(kind: .same, text: "the", trailing: " "),
+      .init(kind: .removed, text: "um", trailing: " "),
+      .init(kind: .changed, text: "gonna", trailing: " "),
+      .init(kind: .added, text: "morning.", trailing: ""),
+    ])
+    var runs: [(String, Bool, Bool)] = []
+    for run in text.runs {
+      let word = String(text[run.range].characters)
+      guard !word.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+      runs.append((word, run.strikethroughStyle != nil, run.backgroundColor != nil))
+    }
+    #expect(runs.map(\.0) == ["the", "um", "gonna", "morning."])
+    #expect(runs.map(\.1) == [false, true, false, false], "strikethrough marks exactly the removed word")
+    #expect(runs.map(\.2) == [false, false, true, true], "the highlight marks exactly the altered and added words")
+  }
 }

--- a/Tests/EnviousWisprTests/Views/TranscribeFileDoneHeaderTests.swift
+++ b/Tests/EnviousWisprTests/Views/TranscribeFileDoneHeaderTests.swift
@@ -92,8 +92,8 @@ struct TranscribeFileDoneHeaderTests {
     // And the weight, which is what makes the highlight readable without its colour.
     let weighted = text.runs
       .filter { !String(text[$0.range].characters).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-      .map { $0.swiftUI.font != nil }
-    #expect(weighted == [false, false, true, true])
+      .map { $0.swiftUI.font }
+    #expect(weighted == [nil, nil, .body.weight(.semibold), .body.weight(.semibold)])
     // What a screen reader gets, since the marks say nothing aloud.
     #expect(
       TranscribeFileView.markedUpAccessibilityText([

--- a/Tests/EnviousWisprTests/Views/TranscribeFileDoneHeaderTests.swift
+++ b/Tests/EnviousWisprTests/Views/TranscribeFileDoneHeaderTests.swift
@@ -89,5 +89,16 @@ struct TranscribeFileDoneHeaderTests {
     #expect(runs.map(\.0) == ["the", "um", "gonna", "morning."])
     #expect(runs.map(\.1) == [false, true, false, false], "strikethrough marks exactly the removed word")
     #expect(runs.map(\.2) == [false, false, true, true], "the highlight marks exactly the altered and added words")
+    // And the weight, which is what makes the highlight readable without its colour.
+    let weighted = text.runs
+      .filter { !String(text[$0.range].characters).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+      .map { $0.swiftUI.font != nil }
+    #expect(weighted == [false, false, true, true])
+    // What a screen reader gets, since the marks say nothing aloud.
+    #expect(
+      TranscribeFileView.markedUpAccessibilityText([
+        .init(kind: .same, text: "the", trailing: " "),
+        .init(kind: .removed, text: "um", trailing: " "),
+      ]) == "the Removed: um. ")
   }
 }


### PR DESCRIPTION
Closes #2773.

## What the user gets

On the Done step of Transcribe a File, a third view beside Cleaned and Original: the ORIGINAL
words with the cleanup marked on them. A removed word is struck through; an altered word is
highlighted and heavier; a word the cleanup added is shown highlighted in place. Above the
text, the counts the founder asked for: "1,204 words removed · 318 changed". The three views
are one segmented control in the Done chips row. Copy, Save and Share follow Cleaned and
Original as before and export the cleaned text from the marked-up view, because marks have
no plain-text form.

Founder's words: "people can quickly see that it worked vs just seeing a large blob of text
and the cleaned up text without really understanding how much cleanup actually happened".

## How

`WordDiff` (new, EnviousWisprCore): whitespace tokens compared by their letters, Myers in
LINEAR space with the middle-snake refinement, compared PASSAGE BY PASSAGE the way the
cleanup itself ran, with each passage's original recovered from the transcript so the
whitespace the splitter drops between pieces renders exactly as spoken. A passage the
cleanup never reached is all the same. The comparison runs off the main actor, once per
input, with a placeholder until it lands.

Measured before choosing the algorithm (on #2773): 1.8 ms at 2,000 words, 26 ms at 9,000,
107 ms at 27,000 on cleanup-shaped input; about three seconds at 27,000 for two transcripts
with nothing in common (the reviewer's measurement), which is why it is off-main.

## Review

Build orchestrator (persistent Codex session): CHUNK-CLEAN after three rounds, then a
second-pass behavioural review with the diff and no author reasoning, then two confirming
rounds on its findings: CHUNK-CLEAN at `8cb9dd49`. Findings fixed along the way: stopped
imports marking untouched passages as removed, a synchronous comparison in a getter, lost and
invented whitespace, an unobserved cache, a self-skipping test, a US-locale legend test, a
weight assertion that accepted any font, and the splitter's dropped inter-passage whitespace.

## Tests

`WordDiffTests` (10): the founder's cases, the count policy, edges, layout survival, the
legend in two locales, per-passage comparison including a no-spaces run, a 300-case random
differential test against a quadratic LCS reference (rebuild + minimality; the reviewer also
ran 16,129 exhaustive binary pairs), and a 27,000-word bounded-time run. Coordinator: export
rule and counts; a stopped import compares against the untouched tail with every waiting
token unchanged and a byte-for-byte rebuild of the transcript. View: strikethrough on exactly
the removed run, highlight and semibold on exactly the altered and added runs, and the spoken
form of the marks.

`scripts/xcode-test.sh`: 7892 tests across the three lanes, 4 failures, all four the
`RenderedPillFreezeTests` host-metric rows (#2790, macOS 27.0, fails identically on unchanged
main on this Mac), every other suite green.

## Live UAT: blocked by #2798, stated plainly

A real screenshot of the marked-up view was attempted on the rebuilt dev app and could not be
taken: the wizard's REVIEW step crashes (stack overflow) or, with a bigger main-thread stack,
hangs at 100% CPU in a SwiftUI layout loop on macOS 27.0, on unchanged `main` as well as on
this branch. Filed as #2798 with both crash reports and the sample; it blocks every session's
Live UAT past Polish on this Mac and is the next task. The evidence for this PR is the tests
above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjGY8kCx8KYXAbwuiEALsm
