### PR TITLE
feat(website): apply bold header navigation and active-page styling

### DIFF
--- a/website/src/components/SiteHeader.astro
+++ b/website/src/components/SiteHeader.astro
@@ -76,7 +76,7 @@ const { activePage = 'home', themed = false } = Astro.props;
       <a class:list={['nav-link', { active: activePage === 'compare' }]} href="/compare/">Compare</a>
       <div class="resource-parent" data-nav-parent>
         <a
-          class="nav-trigger"
+          class:list={['nav-trigger', { active: resources.some(([label]) => activePage === label.toLowerCase()) }]}
           href="/blog/"
           id="resources-trigger"
           aria-controls="resources-menu"

--- a/website/src/styles/site-header.css
+++ b/website/src/styles/site-header.css
@@ -413,6 +413,26 @@ html[data-theme='dark'] .site-chrome {
 }
 
 /* ── Responsive ─────────────────────────────────────────────────────────── */
+@media (min-width: 1000px) {
+  .chrome-header[data-nav-ready] .main-nav {
+    flex: 1;
+    justify-content: space-evenly;
+    gap: clamp(24px, 3.2vw, 48px);
+    margin-left: 0;
+    font-size: 16px;
+  }
+  .chrome-header[data-nav-ready] .nav-trigger,
+  .chrome-header[data-nav-ready] .nav-link {
+    font-size: inherit;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+}
+@media (min-width: 1000px) and (max-width: 1190px) {
+  .chrome-header[data-nav-ready] .main-nav {
+    gap: 22px;
+  }
+}
 @media (max-width: 1190px) {
   .chrome-header,
   .chrome-footer {

--- a/website/src/styles/site-header.css
+++ b/website/src/styles/site-header.css
@@ -414,23 +414,58 @@ html[data-theme='dark'] .site-chrome {
 
 /* ── Responsive ─────────────────────────────────────────────────────────── */
 @media (min-width: 1000px) {
+  .chrome-header {
+    background: var(--nav-card);
+    box-shadow: 0 8px 28px #2714380a;
+  }
   .chrome-header[data-nav-ready] .main-nav {
     flex: 1;
-    justify-content: space-evenly;
-    gap: clamp(24px, 3.2vw, 48px);
+    justify-content: center;
+    gap: 36px;
     margin-left: 0;
     font-size: 16px;
   }
   .chrome-header[data-nav-ready] .nav-trigger,
   .chrome-header[data-nav-ready] .nav-link {
-    font-size: inherit;
-    font-weight: 500;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--nav-ink);
     white-space: nowrap;
+    position: relative;
+  }
+  .chrome-header[data-nav-ready] .nav-link.active,
+  .chrome-header[data-nav-ready] .nav-link:hover,
+  .chrome-header[data-nav-ready] .nav-trigger.active,
+  .chrome-header[data-nav-ready] .nav-trigger:hover,
+  .chrome-header[data-nav-ready] .nav-trigger[aria-expanded='true'] {
+    color: var(--nav-accent);
+  }
+  .chrome-header[data-nav-ready] .nav-link.active::after,
+  .chrome-header[data-nav-ready] .nav-trigger.active::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 2px;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--nav-accent);
+  }
+  .chrome-header .chrome-download {
+    font-size: 16px;
+    min-height: 48px;
+  }
+  .chrome-header .chrome-brand {
+    font-size: 26px;
   }
 }
 @media (min-width: 1000px) and (max-width: 1190px) {
   .chrome-header[data-nav-ready] .main-nav {
     gap: 22px;
+  }
+  .chrome-header[data-nav-ready] .nav-trigger,
+  .chrome-header[data-nav-ready] .nav-link {
+    font-size: 16px;
   }
 }
 @media (max-width: 1190px) {


### PR DESCRIPTION
Apply the founder-selected “Bold and clean” header across the website. Desktop navigation uses larger semibold labels, strong text contrast, a tighter centered group and a purple underline for the active page. The wordmark and download control have more presence; the header uses a solid themed surface with a subtle shadow.

Compact desktop widths retain smaller labels and tighter gaps. Header height, dropdown anchoring, mobile navigation, no-script links and keyboard controls retain their existing behavior. Shared header styling and the Resources active class are updated; page content and metadata are untouched.

Closes #2832

### Validation
- 143-page Astro build,13 homepage tests,71 help routes,47 search checks and9 feature pages pass.
- Actual browser checks at1360/1280/1191/1190/1000px: no overflow or control overlap. Mobile menu retained at999/390px.
- Blog, Help and Contact propagate their active category to the Resources button.
- Both themes, active underline, Features/Resources dropdowns, Escape and the no-theme detail-page header checked.
- Local independent review approved the selected implementation. All original navigation destinations remain.

The founder selected option1 and explicitly authorized publishing without another approval stop. Concept board: http://127.0.0.1:8897/ . Implementation preview: http://127.0.0.1:8896/compare/ .

Local evidence: `.validation/runs/2026-09-12T19-52-29Z-f30226cc/`.
