### PR TITLE
feat(ui): History tells a dictation from a transcript, with a filter and the words to match (#2808)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
+++ b/Sources/EnviousWisprAppKit/App/DictationNarrator.swift
@@ -260,17 +260,18 @@ enum DictationNarrator {
       return "Bluetooth microphone detected. Wait a moment before speaking on a cold start."
     // #2087: no "Warning: " or "Error: " prefix — nothing went wrong. The
     // sentence names what happened and the one action, matching the pill's
-    // founder-locked copy (`Transcript cancelled` · Undo). History is named
-    // because a VoiceOver user who misses a 3-second dwell needs the unhurried
-    // door, and the pill must never be the only way back to the text.
+    // copy (`Dictation cancelled` · Undo, see `escapeRecoveryPillTitle`). History
+    // is named because a VoiceOver user who misses a 3-second dwell needs the
+    // unhurried door, and the pill must never be the only way back to the text.
     case .escapeRecovery:
-      return "Transcript cancelled. Press Undo to get it back, or find it in History."
+      return "Dictation cancelled. Press Undo to get it back, or find it in History."
     }
   }
 
   // MARK: - Fixed status-pill + window/badge/sidebar copy (E4, #1569). Byte-identical.
 
-  /// #2087, founder-locked (revised 2026-08-18 after hand-testing the build).
+  /// #2087, founder-locked (revised 2026-08-18 after hand-testing the build); noun revised
+  /// again by the founder's vocabulary decision of 2026-09-11 (#2807).
   ///
   /// Names the EVENT the user just caused, then offers the reversal. The earlier
   /// pair — "Recording kept" · Paste — announced our internal outcome and named
