### PR TITLE
feat(settings): show AFM generation and live token capacity on the Apple Intelligence card

### DIFF
--- a/Sources/EnviousWisprAppKit/Views/Settings/ProviderSetup.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ProviderSetup.swift
@@ -1503,6 +1503,23 @@ struct ProviderSetupSection: View {
       .accessibilityLabel("Check Apple Intelligence availability")
     }
 
+    // Which Apple on-device model is running, and its live shared capacity
+    // (#2834). Only meaningful once Apple Intelligence is actually usable.
+    // "AFM 2"/"AFM 3" naming and the live token count both from #2795 (see
+    // AppleIntelligenceConnector.isOnNewerPromptGeneration / .currentContextWindowTokens).
+    if let report = aiAvailability.latestReport, report.overallStatus == .available {
+      HStack {
+        Text(
+          "Model: \(AppleIntelligenceConnector.isOnNewerPromptGeneration ? "AFM 3" : "AFM 2") · Capacity: \(AppleIntelligenceConnector.currentContextWindowTokens.formatted()) tokens"
+        )
+        .font(.stHelper)
+        .foregroundStyle(Color.stTextSecondary)
+        Spacer()
+      }
+      .help(
+        "Tokens are shared between the model's setup instructions, your dictation, and its answer.")
+    }
+
     // "Why?" detail text
     if let report = aiAvailability.latestReport,
       report.overallStatus != .available

--- a/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
+++ b/Sources/EnviousWisprLLM/AppleIntelligenceConnector.swift
@@ -120,10 +120,34 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
 
   // MARK: - AFM context-window preflight (#1055)
 
-  /// Apple Intelligence shares a 4,096-token context window across instructions
-  /// + prompt + generated output (Apple docs; measured 2026-06-17, see
-  /// `.claude/knowledge/llm-contract.md` FACT: afm-context-window-4096).
-  static let afmContextWindowTokens = 4096
+  /// The macOS 26 (AFM 2) on-device context window: instructions + prompt +
+  /// generated output share this many tokens total (Apple docs; measured
+  /// 2026-06-17, see `.claude/knowledge/llm-contract.md` FACT:
+  /// afm-context-window-4096). macOS 27 (AFM 3) doubles this to 8,192
+  /// (measured 2026-09-10, #2795 item 2) — `currentContextWindowTokens` below
+  /// reads the real value live; this constant is now ONLY the fallback floor
+  /// for when the live read is unavailable (pre-26.0, or FoundationModels not
+  /// compiled in). `package` so the settings UI can display it (#2834)
+  /// without duplicating the literal.
+  package static let afmContextWindowTokens = 4096
+
+  /// This Mac's LIVE on-device context budget: `SystemLanguageModel
+  /// .contextSize` where available (`@backDeployed` to macOS 26.0, so no
+  /// extra OS-version branch is needed — it works on 26.0-26.3 too, not only
+  /// 26.4+) — 4,096 on macOS 26 (AFM 2), 8,192 on macOS 27 (AFM 3, #2795 item
+  /// 2). Falls back to the static `afmContextWindowTokens` floor when
+  /// FoundationModels isn't compiled in or the OS predates 26.0, so this is
+  /// safe to call unconditionally. Settings-UI display (#2834); the #1055
+  /// preflight below reads `prepared.model.contextSize` directly off the live
+  /// session so the two never disagree.
+  package static var currentContextWindowTokens: Int {
+    #if canImport(FoundationModels)
+      if #available(macOS 26.0, *) {
+        return SystemLanguageModel.default.contextSize
+      }
+    #endif
+    return afmContextWindowTokens
+  }
   /// Headroom kept below the hard window. Tuned by on-device validation (#1055).
   static let afmContextSafetyMarginTokens = 128
   /// PREFLIGHT output reserve as a multiple of input tokens. A clean transcript
@@ -299,6 +323,18 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       overrideText: overrideText, exampleOverride: exampleOverride, suffix: suffix)
   }
 
+  /// OS major version at which prompt selection switches to v39 (see
+  /// `promptSelection` below). Named here so a display label never repeats
+  /// this literal on its own (#2834).
+  package static let modernPromptMajorVersionFloor = 27
+
+  /// Whether THIS Mac is on the macOS 27+ prompt generation `promptSelection`
+  /// would select — display only, never used to route polish behaviour.
+  /// (#2834, settings UI "which model" line.)
+  package static var isOnNewerPromptGeneration: Bool {
+    ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= modernPromptMajorVersionFloor
+  }
+
   /// The one owner of "which Apple prompt, which suffix and which example turns
   /// does this OS get" (#2795). Pure so the gate is testable without touching
   /// the OS:
