### PR TITLE
fix(website): enlarge the desktop preview without crowding the backdrop

### DIFF
--- a/website/src/styles/home/hero.css
+++ b/website/src/styles/home/hero.css
@@ -334,6 +334,20 @@ html[data-theme='dark'] .hero-screen-frame {
     display: none;
   }
 }
+@media (min-width: 1200px) {
+  .hero-product-demo {
+    /* Short desktop screens need clearance above the backdrop laptop. */
+    top: 110px;
+    transform: scale(0.73);
+  }
+}
+@media (min-width: 1200px) and (min-height: 900px) {
+  .hero-product-demo {
+    /* Grow upward and leave a little more room above the laptop. */
+    top: 210px;
+    transform: translateY(-15%) scale(0.8);
+  }
+}
 @media (max-width: 999px) {
   .screen-hero {
     margin-top: -84px;


### PR DESCRIPTION
The homepage demonstration is too small on desktop. This enlarges it by approximately 19% in each dimension on windows at least 1200px wide and 900px tall, and by approximately 9% on shorter desktop windows. The preview moves upward to leave the person and laptop visible. Layouts below 1200px retain their existing sizing and placement.

Closes #2821.

Validation: 13 homepage tests pass; Astro builds all 143 pages; help checks find 0 dead internal links, all 47 search checks pass, and all 9 feature pages pass. Local diff and independent behavioral reviews report no findings. Strict Content validation passes.

Browser validation: 44 before/after layouts in Chromium and WebKit across light/dark themes, 375–1920px widths; unchanged measured mobile/compact geometry, correct desktop growth, no horizontal overflow, and Next works in every case. Separately verified Replay, real resizing across desktop/mobile breakpoints, heights 780/781/899/900, reduced motion, and JavaScript-disabled static previews. Inspected screenshots for clearance from navigation, the person and laptop. Physical-device Safari was not tested.

Evidence: main checkout `.validation/desktop-preview/`; final validation run in the feature checkout `.validation/runs/2026-09-12T14-47-48Z-f12fecc4/`. Local built preview: http://127.0.0.1:8892/.

Only `website/src/styles/home/hero.css` changes. Swift/audio builds and polish evaluations do not apply to this Content-only change. CI and cloud review will be checked before publication.
