### PR TITLE
feat(menubar): "Transcribe a File..." in the drop-down opens the wizard (#2772)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -447,6 +447,15 @@ final class MenuBarController: NSObject {
 
     menu.addItem(.separator())
 
+    // Transcribe a File (#2772): the founder asked for it in the first UAT round of the
+    // import wizard. Opens the unified window on that page; the page itself does the rest.
+    let transcribeFileItem = NSMenuItem(
+      title: "Transcribe a File...", action: #selector(openTranscribeFileAction), keyEquivalent: "")
+    transcribeFileItem.image = NSImage(
+      systemSymbolName: "doc.badge.plus", accessibilityDescription: "Transcribe a File")
+    transcribeFileItem.target = self
+    menu.addItem(transcribeFileItem)
+
     // Settings (opens unified window to Speech Engine tab)
     let settingsItem = NSMenuItem(
       title: "Settings...", action: #selector(openSettingsAction), keyEquivalent: ",")
@@ -599,6 +608,10 @@ final class MenuBarController: NSObject {
     actions.openSettings()
   }
 
+  @objc private func openTranscribeFileAction() {
+    actions.openTranscribeFile()
+  }
+
   /// #1047: set the window-appearance preference from the Appearance submenu.
   /// The `didSet` persists it and the bootstrapper applies it to `NSApp`.
   @objc private func setAppearanceAction(_ sender: NSMenuItem) {
@@ -709,6 +722,8 @@ struct MenuBarActions: Sendable {
       Void
   let continueOnboarding: @MainActor () -> Void
   let openSettings: @MainActor () -> Void
+  /// Open the unified window on the Transcribe a File page (#2772).
+  let openTranscribeFile: @MainActor () -> Void
   let openPermissions: @MainActor () -> Void
   let toggleRecording: @MainActor () async -> Void
   let quit: @MainActor () -> Void

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1305,6 +1305,10 @@ package final class WisprBootstrapper {
           navigationCoordinator.request(.speechEngine)
           appWindowCoordinator.showWindow()
         },
+        openTranscribeFile: {
+          navigationCoordinator.request(.transcribeFile)
+          appWindowCoordinator.showWindow()
+        },
         openPermissions: {
           navigationCoordinator.request(.permissions)
           appWindowCoordinator.showWindow()

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -132,6 +132,7 @@ struct MenuBarControllerTests {
         "Start Recording",
         "Add Selected Word  \u{2303}\u{2325} W",  // #2412, disabled; the chord rides in the title
         "",  // separator
+        "Transcribe a File...",  // #2772, opens the window on that page
         "Settings...",
         "Appearance",  // #1047 submenu parent
         "",  // separator
@@ -145,7 +146,7 @@ struct MenuBarControllerTests {
     // Separators are separators.
     #expect(menu.items[2].isSeparatorItem)
     #expect(menu.items[5].isSeparatorItem)
-    #expect(menu.items[8].isSeparatorItem)
+    #expect(menu.items[9].isSeparatorItem)
     // Settings carries the comma key-equivalent; Quit carries "q".
     #expect(item(menu, "Settings...")?.keyEquivalent == ",")
     #expect(item(menu, "Quit \(AppConstants.appName)")?.keyEquivalent == "q")
@@ -597,8 +598,12 @@ struct MenuBarControllerTests {
     perform(item(menu, "Settings..."))
     #expect(spy.fired == ["continueOnboarding", "openSettings"])
 
+    // #2772: the drop-down entry opens the window on the Transcribe a File page.
+    perform(item(menu, "Transcribe a File..."))
+    #expect(spy.fired == ["continueOnboarding", "openSettings", "openTranscribeFile"])
+
     perform(item(menu, "Quit \(AppConstants.appName)"))
-    #expect(spy.fired == ["continueOnboarding", "openSettings", "quit"])
+    #expect(spy.fired == ["continueOnboarding", "openSettings", "openTranscribeFile", "quit"])
 
     // toggleRecording dispatches through an async Task — yield so it runs.
     perform(item(menu, "Start Recording"))
@@ -720,6 +725,7 @@ struct MenuBarControllerTests {
         },
         continueOnboarding: { spy.fired.append("continueOnboarding") },
         openSettings: { spy.fired.append("openSettings") },
+        openTranscribeFile: { spy.fired.append("openTranscribeFile") },
         openPermissions: { spy.fired.append("openPermissions") },
         toggleRecording: { spy.fired.append("toggleRecording") },
         quit: { spy.fired.append("quit") }


### PR DESCRIPTION
Part of #2772 (the founder's request from the first UAT round; #2772 is already closed and stays closed).

## What
A "Transcribe a File..." entry in the menu bar drop-down, above "Settings...". Clicking it opens the app window on the Transcribe a File page. It uses the same navigation request the permissions warning uses, so nothing new is invented.

## Tests
`MenuBarControllerTests`: the idle golden fixture freezes the entry's position; the dispatch test requires the entry to fire `openTranscribeFile`. Full Debug lane: `scripts/xcode-test.sh` on the Debug lane; 7701 tests in 689 suites, 4 failures, all four the `RenderedPillFreezeTests` host-metric rows (#2790, macOS 27.0), every other suite green. `MenuBarControllerTests` filtered: 42 passed.. Test-hardening recipe: #2802.

## Verified live (macOS 27.0, Dev build)
Driven with the accessibility API: The entry opens the page from a closed window, from the History page, and when the page is already showing (`docs/feature-requests/2772-uat-evidence/menubar-entry-from-closed.png`, `menubar-entry-from-history.png`, `menubar-dropdown-open.png`).

Codex (local) raised one hypothetical: a fresh window view could miss a pending page request (the Settings view consumes it on change, not initially). The closed-window case above is exactly that path and it landed on the page, so no change was made; noted in the commit as a known limit.

Lane: Code. Tier: SMALL. council-skip: zero-blast-radius (one menu entry, three files).
