### PR TITLE
fix(import): the Review step no longer places the wizard inside its own card (#2798)

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -589,7 +589,7 @@ struct TranscribeFileView: View {
           HStack(spacing: 8) {
             Image(systemName: icon).foregroundStyle(Color.stAccent)
             Text(title).font(.stRowTitle).lineLimit(1).fixedSize()
-            if recommended { Self.badge("Recommended") }
+            if recommended { Self.wizardBadge("Recommended") }
             Spacer(minLength: 8)
             check
           }
@@ -600,7 +600,7 @@ struct TranscribeFileView: View {
               Spacer(minLength: 8)
               check
             }
-            if recommended { Self.badge("Recommended") }
+            if recommended { Self.wizardBadge("Recommended") }
           }
         }
         Text(blurb)
@@ -629,7 +629,15 @@ struct TranscribeFileView: View {
 
   /// Static and internal so `TranscribeFilePolishGridTests` can measure the one badge that
   /// sets the polish card's minimum width.
-  static func badge(_ text: String) -> some View {
+  ///
+  /// Named so that no unqualified call can resolve to SwiftUI's own `View.badge(_:)`. When
+  /// this helper was `badge(_:)` and became static, one call site inside an instance method
+  /// stayed unqualified, and the compiler quietly chose `self.badge("Recommended")`: the
+  /// whole wizard, placed inside its own processing-path card, inside the wizard, without
+  /// end. On macOS 27.0 that was a main-thread stack overflow the moment Review opened
+  /// (#2798; 42,933 frames of SwiftUI stack sizing). `wizardBadge` has no SwiftUI twin, so
+  /// an unqualified call is a compile error rather than a recursion.
+  static func wizardBadge(_ text: String) -> some View {
     Text(text)
       .font(.system(size: 13, weight: .semibold))
       // Never "Recomme…": a badge that cannot say its word is not a badge. At the minimum
@@ -899,7 +907,7 @@ struct TranscribeFileView: View {
             .foregroundStyle(selected ? Color.stAccent : Color.stTextSecondary)
         }
         Text(choice.title).font(.stRowLabel).fixedSize(horizontal: false, vertical: true)
-        if choice.provider == .egOne { Self.badge("Recommended") }
+        if choice.provider == .egOne { Self.wizardBadge("Recommended") }
         // Wraps, like the title. A single-line subtitle truncated at three columns, and the
         // words it lost were the ones saying whether the engine is ready.
         Text(cardSubtitle(for: choice.provider))
@@ -1124,7 +1132,7 @@ struct TranscribeFileView: View {
       HStack(spacing: 8) {
         mark()
         Text(title).font(.stRowLabel)
-        if recommended { badge("Recommended") }
+        if recommended { Self.wizardBadge("Recommended") }
         Spacer(minLength: 0)
       }
       Text(blurb).foregroundStyle(Color.stTextSecondary)

--- a/Tests/EnviousWisprTests/Settings/TranscribeFilePolishGridTests.swift
+++ b/Tests/EnviousWisprTests/Settings/TranscribeFilePolishGridTests.swift
@@ -39,7 +39,7 @@ struct TranscribeFilePolishGridTests {
   /// wrap, so the badge is the one thing in a card that sets its floor.
   @Test("the minimum card width holds the Recommended badge inside the card's padding")
   func theMinimumHoldsTheBadge() {
-    let host = NSHostingView(rootView: TranscribeFileView.badge("Recommended"))
+    let host = NSHostingView(rootView: TranscribeFileView.wizardBadge("Recommended"))
     let badge = host.fittingSize.width
     #expect(badge > 0, "the harness returned nothing, which is not a pass")
     let padding: CGFloat = 12 * 2


### PR DESCRIPTION
Closes #2798.

## What was wrong
PR #2786 made the "Recommended" pill a static helper named `badge(_:)` and qualified three of its four call sites. The fourth, inside `pathCard` on the Review step, stayed `badge("Recommended")`. From an instance method that name no longer reached the static helper, so the compiler resolved it to SwiftUI's `View.badge(_:)` on `self`: the processing-path card carried the whole `TranscribeFileView`, whose Review step carried the card, without end. On macOS 27.0 that was a main-thread stack overflow the moment Review opened. The shipped v2.4.8 is before #2786 and is unaffected.

Measured with lldb attached at the stack-guard hit: 42,933 frames, one 110-frame block of SwiftUI stack sizing repeating about 390 times. The crash reporter had cut the middle out and shown 140 frames, which is why the first reads went after frame sizes and the polish grid (both patches kept under `docs/feature-requests/2773-uat-evidence/`).

## The fix
The helper is now `wizardBadge(_:)`, a name with no SwiftUI twin, so an unqualified call from an instance method is a compile error instead of a recursion; every call is `Self.wizardBadge`. Rendering is unchanged. One test updates its reference.

## Verified live (macOS 27.0, Dev build, this Mac)
Choose a file → Continue → Continue reaches Review and stays alive (`review-step-fixed.png`), Start transcription reaches Done with the transcript saved to History and polished by EG-1, and all three views render (`done-step-cleaned.png`, `done-step-marked-up.png`, `done-step-original.png`), which was the #2773 Live UAT this crash had blocked.

Lane: Code. Tier: SMALL. council-skip: zero-blast-radius (rename, 2 files).