@@ -278,7 +279,12 @@ enum DictationNarrator {
   /// taking that back. It also stops the button reading as a second, competing
   /// paste beside History's, which does something different: History pastes
   /// wherever you are NOW, this returns the text to where you were dictating.
-  static let escapeRecoveryPillTitle = "Transcript cancelled"
+  ///
+  /// #2807: a take made with the keybind is a Dictation and a file put through Transcribe
+  /// a File is a Transcript, everywhere the app speaks. What was cancelled here is a
+  /// dictation, so the pill says so. The verb, the Undo action and the announcement's
+  /// shape are the 2026-08-18 lock, unchanged.
+  static let escapeRecoveryPillTitle = "Dictation cancelled"
   static let escapeRecoveryPillAction = "Undo"
 
   static let coldStartTitle = "Getting dictation ready…"

--- a/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
+++ b/Sources/EnviousWisprAppKit/App/EscapeRecoveryPillView.swift
@@ -240,7 +240,7 @@ enum PillMetrics {
   ///
   /// A hand-tuned constant here is a latent truncation bug: the copy is
   /// founder-owned and has already been revised once (#2087, 2026-08-18), and a
-  /// pill too narrow by two points silently renders "Transcript cance…". The
+  /// pill too narrow by two points silently renders "Dictation cance…". The
   /// two points of slack absorb rounding between this measurement and the
   /// renderer's own layout.
   static let pillWidth: CGFloat = {

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -571,6 +571,10 @@ final class TranscriptCoordinator {
       if swept.walkComplete, swept.unremovable == 0 {
         transcripts.removeAll { $0.escapeRecoveredAt != nil && !Self.isVisible($0, at: now) }
       }
+      // #2807: an evicted row may have been the selected one. Clearing it here, where the
+      // expiry is detected, is what lets the next completed dictation show in the pane
+      // instead of hiding behind an id that resolves to nothing. Cloud review of PR #2815.
+      reconcileSelectionWithDisplayedSet()
       for row in swept.expired {
         guard let takeID = row.takeID else { continue }
         // The row's REAL age, not the retention constant. A Mac left off for
@@ -706,6 +710,14 @@ final class TranscriptCoordinator {
     // the suppression, and nor does a row the current filter does not list.
     if transcript.escapeRecoveredAt == nil {
       liveFallbackRowID = transcript.id
+      // A selection that no longer resolves is no selection: the row expired between
+      // renders or was swept, and read-time expiry hides it without a state change. Left
+      // in place it would hide this completion behind an empty pane. Cloud review of PR #2815.
+      if let selected = selectedTranscriptID,
+        !filteredTranscripts.contains(where: { $0.id == selected })
+      {
+        selectedTranscriptID = nil
+      }
       if selectedTranscriptID == nil {
         // The pane follows the list in BOTH directions: a completion the list shows lets
         // the fallback show again, and one the list does not show (a search or a filter

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -239,6 +239,16 @@ final class TranscriptCoordinator {
   /// stands unless something cleared a selection out from under the user.
   var detail: HistoryDetail {
     guard let selected = selectedTranscriptID else {
+      // ONE source for the just-finished dictation: its History row, never the live
+      // pipeline's copy beside it. The row is what the list shows, so the pane cannot
+      // show a text the list does not; a row this object has not seen yet, or that
+      // the list stopped showing, is nothing rather than the live transcript.
+      if let fallbackRow = liveFallbackRowID {
+        guard !liveFallbackSuppressed,
+          let row = filteredTranscripts.first(where: { $0.id == fallbackRow })
+        else { return .empty }
+        return .row(row)
+      }
       return liveFallbackSuppressed ? .empty : .liveFallback
     }
     if let match = filteredTranscripts.first(where: { $0.id == selected }) {
@@ -247,7 +257,9 @@ final class TranscriptCoordinator {
     return .empty
   }
 
-  /// The detail pane follows the list (#2807). Called when the filter or the search changes.
+  /// The detail pane follows the list (#2807). Called when the filter or the search changes,
+  /// and after any write that replaces rows, because a cleanup can change the text a search
+  /// matched on.
   ///
   /// A selection that the displayed set no longer lists is cleared, and the live fallback is
   /// suppressed by the setter, so a filter or a search never reveals it. With nothing selected
@@ -664,6 +676,7 @@ final class TranscriptCoordinator {
         // unchanged, so History is byte-identical for anyone who never turns
         // Escape Recovery on.
         transcripts = inFlightRows + Self.mergeNewestFirst(heldRows, diskRows)
+        reconcileSelectionWithDisplayedSet()
         startPulseIfNeeded()
       } catch {
         await AppLogger.shared.log(
@@ -728,6 +741,7 @@ final class TranscriptCoordinator {
     } else {
       transcripts.insert(transcript, at: 0)
     }
+    reconcileSelectionWithDisplayedSet()
     startPulseIfNeeded()
   }
 
@@ -753,6 +767,8 @@ final class TranscriptCoordinator {
     historyWriteRevision += 1
     writtenAtRevision[transcript.id] = historyWriteRevision
     transcripts[existing] = transcript
+    // #2807: the cleaned text can stop matching the search the row was selected under.
+    reconcileSelectionWithDisplayedSet()
     startPulseIfNeeded()
     return true
   }
@@ -1217,9 +1233,10 @@ enum HistoryEmptyState: Equatable, Sendable {
 
 /// What the History detail pane shows (#2807).
 enum HistoryDetail {
-  /// A row the list displays.
+  /// A row the list displays: the selected one, or the just-finished dictation's own row.
   case row(Transcript)
-  /// Nothing is selected and nothing cleared a selection away: the live transcript, if any.
+  /// Nothing is selected, no completed dictation has landed in this session, and nothing has
+  /// narrowed the list: the live pipeline's transcript, if any.
   case liveFallback
   /// Nothing to show, and the live transcript must not stand in.
   case empty

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -19,8 +19,54 @@ final class TranscriptCoordinator {
   /// and misses a bare access from an extension. The compiler makes the mistake
   /// unavailable instead. Read `visibleTranscripts` or `filteredTranscripts`.
   private var transcripts: [Transcript] = []
-  var searchQuery: String = ""
-  var selectedTranscriptID: UUID?
+  var searchQuery: String = "" {
+    didSet { reconcileSelectionWithDisplayedSet() }
+  }
+
+  /// The row the list has selected.
+  ///
+  /// #2807: the detail pane resolves from what is DISPLAYED, and this setter is the one
+  /// door every selection change goes through: the list's binding, the filter, a search, a
+  /// deletion. A selection that resolves inside the displayed set lifts the live-transcript
+  /// suppression; a selection going away, whoever cleared it, arms it. The coordinator cannot
+  /// tell a user's deselect from a row vanishing under the list's binding, so both arm it —
+  /// the cost is a status view where the live transcript used to be, which is the same thing
+  /// the user sees after deleting a row.
+  var selectedTranscriptID: UUID? {
+    didSet {
+      if let selected = selectedTranscriptID {
+        if filteredTranscripts.contains(where: { $0.id == selected }) {
+          liveFallbackSuppressed = false
+        }
+      } else if oldValue != nil {
+        liveFallbackSuppressed = true
+      }
+    }
+  }
+
+  /// Which kind of History row is listed (#2807). View state: never persisted, so a relaunch
+  /// starts at All.
+  var historyFilter: HistoryFilter = .all {
+    didSet { reconcileSelectionWithDisplayedSet() }
+  }
+
+  /// #2807: whether the detail pane may show the live transcript when nothing is selected.
+  ///
+  /// The live fallback exists for one moment: a dictation just finished and History is open
+  /// with nothing selected, so the pane shows what was just said. It is UNRELATED to anything
+  /// the user did in the list. So when a selection is cleared because a filter, a search or a
+  /// deletion took the row away, the pane must show nothing rather than a transcript from
+  /// another time. Lifted only by a selection that resolves inside the displayed set, or by a
+  /// completed dictation landing in it (`append`), which is the moment the fallback is for.
+  private var liveFallbackSuppressed = false
+
+  /// The completed dictation the live fallback is showing, if this object saw it land (#2807).
+  ///
+  /// The fallback is the live pipeline's transcript, which this object cannot see; what it
+  /// CAN see is the row `append` inserted for it. Kept so a filter or a search that stops
+  /// listing that row also stops the pane showing its text: the pane must follow the list.
+  /// Nil until a dictation completes in this session, or after Delete All removes the row.
+  private var liveFallbackRowID: UUID?
 
   /// Re-render pulse for pending Escape Recovery rows (#2087).
   ///
@@ -71,13 +117,25 @@ final class TranscriptCoordinator {
     return transcripts.filter { Self.isVisible($0, at: now) }
   }
 
+  /// The rows History lists: visible rows, inside the kind filter, then inside the search.
+  ///
+  /// #2807: the kind filter runs FIRST and reads `isImported`, which is the row's only kind.
+  /// A pending Escape-recovery row is a dictation that was cancelled, so it stays under All
+  /// and Dictations exactly as it did before the filter existed, and is absent under
+  /// Transcripts. The search then keeps its own rule below.
   var filteredTranscripts: [Transcript] {
     let visible = visibleTranscripts
-    guard !searchQuery.isEmpty else { return visible }
+    let listed: [Transcript]
+    switch historyFilter {
+    case .all: listed = visible
+    case .dictations: listed = visible.filter { !$0.isImported }
+    case .transcripts: listed = visible.filter { $0.isImported }
+    }
+    guard !searchQuery.isEmpty else { return listed }
     // Pending rows are excluded from search DELIBERATELY: an accidental Escape
     // would otherwise pollute results for 24 hours, and the row is reachable
     // the whole time by scrolling History, which is where the user left it.
-    return visible.filter {
+    return listed.filter {
       // #2772: the imported file's name is on the row, and it is the thing a person looking
       // for a meeting they transcribed types, so it is searchable. Searching "marketing" for
       // `marketing_sync.wav` removed the row while its badge said the word. Found by the
@@ -88,7 +146,7 @@ final class TranscriptCoordinator {
     }
   }
 
-  /// Completed dictations. A held recovery is an OFFER, not a dictation the
+  /// Completed rows. A held recovery is an OFFER, not a dictation the
   /// user made — counting it would inflate the stat the moment they cancelled
   /// something, which is the opposite of what cancelling meant.
   ///
@@ -103,15 +161,17 @@ final class TranscriptCoordinator {
   ///
   /// `deletableCount` deliberately counts imports too: it answers "how many rows would
   /// Delete All take", where an uncounted row is a row destroyed without warning.
-  var transcriptCount: Int {
-    _ = expiryPulse
-    let now = Date()
-    return transcripts.filter { Self.isVisible($0, at: now) && $0.escapeRecoveredAt == nil }
-      .count
+  ///
+  /// #2807: counts inside the filter and the search, because the number sits beside the list
+  /// it describes. Under All with an empty search it is exactly the pre-filter count. Renamed
+  /// from `transcriptCount`, because a Transcript is now a file import and this counts every
+  /// kind.
+  var listedCount: Int {
+    filteredTranscripts.filter { $0.escapeRecoveredAt == nil }.count
   }
 
-  /// How many dictations exist: `transcriptCount` without the imports. Onboarding's success
-  /// detector reads this one.
+  /// How many dictations exist: every completed row that is not an import, whatever the
+  /// filter shows. Onboarding's success detector reads this one.
   var dictationCount: Int {
     _ = expiryPulse
     let now = Date()
@@ -123,8 +183,8 @@ final class TranscriptCoordinator {
   /// How many rows a Delete All would actually take, from the user's point of
   /// view (#2087).
   ///
-  /// Deliberately NOT `transcriptCount`. That one answers "how many dictations
-  /// have I made" and excludes held recoveries, which is right for a statistic
+  /// Deliberately NOT `listedCount`. That one answers "how many rows does the
+  /// list show" and excludes held recoveries, which is right for a statistic
   /// and wrong for a destructive confirmation: with only held rows on screen it
   /// reads zero, so the dialog would offer to delete "all 0 transcripts" and
   /// then delete them. A confirmation must count what it is about to destroy.
@@ -143,8 +203,76 @@ final class TranscriptCoordinator {
     // "all 1 transcripts" is what centralising the sentence without reading it
     // produced, and a test then pinned it. One row is not a plural, and "all"
     // reads as boilerplate when there is nothing to be exhaustive about.
-    let subject = count == 1 ? "1 transcript" : "all \(count) transcripts"
+    //
+    // #2807: Delete All is GLOBAL while the list can be filtered or searched, so the
+    // sentence says that a hidden row goes too. The count is the global one for the same
+    // reason: a confirmation must count what it is about to destroy, not what is on screen.
+    let subject =
+      count == 1
+      ? "the only item in History, even if a filter or search is hiding it"
+      : "all \(count) items in History, including any hidden by a filter or search"
     return "This will permanently delete \(subject). This action cannot be undone."
+  }
+
+  /// What the list shows when it has no rows (#2807), or nil while it has some.
+  ///
+  /// Four different absences, because the fix for each is different: nothing has ever been
+  /// recorded; nothing of the chosen kind; nothing matches the search. Answered here so the
+  /// view cannot pick the global "nothing yet" for a list that a filter emptied.
+  var emptyState: HistoryEmptyState? {
+    guard !visibleTranscripts.isEmpty else { return .nothingYet }
+    guard filteredTranscripts.isEmpty else { return nil }
+    guard searchQuery.isEmpty else { return .noMatches }
+    switch historyFilter {
+    // Unreachable: with no search, All lists every visible row, and there is at least one.
+    case .all: return .nothingYet
+    case .dictations: return .noDictations
+    case .transcripts: return .noTranscripts
+    }
+  }
+
+  /// What the detail pane shows (#2807), resolved from the DISPLAYED set.
+  ///
+  /// A selected row that the filter or the search does not list, or that expired since it was
+  /// picked, is `.empty` rather than the live fallback: the pane must never answer a narrowing
+  /// of the list with a transcript from another time. With nothing selected the live fallback
+  /// stands unless something cleared a selection out from under the user.
+  var detail: HistoryDetail {
+    guard let selected = selectedTranscriptID else {
+      return liveFallbackSuppressed ? .empty : .liveFallback
+    }
+    if let match = filteredTranscripts.first(where: { $0.id == selected }) {
+      return .row(match)
+    }
+    return .empty
+  }
+
+  /// The detail pane follows the list (#2807). Called when the filter or the search changes.
+  ///
+  /// A selection that the displayed set no longer lists is cleared, and the live fallback is
+  /// suppressed by the setter, so a filter or a search never reveals it. With nothing selected
+  /// the same question is asked of the fallback's own row: if the list stops showing the
+  /// dictation the pane is showing, the pane goes empty. Where that row is unknown, any
+  /// narrowing of the list suppresses the fallback, because nothing can prove the pane's text
+  /// is among the rows on screen. Widening the list later does not bring either back; only a
+  /// selection, or the next completed dictation, does.
+  private func reconcileSelectionWithDisplayedSet() {
+    let displayed = filteredTranscripts
+    if let selected = selectedTranscriptID {
+      guard !displayed.contains(where: { $0.id == selected }) else { return }
+      selectedTranscriptID = nil
+      return
+    }
+    guard !liveFallbackSuppressed else { return }
+    let fallbackRowIsListed: Bool
+    if let fallbackRow = liveFallbackRowID {
+      fallbackRowIsListed = displayed.contains(where: { $0.id == fallbackRow })
+    } else {
+      fallbackRowIsListed = historyFilter == .all && searchQuery.isEmpty
+    }
+    if !fallbackRowIsListed {
+      liveFallbackSuppressed = true
+    }
   }
 
   /// Held rows IN MEMORY whose window has elapsed.
@@ -521,7 +649,8 @@ final class TranscriptCoordinator {
         // start of a load replaces the cleaned version saved a moment later, and History
         // shows unpolished words until something else refreshes it. Found by Codex.
         let newerRows = Dictionary(
-          uniqueKeysWithValues: transcripts
+          uniqueKeysWithValues:
+            transcripts
             .filter { (writtenAtRevision[$0.id] ?? 0) > revisionAtRead }
             .map { ($0.id, $0) })
         diskRows = diskRows.map { newerRows[$0.id] ?? $0 }
@@ -558,6 +687,19 @@ final class TranscriptCoordinator {
   /// protection would mask heart-path bugs.
   func append(_ transcript: Transcript) {
     transcripts.insert(transcript, at: 0)
+    // #2807: a COMPLETED dictation landing in the displayed set with nothing selected is the
+    // one moment the live fallback exists for, so it may show again. A held recovery is a
+    // cancellation, not a completion, and an import never comes through here; neither lifts
+    // the suppression, and nor does a row the current filter does not list.
+    if transcript.escapeRecoveredAt == nil {
+      liveFallbackRowID = transcript.id
+      if selectedTranscriptID == nil {
+        // The pane follows the list in BOTH directions: a completion the list shows lets
+        // the fallback show again, and one the list does not show (a search or a filter
+        // that excludes it) suppresses a fallback that was showing the previous dictation.
+        liveFallbackSuppressed = !filteredTranscripts.contains(where: { $0.id == transcript.id })
+      }
+    }
     // A held row appended at runtime is the production route once the feature
     // is activated, and it arrives with a countdown already running. Without
     // this the pulse would only ever start at launch, so a recovery held during
@@ -634,11 +776,20 @@ final class TranscriptCoordinator {
 
   func delete(_ transcript: Transcript) {
     do {
+      // #2807: the displayed set BEFORE the removal, so the neighbour is the row the user
+      // saw beside the one they deleted.
+      let displayed = filteredTranscripts
       try store.delete(id: transcript.id)
       transcripts.removeAll { $0.id == transcript.id }
       if selectedTranscriptID == transcript.id {
-        selectedTranscriptID = nil
+        // The next row in the same filter, else the previous one, else nothing — and
+        // nothing means the status view, never the live fallback (the setter arms that).
+        selectedTranscriptID = Self.neighbour(of: transcript.id, in: displayed)
+      } else if selectedTranscriptID == nil, transcript.id == liveFallbackRowID {
+        // The pane was showing this row's text through the fallback; the row is gone.
+        liveFallbackSuppressed = true
       }
+      if transcript.id == liveFallbackRowID { liveFallbackRowID = nil }
       refreshDiskStateThenStopIfIdle()
     } catch {
       Task {
@@ -765,6 +916,9 @@ final class TranscriptCoordinator {
       try store.deleteAll()
       transcripts.removeAll()
       selectedTranscriptID = nil
+      // #2807: an empty History shows nothing, whatever the live pipeline last produced.
+      liveFallbackSuppressed = true
+      liveFallbackRowID = nil
       refreshDiskStateThenStopIfIdle()
     } catch {
       Task {
@@ -774,6 +928,15 @@ final class TranscriptCoordinator {
         )
       }
     }
+  }
+
+  /// The row to select after `id` is deleted from `displayed`: the one after it, else the one
+  /// before it, else nil (#2807). Pure, so the choice is unit-drivable.
+  private static func neighbour(of id: UUID, in displayed: [Transcript]) -> UUID? {
+    guard let index = displayed.firstIndex(where: { $0.id == id }) else { return nil }
+    if index + 1 < displayed.count { return displayed[index + 1].id }
+    if index > 0 { return displayed[index - 1].id }
+    return nil
   }
 
   // MARK: - Escape Recovery expiry pulse (#2087)
@@ -1017,4 +1180,47 @@ final class TranscriptCoordinator {
       startPulseIfNeeded()
     }
   #endif
+}
+
+/// Which kind of History row the list shows (#2807).
+///
+/// Two words, by meaning: a **Dictation** is a take made with the hotkey, a **Transcript** is
+/// a file put through Transcribe a File, and History is the collection of both. The kind is
+/// read from `Transcript.isImported`; nothing stores a second flag.
+enum HistoryFilter: String, CaseIterable, Sendable {
+  case all
+  case dictations
+  case transcripts
+
+  /// The word on the control.
+  var title: String {
+    switch self {
+    case .all: return "All"
+    case .dictations: return "Dictations"
+    case .transcripts: return "Transcripts"
+    }
+  }
+}
+
+/// Why the History list is empty (#2807). Each case has a different fix, so each gets its own
+/// sentence.
+enum HistoryEmptyState: Equatable, Sendable {
+  /// Nothing has ever been recorded or imported.
+  case nothingYet
+  /// Rows exist, none of them a dictation.
+  case noDictations
+  /// Rows exist, none of them a transcript.
+  case noTranscripts
+  /// Rows exist, none matching the search.
+  case noMatches
+}
+
+/// What the History detail pane shows (#2807).
+enum HistoryDetail {
+  /// A row the list displays.
+  case row(Transcript)
+  /// Nothing is selected and nothing cleared a selection away: the live transcript, if any.
+  case liveFallback
+  /// Nothing to show, and the live transcript must not stand in.
+  case empty
 }

--- a/Sources/EnviousWisprAppKit/Views/Main/HistoryContentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/HistoryContentView.swift
@@ -24,18 +24,19 @@ struct HistoryContentView: View {
   /// PR7 of #763: compose the displayed transcript inline. History selection
   /// from `TranscriptCoordinator` wins over the in-flight live fallback —
   /// same priority the pre-PR7 root-state getter delivered.
+  ///
+  /// #2807: the coordinator resolves the row from the DISPLAYED set and says whether the live
+  /// fallback may stand in. That set is built on `visibleTranscripts`, which keeps #2087's
+  /// rule: a row selected before it expired does not stay open in the detail pane after it
+  /// stopped being offered, which is the one thing the 24-hour promise says will not happen.
+  /// And a selection a filter, a search or a deletion cleared shows nothing, never a transcript
+  /// from another time.
   private var displayedTranscript: Transcript? {
-    let tc = transcriptCoordinator
-    // #2087: `visibleTranscripts`, not `transcripts`. A row selected before it
-    // expired would otherwise stay open in the detail pane after it stopped
-    // being offered — still readable, still restorable — which is the one thing
-    // the 24-hour promise says will not happen.
-    if let selected = tc.selectedTranscriptID,
-      let match = tc.visibleTranscripts.first(where: { $0.id == selected })
-    {
-      return match
+    switch transcriptCoordinator.detail {
+    case .row(let row): return row
+    case .liveFallback: return liveRecordingState.currentTranscript
+    case .empty: return nil
     }
-    return liveRecordingState.currentTranscript
   }
 
   var body: some View {

--- a/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/MainWindowView.swift
@@ -166,7 +166,8 @@ struct StatusView: View {
           ContentUnavailableView {
             Label("Transcription Complete", systemImage: "checkmark.circle")
           } description: {
-            Text("Select a transcript from the sidebar to view it.")
+            // #2807: History lists dictations and transcripts, so "item".
+            Text("Select an item from the sidebar to view it.")
           }
 
           if let polishError = lastRecordingResult.polishError {

--- a/Sources/EnviousWisprAppKit/Views/Main/SidebarStatsHeader.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/SidebarStatsHeader.swift
@@ -26,7 +26,8 @@ struct SidebarStatsHeader: View {
         HStack(spacing: 4) {
           Image(systemName: "magnifyingglass")
             .foregroundStyle(.stTextTertiary)
-          TextField("Search transcripts", text: $tc.searchQuery)
+          // #2807: History holds dictations AND transcripts, so the box searches "history".
+          TextField("Search history", text: $tc.searchQuery)
             .textFieldStyle(.plain)
             .font(.caption)
         }
@@ -34,11 +35,25 @@ struct SidebarStatsHeader: View {
         .padding(.vertical, 5)
         .background(Color.stSectionBg, in: RoundedRectangle(cornerRadius: 6))
 
-        Text("\(transcriptCoordinator.transcriptCount)")
+        // The rows the list shows right now, inside the filter and the search (#2807).
+        Text("\(transcriptCoordinator.listedCount)")
           .font(.caption.bold())
           .foregroundStyle(.stTextSecondary)
           .monospacedDigit()
       }
+      .opacity(isRecording ? 0.4 : 1.0)
+
+      // #2807: which kind of row the list shows. A segmented control rather than chips: three
+      // short words fit the sidebar at its narrowest, and it reads to VoiceOver as one choice.
+      Picker("Show", selection: $tc.historyFilter) {
+        ForEach(HistoryFilter.allCases, id: \.self) { filter in
+          Text(filter.title).tag(filter)
+        }
+      }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+      .controlSize(.small)
+      .accessibilityLabel("Show")
       .opacity(isRecording ? 0.4 : 1.0)
 
       // Model status bar

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -38,6 +38,12 @@ struct TranscriptDetailView: View {
       for: transcript, now: Date(), dictationInFlight: isDictationInFlight)
   }
 
+  /// #2807: what this row IS, by name. A Dictation was made with the keybind; a Transcript
+  /// came from Transcribe a File. Read from `isImported`, the row's only kind.
+  private var kindWord: String {
+    transcript.isImported ? "Transcript" : "Dictation"
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       actionBar
@@ -51,9 +57,11 @@ struct TranscriptDetailView: View {
           // still has a derived document worth showing — numbers formatted, saved words
           // corrected — and it must not be labelled as AI-polished. Falling back to the raw
           // words instead would silently discard that work.
+          // #2807: the section names say what the TEXT is (polished, processed, original);
+          // the title above says what the row is (a dictation or a transcript).
           if let output = transcript.polishedText ?? transcript.processedText {
             transcriptSection(
-              transcript.polishedText == nil ? "Processed Transcript" : "Polished Transcript",
+              transcript.polishedText == nil ? "Processed" : "Polished",
               icon: transcript.polishedText == nil ? "doc.text" : "sparkles"
             ) {
               Text(output)
@@ -62,7 +70,7 @@ struct TranscriptDetailView: View {
                 .foregroundStyle(.stTextPrimary)
                 .textSelection(.enabled)
             }
-            transcriptSection("Original Transcript", icon: "doc.text") {
+            transcriptSection("Original", icon: "doc.text") {
               Text(transcript.text)
                 .font(.system(size: 15))
                 .lineSpacing(3)
@@ -70,7 +78,7 @@ struct TranscriptDetailView: View {
                 .textSelection(.enabled)
             }
           } else {
-            transcriptSection("Transcript", icon: "doc.text") {
+            transcriptSection(kindWord, icon: "doc.text") {
               Text(transcript.text)
                 .font(.system(size: 16))
                 .lineSpacing(3)
@@ -156,7 +164,7 @@ struct TranscriptDetailView: View {
       }
       .buttonStyle(.borderless)
       .foregroundStyle(.stTextSecondary)
-      .accessibilityLabel("Delete transcript")
+      .accessibilityLabel("Delete \(kindWord.lowercased())")
     }
     .buttonStyle(.bordered)
     .controlSize(.large)
@@ -169,7 +177,7 @@ struct TranscriptDetailView: View {
 
   private var header: some View {
     HStack(alignment: .top, spacing: 14) {
-      Image(systemName: "doc.text")
+      Image(systemName: transcript.isImported ? "doc.text" : "mic")
         .font(.system(size: 20, weight: .medium))
         .foregroundStyle(.stAccent)
         .frame(width: 46, height: 46)
@@ -181,7 +189,7 @@ struct TranscriptDetailView: View {
         .accessibilityHidden(true)
 
       VStack(alignment: .leading, spacing: 6) {
-        Text("Transcript")
+        Text(kindWord)
           .font(.system(size: 22, weight: .semibold))
           .foregroundStyle(.stTextPrimary)
 

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
@@ -39,12 +39,10 @@ struct TranscriptHistoryView: View {
       .opacity(isRecording ? 0.4 : 1.0)
       .animation(.easeInOut(duration: 0.3), value: isRecording)
       .overlay {
-        if transcriptCoordinator.visibleTranscripts.isEmpty {
-          ContentUnavailableView(
-            "No Transcripts Yet",
-            systemImage: "doc.text",
-            description: Text("Your transcription history will appear here.")
-          )
+        // #2807: the coordinator decides WHICH absence this is, so a list a filter emptied
+        // cannot show the global "nothing yet" over rows that exist.
+        if let emptyState = transcriptCoordinator.emptyState {
+          HistoryEmptyView(state: emptyState)
         }
       }
 
@@ -53,7 +51,9 @@ struct TranscriptHistoryView: View {
         Button(role: .destructive) {
           showDeleteAllConfirmation = true
         } label: {
-          Label("Delete All", systemImage: "trash")
+          // #2807: "history", because the button is GLOBAL while the list can be filtered
+          // or searched; the confirmation sentence says so too.
+          Label("Delete all history", systemImage: "trash")
             .font(.caption)
             .settingsHoverQuiet(tint: .stError)
         }
@@ -63,9 +63,9 @@ struct TranscriptHistoryView: View {
         .frame(maxWidth: .infinity, alignment: .trailing)
       }
     }
-    .alert("Delete All Transcripts?", isPresented: $showDeleteAllConfirmation) {
+    .alert("Delete all history?", isPresented: $showDeleteAllConfirmation) {
       Button("Cancel", role: .cancel) {}
-      Button("Delete All", role: .destructive) {
+      Button("Delete all", role: .destructive) {
         transcriptCoordinator.deleteAll()
       }
     } message: {
@@ -73,6 +73,42 @@ struct TranscriptHistoryView: View {
       // meant the right one and the dictation statistic were both in scope and
       // equally easy to type, with nothing testable observing the choice.
       Text(transcriptCoordinator.deleteAllConfirmationMessage)
+    }
+  }
+}
+
+/// What the History list shows when it lists nothing (#2807). One sentence per reason, because
+/// the fix for each is different: record something, import something, change the filter, or
+/// change the search.
+struct HistoryEmptyView: View {
+  let state: HistoryEmptyState
+
+  var body: some View {
+    switch state {
+    case .nothingYet:
+      ContentUnavailableView(
+        "Nothing here yet",
+        systemImage: "doc.text",
+        description: Text("Your dictations and transcripts will appear here.")
+      )
+    case .noDictations:
+      ContentUnavailableView(
+        "No dictations yet",
+        systemImage: "mic",
+        description: Text("Press your keybind and start talking.")
+      )
+    case .noTranscripts:
+      ContentUnavailableView(
+        "No transcripts yet",
+        systemImage: "doc.text",
+        description: Text("Use Transcribe a File to add one.")
+      )
+    case .noMatches:
+      ContentUnavailableView(
+        "No matching history.",
+        systemImage: "magnifyingglass",
+        description: Text("Try a different search, or another filter.")
+      )
     }
   }
 }
@@ -154,6 +190,19 @@ struct TranscriptRowView: View {
         case nil:
           EmptyView()
         }
+
+        // #2807: the row's kind, by name. A Dictation was made with the keybind; a Transcript
+        // came from Transcribe a File. Read from `isImported`, the row's only kind. Icon plus
+        // text, never colour alone, like every other badge in this row.
+        HStack(spacing: 2) {
+          Image(systemName: transcript.isImported ? "doc.text" : "mic")
+          Text(transcript.isImported ? "Transcript" : "Dictation")
+        }
+        .font(.caption2)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(Color.stTextSecondary.opacity(0.14), in: Capsule())
+        .foregroundStyle(.stTextSecondary)
 
         if let importedFileName = transcript.importedFileName {
           // #2772 finding 11 — this row came from Transcribe a File, not from the keybind.

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
@@ -152,7 +152,11 @@ struct TranscriptRowView: View {
         .font(.body)
         .foregroundStyle(.stTextPrimary)
 
-      HStack(spacing: 6) {
+      // #2807: the chips WRAP. With the kind chip added, an import row carries five chips
+      // (kind, file name, polish, engine, and any recovery badge), which is wider than the
+      // list at its narrowest; a plain HStack then squeezed every chip and broke "Transcript"
+      // across three lines. Seen in the phase-1 Live UAT screenshot.
+      WrappingHStack(spacing: 6) {
         // #2087. Deliberately NOT the "Recovered" capsule below: that one means
         // crash rescue, and a held recovery is an ordinary cancel the user can
         // still change their mind about. The decision and the wording both come

--- a/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift
@@ -79,6 +79,19 @@ enum WhatsNewContent {
       version: "2.4.9"
     ),
 
+    // #2808, phase 1 of #2807. The founder's vocabulary decision of 2026-09-11: a keybind
+    // take is a Dictation, a file import is a Transcript, History holds both. The cancel
+    // pill's noun changed with it ("Dictation cancelled"); that is the same vocabulary, not
+    // a repair, so it is not narrated separately.
+    Entry(
+      id: "history-dictations-and-transcripts",
+      icon: "line.3.horizontal.decrease.circle",
+      title: "History tells a dictation from a transcript",
+      description:
+        "Everything you say with your keybind is a Dictation. Every file you put through Transcribe a File is a Transcript. History now labels each row, and a new All, Dictations, Transcripts switch above the list shows just the kind you want.",
+      version: "2.4.9"
+    ),
+
     // MARK: - v2.4.8
 
     // #2483, #2691 and #2697, merged fe044f6e / 85ddc26e / d49494f3. ONE user

--- a/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
+++ b/Tests/EnviousWisprTests/App/DictationNarratorTests.swift
@@ -311,7 +311,7 @@ import Testing
       ),
       (
         .escapeRecovery(transcriptID: UUID()),
-        "Transcript cancelled. Press Undo to get it back, or find it in History."
+        "Dictation cancelled. Press Undo to get it back, or find it in History."
       ),
     ]
     for (intent, want) in cases {

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryHistoryPolicyTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryHistoryPolicyTests.swift
@@ -254,9 +254,9 @@ struct EscapeRecoveryHistoryPolicyTests {
 
   /// A destructive confirmation must count what it will destroy.
   ///
-  /// `transcriptCount` is the DICTATION statistic and excludes held recoveries,
+  /// `listedCount` is the sidebar statistic and excludes held recoveries,
   /// which is right for a sidebar and wrong for a Delete All dialog: a history
-  /// showing only held rows would offer to delete "all 0 transcripts" and then
+  /// showing only held rows would offer to delete "all 0 items" and then
   /// delete them. The two counts are different questions, so they are different
   /// properties.
   @Test("the delete confirmation counts held rows; the dictation stat does not")
@@ -267,18 +267,21 @@ struct EscapeRecoveryHistoryPolicyTests {
     coordinator.load()
     await coordinator.waitForLoadForTesting()
 
-    #expect(coordinator.transcriptCount == 0, "a held row is not a dictation")
+    #expect(coordinator.listedCount == 0, "a held row is not a dictation")
     #expect(
       coordinator.deletableCount == 1,
       "but Delete All would take it, so the confirmation must say so")
     // The SENTENCE, not just the count. While the view interpolated a count of
     // its own choosing, swapping it for the dictation statistic survived the
     // entire suite — nothing testable observed which one the dialog used.
+    // #2807: History holds dictations AND transcripts, so the sentence says "item", and it
+    // says a hidden row goes too, because Delete All is global while the list can be filtered.
     #expect(
-      coordinator.deleteAllConfirmationMessage.contains("delete 1 transcript."),
-      "the dialog must not offer to delete 'all 0 transcripts' and then delete one")
+      coordinator.deleteAllConfirmationMessage.contains(
+        "delete the only item in History, even if a filter or search is hiding it."),
+      "the dialog must not offer to delete 'all 0 items' and then delete one")
     #expect(
-      coordinator.deleteAllConfirmationMessage.contains("transcripts") == false,
+      coordinator.deleteAllConfirmationMessage.contains("items") == false,
       "one row is not a plural — an earlier version of this test PINNED 'all 1 transcripts'")
   }
 
@@ -291,7 +294,9 @@ struct EscapeRecoveryHistoryPolicyTests {
     coordinator.load()
     await coordinator.waitForLoadForTesting()
 
-    #expect(coordinator.deleteAllConfirmationMessage.contains("all 2 transcripts"))
+    #expect(
+      coordinator.deleteAllConfirmationMessage.contains(
+        "all 2 items in History, including any hidden by a filter or search."))
   }
 
   @Test("the delete confirmation counts nothing when there is nothing")
@@ -300,7 +305,7 @@ struct EscapeRecoveryHistoryPolicyTests {
     let coordinator = TranscriptCoordinator(store: store)
 
     #expect(
-      coordinator.deleteAllConfirmationMessage.contains("all 0 transcripts"),
+      coordinator.deleteAllConfirmationMessage.contains("all 0 items in History"),
       "zero is plural, and the button is hidden at zero anyway")
   }
 
@@ -356,7 +361,7 @@ struct EscapeRecoveryHistoryPolicyTests {
     #expect(
       coordinator.visibleTranscripts.first?.escapeRecoveredAt == nil,
       "the in-memory row stops being pending")
-    #expect(coordinator.transcriptCount == 1, "and starts counting as a dictation")
+    #expect(coordinator.listedCount == 1, "and starts counting as a dictation")
     #expect(
       try await store.loadPending().isEmpty,
       "the pending file is gone, so a relaunch cannot resume the countdown")
@@ -388,7 +393,7 @@ struct EscapeRecoveryHistoryPolicyTests {
     coordinator.load()
     await coordinator.waitForLoadForTesting()
 
-    #expect(coordinator.transcriptCount == 1, "a held row is an offer, not a dictation")
+    #expect(coordinator.listedCount == 1, "a held row is an offer, not a dictation")
 
     coordinator.searchQuery = "quarterly"
     #expect(
@@ -469,7 +474,7 @@ struct EscapeRecoveryHistoryPolicyTests {
       coordinator.setTranscriptsForTesting([skewed])
 
       #expect(coordinator.visibleTranscripts.isEmpty, "beyond tolerance is corrupt, not fresh")
-      #expect(coordinator.transcriptCount == 0)
+      #expect(coordinator.listedCount == 0)
       #expect(
         coordinator.hasPendingPulseForTesting == false,
         "and nothing counts down toward a deadline that has not begun")
@@ -502,7 +507,7 @@ struct EscapeRecoveryHistoryPolicyTests {
         permanent("kept"),
       ])
 
-      #expect(coordinator.transcriptCount == 1)
+      #expect(coordinator.listedCount == 1)
     }
 
     /// Inert on BOTH sides. An earlier version of this test checked only the
@@ -533,7 +538,7 @@ struct EscapeRecoveryHistoryPolicyTests {
       #expect(
         coordinator.visibleTranscripts.isEmpty,
         "so it stays invisible, which is what the user was promised")
-      #expect(coordinator.transcriptCount == 0, "and is still not a dictation")
+      #expect(coordinator.listedCount == 0, "and is still not a dictation")
     }
 
     @Test("a held row appended mid-session starts its countdown")

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillLayoutTests.swift
@@ -31,7 +31,7 @@ struct EscapeRecoveryPillLayoutTests {
       PillMetrics.leadInset + sentence + PillMetrics.midGap
       + PillMetrics.actionWidth + PillMetrics.trailInset
 
-    // Failing this renders "Transcript cance…", which the earlier fixed-width
+    // Failing this renders "Dictation cance…", which the earlier fixed-width
     // pill did when the copy was revised.
     #expect(PillMetrics.pillWidth >= claimed)
   }

--- a/Tests/EnviousWisprTests/App/EscapeRecoveryPillTests.swift
+++ b/Tests/EnviousWisprTests/App/EscapeRecoveryPillTests.swift
@@ -271,7 +271,8 @@ struct EscapeRecoveryPillTests {
   /// refused it.
   @Test("the pill's copy and its spoken announcement agree")
   func copyAgreesWithTheAnnouncement() {
-    #expect(DictationNarrator.escapeRecoveryPillTitle == "Transcript cancelled")
+    // #2807: "Dictation", the founder's word for a keybind take, since 2026-09-11.
+    #expect(DictationNarrator.escapeRecoveryPillTitle == "Dictation cancelled")
     #expect(DictationNarrator.escapeRecoveryPillAction == "Undo")
 
     let spoken = DictationNarrator.announcement(

--- a/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
+++ b/Tests/EnviousWisprTests/App/Overlay/FrozenPillParityFixture.swift
@@ -290,12 +290,15 @@ enum FrozenPillParity {
           "Bluetooth microphone detected. Wait a moment before speaking on a cold start.",
         isHighPriority: false)),
 
+    // Announcement text re-frozen 2026-09-11 (#2807): the founder renamed the cancelled
+    // thing from "Transcript" to "Dictation", a deliberate copy change, so the oracle
+    // carries the new sentence. Every other value in this row is the `da103706` capture.
     FrozenRow(
       label: "escapeRecovery", hasDefinition: true, contentTag: "escapeRecovery", notice: nil,
       width: .measured, fixedHeight: nil,
       expiry: .after(seconds: 3, pausesOnHover: true),
       announcement: FrozenAnnouncement(
-        text: "Transcript cancelled. Press Undo to get it back, or find it in History.",
+        text: "Dictation cancelled. Press Undo to get it back, or find it in History.",
         isHighPriority: false)),
 
     // The one presentation with no matching intent, so the shipped announcement

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
@@ -331,18 +331,20 @@ struct TranscriptCoordinatorFilterTests {
     coordinator.delete(d)
     #expect(isEmpty(coordinator.detail), "the deletion suppressed the fallback")
 
-    coordinator.append(dictation("just finished"))
-    #expect(isLiveFallback(coordinator.detail), "this is the moment the fallback exists for")
+    let finished = dictation("just finished")
+    coordinator.append(finished)
+    #expect(isRow(coordinator.detail, finished.id), "the pane shows the dictation's own row")
   }
 
   @Test("narrowing the list away from the dictation the pane is showing empties the pane")
   func narrowingAwayFromTheFallbackRowEmptiesThePane() {
     let (coordinator, _) = makeCoordinator()
-    coordinator.append(dictation("just finished"))
-    #expect(isLiveFallback(coordinator.detail))
+    let finished = dictation("just finished")
+    coordinator.append(finished)
+    #expect(isRow(coordinator.detail, finished.id))
 
     coordinator.historyFilter = .dictations
-    #expect(isLiveFallback(coordinator.detail), "the dictation is still listed")
+    #expect(isRow(coordinator.detail, finished.id), "the dictation is still listed")
 
     coordinator.historyFilter = .transcripts
     #expect(isEmpty(coordinator.detail), "the list no longer shows what the pane shows")
@@ -354,10 +356,11 @@ struct TranscriptCoordinatorFilterTests {
   @Test("a search that hides the dictation the pane is showing empties the pane")
   func searchAwayFromTheFallbackRowEmptiesThePane() {
     let (coordinator, _) = makeCoordinator()
-    coordinator.append(dictation("just finished"))
+    let finished = dictation("just finished")
+    coordinator.append(finished)
 
     coordinator.searchQuery = "finished"
-    #expect(isLiveFallback(coordinator.detail), "the dictation matches, so it is still listed")
+    #expect(isRow(coordinator.detail, finished.id), "the dictation matches, so it is still listed")
 
     coordinator.searchQuery = "nothing like this"
     #expect(isEmpty(coordinator.detail))
@@ -370,8 +373,9 @@ struct TranscriptCoordinatorFilterTests {
   func aCompletionOutsideTheSearchSuppressesAnActiveFallback() {
     let (coordinator, _) = makeCoordinator()
     coordinator.searchQuery = "apples"
-    coordinator.append(dictation("apples", ageSeconds: 10))
-    #expect(isLiveFallback(coordinator.detail), "the completion matches the search")
+    let apples = dictation("apples", ageSeconds: 10)
+    coordinator.append(apples)
+    #expect(isRow(coordinator.detail, apples.id), "the completion matches the search")
 
     coordinator.append(dictation("pears"))
     #expect(isEmpty(coordinator.detail), "the pane would otherwise show pears beside apples")
@@ -398,13 +402,44 @@ struct TranscriptCoordinatorFilterTests {
     coordinator.append(dictation("older, but appended second", ageSeconds: 10))
     let shown = dictation("shown")
     coordinator.append(shown)
-    #expect(isLiveFallback(coordinator.detail))
+    #expect(isRow(coordinator.detail, shown.id))
 
     coordinator.delete(d)
-    #expect(isLiveFallback(coordinator.detail), "another row went, the pane's row is still here")
+    #expect(isRow(coordinator.detail, shown.id), "another row went, the pane's row is still here")
 
     coordinator.delete(shown)
     #expect(isEmpty(coordinator.detail))
+  }
+
+  @Test("the pane shows the just-finished dictation from History, not a second copy of it")
+  func thePaneShowsTheFinishedDictationsOwnRow() throws {
+    let (coordinator, _) = makeCoordinator()
+    let finished = dictation("just finished")
+    coordinator.append(finished)
+    #expect(isRow(coordinator.detail, finished.id))
+    #expect(
+      isLiveFallback(coordinator.detail) == false,
+      "once History has the row, the live pipeline's copy is never the source")
+  }
+
+  @Test("a cleanup that stops a selected import matching the search clears the selection")
+  func aRowUpdateThatLeavesTheSearchClearsTheSelection() throws {
+    let (coordinator, _) = makeCoordinator()
+    let raw = transcript("um so the plan is", file: "plan.m4a")
+    try coordinator.saveAndShow(raw)
+    coordinator.searchQuery = "um"
+    coordinator.selectedTranscriptID = raw.id
+    #expect(isRow(coordinator.detail, raw.id))
+
+    let cleaned = Transcript(
+      id: raw.id, text: raw.text, polishedText: "So the plan is.", language: "en", duration: 61,
+      backendType: .parakeet, createdAt: raw.createdAt, importedFileName: "plan.m4a")
+    try coordinator.updateExistingRow(cleaned)
+    #expect(coordinator.selectedTranscriptID == nil, "the row left the displayed set")
+    #expect(isEmpty(coordinator.detail))
+
+    coordinator.searchQuery = ""
+    #expect(isEmpty(coordinator.detail), "clearing the search does not bring it back")
   }
 
   @Test("a held recovery arriving does not bring the live transcript back")

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
@@ -565,5 +565,50 @@ struct TranscriptCoordinatorFilterTests {
       coordinator.setTranscriptsForTesting([expired])
       #expect(isEmpty(coordinator.detail))
     }
+
+    /// Cloud review of PR #2815: the stale id must not hide the NEXT dictation. Two doors
+    /// close it: the sweep that evicts the expired row clears the selection where the expiry
+    /// is detected, and `append` treats a selection that resolves to nothing as none.
+    @Test("a selected recovery that expired does not hide the next completed dictation")
+    func expiredSelectionDoesNotHideTheNextDictation() async {
+      let (coordinator, _) = makeCoordinator()
+      let live = held("cancelled", age: 60)
+      coordinator.setTranscriptsForTesting([live])
+      coordinator.selectedTranscriptID = live.id
+
+      let expired = Transcript(
+        id: live.id, text: live.text, createdAt: live.createdAt,
+        escapeRecoveredAt: Date().addingTimeInterval(-AppConstants.pendingTranscriptRetention - 60),
+        escapeRecoveryTakeID: live.escapeRecoveryTakeID)
+      coordinator.setTranscriptsForTesting([expired])
+
+      // Door one: the sweep evicts the lapsed row and clears the selection with it.
+      await coordinator.sweepExpiredPending()
+      #expect(coordinator.selectedTranscriptID == nil, "the expiry cleared the selection")
+      #expect(isEmpty(coordinator.detail))
+
+      let finished = dictation("just finished")
+      coordinator.append(finished)
+      #expect(isRow(coordinator.detail, finished.id), "the new dictation shows")
+    }
+
+    @Test("a stale selection at the moment a dictation completes is treated as no selection")
+    func staleSelectionAtAppendIsTreatedAsNone() {
+      let (coordinator, _) = makeCoordinator()
+      let live = held("cancelled", age: 60)
+      coordinator.setTranscriptsForTesting([live])
+      coordinator.selectedTranscriptID = live.id
+      let expired = Transcript(
+        id: live.id, text: live.text, createdAt: live.createdAt,
+        escapeRecoveredAt: Date().addingTimeInterval(-AppConstants.pendingTranscriptRetention - 60),
+        escapeRecoveryTakeID: live.escapeRecoveryTakeID)
+      // No sweep has run: door two alone must open.
+      coordinator.setTranscriptsForTesting([expired])
+
+      let finished = dictation("just finished")
+      coordinator.append(finished)
+      #expect(coordinator.selectedTranscriptID == nil)
+      #expect(isRow(coordinator.detail, finished.id))
+    }
   #endif
 }

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
@@ -1,0 +1,534 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprStorage
+
+/// History tells a dictation from a transcript (#2808, phase 1 of #2807).
+///
+/// The filter is view state over `Transcript.isImported`; nothing is stored. Every rule here
+/// is what a person sees in the History list and its detail pane: which rows are listed under
+/// each filter, what the count beside the search box says, what the empty list says, and what
+/// the detail pane shows after a filter, a search or a deletion takes the selected row away.
+///
+/// Rows go through a real `TranscriptStore` under a temp directory, the way the coordinator's
+/// other suites do, so the in-memory contract is asserted against real disk semantics.
+@MainActor
+/// Class: `.productOutcome` — the rows History lists, the count beside them, and what the detail
+/// pane shows when the list changes under the user.
+@Suite(
+  "History filter: dictations, transcripts, and the detail pane (#2808)", .tags(.productOutcome))
+struct TranscriptCoordinatorFilterTests {
+
+  // MARK: Fixtures
+
+  private func makeCoordinator() -> (TranscriptCoordinator, TranscriptStore) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ew-2808-filter-\(UUID().uuidString)", isDirectory: true)
+    let store = TranscriptStore(directory: dir)
+    return (TranscriptCoordinator(store: store), store)
+  }
+
+  /// A completed dictation. `createdAt` steps backwards so the newest-first order is fixed.
+  private func dictation(_ text: String, ageSeconds: TimeInterval = 0) -> Transcript {
+    Transcript(text: text, createdAt: Date().addingTimeInterval(-ageSeconds))
+  }
+
+  /// A row from Transcribe a File: the file name is the kind.
+  private func transcript(_ text: String, file: String, ageSeconds: TimeInterval = 0)
+    -> Transcript
+  {
+    Transcript(
+      text: text, language: "en", duration: 61, backendType: .parakeet,
+      createdAt: Date().addingTimeInterval(-ageSeconds), importedFileName: file)
+  }
+
+  /// A held Escape-recovery row whose retention window began `age` seconds ago.
+  private func held(_ text: String, age: TimeInterval) -> Transcript {
+    Transcript(
+      text: text, createdAt: Date(),
+      escapeRecoveredAt: Date().addingTimeInterval(-age),
+      escapeRecoveryTakeID: "take-\(text)")
+  }
+
+  private func ids(_ rows: [Transcript]) -> [UUID] { rows.map(\.id) }
+
+  private func isRow(_ detail: HistoryDetail, _ id: UUID) -> Bool {
+    if case .row(let row) = detail { return row.id == id }
+    return false
+  }
+
+  private func isEmpty(_ detail: HistoryDetail) -> Bool {
+    if case .empty = detail { return true }
+    return false
+  }
+
+  private func isLiveFallback(_ detail: HistoryDetail) -> Bool {
+    if case .liveFallback = detail { return true }
+    return false
+  }
+
+  // MARK: Which rows are listed
+
+  @Test("All lists both kinds; Dictations and Transcripts each list only their own")
+  func filterListsByKind() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d1 = dictation("first dictation", ageSeconds: 30)
+    let t1 = transcript("an interview", file: "interview.m4a", ageSeconds: 20)
+    let d2 = dictation("second dictation", ageSeconds: 10)
+    try coordinator.saveAndShow(d1)
+    try coordinator.saveAndShow(t1)
+    try coordinator.saveAndShow(d2)
+
+    #expect(coordinator.historyFilter == .all, "a fresh coordinator starts at All")
+    #expect(ids(coordinator.filteredTranscripts) == [d2.id, t1.id, d1.id])
+
+    coordinator.historyFilter = .dictations
+    #expect(ids(coordinator.filteredTranscripts) == [d2.id, d1.id])
+
+    coordinator.historyFilter = .transcripts
+    #expect(ids(coordinator.filteredTranscripts) == [t1.id])
+  }
+
+  @Test("search runs inside the filter, and still reaches the imported file name")
+  func searchRunsInsideTheFilter() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("notes from the marketing call", ageSeconds: 20)
+    let t = transcript("we talked about the launch", file: "marketing_sync.wav", ageSeconds: 10)
+    try coordinator.saveAndShow(d)
+    try coordinator.saveAndShow(t)
+
+    coordinator.searchQuery = "marketing"
+    #expect(ids(coordinator.filteredTranscripts) == [t.id, d.id], "both match under All")
+
+    coordinator.historyFilter = .dictations
+    #expect(ids(coordinator.filteredTranscripts) == [d.id], "the import is outside the filter")
+
+    coordinator.historyFilter = .transcripts
+    #expect(ids(coordinator.filteredTranscripts) == [t.id], "found by its file name")
+  }
+
+  @Test("a held recovery is listed under All and Dictations, never under Transcripts")
+  func heldRowIsADictation() async throws {
+    let (coordinator, store) = makeCoordinator()
+    let heldRow = held("cancelled words", age: 60)
+    try store.savePending(heldRow)
+    try store.save(transcript("a file", file: "file.m4a", ageSeconds: 10))
+    coordinator.load()
+    await coordinator.waitForLoadForTesting()
+
+    #expect(ids(coordinator.filteredTranscripts).contains(heldRow.id), "under All")
+
+    coordinator.historyFilter = .dictations
+    #expect(ids(coordinator.filteredTranscripts) == [heldRow.id], "under Dictations")
+
+    coordinator.historyFilter = .transcripts
+    #expect(
+      ids(coordinator.filteredTranscripts).contains(heldRow.id) == false,
+      "a cancelled take is not a file import")
+  }
+
+  @Test("a held recovery is excluded from a nonempty search under every filter")
+  func heldRowIsNeverSearched() async throws {
+    let (coordinator, store) = makeCoordinator()
+    let heldRow = held("cancelled words", age: 60)
+    try store.savePending(heldRow)
+    coordinator.load()
+    await coordinator.waitForLoadForTesting()
+
+    for filter in HistoryFilter.allCases {
+      coordinator.historyFilter = filter
+      coordinator.searchQuery = "cancelled"
+      #expect(
+        ids(coordinator.filteredTranscripts).contains(heldRow.id) == false,
+        "an accidental Escape must not pollute search results under \(filter)")
+      coordinator.searchQuery = ""
+    }
+  }
+
+  // MARK: The count beside the search box
+
+  @Test("the listed count follows the filter and the search, and never counts a held offer")
+  func listedCountFollowsTheFilter() async throws {
+    let (coordinator, store) = makeCoordinator()
+    try store.savePending(held("cancelled", age: 60))
+    coordinator.load()
+    await coordinator.waitForLoadForTesting()
+    try coordinator.saveAndShow(dictation("one", ageSeconds: 30))
+    try coordinator.saveAndShow(dictation("two", ageSeconds: 20))
+    try coordinator.saveAndShow(transcript("three", file: "three.m4a", ageSeconds: 10))
+
+    #expect(coordinator.listedCount == 3, "three completed rows, the held offer is not one")
+    #expect(coordinator.dictationCount == 2)
+
+    coordinator.historyFilter = .dictations
+    #expect(coordinator.listedCount == 2)
+    coordinator.historyFilter = .transcripts
+    #expect(coordinator.listedCount == 1)
+    #expect(coordinator.dictationCount == 2, "onboarding's count does not follow the filter")
+
+    coordinator.historyFilter = .all
+    coordinator.searchQuery = "two"
+    #expect(coordinator.listedCount == 1)
+  }
+
+  // MARK: The empty list
+
+  @Test("each way of being empty has its own sentence")
+  func emptyStates() throws {
+    let (coordinator, _) = makeCoordinator()
+    #expect(coordinator.emptyState == .nothingYet)
+
+    try coordinator.saveAndShow(dictation("a dictation"))
+    #expect(coordinator.emptyState == nil)
+
+    coordinator.historyFilter = .transcripts
+    #expect(coordinator.emptyState == .noTranscripts)
+
+    coordinator.historyFilter = .all
+    coordinator.searchQuery = "nothing like this"
+    #expect(coordinator.emptyState == .noMatches)
+
+    coordinator.searchQuery = ""
+    coordinator.deleteAll()
+    #expect(coordinator.emptyState == .nothingYet, "an emptied History is back to nothing yet")
+
+    try coordinator.saveAndShow(transcript("a file", file: "file.m4a"))
+    coordinator.historyFilter = .dictations
+    #expect(coordinator.emptyState == .noDictations)
+  }
+
+  // MARK: The detail pane
+
+  @Test("nothing selected on a fresh History shows the live transcript, as before")
+  func freshHistoryFallsBackToTheLiveTranscript() {
+    let (coordinator, _) = makeCoordinator()
+    #expect(isLiveFallback(coordinator.detail))
+  }
+
+  @Test("a selected row that the filter stops listing is cleared and the pane goes empty")
+  func filterClearsASelectionItNoLongerLists() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("a dictation", ageSeconds: 10)
+    let t = transcript("a file", file: "file.m4a")
+    try coordinator.saveAndShow(d)
+    try coordinator.saveAndShow(t)
+
+    coordinator.selectedTranscriptID = d.id
+    #expect(isRow(coordinator.detail, d.id))
+
+    coordinator.historyFilter = .transcripts
+    #expect(coordinator.selectedTranscriptID == nil, "the selection left the displayed set")
+    #expect(isEmpty(coordinator.detail), "and the live transcript must not stand in for it")
+
+    coordinator.historyFilter = .all
+    #expect(isEmpty(coordinator.detail), "widening the filter does not bring the fallback back")
+
+    coordinator.selectedTranscriptID = t.id
+    #expect(isRow(coordinator.detail, t.id), "picking a row is what shows something again")
+  }
+
+  @Test("a search that hides the selected row clears it and the pane goes empty")
+  func searchClearsASelectionItNoLongerLists() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("apples", ageSeconds: 10)
+    try coordinator.saveAndShow(d)
+    try coordinator.saveAndShow(dictation("pears"))
+
+    coordinator.selectedTranscriptID = d.id
+    coordinator.searchQuery = "pears"
+    #expect(coordinator.selectedTranscriptID == nil)
+    #expect(isEmpty(coordinator.detail))
+
+    coordinator.searchQuery = ""
+    #expect(isEmpty(coordinator.detail), "clearing the search does not bring the fallback back")
+  }
+
+  @Test("a selected row that stops being listed without a filter change is empty, not the fallback")
+  func staleSelectionIsEmptyNotFallback() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("a dictation")
+    try coordinator.saveAndShow(d)
+    coordinator.selectedTranscriptID = d.id
+
+    // Selected ids that no longer resolve arrive from outside this object: a row that expired
+    // between renders, or the list's binding carrying an id from before a reload.
+    coordinator.selectedTranscriptID = UUID()
+    #expect(isEmpty(coordinator.detail))
+  }
+
+  @Test("the user deselecting shows nothing rather than the live transcript")
+  func deselectionSuppressesTheFallback() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("a dictation")
+    try coordinator.saveAndShow(d)
+
+    coordinator.selectedTranscriptID = d.id
+    coordinator.selectedTranscriptID = nil
+    #expect(isEmpty(coordinator.detail))
+  }
+
+  @Test("deleting the selected row under a filter selects its neighbour in that filter")
+  func deleteSelectsTheNeighbourInTheSameFilter() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d1 = dictation("first", ageSeconds: 30)
+    let t = transcript("a file", file: "file.m4a", ageSeconds: 20)
+    let d2 = dictation("second", ageSeconds: 10)
+    let d3 = dictation("third", ageSeconds: 0)
+    for row in [d1, t, d2, d3] { try coordinator.saveAndShow(row) }
+
+    coordinator.historyFilter = .dictations
+    // Displayed order is newest first: d3, d2, d1. Delete the middle one.
+    coordinator.selectedTranscriptID = d2.id
+    coordinator.delete(d2)
+    #expect(coordinator.selectedTranscriptID == d1.id, "the row after it in the same filter")
+    #expect(isRow(coordinator.detail, d1.id))
+
+    // Delete the last row: nothing after it, so the one before it.
+    coordinator.delete(d1)
+    #expect(coordinator.selectedTranscriptID == d3.id)
+
+    // Delete the only remaining dictation: nothing to select, and no fallback.
+    coordinator.delete(d3)
+    #expect(coordinator.selectedTranscriptID == nil)
+    #expect(isEmpty(coordinator.detail))
+    #expect(coordinator.emptyState == .noDictations)
+
+    coordinator.historyFilter = .all
+    #expect(ids(coordinator.filteredTranscripts) == [t.id], "the transcript was never touched")
+  }
+
+  @Test("deleting a row that is not selected leaves the selection alone")
+  func deleteOfAnotherRowKeepsTheSelection() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d1 = dictation("first", ageSeconds: 10)
+    let d2 = dictation("second")
+    try coordinator.saveAndShow(d1)
+    try coordinator.saveAndShow(d2)
+
+    coordinator.selectedTranscriptID = d1.id
+    coordinator.delete(d2)
+    #expect(coordinator.selectedTranscriptID == d1.id)
+    #expect(isRow(coordinator.detail, d1.id))
+  }
+
+  @Test("Delete All empties the pane, whatever the live pipeline last produced")
+  func deleteAllShowsNothing() throws {
+    let (coordinator, _) = makeCoordinator()
+    try coordinator.saveAndShow(dictation("a dictation"))
+    coordinator.deleteAll()
+    #expect(isEmpty(coordinator.detail))
+    #expect(coordinator.emptyState == .nothingYet)
+  }
+
+  @Test("a completed dictation landing in the displayed set lets the live transcript show again")
+  func aCompletedDictationRestoresTheFallback() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("a dictation")
+    try coordinator.saveAndShow(d)
+    coordinator.selectedTranscriptID = d.id
+    coordinator.delete(d)
+    #expect(isEmpty(coordinator.detail), "the deletion suppressed the fallback")
+
+    coordinator.append(dictation("just finished"))
+    #expect(isLiveFallback(coordinator.detail), "this is the moment the fallback exists for")
+  }
+
+  @Test("narrowing the list away from the dictation the pane is showing empties the pane")
+  func narrowingAwayFromTheFallbackRowEmptiesThePane() {
+    let (coordinator, _) = makeCoordinator()
+    coordinator.append(dictation("just finished"))
+    #expect(isLiveFallback(coordinator.detail))
+
+    coordinator.historyFilter = .dictations
+    #expect(isLiveFallback(coordinator.detail), "the dictation is still listed")
+
+    coordinator.historyFilter = .transcripts
+    #expect(isEmpty(coordinator.detail), "the list no longer shows what the pane shows")
+
+    coordinator.historyFilter = .all
+    #expect(isEmpty(coordinator.detail), "widening does not bring it back")
+  }
+
+  @Test("a search that hides the dictation the pane is showing empties the pane")
+  func searchAwayFromTheFallbackRowEmptiesThePane() {
+    let (coordinator, _) = makeCoordinator()
+    coordinator.append(dictation("just finished"))
+
+    coordinator.searchQuery = "finished"
+    #expect(isLiveFallback(coordinator.detail), "the dictation matches, so it is still listed")
+
+    coordinator.searchQuery = "nothing like this"
+    #expect(isEmpty(coordinator.detail))
+
+    coordinator.searchQuery = ""
+    #expect(isEmpty(coordinator.detail), "clearing the search does not bring it back")
+  }
+
+  @Test("a completion the search does not list suppresses a fallback that was showing")
+  func aCompletionOutsideTheSearchSuppressesAnActiveFallback() {
+    let (coordinator, _) = makeCoordinator()
+    coordinator.searchQuery = "apples"
+    coordinator.append(dictation("apples", ageSeconds: 10))
+    #expect(isLiveFallback(coordinator.detail), "the completion matches the search")
+
+    coordinator.append(dictation("pears"))
+    #expect(isEmpty(coordinator.detail), "the pane would otherwise show pears beside apples")
+
+    coordinator.searchQuery = ""
+    #expect(isEmpty(coordinator.detail), "clearing the search does not bring it back")
+  }
+
+  @Test("before any dictation lands, narrowing the list suppresses the fallback")
+  func narrowingWithNoKnownFallbackRowSuppressesIt() throws {
+    let (coordinator, _) = makeCoordinator()
+    try coordinator.saveAndShow(transcript("a file", file: "file.m4a"))
+    #expect(isLiveFallback(coordinator.detail), "nothing has narrowed the list")
+
+    coordinator.historyFilter = .transcripts
+    #expect(isEmpty(coordinator.detail), "nothing can prove the pane's text is on screen")
+  }
+
+  @Test("deleting the dictation the pane is showing through the fallback empties the pane")
+  func deletingTheFallbackRowEmptiesThePane() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("just finished")
+    try coordinator.saveAndShow(d)
+    coordinator.append(dictation("older, but appended second", ageSeconds: 10))
+    let shown = dictation("shown")
+    coordinator.append(shown)
+    #expect(isLiveFallback(coordinator.detail))
+
+    coordinator.delete(d)
+    #expect(isLiveFallback(coordinator.detail), "another row went, the pane's row is still here")
+
+    coordinator.delete(shown)
+    #expect(isEmpty(coordinator.detail))
+  }
+
+  @Test("a held recovery arriving does not bring the live transcript back")
+  func aHeldRecoveryDoesNotRestoreTheFallback() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("a dictation")
+    try coordinator.saveAndShow(d)
+    coordinator.selectedTranscriptID = d.id
+    coordinator.delete(d)
+
+    coordinator.append(held("cancelled", age: 1))
+    #expect(isEmpty(coordinator.detail), "a cancellation is not a completion")
+  }
+
+  @Test("a dictation arriving outside the current filter does not bring the live transcript back")
+  func aDictationOutsideTheFilterDoesNotRestoreTheFallback() throws {
+    let (coordinator, _) = makeCoordinator()
+    let t = transcript("a file", file: "file.m4a")
+    try coordinator.saveAndShow(t)
+    coordinator.selectedTranscriptID = t.id
+    coordinator.historyFilter = .dictations
+    #expect(isEmpty(coordinator.detail))
+
+    coordinator.historyFilter = .transcripts
+    coordinator.append(dictation("just finished"))
+    #expect(isEmpty(coordinator.detail), "the new row is not on screen, so nothing changed")
+  }
+
+  @Test("an import's second write does not bring the live transcript back")
+  func anImportUpdateDoesNotRestoreTheFallback() throws {
+    let (coordinator, _) = makeCoordinator()
+    let d = dictation("a dictation")
+    try coordinator.saveAndShow(d)
+    coordinator.selectedTranscriptID = d.id
+    coordinator.delete(d)
+
+    let raw = transcript("raw words", file: "file.m4a")
+    try coordinator.saveAndShow(raw)
+    #expect(isEmpty(coordinator.detail), "an import is not the dictation the fallback shows")
+    try coordinator.updateExistingRow(raw)
+    #expect(isEmpty(coordinator.detail))
+  }
+
+  // MARK: Cost
+
+  /// The kind filter is one more pass over the same array as the search, so it must cost the
+  /// same order as the pass History already makes. A relation between two passes measured in
+  /// one process, never an absolute: an absolute would freeze this machine, not the code.
+  @Test("filtering 25,000 rows costs the same order as listing them")
+  func filterCostIsTheSameOrderAsListing() throws {
+    let (coordinator, _) = makeCoordinator()
+    var rows: [Transcript] = []
+    rows.reserveCapacity(25_000)
+    for i in 0..<25_000 {
+      rows.append(
+        i % 5 == 0
+          ? transcript("row \(i)", file: "file-\(i).m4a", ageSeconds: TimeInterval(i))
+          : dictation("row \(i)", ageSeconds: TimeInterval(i)))
+    }
+    #if DEBUG
+      coordinator.setTranscriptsForTesting(rows)
+    #else
+      for row in rows { try coordinator.saveAndShow(row) }
+    #endif
+
+    let clock = ContinuousClock()
+    func fastest(_ body: () -> Int) -> (Duration, Int) {
+      var best: Duration = .seconds(1_000)
+      var count = 0
+      for _ in 0..<3 {
+        let start = clock.now
+        count = body()
+        best = min(best, clock.now - start)
+      }
+      return (best, count)
+    }
+
+    coordinator.historyFilter = .all
+    let (unfiltered, allCount) = fastest { coordinator.filteredTranscripts.count }
+    coordinator.historyFilter = .transcripts
+    let (filtered, transcriptCount) = fastest { coordinator.filteredTranscripts.count }
+
+    #expect(allCount == 25_000)
+    #expect(transcriptCount == 5_000)
+    #expect(
+      filtered <= unfiltered * 4,
+      "one extra pass over the array must stay within a small multiple of the pass History already makes: filtered \(filtered) vs listed \(unfiltered)"
+    )
+  }
+
+  #if DEBUG
+    // MARK: Rows the store would refuse to return
+
+    @Test("an expired recovery is listed under no filter")
+    func expiredRowIsNeverListed() {
+      let (coordinator, _) = makeCoordinator()
+      let expired = held("expired", age: AppConstants.pendingTranscriptRetention + 60)
+      coordinator.setTranscriptsForTesting([expired, dictation("kept")])
+
+      for filter in HistoryFilter.allCases {
+        coordinator.historyFilter = filter
+        #expect(
+          ids(coordinator.filteredTranscripts).contains(expired.id) == false,
+          "expired under \(filter)")
+      }
+      coordinator.historyFilter = .all
+      #expect(coordinator.listedCount == 1, "the kept dictation is the only row counted")
+    }
+
+    @Test("a selected recovery that expires shows nothing, not the live transcript")
+    func selectedRowExpiringIsEmptyNotFallback() {
+      let (coordinator, _) = makeCoordinator()
+      let live = held("cancelled", age: 60)
+      coordinator.setTranscriptsForTesting([live])
+      coordinator.selectedTranscriptID = live.id
+      #expect(isRow(coordinator.detail, live.id))
+
+      // The same row, past its window: what read-time expiry sees on the next render.
+      let expired = Transcript(
+        id: live.id, text: live.text, createdAt: live.createdAt,
+        escapeRecoveredAt: Date().addingTimeInterval(-AppConstants.pendingTranscriptRetention - 60),
+        escapeRecoveryTakeID: live.escapeRecoveryTakeID)
+      coordinator.setTranscriptsForTesting([expired])
+      #expect(isEmpty(coordinator.detail))
+    }
+  #endif
+}

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorTests.swift
@@ -67,7 +67,7 @@ struct TranscriptCoordinatorTests {
       Transcript(
         text: "an import", language: "en", duration: 61, backendType: .parakeet,
         importedFileName: "sync.m4a"))
-    #expect(coordinator.transcriptCount == 2, "History lists two rows")
+    #expect(coordinator.listedCount == 2, "History lists two rows")
     #expect(coordinator.dictationCount == 1, "only one of them was dictated")
   }
 

--- a/website/src/content/help/escape-recovery.md
+++ b/website/src/content/help/escape-recovery.md
@@ -22,7 +22,7 @@ A recording follows the setting as it stood when that recording started. Changin
 
 Your cancel keybind, Escape by default, still stops the recording. Instead of discarding it, EnviousWispr transcribes and polishes it the same way it would any dictation, then holds the text rather than pasting it.
 
-A small **Transcript cancelled** notice appears with an **Undo** button. Press it and the text goes into the app you were dictating into. If you miss the notice, nothing is lost: the dictation is waiting in your History.
+A small **Dictation cancelled** notice appears with an **Undo** button. Press it and the text goes into the app you were dictating into. If you miss the notice, nothing is lost: the dictation is waiting in your History.
 
 Two things follow from the recording being processed rather than thrown away.
 


### PR DESCRIPTION
Part of #2807 (phase 1 of 5). #2808 is the phase issue and stays open until the phase's UAT evidence is posted.

## What changes for the user

A row made with the keybind is a **Dictation**. A row from Transcribe a File is a **Transcript**. History holds both.

- A new **All / Dictations / Transcripts** control sits above the History list. It is view state: a relaunch starts at All.
- Every row carries a **Dictation** or **Transcript** chip. The detail pane's title, icon and delete label say the kind.
- The search box says **Search history** and searches inside the chosen filter. The count beside it counts what the list shows.
- Four empty-list sentences: nothing here yet, no dictations yet, no transcripts yet, no matching history.
- **Delete all history** stays global, says it includes rows a filter or search hides, and confirms with the global count.
- The cancel pill and its VoiceOver sentence say **Dictation cancelled**.
- One What's New card in the open 2.4.9 group.

## What the detail pane does now

It resolves from the rows on screen. A selection that a filter, a search or a deletion takes away shows nothing, never the live transcript. The live transcript follows its own row: when the list stops showing the dictation the pane is showing, the pane goes empty; a completed dictation the list shows lets it show again. Deleting the selected row selects its neighbour in the same filter.

## Review

Codex build-orchestrator session, two chunks, both CHUNK-CLEAN (one revision each on the live-fallback rules). Independent whole-diff review and the second behavioural pass are recorded on #2808.

## Tests

New `TranscriptCoordinatorFilterTests` (26 cases, product outcome). Updated: the Delete All sentence assertions, the pill copy assertions, the frozen pill parity oracle's announcement row (provenance note in the file). Lane receipts on #2808.

## Vocabulary sweep

Phase 5 (#2812) sweeps the help centre and website. This PR changes only the one help line that quotes the pill (`claim-sweep.sh "Transcript cancelled"`: 4 hits, all closed).

Lane: Code, `mixed_pr: true` (one help-centre line).

## Local lanes

Full Debug lane: 7,729 tests, 4 failures, all in `RenderedPillFreezeTests` on pills this PR does not touch, each one point taller than the frozen table. Reproduced identically on untouched main at `10c96f43`, so it is the dev machine's text metrics after the OS update, not this change: tracked as #2814. Release-configuration compile of every test plus the new suite in Release: receipt on #2808.