@@ -314,7 +350,7 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
     majorVersion: Int, overrideText: String?, exampleOverride: [OnDeviceExampleTurn]? = nil,
     suffix: String
   ) -> PromptSelection {
-    let modern = majorVersion >= 27
+    let modern = majorVersion >= modernPromptMajorVersionFloor
     var base = modern ? onDeviceInstructionsV39 : onDeviceInstructionsSingle
     if let text = overrideText, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
       base = text
@@ -753,7 +789,11 @@ public struct AppleIntelligenceConnector: TranscriptPolisher {
       let reservedOutputTokens = Int(
         (Double(inputTokens) * afmPreflightOutputReserveMultiplier).rounded(.up))
       let projected = promptTokens + inputTokens + reservedOutputTokens
-      let budget = afmContextWindowTokens - afmContextSafetyMarginTokens
+      // The live per-session window (#2795 item 2): macOS 26 (AFM 2) reports
+      // 4,096 here, macOS 27 (AFM 3) reports 8,192. Using the static
+      // `afmContextWindowTokens` floor instead would wrongly skip on-device
+      // polish on long AFM 3 dictations that actually fit.
+      let budget = prepared.model.contextSize - afmContextSafetyMarginTokens
       // Advisory response cap, CLAMPED to the room actually left in the window
       // after instructions + prompt. Empirically this SDK does not reject a call
       // whose `maximumResponseTokens` would overrun the window (measured

--- a/Sources/EnviousWisprPipeline/EmojiRestoreStep.swift
+++ b/Sources/EnviousWisprPipeline/EmojiRestoreStep.swift
@@ -135,13 +135,9 @@ final class EmojiRestoreStep: TextProcessingStep {
       return context
     }
 
-    // LENGTH CAP (#1948, cloud review r7). `EmojiRestorer.alignWords` allocates an
-    // (n+1)x(m+1) `[[Int]]` LCS table and runs synchronously on the main actor, so its cost
-    // is quadratic in dictation length. The AFM path was bounded incidentally by Apple's
-    // 4096-token context (polish is skipped above it, so `polishedText` is nil and this step
-    // no-ops). Local Ollama has no such ceiling and its output cap SCALES with input
-    // (`LLMPolishStep` `outputTokenPolicy`), so widening the gate exposed lengths the
-    // algorithm was never asked to handle.
+    // LENGTH CAP (#1948, cloud review r7; widened to AFM #2834 PR review). `EmojiRestorer
+    // .alignWords` allocates an (n+1)x(m+1) `[[Int]]` LCS table and runs synchronously on
+    // the main actor, so its cost is quadratic in dictation length.
     //
     // Measured against the real restorer on this machine: 200 words 3.6 ms / <1 MB;
     // 1,000 words 54 ms / 8 MB; 3,000 words 484 ms / 69 MB; 6,000 words 1.9 s / 275 MB;
@@ -162,17 +158,17 @@ final class EmojiRestoreStep: TextProcessingStep {
     // precisely the pathological inputs it exists to reject. The unit has to match the
     // quantity being bounded.
     //
-    // SCOPED TO THE NEWLY WIDENED PATH (cloud review r8). Apple Intelligence restored emoji
-    // for EVERY successful polish before #1948, bounded incidentally by Apple's own
-    // 4096-token preflight — roughly 3,000 words, ~484 ms by the table above. Applying this
-    // cap to AFM as well would silently withdraw restoration from long AFM dictations, which
-    // is a behaviour change on a path this change is not about. Ollama has no equivalent
-    // ceiling and its output cap SCALES with input, which is the exposure being bounded.
-    if isLocalOllama {
-      let preTokens = EmojiRestorer.alignmentTokenCount(context.text)
-      let postTokens = EmojiRestorer.alignmentTokenCount(polished)
-      guard max(preTokens, postTokens) <= Self.maxAlignmentTokens else { return context }
-    }
+    // APPLIES TO BOTH RESTORING PATHS (#2834; retires cloud review r8's Ollama-only scoping).
+    // r8 scoped this cap to Ollama because AFM was bounded INCIDENTALLY by Apple's own FIXED
+    // 4,096-token preflight — an AFM dictation could never reach the lengths that make this
+    // quadratic cost matter. #2834 makes that same preflight window LIVE (4,096 on macOS 26,
+    // 8,192 on macOS 27, and whatever a future OS reports), which is exactly the premise r8's
+    // scoping rested on, so its reasoning no longer holds and AFM needs the same guard Ollama
+    // already has for the same reason: an output cap that scales with input rather than a
+    // fixed ceiling below this step's danger zone.
+    let preTokens = EmojiRestorer.alignmentTokenCount(context.text)
+    let postTokens = EmojiRestorer.alignmentTokenCount(polished)
+    guard max(preTokens, postTokens) <= Self.maxAlignmentTokens else { return context }
 
     let start = CFAbsoluteTimeGetCurrent()
     let result = restorer.restore(polished: polished, prePolish: context.text)

--- a/Tests/EnviousWisprTests/Pipeline/EmojiRestoreStepTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/EmojiRestoreStepTests.swift
@@ -303,33 +303,40 @@ import Testing
     #expect(s.lastRun == nil)
   }
 
-  /// The cap must NOT apply to Apple Intelligence (cloud review r8). AFM restored emoji for
-  /// every successful polish before #1948, bounded only by Apple's own 4096-token preflight
-  /// (~3,000 words). Capping it here would silently withdraw restoration from long AFM
-  /// dictations — a behaviour change on a path this change is not about.
-  @Test("a long Apple Intelligence dictation still restores, uncapped (#1948 r8)")
-  func longAppleIntelligenceStillRestores() async throws {
+  /// The cap now applies to Apple Intelligence TOO (#2834; retires cloud review r8's
+  /// Ollama-only scoping). r8 declined to cap AFM because it was bounded INCIDENTALLY by
+  /// Apple's own FIXED 4096-token preflight, so a real dictation could never reach the
+  /// lengths that make this quadratic cost matter. #2834 made that preflight window LIVE
+  /// (4,096 on macOS 26, 8,192 on macOS 27, more on a future OS), which is exactly the
+  /// premise r8's scoping rested on — so a long AFM dictation can now reach this step the
+  /// same way a long Ollama one always could, and needs the same guard.
+  @Test("a long Apple Intelligence dictation is capped too, leaving the polish untouched (#2834)")
+  func longAppleIntelligenceSkipsRestorationToo() async throws {
     let long = (0..<(EmojiRestoreStep.maxAlignmentTokens + 200))
       .map { "word\($0 % 97)" }.joined(separator: " ")
-    var c = TextProcessingContext(text: long + " 🙏", language: nil)
-    c.llmProvider = LLMProvider.appleIntelligence.rawValue
-    c.promptFamily = nil
-    c.polishedText = long + "."
     let s = step()
-    let out = try await s.process(c)
-    #expect(out.polishedText?.contains("🙏") == true, "AFM restoration must not be capped")
-    #expect(s.lastRun?.restored == 1)
+    let out = try await s.process(afmContext(pre: long + " 🙏", polished: long + "."))
+    #expect(out.polishedText == long + ".")
+    #expect(out.polishedText?.contains("🙏") == false)
+    // No restore happened, so no telemetry may claim one.
+    #expect(s.lastRun == nil)
   }
 
   /// Two-way control at the boundary: just UNDER the cap must still restore, so the guard
-  /// cannot be satisfied by disabling restoration outright.
-  @Test("a dictation just under the cap still restores")
-  func justUnderCapStillRestores() async throws {
+  /// cannot be satisfied by disabling restoration outright. Both restoring providers, since
+  /// #2834 made both subject to the same cap.
+  @Test("a dictation just under the cap still restores", arguments: [LLMProvider.ollama, .appleIntelligence])
+  func justUnderCapStillRestores(provider: LLMProvider) async throws {
     let body = (0..<(EmojiRestoreStep.maxAlignmentTokens - 5))
       .map { "word\($0 % 97)" }.joined(separator: " ")
     let s = step()
-    let out = try await s.process(
-      ollamaContext(pre: body + " 🙏", polished: body + "."))
+    let out: TextProcessingContext
+    switch provider {
+    case .ollama:
+      out = try await s.process(ollamaContext(pre: body + " 🙏", polished: body + "."))
+    default:
+      out = try await s.process(afmContext(pre: body + " 🙏", polished: body + "."))
+    }
     #expect(out.polishedText?.contains("🙏") == true)
     #expect(s.lastRun?.restored == 1)
   }


### PR DESCRIPTION
## Summary
- Shows which Apple on-device model is running (AFM 2 / AFM 3) and its live token capacity on the Apple Intelligence settings card, next to Status (#2834).
- Fixes the real bug this surfaced: `AppleIntelligenceConnector.afmContextWindowTokens` was a hardcoded 4096 used both for display AND for the `#1055` context-window preflight. macOS 27's AFM 3 model actually reports 8192 (`SystemLanguageModel.contextSize`, measured on host 26A428, `#2795` item 2) — the preflight was silently skipping on-device polish on long AFM 3 dictations that would have fit. Added `AppleIntelligenceConnector.currentContextWindowTokens` (reads the live value, `@backDeployed` to macOS 26.0, falls back to the 4096 floor when unavailable) and pointed the preflight at the live per-session value directly.

## Test plan
- [x] `swift build` clean
- [x] Full `scripts/xcode-test.sh --filter EnviousWisprTests` — one pre-existing failure (`RenderedPillFreezeTests`, a host-dependent absolute-pixel-size drift guard, unrelated to this change) confirmed to fail identically on unmodified `origin/main` before re-applying this diff; everything else green
- [x] Rebuilt the dev app and visually confirmed the settings card shows "Model: AFM 3 · Capacity: 8,192 tokens" on this macOS 27 machine
