### PR TITLE
feat(pipeline): turn-safe cleanup and storage for speaker turns, dormant (#2810)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1552,6 +1552,15 @@ final class FileImportCoordinator {
       // `originalHistoryRow` never learned about this write (found by whole-diff review).
       // Guarded by id: `originalHistoryRow` can be nil, or belong to a DIFFERENT file
       // chosen while this background pass was still running.
+      //
+      // KNOWN LIMIT for phase 4 (second-pass review): this closes the loop for writes THIS
+      // coordinator makes, but `originalHistoryRow` is still a private snapshot — an
+      // explicit rename (`mergeSpeakerFields`'s `explicitRename:` parameter) applied from
+      // anywhere else against the SAME row would not update it, and a later re-polish here
+      // would silently revert that rename via `withImportResult`. Not reachable today: no
+      // UI calls `explicitRename` yet (phase 4 ships that). Phase 4's rename design should
+      // either read the row fresh from History at write time or push its own update through
+      // this same path rather than assuming this cache is authoritative.
       if saved, originalHistoryRow?.id == historyID {
         originalHistoryRow = originalHistoryRow?.mergingSpeakerFields(
           analysis: analysis, turns: turns)

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1469,7 +1469,14 @@ final class FileImportCoordinator {
       return
     }
 
-    let assembledTurns = TurnAssembler.assemble(entries: wordTimings, segments: segments)
+    // Off the main actor: a multi-hour, highly segmented recording's O(words × segments)
+    // scan would otherwise run synchronously on this MainActor-isolated method and freeze
+    // the UI before the background cleanup even claims the engine (found by cloud review).
+    // `entries`/`segments`/`Turn` are all `Sendable` value types, so handing the pure
+    // computation to a detached task changes nothing about its result.
+    let assembledTurns = await Task.detached(priority: .utility) {
+      TurnAssembler.assemble(entries: wordTimings, segments: segments)
+    }.value
 
     let token: EngineLease.Token
     switch engineAdmission.claim() {

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1474,9 +1474,21 @@ final class FileImportCoordinator {
     // the UI before the background cleanup even claims the engine (found by cloud review).
     // `entries`/`segments`/`Turn` are all `Sendable` value types, so handing the pure
     // computation to a detached task changes nothing about its result.
-    let assembledTurns = await Task.detached(priority: .utility) {
+    //
+    // `Task.detached` is UNSTRUCTURED: cancelling THIS task (e.g. `stop()`'s unconditional
+    // `speakerStepTask?.cancel()`) would not by itself cancel the detached child, leaving it
+    // to run the full scan to completion and this task waiting on it the whole time
+    // (found by cloud review). `withTaskCancellationHandler` propagates cancellation into
+    // the child explicitly; `TurnAssembler.assemble`'s own loop checks `Task.isCancelled`
+    // per entry so the propagated cancellation actually shortens the scan.
+    let assemblyTask = Task.detached(priority: .utility) {
       TurnAssembler.assemble(entries: wordTimings, segments: segments)
-    }.value
+    }
+    let assembledTurns = await withTaskCancellationHandler(
+      operation: { await assemblyTask.value },
+      onCancel: { assemblyTask.cancel() }
+    )
+    guard generationAtStart == generation, !Task.isCancelled else { return }
 
     let token: EngineLease.Token
     switch engineAdmission.claim() {

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1370,11 +1370,18 @@ final class FileImportCoordinator {
       // superseded run's own generation guards inside `runSpeakerStep` discard its result
       // either way.
       speakerStepTask?.cancel()
+      // Captured HERE, not re-read later: identifies which DOCUMENT this background pass is
+      // for, independent of `generation` — `rePolish()` ("Clean it again") bumps `generation`
+      // for the SAME document without restarting speaker analysis, and the OLD generation
+      // check alone used to make this pass discard the only analysis this document will ever
+      // get (found by cloud review). `choose`/`startOver` still invalidate this correctly:
+      // both reset `originalHistoryRow` before any later save gives it a new id.
+      let historyIDAtStart = historyID
       speakerStepTask = Task { [weak self] in
         await self?.runSpeakerStep(
           analysisSamples: analysisSamples, generationAtStart: generationAtStart,
-          rawText: result.text, wordTimings: result.wordTimings,
-          wordTimingCoverage: result.wordTimingCoverage)
+          historyIDAtStart: historyIDAtStart, rawText: result.text,
+          wordTimings: result.wordTimings, wordTimingCoverage: result.wordTimingCoverage)
       }
       phase = "Dividing it up to clean"
       await polishAll(
@@ -1392,33 +1399,37 @@ final class FileImportCoordinator {
 
   /// The phase-2 speaker step, now feeding phase-3 turn assembly and storage (#2810
   /// addendum §3 C-E). Runs the bounded, cancellable analysis on the captured PCM, guards
-  /// generation once more before recording anything (a Stop during analysis must not
-  /// attribute telemetry or a log line to a run nobody is watching), and never surfaces a UI
+  /// on DOCUMENT IDENTITY once more before recording anything, and never surfaces a UI
   /// signal on any outcome — `speakerAnalysis` is read only by telemetry and the log.
   private func runSpeakerStep(
-    analysisSamples: [Float], generationAtStart: Int, rawText: String,
+    analysisSamples: [Float], generationAtStart: Int, historyIDAtStart: UUID?, rawText: String,
     wordTimings: [ASRWordTiming]?, wordTimingCoverage: ASRWordTimingCoverage?
   ) async {
     let durationSeconds = file?.seconds ?? 0
     let analysisStart = CFAbsoluteTimeGetCurrent()
     let outcome = await speakerLabeler(analysisSamples, durationSeconds)
     let analysisMs = Int(((CFAbsoluteTimeGetCurrent() - analysisStart) * 1000).rounded())
-    // A Stop landing during analysis already released the resources it owns (`stop()`
-    // clears `decodedSamples` and bumps `generation`); nothing here should attribute
-    // telemetry or a log line to a run nobody is watching.
-    guard generationAtStart == generation else { return }
+    // Gates on the DOCUMENT this pass is for, not on `generation`: `rePolish()` ("Clean it
+    // again") bumps `generation` for the SAME document without restarting speaker analysis,
+    // and gating on generation alone made a re-polish right after import discard the only
+    // analysis this document will ever get (found by cloud review). `choose`/`startOver`
+    // still invalidate this correctly — both reset `originalHistoryRow` before any later
+    // save gives it a new id. A genuine Stop is caught by `!Task.isCancelled`, since `stop()`
+    // does not always bump `generation` either (a direct Stop press after the visible run
+    // already finished leaves it untouched).
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
     speakerAnalysis = outcome
     await AppLogger.shared.log(
       "[SpeakerLabeler] outcome=\(Self.speakerLogOutcome(outcome)) speakers=\(Self.speakerLogCount(outcome)) ms=\(analysisMs)",
       level: .info, category: "FileImportCoordinator")
     // The log line above is itself a suspension point; re-check rather than assume the
     // first guard still holds by the time telemetry fires. Found by Codex.
-    guard generationAtStart == generation else { return }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
     emitSpeakerTelemetry(outcome, durationSeconds, analysisMs, wordTimingCoverage)
 
     await runTurnStorage(
       outcome: outcome, wordTimings: wordTimings, rawText: rawText,
-      generationAtStart: generationAtStart)
+      generationAtStart: generationAtStart, historyIDAtStart: historyIDAtStart)
   }
 
   /// Phase 3: turn assembly, background turn-safe cleanup, and storage (#2810 addendum §3
@@ -1428,7 +1439,7 @@ final class FileImportCoordinator {
   /// duration, exactly as round 2 of the addendum's review settled.
   private func runTurnStorage(
     outcome: SpeakerAnalysis, wordTimings: [ASRWordTiming]?, rawText: String,
-    generationAtStart: Int
+    generationAtStart: Int, historyIDAtStart: UUID?
   ) async {
     guard let historyID else { return }
     let passStart = CFAbsoluteTimeGetCurrent()
@@ -1437,13 +1448,18 @@ final class FileImportCoordinator {
     // — an early write here would race `savePolishedToHistory`'s own stale-captured-row
     // overwrite (found by chunk review: two early-return branches used to write before this
     // wait existed, so their result could be silently erased once the visible run's own
-    // save landed). Rechecks generation AND cancellation together: `stop()` cancels this
-    // task unconditionally and does not always bump `generation` (a direct Stop press after
-    // the visible run already finished leaves `generation` untouched), so cancellation is
-    // its own signal, never implied by the generation check alone.
+    // save landed). `generationAtStart` is still needed here purely to INDEX the right
+    // generation's completion gate — `waitForVisibleCleanup`/`finishVisibleCleanup` are
+    // keyed by `polishAll`'s own generation number, which a re-polish genuinely does start
+    // fresh. Every STALENESS check below gates on document identity instead (see
+    // `runSpeakerStep`'s comment): `rePolish()` bumps `generation` for the SAME document
+    // without restarting this pass, and gating on generation alone discarded the only
+    // analysis a document would ever get (found by cloud review). A genuine Stop is still
+    // caught by `!Task.isCancelled`, which `stop()`'s unconditional cancel sets regardless
+    // of whether it also bumped `generation`.
     await waitForVisibleCleanup(generation: generationAtStart)
     onVisibleCleanupWaitResolved(generationAtStart)
-    guard generationAtStart == generation, !Task.isCancelled else { return }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
 
     // Non-labeled outcomes map directly through the one exhaustive mapping (chunk 1) and
     // never touch turn assembly. A missing `wordTimings` matters ONLY when assembly is
@@ -1488,7 +1504,25 @@ final class FileImportCoordinator {
       operation: { await assemblyTask.value },
       onCancel: { assemblyTask.cancel() }
     )
-    guard generationAtStart == generation, !Task.isCancelled else { return }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
+
+    // A space-free script (Chinese, Japanese, ...) makes the production word-timing mapper
+    // (`WordTimingRangeMapper`, #2809) return exactly one untimed entry for the whole
+    // transcript — there is no whitespace to tokenize on, so no engine word can bind to any
+    // text run. Every entry then resolves to "unknown" here, and persisting `.labeled(count:)`
+    // alongside turns that are ALL "unknown" would store a self-contradictory row: the
+    // analysis claims real speakers while the turns say none were ever found (found by cloud
+    // review). Treated the same as `noWordTimings` — from turn assembly's own perspective,
+    // timings that never bind to anything are exactly "nothing to merge against," matching
+    // that reason's own documented scope. The real fix (a mapper that can tokenize a
+    // space-free script) belongs to `WordTimingRangeMapper` itself, out of this phase's scope.
+    guard assembledTurns.contains(where: { $0.speakerId != TurnAssembler.unknownSpeakerID })
+    else {
+      await mergeAndReport(
+        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
+        outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
+      return
+    }
 
     let token: EngineLease.Token
     switch engineAdmission.claim() {
@@ -1510,7 +1544,7 @@ final class FileImportCoordinator {
       engineAdmission.release(token)
       finishEngineHold()
     }
-    guard generationAtStart == generation, !Task.isCancelled else { return }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
 
     // Mirrors `start()`/`rePolish()`: the visible run's own claim already warmed this
     // provider, but that hold has since been released (and its own `onEngineReleased` may
@@ -1519,7 +1553,7 @@ final class FileImportCoordinator {
     // anything on it (found by chunk review).
     let polisherReady =
       if let configuration { await prepareLocalPolish(configuration) } else { true }
-    guard generationAtStart == generation, !Task.isCancelled else { return }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
     guard polisherReady else {
       await AppLogger.shared.log(
         "[TurnCleanup] outcome=polisher_not_ready ms=\(Self.elapsedMs(since: passStart))",
@@ -1530,7 +1564,7 @@ final class FileImportCoordinator {
 
     let (cleanedTurns, fallbackTurnCount) = await TurnCleanupRunner(processPart: processPart)
       .run(turns: assembledTurns, rawText: rawText, engineLanguage: engineReportedLanguage)
-    guard generationAtStart == generation, !Task.isCancelled else { return }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
 
     await mergeAndReport(
       historyID: historyID, analysis: .labeled(count: labeledCount), turns: cleanedTurns,

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -2,6 +2,7 @@ import CryptoKit
 import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprPipeline
+import EnviousWisprServices
 import Foundation
 import Observation
 
@@ -337,6 +338,20 @@ final class FileImportCoordinator {
   /// telemetry-shaped closure in this app.
   private let emitSpeakerTelemetry:
     @MainActor (SpeakerAnalysis, TimeInterval, Int, ASRWordTimingCoverage?) -> Void
+
+  /// Shape-only telemetry for the background turn-cleanup pass (#2810 addendum §3a):
+  /// outcome, the turn count (only meaningful on a successful store), and how many turns
+  /// carried at least one unpolished part. No-op default, same as every other
+  /// telemetry-shaped closure in this app.
+  private let emitTurnTelemetry:
+    @MainActor (TelemetryService.FileImportTurnsOutcome, Int?, Int) -> Void
+
+  /// Fires the instant `waitForVisibleCleanup(generation:)` actually returns for that
+  /// generation — never on a timeout, never on a guess. No-op default. Exists purely so a
+  /// test can prove the underlying `CheckedContinuation` was genuinely resumed rather than
+  /// asserting bookkeeping state that stays consistent even if `finishVisibleCleanup`'s own
+  /// `waiter.resume()` call were deleted (found by chunk review round 3).
+  private let onVisibleCleanupWaitResolved: @MainActor (Int) -> Void
   private let engineAdmission: EngineAdmissionAccess
 
   /// Stops both engines' pending model-unload timers, and puts the user's
@@ -503,6 +518,13 @@ final class FileImportCoordinator {
   /// with a flag: the first CREATES and must be allowed to, the second may not.
   private let updateHistoryRow: @MainActor (Transcript) throws -> Bool
 
+  /// The turn-cleanup write (#2810 addendum §3 E), separate from `updateHistoryRow` because
+  /// it merges speaker fields against the row's CURRENT state at call time — never a value
+  /// captured earlier — which is what makes it safe against a rename racing this write.
+  /// Returns false when the row is no longer in History, same meaning as `updateHistoryRow`.
+  private let mergeSpeakerFields:
+    @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?) throws -> Bool
+
   /// Whether the import's row is in History RIGHT NOW. Every "saved" answer on this page
   /// goes through it, because a remembered write is not a row: the user can delete the row
   /// from History at any moment after either write, including after a Stop that ends the
@@ -558,7 +580,7 @@ final class FileImportCoordinator {
   /// changes what the user sees at once and bumps this, so a late part cannot
   /// write into a run the user has already ended — while the claim is released
   /// only from the run task's own `defer`, after the physical work has exited.
-  private var generation = 0
+  private(set) var generation = 0
   private var runTask: Task<Void, Never>?
 
   init(
@@ -570,6 +592,9 @@ final class FileImportCoordinator {
     emitSpeakerTelemetry: @escaping @MainActor (
       SpeakerAnalysis, TimeInterval, Int, ASRWordTimingCoverage?
     ) -> Void = { _, _, _, _ in },
+    emitTurnTelemetry: @escaping @MainActor (TelemetryService.FileImportTurnsOutcome, Int?, Int) ->
+      Void = { _, _, _ in },
+    onVisibleCleanupWaitResolved: @escaping @MainActor (Int) -> Void = { _ in },
     engineAdmission: EngineAdmissionAccess,
     polishOllamaLocalityNow: @escaping @MainActor () -> Bool? = { false },
     refreshOllamaFacts: @escaping @MainActor () async -> Void = {},
@@ -586,6 +611,8 @@ final class FileImportCoordinator {
     // simulate History says so at the call site.
     saveToHistory: @escaping @MainActor (Transcript) throws -> Void,
     updateHistoryRow: @escaping @MainActor (Transcript) throws -> Bool,
+    mergeSpeakerFields:
+      @escaping @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?) throws -> Bool,
     historyRowExists: @escaping @MainActor (UUID) -> Bool,
     processPart:
       @escaping @MainActor (String, String?) async throws -> FileImportRunner.PartOutcome
@@ -601,11 +628,14 @@ final class FileImportCoordinator {
     self.transcribe = transcribe
     self.speakerLabeler = speakerLabeler
     self.emitSpeakerTelemetry = emitSpeakerTelemetry
+    self.emitTurnTelemetry = emitTurnTelemetry
+    self.onVisibleCleanupWaitResolved = onVisibleCleanupWaitResolved
     self.engineAdmission = engineAdmission
     self.beginRun = beginRun
     self.prepareLocalPolish = prepareLocalPolish
     self.saveToHistory = saveToHistory
     self.updateHistoryRow = updateHistoryRow
+    self.mergeSpeakerFields = mergeSpeakerFields
     self.historyRowExists = historyRowExists
     self.processPart = processPart
   }
@@ -1065,6 +1095,34 @@ final class FileImportCoordinator {
   /// Cancelled by `stop()`/a new `choose()`/`startOver()`, same as `decodeTask`.
   private var speakerStepTask: Task<Void, Never>?
 
+  /// Which generations' `polishAll` has already finished, and everyone still waiting for a
+  /// generation that has not (#2810 addendum §2.5 item 4). The turn-cleanup background pass
+  /// awaits this BEFORE its first call into `FileImportRunner.process`, so it never competes
+  /// with the visible document's own cleanup for EG-1's one inference slot. `polishAll`
+  /// settles its own generation in a `defer` at the top of its body, covering every exit path
+  /// exactly once; `finishVisibleCleanup` is idempotent and removes each generation's waiters
+  /// before resuming them, so a continuation can never be resumed twice.
+  private(set) var visibleCleanupFinished: Set<Int> = []
+  private(set) var visibleCleanupWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
+
+  /// Suspends until `polishAll` for `generation` has returned, however it exited — including
+  /// via cancellation, whose `defer` still runs when the function body actually exits
+  /// (`Task.cancel()` only sets a flag; it does not force an early return on its own).
+  /// Returns immediately if that generation already finished.
+  private func waitForVisibleCleanup(generation: Int) async {
+    guard !visibleCleanupFinished.contains(generation) else { return }
+    await withCheckedContinuation { continuation in
+      visibleCleanupWaiters[generation, default: []].append(continuation)
+    }
+  }
+
+  private func finishVisibleCleanup(generation: Int) {
+    guard !visibleCleanupFinished.contains(generation) else { return }
+    visibleCleanupFinished.insert(generation)
+    let waiters = visibleCleanupWaiters.removeValue(forKey: generation) ?? []
+    for waiter in waiters { waiter.resume() }
+  }
+
   /// SHA-256 over the raw Float32 bytes of the PCM ASR consumed, so a retry can compare a
   /// re-decoded source against what actually ran without re-reading the whole buffer.
   /// #2809 addendum §2.5 "Retry identity" — a method with a unit test and no caller in
@@ -1180,6 +1238,13 @@ final class FileImportCoordinator {
   /// Stop changes what the user sees at once and keeps whatever is finished.
   /// The claim is not released here — see `start`.
   func stop() {
+    // Unconditional, BEFORE the `isRunning` guard (#2810 addendum §2.5 item 4): the
+    // background turn-cleanup pass can still be running after the visible screen already
+    // shows Done, and `choose(url:)`/`startOver()` already cancel it unconditionally in
+    // exactly that situation. A direct Stop press must behave the same way, or it becomes
+    // the one "user moves on" path that leaves a background engine hold with no way to end
+    // it. Cancelling a nil or already-finished task is a documented no-op.
+    speakerStepTask?.cancel()
     guard isRunning else { return }
     generation += 1
     state = .stopped
@@ -1204,10 +1269,7 @@ final class FileImportCoordinator {
     // ENGINE, and a re-polish reads `rawTranscript`. Nothing left can want it.
     releaseDecodedAudio()
     runTask?.cancel()
-    // Detached from `runTask` (see `run()`): Stop must cancel it explicitly, or a
-    // background speaker analysis keeps running for up to its own deadline after the
-    // user has already moved on.
-    speakerStepTask?.cancel()
+    // speakerStepTask is already cancelled unconditionally above, before this guard.
   }
 
   /// Re-runs the cleanup under the current settings, from the transcript already
@@ -1311,6 +1373,7 @@ final class FileImportCoordinator {
       speakerStepTask = Task { [weak self] in
         await self?.runSpeakerStep(
           analysisSamples: analysisSamples, generationAtStart: generationAtStart,
+          rawText: result.text, wordTimings: result.wordTimings,
           wordTimingCoverage: result.wordTimingCoverage)
       }
       phase = "Dividing it up to clean"
@@ -1327,13 +1390,14 @@ final class FileImportCoordinator {
     }
   }
 
-  /// The dormant, phase-2 speaker step (#2809 addendum §3 B). Runs the bounded, cancellable
-  /// analysis on the captured PCM, guards generation once more before recording anything
-  /// (a Stop during analysis must not attribute telemetry or a log line to a run nobody is
-  /// watching), and never surfaces a UI signal on any outcome — `speakerAnalysis` is read
-  /// only by telemetry and the log in this phase.
+  /// The phase-2 speaker step, now feeding phase-3 turn assembly and storage (#2810
+  /// addendum §3 C-E). Runs the bounded, cancellable analysis on the captured PCM, guards
+  /// generation once more before recording anything (a Stop during analysis must not
+  /// attribute telemetry or a log line to a run nobody is watching), and never surfaces a UI
+  /// signal on any outcome — `speakerAnalysis` is read only by telemetry and the log.
   private func runSpeakerStep(
-    analysisSamples: [Float], generationAtStart: Int, wordTimingCoverage: ASRWordTimingCoverage?
+    analysisSamples: [Float], generationAtStart: Int, rawText: String,
+    wordTimings: [ASRWordTiming]?, wordTimingCoverage: ASRWordTimingCoverage?
   ) async {
     let durationSeconds = file?.seconds ?? 0
     let analysisStart = CFAbsoluteTimeGetCurrent()
@@ -1351,6 +1415,146 @@ final class FileImportCoordinator {
     // first guard still holds by the time telemetry fires. Found by Codex.
     guard generationAtStart == generation else { return }
     emitSpeakerTelemetry(outcome, durationSeconds, analysisMs, wordTimingCoverage)
+
+    await runTurnStorage(
+      outcome: outcome, wordTimings: wordTimings, rawText: rawText,
+      generationAtStart: generationAtStart)
+  }
+
+  /// Phase 3: turn assembly, background turn-safe cleanup, and storage (#2810 addendum §3
+  /// C-E, §2.5 item 4). Never awaited by `run()` — reached only from `runSpeakerStep`, itself
+  /// already fully detached. Sequenced strictly after the visible document's own cleanup
+  /// finishes, and claims the same engine admission the visible run does for its own
+  /// duration, exactly as round 2 of the addendum's review settled.
+  private func runTurnStorage(
+    outcome: SpeakerAnalysis, wordTimings: [ASRWordTiming]?, rawText: String,
+    generationAtStart: Int
+  ) async {
+    guard let historyID else { return }
+    let passStart = CFAbsoluteTimeGetCurrent()
+
+    // Waits for the visible document's own cleanup FIRST, uniformly for EVERY branch below
+    // — an early write here would race `savePolishedToHistory`'s own stale-captured-row
+    // overwrite (found by chunk review: two early-return branches used to write before this
+    // wait existed, so their result could be silently erased once the visible run's own
+    // save landed). Rechecks generation AND cancellation together: `stop()` cancels this
+    // task unconditionally and does not always bump `generation` (a direct Stop press after
+    // the visible run already finished leaves `generation` untouched), so cancellation is
+    // its own signal, never implied by the generation check alone.
+    await waitForVisibleCleanup(generation: generationAtStart)
+    onVisibleCleanupWaitResolved(generationAtStart)
+    guard generationAtStart == generation, !Task.isCancelled else { return }
+
+    // Non-labeled outcomes map directly through the one exhaustive mapping (chunk 1) and
+    // never touch turn assembly. A missing `wordTimings` matters ONLY when assembly is
+    // actually needed — checking it before the outcome type would let a merge-input gap
+    // silently override a perfectly good `.single`/`.failed`/`.timedOut` result that has
+    // nothing to do with timings (found by chunk review).
+    guard case .labeled(let labeledCount, let segments) = outcome else {
+      // `.single` is the one non-labeled outcome worth a turn-storage telemetry event of
+      // its own (there is genuinely nothing to store, by design). `.failed`/`.timedOut`/
+      // `.cancelled` are ANALYZER outcomes `emitSpeakerTelemetry` already reported moments
+      // earlier — `nil` here means "write silently, do not double-report."
+      let turnsOutcome: TelemetryService.FileImportTurnsOutcome? =
+        if case .single = outcome { .singleNoTurns } else { nil }
+      await mergeAndReport(
+        historyID: historyID, analysis: outcome.asStorageAnalysis, turns: nil,
+        outcome: turnsOutcome, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
+      return
+    }
+    guard let wordTimings else {
+      await mergeAndReport(
+        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
+        outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
+      return
+    }
+
+    let assembledTurns = TurnAssembler.assemble(entries: wordTimings, segments: segments)
+
+    let token: EngineLease.Token
+    switch engineAdmission.claim() {
+    case .granted(let granted): token = granted
+    case .refused:
+      // A refusal lock, not a queue (`EngineLease` header): skip this pass entirely, no
+      // wait, no retry inline. The row stays `.unanalyzed` for turns.
+      await AppLogger.shared.log(
+        "[TurnCleanup] outcome=admission_refused ms=\(Self.elapsedMs(since: passStart))",
+        level: .info, category: "FileImportCoordinator")
+      emitTurnTelemetry(.admissionRefused, nil, 0)
+      return
+    }
+    isEngineHeld = true
+    let configuration = runConfiguration
+    heldLocalPolishProvider = configuration?.localPolishProvider
+    heldOllamaModel = configuration?.ollamaModel
+    defer {
+      engineAdmission.release(token)
+      finishEngineHold()
+    }
+    guard generationAtStart == generation, !Task.isCancelled else { return }
+
+    // Mirrors `start()`/`rePolish()`: the visible run's own claim already warmed this
+    // provider, but that hold has since been released (and its own `onEngineReleased` may
+    // have reconciled a DIFFERENT workload's provider in between) — re-preparing under this
+    // SEPARATE claim is what proves the right server is actually up before spending
+    // anything on it (found by chunk review).
+    let polisherReady =
+      if let configuration { await prepareLocalPolish(configuration) } else { true }
+    guard generationAtStart == generation, !Task.isCancelled else { return }
+    guard polisherReady else {
+      await AppLogger.shared.log(
+        "[TurnCleanup] outcome=polisher_not_ready ms=\(Self.elapsedMs(since: passStart))",
+        level: .info, category: "FileImportCoordinator")
+      emitTurnTelemetry(.polisherNotReady, nil, 0)
+      return
+    }
+
+    let (cleanedTurns, fallbackTurnCount) = await TurnCleanupRunner(processPart: processPart)
+      .run(turns: assembledTurns, rawText: rawText, engineLanguage: engineReportedLanguage)
+    guard generationAtStart == generation, !Task.isCancelled else { return }
+
+    await mergeAndReport(
+      historyID: historyID, analysis: .labeled(count: labeledCount), turns: cleanedTurns,
+      outcome: .stored, turnCount: cleanedTurns.count, fallbackTurnCount: fallbackTurnCount,
+      passStart: passStart)
+  }
+
+  private static func elapsedMs(since start: CFAbsoluteTime) -> Int {
+    Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
+  }
+
+  /// The one place `runTurnStorage` writes and reports telemetry, so every branch — success,
+  /// a deleted row, or a save failure — is classified consistently (#2810 addendum §3a: the
+  /// metric must never claim persistence that did not happen).
+  /// `outcome: nil` means "write silently ON SUCCESS" — used only for `.failed`/`.timedOut`/
+  /// `.cancelled` analyzer outcomes, which `emitSpeakerTelemetry` already reported; a
+  /// successful write here has nothing new to say. A FAILED write is always new information
+  /// (the analyzer's own event says nothing about whether persisting that failure reason
+  /// succeeded), so `saveFailed`/`rowDeleted` are reported even when `outcome` is nil —
+  /// found by chunk review round 2.
+  private func mergeAndReport(
+    historyID: UUID, analysis: TranscriptSpeakerAnalysis, turns: [Turn]?,
+    outcome: TelemetryService.FileImportTurnsOutcome?, turnCount: Int?, fallbackTurnCount: Int,
+    passStart: CFAbsoluteTime
+  ) async {
+    let saveFailed: Bool
+    let rowDeleted: Bool
+    do {
+      let saved = try mergeSpeakerFields(historyID, analysis, turns)
+      saveFailed = false
+      rowDeleted = !saved
+    } catch {
+      saveFailed = true
+      rowDeleted = false
+    }
+    let reportedOutcome: TelemetryService.FileImportTurnsOutcome? =
+      saveFailed ? .saveFailed : (rowDeleted ? .rowDeleted : outcome)
+    guard let reportedOutcome else { return }
+    await AppLogger.shared.log(
+      "[TurnCleanup] outcome=\(reportedOutcome.rawValue) turns=\(turnCount ?? 0) fallback=\(fallbackTurnCount) ms=\(Self.elapsedMs(since: passStart))",
+      level: .info, category: "FileImportCoordinator")
+    emitTurnTelemetry(
+      reportedOutcome, reportedOutcome == .stored ? turnCount : nil, fallbackTurnCount)
   }
 
   private static func speakerLogOutcome(_ analysis: SpeakerAnalysis) -> String {
@@ -1407,6 +1611,11 @@ final class FileImportCoordinator {
   /// inference slot, so parts in parallel would queue inside it and the progress
   /// the user sees would stop meaning anything.
   private func polishAll(_ pieces: [String], generationAtStart: Int) async {
+    // #2810 addendum §2.5 item 4: settles the turn-cleanup completion gate on EVERY exit
+    // path of this function, exactly once, so the background turn-cleanup pass (which waits
+    // on this signal before its own first EG-1 call) never starts while this function is
+    // still competing for the same one inference slot.
+    defer { finishVisibleCleanup(generation: generationAtStart) }
     // #2772 finding 14: the queue the Working step renders. Published here, at the one place
     // the split exists, so the rows on screen are the pieces that will actually be cleaned.
     pendingPieces = pieces

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1543,6 +1543,19 @@ final class FileImportCoordinator {
       let saved = try mergeSpeakerFields(historyID, analysis, turns)
       saveFailed = false
       rowDeleted = !saved
+      // Keeps this coordinator's OWN in-memory snapshot in step with what was just
+      // persisted. `withImportResult` (used by a later "Clean it again" / `rePolish`'s
+      // `savePolishedToHistory`) never touches the speaker fields, so it PRESERVES
+      // whatever `originalHistoryRow` already carries — but only if this write updates
+      // that carried value first. Without this, a re-polish after turn storage silently
+      // overwrote the just-saved speaker analysis, names and turns back to nil, because
+      // `originalHistoryRow` never learned about this write (found by whole-diff review).
+      // Guarded by id: `originalHistoryRow` can be nil, or belong to a DIFFERENT file
+      // chosen while this background pass was still running.
+      if saved, originalHistoryRow?.id == historyID {
+        originalHistoryRow = originalHistoryRow?.mergingSpeakerFields(
+          analysis: analysis, turns: turns)
+      }
     } catch {
       saveFailed = true
       rowDeleted = false

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -785,6 +785,23 @@ final class TranscriptCoordinator {
     return true
   }
 
+  /// The turn-cleanup write (#2810 addendum §3 E), and the one future rename write (phase
+  /// 4) will share it. Reads the CURRENT row from `transcripts` at call time — never a value
+  /// captured earlier — so "merge into the latest existing row, never overwrite newer
+  /// names" holds structurally: whichever call runs second reads what the first one left.
+  /// Goes through `updateExistingRow`, inheriting its "never resurrect a deleted row" guard
+  /// for free.
+  @discardableResult
+  func mergeSpeakerFields(
+    id: UUID, analysis: TranscriptSpeakerAnalysis, turns: [Turn]?,
+    explicitRename: (speakerId: String, name: String)? = nil
+  ) throws -> Bool {
+    guard let existing = transcripts.first(where: { $0.id == id }) else { return false }
+    let merged = existing.mergingSpeakerFields(
+      analysis: analysis, turns: turns, explicitRename: explicitRename)
+    return try updateExistingRow(merged)
+  }
+
   /// Whether a row is in History right now. The import's "Saved to History" badge asks this
   /// live rather than remembering that a write once succeeded (#2772): a row can be deleted
   /// at any moment after either of the import's writes, and a remembered success then

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1438,6 +1438,10 @@ package final class WisprBootstrapper {
           outcome: outcome, durationSeconds: durationSeconds, analysisMs: analysisMs,
           wordTimingCoverage: wordTimingCoverage)
       },
+      emitTurnTelemetry: { outcome, turnCount, fallbackTurnCount in
+        TelemetryService.shared.trackFileImportTurns(
+          outcome: outcome, turnCount: turnCount, fallbackTurnCount: fallbackTurnCount)
+      },
       // The third workload, claiming the same one-slot engine as a dictation and
       // a crash replay.
       engineAdmission: .live(lease: engineLease, as: .fileImport),
@@ -1591,6 +1595,11 @@ package final class WisprBootstrapper {
       // reachable throughout a cleanup, so a deletion between the two writes has to stand.
       updateHistoryRow: { [transcriptCoordinator] transcript in
         try transcriptCoordinator.updateExistingRow(transcript)
+      },
+      // The turn-cleanup write (#2810 addendum §3 E) — reads the row's CURRENT state at
+      // call time, so it can never clobber a rename that landed while cleanup was running.
+      mergeSpeakerFields: { [transcriptCoordinator] id, analysis, turns in
+        try transcriptCoordinator.mergeSpeakerFields(id: id, analysis: analysis, turns: turns)
       },
       historyRowExists: { [transcriptCoordinator] id in transcriptCoordinator.hasRow(id: id) },
       processPart: { [fileImportRunner] part, language in

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -537,10 +537,17 @@ public struct Transcript: Codable, Identifiable, Sendable {
     let survivingSpeakerIDs = Set(newTurns.map(\.speakerId)).subtracting([
       TurnAssembler.unknownSpeakerID
     ])
-    let defaultNames = TurnAssembler.defaultSpeakerNames(for: newTurns)
+    // Only the names that will actually remain ON SCREEN after this merge — a RETIRED
+    // speakerId's old number is free to reuse, but a SURVIVING one's number must never be
+    // handed to a different, newly-appearing speaker (found by cloud review).
+    let preservedNames = survivingSpeakerIDs.reduce(into: [String: String]()) { result, id in
+      if let existing = speakerNames?[id] { result[id] = existing }
+    }
+    let defaultNames = TurnAssembler.defaultSpeakerNames(
+      for: newTurns, existingNames: preservedNames)
     var mergedNames: [String: String] = [:]
     for speakerID in survivingSpeakerIDs {
-      mergedNames[speakerID] = speakerNames?[speakerID] ?? defaultNames[speakerID]
+      mergedNames[speakerID] = preservedNames[speakerID] ?? defaultNames[speakerID]
     }
     if let explicitRename, survivingSpeakerIDs.contains(explicitRename.speakerId) {
       mergedNames[explicitRename.speakerId] = explicitRename.name

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -398,6 +398,19 @@ public struct Transcript: Codable, Identifiable, Sendable {
   /// always been carried by the pipeline rather than persisted separately.
   public private(set) var processedText: String? = nil
 
+  /// Speaker-analysis outcome for an imported transcript (#2810, phase 3 of #2807). `nil` on
+  /// any pre-#2810 row (synthesized `Codable`, no custom decode) — treated as `.unanalyzed`.
+  /// Non-`.labeled` values keep `turns`/`speakerNames` empty; only `mergeSpeakerFields` writes
+  /// these three fields together, so a hand-crafted or corrupted row that violates that
+  /// invariant should be read as `.unanalyzed` rather than trusted.
+  public private(set) var speakerAnalysis: TranscriptSpeakerAnalysis?
+  /// `speakerId -> display name`, keys equal to the non-`"unknown"` speakerIds appearing in
+  /// `turns`. Defaulted to `"Speaker N"` by `TurnAssembler.defaultSpeakerNames`, overwritten
+  /// only by an explicit rename (phase 4).
+  public private(set) var speakerNames: [String: String]?
+  /// Non-nil only when `speakerAnalysis == .labeled`.
+  public private(set) var turns: [Turn]?
+
   /// Whether this row came from Transcribe a File. Derived, never stored twice.
   public var isImported: Bool { importedFileName != nil }
 
@@ -419,7 +432,10 @@ public struct Transcript: Codable, Identifiable, Sendable {
     escapeRecoveredAt: Date? = nil,
     escapeRecoveryTakeID: String? = nil,
     importedFileName: String? = nil,
-    processedText: String? = nil
+    processedText: String? = nil,
+    speakerAnalysis: TranscriptSpeakerAnalysis? = nil,
+    speakerNames: [String: String]? = nil,
+    turns: [Turn]? = nil
   ) {
     self.id = id
     self.text = text
@@ -439,6 +455,9 @@ public struct Transcript: Codable, Identifiable, Sendable {
     self.escapeRecoveryTakeID = escapeRecoveryTakeID
     self.importedFileName = importedFileName
     self.processedText = processedText
+    self.speakerAnalysis = speakerAnalysis
+    self.speakerNames = speakerNames
+    self.turns = turns
   }
 
   /// A copy promoted to permanent History: the clock is cleared, everything else is
@@ -485,5 +504,48 @@ public struct Transcript: Codable, Identifiable, Sendable {
   /// polish still has formatting and saved-word corrections worth showing.
   public var displayText: String {
     polishedText ?? processedText ?? text
+  }
+
+  /// The same row with a fresh speaker-analysis result merged in (#2810, phase 3 of #2807).
+  ///
+  /// TWO CALLERS, one shared invariant enforcement. The turn-cleanup write (`explicitRename:
+  /// nil`) PRESERVES an existing name for any speakerId still present in `newTurns`, REMOVES a
+  /// name whose speakerId no longer appears (a retired id from a prior pass), and FILLS a
+  /// newly-appearing speakerId from `TurnAssembler.defaultSpeakerNames(for: newTurns)` —
+  /// computed HERE, never taken as a caller-supplied dictionary, so a caller cannot pass an
+  /// incomplete map and silently drop a surviving speakerId's name (found by chunk review).
+  /// A future phase-4 rename write (`explicitRename: (id, name)`) applies the same
+  /// preserve/retire/fill pass first, then OVERWRITES exactly the named speakerId's entry —
+  /// the one deliberate exception to "never overwrite," scoped to a single id an explicit
+  /// user action named.
+  ///
+  /// A non-`.labeled` analysis clears both `turns` and `speakerNames`, matching the invariant
+  /// that `turns` is non-nil only when `speakerAnalysis == .labeled`.
+  public func mergingSpeakerFields(
+    analysis: TranscriptSpeakerAnalysis, turns newTurns: [Turn]?,
+    explicitRename: (speakerId: String, name: String)? = nil
+  ) -> Transcript {
+    var copy = self
+    copy.speakerAnalysis = analysis
+    guard case .labeled = analysis, let newTurns else {
+      copy.turns = nil
+      copy.speakerNames = nil
+      return copy
+    }
+    copy.turns = newTurns
+
+    let survivingSpeakerIDs = Set(newTurns.map(\.speakerId)).subtracting([
+      TurnAssembler.unknownSpeakerID
+    ])
+    let defaultNames = TurnAssembler.defaultSpeakerNames(for: newTurns)
+    var mergedNames: [String: String] = [:]
+    for speakerID in survivingSpeakerIDs {
+      mergedNames[speakerID] = speakerNames?[speakerID] ?? defaultNames[speakerID]
+    }
+    if let explicitRename, survivingSpeakerIDs.contains(explicitRename.speakerId) {
+      mergedNames[explicitRename.speakerId] = explicitRename.name
+    }
+    copy.speakerNames = mergedNames
+    return copy
   }
 }

--- a/Sources/EnviousWisprCore/Turn.swift
+++ b/Sources/EnviousWisprCore/Turn.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// One speaker's contiguous stretch of an imported transcript (#2810, phase 3 of #2807).
+///
+/// Produced by `TurnAssembler` from phase 2's `ASRWordTiming`/`SpeakerSegment` data, then
+/// filled in by the background turn-cleanup step. Never rendered before phase 4.
+public struct Turn: Sendable, Equatable, Codable {
+  /// Deterministic and range-derived, never a random UUID — a fresh `TurnAssembler` pass over
+  /// identical input reproduces identical ids, which is what lets a retry (phase 4) compare
+  /// old and new turn sets by id rather than by position.
+  public let id: String
+  /// A real diarizer speaker id, or `"unknown"` for an entry with no confident assignment.
+  public let speakerId: String
+  /// Minimum start among the turn's fully-timed member entries; `nil` only when NONE of the
+  /// turn's entries are timed. An entry assigned to `speakerId == "unknown"` by the
+  /// nearest-fallback rule is still "timed" if it has real bounds — timing and speaker
+  /// assignment are independent questions.
+  public let startMs: Int?
+  public let endMs: Int?
+  /// UTF-16 offsets into the SAME raw text `Transcript.text` already stores (not a copy).
+  /// Spans `first.lowerBound..<last.upperBound` of the turn's member entries — this absorbs
+  /// the turn's own intra-turn whitespace but is not gap-free against neighboring turns
+  /// (inter-turn and document-edge whitespace belongs to no turn).
+  public let originalTextRange: Range<Int>
+  /// `nil` until turn-safe cleanup runs for this turn. Once set, joins every part's
+  /// `displayText` (polished where available, the deterministic floor otherwise) regardless
+  /// of that part's own success.
+  public let processedText: String?
+  /// `true` if ANY of the turn's cleanup parts polished successfully; `false` only if every
+  /// part fell back to its deterministic floor.
+  public let wasPolished: Bool
+
+  public init(
+    id: String, speakerId: String, startMs: Int?, endMs: Int?,
+    originalTextRange: Range<Int>, processedText: String? = nil, wasPolished: Bool = false
+  ) {
+    self.id = id
+    self.speakerId = speakerId
+    self.startMs = startMs
+    self.endMs = endMs
+    self.originalTextRange = originalTextRange
+    self.processedText = processedText
+    self.wasPolished = wasPolished
+  }
+}
+
+/// A transcript's speaker-analysis outcome as STORED (distinct from Core's `SpeakerAnalysis`,
+/// the analyzer's own in-memory outcome type) — mapped from it, never a second opinion on it.
+public enum TranscriptSpeakerAnalysis: Sendable, Equatable, Codable {
+  case unanalyzed
+  case failed(TranscriptSpeakerFailureReason)
+  case single
+  case labeled(count: Int)
+}
+
+/// A separate persisted vocabulary from `SpeakerFailure` (both live in Core; this is not a
+/// module-boundary split). Kept separate for Codable STABILITY — a persisted reason must not
+/// reshape when the analyzer's own error type gains a case — and to strip `analyzerThrew`'s
+/// free-text diagnostic string before it reaches a stable JSON schema. `.noWordTimings` has no
+/// analyzer-side counterpart: it is a merge-input failure (the engine gave no timings to merge
+/// against), never an analyzer failure.
+public enum TranscriptSpeakerFailureReason: Sendable, Equatable, Codable {
+  case modelsUnavailable, analyzerThrew, noSpeakerSegments, cancelled, timedOut, noWordTimings
+}
+
+extension SpeakerFailure {
+  /// The one exhaustive mapping from the analyzer's in-memory failure to the persisted
+  /// reason, stripping `analyzerThrew`'s free-text diagnostic before it reaches a stable
+  /// JSON schema. `public` — `FileImportCoordinator` (AppKit) needs it.
+  public var asStorageReason: TranscriptSpeakerFailureReason {
+    switch self {
+    case .modelsUnavailable: return .modelsUnavailable
+    case .analyzerThrew: return .analyzerThrew
+    case .noSpeakerSegments: return .noSpeakerSegments
+    case .cancelled: return .cancelled
+    }
+  }
+}
+
+extension SpeakerAnalysis {
+  /// The one exhaustive mapping from the analyzer's in-memory outcome to the persisted
+  /// speaker-analysis state (#2810 addendum §3 E). `.noWordTimings` has no counterpart here —
+  /// it is a merge-input failure the caller (`FileImportCoordinator`) produces itself when
+  /// `ASRResult.wordTimings` is `nil`, before this mapping would ever run.
+  public var asStorageAnalysis: TranscriptSpeakerAnalysis {
+    switch self {
+    case .single: return .single
+    case .labeled(let count, _): return .labeled(count: count)
+    case .failed(let failure): return .failed(failure.asStorageReason)
+    case .timedOut: return .failed(.timedOut)
+    }
+  }
+}

--- a/Sources/EnviousWisprCore/TurnAssembler.swift
+++ b/Sources/EnviousWisprCore/TurnAssembler.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Partitions a transcript's full, ordered `ASRWordTiming` array into speaker turns by
+/// temporal overlap against a diarizer's `SpeakerSegment`s (#2810, phase 3 of #2807).
+///
+/// Pure and stateless — every original entry is classified into exactly one turn, never
+/// dropped or duplicated, so "every original word preserved" holds by construction: the
+/// classification loop below consumes `entries` once, in order, and every entry is appended to
+/// the turn being built before the loop advances.
+public enum TurnAssembler {
+
+  /// How close an untimed-by-overlap entry's own boundary must be to a segment's boundary to
+  /// be assigned to it anyway, rather than to `"unknown"`. Provisional — no measured diarizer
+  /// boundary-jitter value exists to cite; kept as a named constant so a future measurement
+  /// has one place to update.
+  static let nearestSegmentToleranceMs = 250
+
+  static let unknownSpeakerID = "unknown"
+
+  public static func assemble(entries: [ASRWordTiming], segments: [SpeakerSegment]) -> [Turn] {
+    guard !entries.isEmpty else { return [] }
+
+    var turns: [Turn] = []
+    var groupSpeaker: String?
+    var groupEntries: [ASRWordTiming] = []
+
+    func flushGroup() {
+      guard let speaker = groupSpeaker, !groupEntries.isEmpty else { return }
+      turns.append(makeTurn(speaker: speaker, entries: groupEntries))
+      groupEntries = []
+    }
+
+    for entry in entries {
+      let speaker = resolveSpeaker(for: entry, segments: segments)
+      if speaker != groupSpeaker {
+        flushGroup()
+        groupSpeaker = speaker
+      }
+      groupEntries.append(entry)
+    }
+    flushGroup()
+
+    return turns
+  }
+
+  /// Greatest-overlap assignment with a deterministic tie-break, a bounded nearest-segment
+  /// fallback, and `"unknown"` beyond that or for an untimed entry. Assignment is independent
+  /// of whether the entry itself is timed: an entry can be `"unknown"` and still carry real
+  /// `startMs`/`endMs` (assigned by the tolerance fallback but not within any segment's
+  /// tolerance), or have no bounds at all.
+  private static func resolveSpeaker(for entry: ASRWordTiming, segments: [SpeakerSegment])
+    -> String
+  {
+    guard let entryStart = entry.startMs, let entryEnd = entry.endMs else {
+      return unknownSpeakerID
+    }
+
+    var bestOverlap = 0
+    var bestSegment: SpeakerSegment?
+    for segment in segments {
+      let overlap = max(0, min(entryEnd, segment.endMs) - max(entryStart, segment.startMs))
+      guard overlap > 0 else { continue }
+      if overlap > bestOverlap
+        || (overlap == bestOverlap && isEarlierTiebreak(segment, than: bestSegment))
+      {
+        bestOverlap = overlap
+        bestSegment = segment
+      }
+    }
+    if let bestSegment { return bestSegment.speakerId }
+
+    // No direct overlap: a bounded nearest-segment fallback.
+    var nearestDistance = Int.max
+    var nearestSegment: SpeakerSegment?
+    for segment in segments {
+      let distance: Int
+      if entryEnd <= segment.startMs {
+        distance = segment.startMs - entryEnd
+      } else if entryStart >= segment.endMs {
+        distance = entryStart - segment.endMs
+      } else {
+        distance = 0
+      }
+      if distance < nearestDistance
+        || (distance == nearestDistance && isEarlierTiebreak(segment, than: nearestSegment))
+      {
+        nearestDistance = distance
+        nearestSegment = segment
+      }
+    }
+    if let nearestSegment, nearestDistance <= nearestSegmentToleranceMs {
+      return nearestSegment.speakerId
+    }
+    return unknownSpeakerID
+  }
+
+  /// Deterministic tie-break: lowest `startMs`, then lexicographically lowest `speakerId`.
+  /// No wall-clock or randomness, so a fresh pass over identical input reproduces identical
+  /// assignments.
+  private static func isEarlierTiebreak(_ candidate: SpeakerSegment, than current: SpeakerSegment?)
+    -> Bool
+  {
+    guard let current else { return true }
+    if candidate.startMs != current.startMs { return candidate.startMs < current.startMs }
+    return candidate.speakerId < current.speakerId
+  }
+
+  private static func makeTurn(speaker: String, entries: [ASRWordTiming]) -> Turn {
+    let range = entries.first!.range.lowerBound..<entries.last!.range.upperBound
+    let timedEntries = entries.filter { $0.startMs != nil && $0.endMs != nil }
+    let startMs = timedEntries.map { $0.startMs! }.min()
+    let endMs = timedEntries.map { $0.endMs! }.max()
+    return Turn(
+      id: "\(range.lowerBound)-\(range.upperBound)",
+      speakerId: speaker, startMs: startMs, endMs: endMs, originalTextRange: range)
+  }
+
+  /// Default `"Speaker N"` names in first-appearance order among the turns, excluding
+  /// `"unknown"` — a classification outcome, never a named speaker.
+  public static func defaultSpeakerNames(for turns: [Turn]) -> [String: String] {
+    var names: [String: String] = [:]
+    var nextNumber = 1
+    for turn in turns where turn.speakerId != unknownSpeakerID {
+      guard names[turn.speakerId] == nil else { continue }
+      names[turn.speakerId] = "Speaker \(nextNumber)"
+      nextNumber += 1
+    }
+    return names
+  }
+}

--- a/Sources/EnviousWisprCore/TurnAssembler.swift
+++ b/Sources/EnviousWisprCore/TurnAssembler.swift
@@ -21,7 +21,7 @@ public enum TurnAssembler {
   /// has one place to update.
   static let nearestSegmentToleranceMs = 250
 
-  static let unknownSpeakerID = "unknown"
+  public static let unknownSpeakerID = "unknown"
 
   public static func assemble(entries: [ASRWordTiming], segments: [SpeakerSegment]) -> [Turn] {
     guard !entries.isEmpty else { return [] }

--- a/Sources/EnviousWisprCore/TurnAssembler.swift
+++ b/Sources/EnviousWisprCore/TurnAssembler.swift
@@ -116,15 +116,32 @@ public enum TurnAssembler {
   }
 
   /// Default `"Speaker N"` names in first-appearance order among the turns, excluding
-  /// `"unknown"` — a classification outcome, never a named speaker.
-  public static func defaultSpeakerNames(for turns: [Turn]) -> [String: String] {
+  /// `"unknown"` — a classification outcome, never a named speaker — and excluding any
+  /// speakerId that is a key in `existingNames` (already named, so it needs no default).
+  ///
+  /// Numbering CONTINUES past the highest number already used by an `"Speaker N"`-shaped
+  /// value in `existingNames`, so a newly appearing speaker never gets the SAME generated
+  /// label as a currently-surviving one that kept its number from an earlier pass — a
+  /// retry that turns A/B ("Speaker 1"/"Speaker 2") into B/C would otherwise renumber this
+  /// pass's turns from 1, handing C "Speaker 2" while B still holds it too (found by cloud
+  /// review). Never reuses a number a RETIRED speaker held; simplicity over density.
+  public static func defaultSpeakerNames(
+    for turns: [Turn], existingNames: [String: String] = [:]
+  ) -> [String: String] {
+    let usedNumbers = Set(existingNames.values.compactMap(speakerNumber(in:)))
+    var nextNumber = (usedNumbers.max() ?? 0) + 1
     var names: [String: String] = [:]
-    var nextNumber = 1
     for turn in turns where turn.speakerId != unknownSpeakerID {
-      guard names[turn.speakerId] == nil else { continue }
+      guard names[turn.speakerId] == nil, existingNames[turn.speakerId] == nil else { continue }
       names[turn.speakerId] = "Speaker \(nextNumber)"
       nextNumber += 1
     }
     return names
+  }
+
+  private static func speakerNumber(in name: String) -> Int? {
+    let prefix = "Speaker "
+    guard name.hasPrefix(prefix) else { return nil }
+    return Int(name.dropFirst(prefix.count))
   }
 }

--- a/Sources/EnviousWisprCore/TurnAssembler.swift
+++ b/Sources/EnviousWisprCore/TurnAssembler.swift
@@ -3,10 +3,16 @@ import Foundation
 /// Partitions a transcript's full, ordered `ASRWordTiming` array into speaker turns by
 /// temporal overlap against a diarizer's `SpeakerSegment`s (#2810, phase 3 of #2807).
 ///
-/// Pure and stateless — every original entry is classified into exactly one turn, never
-/// dropped or duplicated, so "every original word preserved" holds by construction: the
-/// classification loop below consumes `entries` once, in order, and every entry is appended to
-/// the turn being built before the loop advances.
+/// Deterministic over its inputs, and reads no state of its own — every original entry is
+/// classified into exactly one turn, never dropped or duplicated, so "every original word
+/// preserved" holds by construction, UNLESS the calling Task is cancelled (see below), in
+/// which case the return is a partial result the caller must treat as unusable.
+///
+/// **Checks `Task.isCancelled` once per entry.** A long, highly segmented recording makes
+/// this an O(words × segments) synchronous scan; called from a detached task (found by
+/// cloud review) specifically so it can be interrupted rather than run to completion after
+/// the user has moved on. The classification loop below consumes `entries` once, in order,
+/// and every entry is appended to the turn being built before the loop advances.
 public enum TurnAssembler {
 
   /// How close an untimed-by-overlap entry's own boundary must be to a segment's boundary to
@@ -31,6 +37,7 @@ public enum TurnAssembler {
     }
 
     for entry in entries {
+      guard !Task.isCancelled else { break }
       let speaker = resolveSpeaker(for: entry, segments: segments)
       if speaker != groupSpeaker {
         flushGroup()

--- a/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
+++ b/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
@@ -83,6 +83,15 @@ public struct TurnCleanupRunner: Sendable {
     var anyPartPolished = false
     var anyPartFellBack = false
     for (index, part) in parts.enumerated() {
+      // `run()`'s own caller checks cancellation BETWEEN turns, not between the several
+      // parts one oversized turn can split into — so without this, a cancelled pass kept
+      // invoking every remaining part of the CURRENT turn (`FileImportRunner.process`
+      // throws `CancellationError` after an interrupted run, and `try?` below silently
+      // converted that into an ordinary fallback), continuing to hold engine admission and
+      // spend the polisher after Stop or a new file choice (found by cloud review). The
+      // resulting turn/count are discarded anyway by `runTurnStorage`'s own post-`run()`
+      // generation guard, so stopping here costs nothing real.
+      guard !Task.isCancelled else { break }
       guard let outcome = try? await processPart(part, engineLanguage) else {
         // A polish failure that also throws (rather than returning a raw-floor outcome) is
         // not expected from `FileImportRunner.process`, whose whole contract is to return a

--- a/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
+++ b/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
@@ -1,0 +1,109 @@
+import EnviousWisprCore
+import Foundation
+
+/// The background, turn-safe cleanup pass for a labeled transcript (#2810 addendum §3 D,
+/// phase 3 of #2807). Never awaited by the visible run; started only after the visible
+/// document's own cleanup has finished and the caller holds engine admission for the whole
+/// pass.
+///
+/// Calls the SAME per-part cleanup machinery the visible document uses
+/// (`FileImportRunner.process`, injected exactly as `FileImportCoordinator`'s own
+/// `processPart` is) — this is not a second cleanup implementation. Speaker names never enter
+/// the prompt or the text: each turn's sliced original-text range is exactly the raw
+/// transcript's characters, with no prefix or marker of any kind.
+public struct TurnCleanupRunner: Sendable {
+
+  private let processPart: @MainActor (String, String?) async throws -> FileImportRunner.PartOutcome
+  private let split: @Sendable (String) -> [String]
+
+  public init(
+    processPart: @escaping @MainActor (String, String?) async throws -> FileImportRunner.PartOutcome
+  ) {
+    self.processPart = processPart
+    self.split = { TranscriptSplitter.split($0) }
+  }
+
+  /// Test-only seam: injects the splitter too, so a fixture can force multi-part turns with
+  /// a tiny ceiling instead of needing a real 500-word turn. `internal` — reached via
+  /// `@testable import`, never a production construction site.
+  init(
+    processPart: @escaping @MainActor (String, String?) async throws ->
+      FileImportRunner.PartOutcome,
+    split: @escaping @Sendable (String) -> [String]
+  ) {
+    self.processPart = processPart
+    self.split = split
+  }
+
+  /// Cleans every turn's text, one part at a time, in turn order then part order. Checks
+  /// cancellation BETWEEN turns, never mid-part — a part already in flight to EG-1 runs to
+  /// completion, matching the visible document's own per-part cancellation granularity.
+  /// Returns the SAME `turns` array with `processedText`/`wasPolished` filled in, in the
+  /// same order, plus the count of turns containing AT LEAST ONE unpolished part (never only
+  /// "every part failed" — matches `Turn.wasPolished`'s own "true if ANY part polished").
+  /// A cancellation partway through leaves the remaining turns' fields untouched (the caller
+  /// must not persist a half-finished pass — this method makes no write of its own).
+  @MainActor
+  public func run(
+    turns: [Turn], rawText: String, engineLanguage: String?
+  ) async -> (turns: [Turn], fallbackTurnCount: Int) {
+    var result: [Turn] = []
+    result.reserveCapacity(turns.count)
+    var fallbackTurnCount = 0
+    for turn in turns {
+      guard !Task.isCancelled else {
+        result.append(contentsOf: turns[result.count...])
+        break
+      }
+      let (cleanedTurn, hadFallbackPart) = await cleaned(
+        turn: turn, rawText: rawText, engineLanguage: engineLanguage)
+      if hadFallbackPart { fallbackTurnCount += 1 }
+      result.append(cleanedTurn)
+    }
+    return (result, fallbackTurnCount)
+  }
+
+  private func cleaned(
+    turn: Turn, rawText: String, engineLanguage: String?
+  ) async -> (turn: Turn, hadFallbackPart: Bool) {
+    // `originalTextRange` is UTF-16 offsets (matching `ASRWordTiming.range`), so the
+    // conversion goes through `String.Index(utf16Offset:in:)`, never `Range(_:in:)` (which
+    // expects an `NSRange`/`AttributedString.Index`, not a bare `Range<Int>`).
+    let lower = String.Index(utf16Offset: turn.originalTextRange.lowerBound, in: rawText)
+    let upper = String.Index(utf16Offset: turn.originalTextRange.upperBound, in: rawText)
+    guard lower <= upper, upper <= rawText.endIndex else {
+      // The range came from `TurnAssembler` over this same `rawText`; a mismatch means the
+      // caller passed the wrong text. Leave the turn untouched rather than crash or guess.
+      return (turn, false)
+    }
+    let turnText = String(rawText[lower..<upper])
+    let parts = split(turnText)
+
+    var joined = ""
+    var anyPartPolished = false
+    var anyPartFellBack = false
+    for (index, part) in parts.enumerated() {
+      guard let outcome = try? await processPart(part, engineLanguage) else {
+        // A polish failure that also throws (rather than returning a raw-floor outcome) is
+        // not expected from `FileImportRunner.process`, whose whole contract is to return a
+        // deterministic floor instead — but a failure here still must not crash the
+        // background pass. Fall back to the turn's own raw slice for this part.
+        joined += index == 0 ? part : "\n\n" + part
+        anyPartFellBack = true
+        continue
+      }
+      joined += index == 0 ? outcome.displayText : "\n\n" + outcome.displayText
+      if !outcome.isUnpolished && outcome.wasPolishAttempted {
+        anyPartPolished = true
+      } else {
+        anyPartFellBack = true
+      }
+    }
+
+    let cleanedTurn = Turn(
+      id: turn.id, speakerId: turn.speakerId, startMs: turn.startMs, endMs: turn.endMs,
+      originalTextRange: turn.originalTextRange, processedText: joined,
+      wasPolished: anyPartPolished)
+    return (cleanedTurn, anyPartFellBack)
+  }
+}

--- a/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
+++ b/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
@@ -95,7 +95,12 @@ public struct TurnCleanupRunner: Sendable {
       joined += index == 0 ? outcome.displayText : "\n\n" + outcome.displayText
       if !outcome.isUnpolished && outcome.wasPolishAttempted {
         anyPartPolished = true
-      } else {
+      } else if outcome.isUnpolished {
+        // `isUnpolished` already requires `wasPolishAttempted` (its own definition), so this
+        // is exactly "asked for polish, got the deterministic floor back" — a genuine
+        // failure. A part where NO polisher was ever asked for (the user picked none, or an
+        // intentional bypass for a short part) is neither a success nor a failure and must
+        // not inflate `fallback_turn_count` (found by cloud review).
         anyPartFellBack = true
       }
     }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -3164,6 +3164,48 @@ public final class TelemetryService {
     return "partial"
   }
 
+  // MARK: - File import turn storage (#2810, phase 3 of #2807)
+
+  /// Shape-only telemetry for the background, dormant turn-safe cleanup pass. `turnCount` is
+  /// present only when `outcome == .stored` — every other outcome has no valid count.
+  /// `fallbackTurnCount` counts turns with AT LEAST ONE unpolished part (never only "every
+  /// part failed"), matching `Turn.wasPolished`'s own "true if ANY part polished" semantics.
+  public enum FileImportTurnsOutcome: String {
+    case stored
+    case saveFailed = "save_failed"
+    case rowDeleted = "row_deleted"
+    case
+      noWordTimings = "no_word_timings"
+    case singleNoTurns = "single_no_turns"
+    case
+      admissionRefused = "admission_refused"
+    /// The background hold's own polisher failed to come up under its separate claim —
+    /// distinct from `saveFailed`, which means a WRITE was attempted and threw. Nothing was
+    /// ever written here (found by chunk review round 2: reusing `saveFailed` for this case
+    /// misclassified "never attempted a save" as "attempted and failed").
+    case polisherNotReady = "polisher_not_ready"
+  }
+
+  public func trackFileImportTurns(
+    outcome: FileImportTurnsOutcome, turnCount: Int?, fallbackTurnCount: Int
+  ) {
+    var props: [String: Any] = ["outcome": outcome.rawValue]
+    if outcome == .stored, let turnCount {
+      props["turn_count"] = Self.fileImportTurnCountBucket(turnCount)
+      props["fallback_turn_count"] = fallbackTurnCount
+    }
+    PostHogSDK.shared.capture("file_import_turns", properties: props)
+  }
+
+  static func fileImportTurnCountBucket(_ count: Int) -> String {
+    switch count {
+    case ...1: return "1"
+    case 2...5: return "2-5"
+    case 6...20: return "6-20"
+    default: return "21+"
+    }
+  }
+
   // MARK: - Update banner (issue #343)
 
   public func updateBannerShown(

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1,6 +1,7 @@
 import EnviousWisprASR
 import EnviousWisprCore
 import EnviousWisprPipeline
+import EnviousWisprServices
 import Foundation
 import Testing
 
@@ -32,6 +33,40 @@ struct FileImportCoordinatorSpeakerTests {
     func waitUntilEntered() async {
       if entered { return }
       await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+  }
+
+  /// A gate a test controls from outside: a call can wait to be told to proceed, and the
+  /// test can wait to know a call has arrived. Used to prove ORDERING (turn-cleanup's own
+  /// calls never arrive before the visible document's cleanup has actually returned).
+  private actor ManualGate {
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+    private var isOpen = false
+    private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+    private var hasArrived = false
+
+    func markArrived() {
+      hasArrived = true
+      for waiter in arrivalWaiters { waiter.resume() }
+      arrivalWaiters = []
+    }
+
+    func waitUntilArrived() async {
+      if hasArrived { return }
+      await withCheckedContinuation { arrivalWaiters.append($0) }
+    }
+
+    func arrivedSoFar() -> Bool { hasArrived }
+
+    func open() {
+      isOpen = true
+      for waiter in openWaiters { waiter.resume() }
+      openWaiters = []
+    }
+
+    func waitUntilOpen() async {
+      if isOpen { return }
+      await withCheckedContinuation { openWaiters.append($0) }
     }
   }
 
@@ -69,12 +104,22 @@ struct FileImportCoordinatorSpeakerTests {
   private func makeCoordinator(
     lease: EngineLease,
     seconds: Double = 1.0,
+    transcribedText: String = "one two three",
+    wordTimings: [ASRWordTiming]? = nil,
     wordTimingCoverage: ASRWordTimingCoverage? = nil,
     speakerLabeler: @escaping @MainActor ([Float], TimeInterval) async -> SpeakerAnalysis,
     saveToHistory: @escaping @MainActor (Transcript) throws -> Void = { _ in },
+    mergeSpeakerFields: @escaping @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?) throws ->
+      Bool = { _, _, _ in true },
     emitSpeakerTelemetry: @escaping @MainActor (
       SpeakerAnalysis, TimeInterval, Int, ASRWordTimingCoverage?
     ) -> Void = { _, _, _, _ in },
+    emitTurnTelemetry: @escaping @MainActor (
+      TelemetryService.FileImportTurnsOutcome, Int?, Int
+    ) -> Void = { _, _, _ in },
+    onVisibleCleanupWaitResolved: @escaping @MainActor (Int) -> Void = { _ in },
+    prepareLocalPolish: @escaping @MainActor (FileImportCoordinator.RunConfiguration) async ->
+      Bool = { _ in true },
     processPart: @escaping @MainActor (String, String?) async throws ->
       FileImportRunner
       .PartOutcome = { part, _ in
@@ -85,19 +130,23 @@ struct FileImportCoordinatorSpeakerTests {
       decode: { _ in Self.decoded(seconds: seconds) },
       transcribe: { _ in
         ASRResult(
-          text: "one two three", language: "en", duration: 0, processingTime: 0,
-          backendType: .parakeet, wordTimings: nil, wordTimingCoverage: wordTimingCoverage)
+          text: transcribedText, language: "en", duration: 0, processingTime: 0,
+          backendType: .parakeet, wordTimings: wordTimings, wordTimingCoverage: wordTimingCoverage)
       },
       speakerLabeler: speakerLabeler,
       emitSpeakerTelemetry: emitSpeakerTelemetry,
+      emitTurnTelemetry: emitTurnTelemetry,
+      onVisibleCleanupWaitResolved: onVisibleCleanupWaitResolved,
       engineAdmission: .live(lease: lease, as: .fileImport),
       beginRun: {
         FileImportCoordinator.RunConfiguration(
           polishIsCloud: false, localPolishProvider: nil, polishProvider: .egOne,
           ollamaModel: nil, polishModel: "eg-1", backendType: .parakeet)
       },
+      prepareLocalPolish: prepareLocalPolish,
       saveToHistory: saveToHistory,
       updateHistoryRow: { _ in true },
+      mergeSpeakerFields: mergeSpeakerFields,
       historyRowExists: { _ in true },
       processPart: processPart)
   }
@@ -333,5 +382,488 @@ struct FileImportCoordinatorSpeakerTests {
   @Test("an empty buffer still produces a stable digest, not a crash")
   func pcmDigestHandlesEmptyBuffer() {
     #expect(FileImportCoordinator.pcmDigestHex([]) == FileImportCoordinator.pcmDigestHex([]))
+  }
+
+  // MARK: - Turn storage (#2810 phase 3)
+
+  private static func twoSpeakerWordTimings() -> [ASRWordTiming] {
+    // "hello there friend": "hello" (0..<5) speaker A; "there friend" (6..<18) speaker B.
+    [
+      ASRWordTiming(word: "hello", range: 0..<5, startMs: 0, endMs: 200),
+      ASRWordTiming(word: "there", range: 6..<11, startMs: 5000, endMs: 5200),
+      ASRWordTiming(word: "friend", range: 12..<18, startMs: 5200, endMs: 5400),
+    ]
+  }
+
+  private static let twoSpeakerSegments = [
+    SpeakerSegment(speakerId: "A", startMs: 0, endMs: 200, quality: 1),
+    SpeakerSegment(speakerId: "B", startMs: 5000, endMs: 5400, quality: 1),
+  ]
+
+  @Test(
+    "turn-safe cleanup's own processPart calls never arrive before the visible document's cleanup has returned"
+  )
+  func turnCleanupWaitsForVisibleCleanupToFinish() async {
+    let documentGate = ManualGate()
+    let turnGate = ManualGate()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      processPart: { part, _ in
+        if part == "hello there friend" {
+          // The visible document's own single piece — hold it open until the test says go.
+          await documentGate.markArrived()
+          await documentGate.waitUntilOpen()
+        } else {
+          // A turn's own sliced text ("hello", or "there friend") — must never arrive
+          // before the document gate above has been explicitly opened.
+          await turnGate.markArrived()
+        }
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await documentGate.waitUntilArrived()
+
+    // The visible pass's own call is in flight and held open; turn-cleanup must not have
+    // started yet, because it has not even been signaled that the visible pass finished.
+    #expect(await turnGate.arrivedSoFar() == false)
+
+    await documentGate.open()
+    let finished = await settleUntil { coordinator.state == .finished }
+    #expect(finished, "the visible run should finish once its own held part is released")
+
+    // NOW turn-cleanup's calls are free to arrive — a BOUNDED wait, never an unconditional
+    // await of the very signal under test: if the gate had a bug and never resolved, this
+    // fails with a clear message instead of hanging the suite forever.
+    let turnCleanupArrived = await settleUntil { await turnGate.arrivedSoFar() }
+    #expect(turnCleanupArrived, "turn-cleanup should have started once the visible pass finished")
+  }
+
+  @Test(
+    "a superseded generation's completion gate still resolves when its run is stopped, never hangs")
+  func supersededGenerationGateStillResolves() async {
+    let documentGate = ManualGate()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      processPart: { part, _ in
+        await documentGate.markArrived()
+        await documentGate.waitUntilOpen()
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await documentGate.waitUntilArrived()
+
+    // Stop while the visible pass's own part call is still held open. `stop()` cancels the
+    // run task and bumps `generation`, but the blocked `processPart` call itself does not
+    // return until the gate opens — `Task.cancel()` alone cannot interrupt an in-flight
+    // `await` with no cooperative check inside it.
+    coordinator.stop()
+    let stopped = await settleUntil { coordinator.state == .stopped }
+    #expect(stopped)
+
+    // NOW let the stale call return. `polishAll`'s own generation guard sees a superseded
+    // generation and returns early — its `defer` must still settle the completion gate for
+    // that generation, so anything that had been waiting on it (or would wait on it later)
+    // is never left hanging forever.
+    await documentGate.open()
+
+    // If the gate were broken (never settled on this exit path), a background task still
+    // waiting on this exact generation would hang. Prove it resolves within a bounded
+    // window by driving a SECOND run and confirming ITS OWN turn-cleanup still completes
+    // normally — a wedged gate implementation (e.g. one that leaked a waiter into the wrong
+    // bucket) would show up as the second run's own sequencing breaking.
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    let secondFinished = await settleUntil { coordinator.state == .finished }
+    #expect(secondFinished, "a fresh run after a superseded generation must complete normally")
+  }
+
+  @Test("a labeled outcome with real word timings persists turns via mergeSpeakerFields")
+  func labeledOutcomeWithWordTimingsPersistsTurns() async {
+    @MainActor final class MergeRecorder {
+      private(set) var analysis: TranscriptSpeakerAnalysis?
+      private(set) var turns: [Turn]?
+      func record(_ analysis: TranscriptSpeakerAnalysis, _ turns: [Turn]?) {
+        self.analysis = analysis
+        self.turns = turns
+      }
+    }
+    let recorder = MergeRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      mergeSpeakerFields: { _, analysis, turns in
+        recorder.record(analysis, turns)
+        return true
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+
+    let mergedTurns = await settleUntil { recorder.turns != nil }
+    #expect(mergedTurns, "mergeSpeakerFields should have been called with a non-nil turns array")
+    #expect(recorder.analysis == .labeled(count: 2))
+    let turns = recorder.turns
+    #expect(turns?.count == 2)
+    #expect(turns?.map(\.speakerId) == ["A", "B"])
+  }
+
+  @Test(
+    "nil word timings on a labeled outcome merge as a noWordTimings failure, never assembling turns"
+  )
+  func nilWordTimingsMergeAsFailure() async {
+    @MainActor final class MergeRecorder {
+      private(set) var analysis: TranscriptSpeakerAnalysis?
+      func record(_ analysis: TranscriptSpeakerAnalysis) { self.analysis = analysis }
+    }
+    let recorder = MergeRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      wordTimings: nil,
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      mergeSpeakerFields: { _, analysis, turns in
+        recorder.record(analysis)
+        #expect(turns == nil)
+        return true
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+
+    let recorded = await settleUntil { recorder.analysis != nil }
+    #expect(recorded)
+    #expect(recorder.analysis == .failed(.noWordTimings))
+  }
+
+  @Test(
+    "a write failure on the silent (already-reported) path still reports saveFailed, never disappearing"
+  )
+  func silentPathReportsSaveFailedWhenMergeThrows() async {
+    struct WriteError: Error {}
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportTurnsOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportTurnsOutcome) { outcomes.append(outcome) }
+    }
+    let telemetry = TelemetryRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      // A non-.single, non-.labeled outcome: `emitSpeakerTelemetry` already reports it, so
+      // `runTurnStorage` passes `outcome: nil` into `mergeAndReport` — the branch found by
+      // chunk review round 2 to have silently dropped a write failure.
+      speakerLabeler: { _, _ in .failed(.modelsUnavailable) },
+      mergeSpeakerFields: { _, _, _ in throw WriteError() },
+      emitTurnTelemetry: { outcome, _, _ in telemetry.record(outcome) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+
+    let reported = await settleUntil { telemetry.outcomes.contains(.saveFailed) }
+    #expect(reported, "a thrown merge on the silent path must still report saveFailed")
+  }
+
+  @Test(
+    "a row deleted before the write on the silent (already-reported) path still reports rowDeleted"
+  )
+  func silentPathReportsRowDeletedWhenMergeReturnsFalse() async {
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportTurnsOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportTurnsOutcome) { outcomes.append(outcome) }
+    }
+    let telemetry = TelemetryRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      speakerLabeler: { _, _ in .failed(.modelsUnavailable) },
+      mergeSpeakerFields: { _, _, _ in false },
+      emitTurnTelemetry: { outcome, _, _ in telemetry.record(outcome) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+
+    let reported = await settleUntil { telemetry.outcomes.contains(.rowDeleted) }
+    #expect(reported, "a merge returning false on the silent path must still report rowDeleted")
+  }
+
+  @Test("a refused engine admission skips the turn-cleanup pass entirely, with no merge call")
+  func refusedAdmissionSkipsCleanupEntirely() async {
+    @MainActor final class MergeRecorder {
+      private(set) var callCount = 0
+      func record() { callCount += 1 }
+    }
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportTurnsOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportTurnsOutcome) { outcomes.append(outcome) }
+    }
+    let recorder = MergeRecorder()
+    let telemetry = TelemetryRecorder()
+    let speakerGate = ManualGate()
+    let lease = EngineLease()
+    let coordinator = makeCoordinator(
+      lease: lease,
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        // Blocks AFTER the main run's own claim has already been granted and released
+        // (the main run does not depend on this returning), so the test can claim the
+        // SAME lease itself in the exact window before turn-cleanup tries to.
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      },
+      mergeSpeakerFields: { _, _, _ in
+        recorder.record()
+        return true
+      },
+      emitTurnTelemetry: { outcome, _, _ in telemetry.record(outcome) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+
+    // The main run finishes on its own (processPart is the fast default fake) while the
+    // speaker step sits blocked before returning its outcome.
+    let finished = await settleUntil { coordinator.state == .finished }
+    #expect(finished)
+    await speakerGate.waitUntilArrived()
+    #expect(coordinator.isEngineHeld == false, "the main run's own claim must already be released")
+
+    // Claim the lease from OUTSIDE, simulating a competing workload — a new dictation, or
+    // another import — taking it in the narrow window before turn-cleanup asks.
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("test setup: could not claim the lease to simulate contention")
+      return
+    }
+
+    // Let the speaker step return its outcome; turn-cleanup's own claim attempt is now
+    // refused, and the pass must skip entirely — no merge call at all. Wait for the actual
+    // refusal EVENT (found by chunk review round 2: 200 unconditional yields only hopes
+    // enough scheduler turns passed, and never proves the refusal branch itself ran) —
+    // a bounded wait on the real telemetry seam the production code already emits through.
+    await speakerGate.open()
+    let refused = await settleUntil { telemetry.outcomes.contains(.admissionRefused) }
+    #expect(refused, "the admission-refused outcome was never observed")
+    #expect(recorder.callCount == 0)
+  }
+
+  @Test(
+    "a superseded generation's own waiter is directly proven to register and then resolve"
+  )
+  func supersededGenerationWaiterObservablyResolves() async {
+    let documentGate = ManualGate()
+    @MainActor final class ResolvedRecorder {
+      private(set) var generations: [Int] = []
+      func record(_ generation: Int) { generations.append(generation) }
+    }
+    let resolvedRecorder = ResolvedRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      onVisibleCleanupWaitResolved: { generation in resolvedRecorder.record(generation) },
+      processPart: { part, _ in
+        await documentGate.markArrived()
+        await documentGate.waitUntilOpen()
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    let firstGeneration = coordinator.generation
+    await documentGate.waitUntilArrived()
+
+    // REGISTRATION: the speaker step's own labeler returns immediately (no gate), so by
+    // the time the visible pass's own part call has arrived, its background turn-cleanup
+    // continuation should already be enqueued as a waiter on THIS generation — a bounded
+    // wait on the actual internal state, never inferred from a later run's success.
+    let registered = await settleUntil {
+      coordinator.visibleCleanupWaiters[firstGeneration]?.isEmpty == false
+    }
+    #expect(
+      registered, "generation \(firstGeneration)'s turn-cleanup pass never registered as a waiter")
+    #expect(coordinator.visibleCleanupFinished.contains(firstGeneration) == false)
+    #expect(resolvedRecorder.generations.isEmpty, "the wait resolved before the gate opened")
+
+    // Stop while the visible pass's own part call is still held open. `stop()` cancels the
+    // run task and bumps `generation`, but the blocked `processPart` call itself does not
+    // return until the gate opens.
+    coordinator.stop()
+    let stopped = await settleUntil { coordinator.state == .stopped }
+    #expect(stopped)
+
+    // COMPLETION: let the stale call return, so `polishAll`'s own `defer` settles THIS
+    // generation's gate. `onVisibleCleanupWaitResolved` fires from INSIDE the previously
+    // suspended background task, the instant its `await` actually returns — proof the
+    // continuation was truly resumed, not just that bookkeeping dictionaries were updated
+    // (which would stay consistent even if `waiter.resume()` were deleted; found by chunk
+    // review round 3). A bounded wait, since a broken resume would otherwise hang forever.
+    await documentGate.open()
+    let resolved = await settleUntil { resolvedRecorder.generations.contains(firstGeneration) }
+    #expect(resolved, "generation \(firstGeneration)'s waiter was never resumed")
+    #expect(coordinator.visibleCleanupFinished.contains(firstGeneration))
+    #expect(coordinator.visibleCleanupWaiters[firstGeneration] == nil)
+  }
+
+  @Test(
+    "Stop pressed AFTER Done cancels an in-flight background cleanup without persisting a partial pass, releasing only once the in-flight call returns"
+  )
+  func stopAfterDoneNeverPersistsAPartialPass() async {
+    @MainActor final class MergeRecorder {
+      private(set) var callCount = 0
+      func record() { callCount += 1 }
+    }
+    let recorder = MergeRecorder()
+    let turnGate = ManualGate()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      mergeSpeakerFields: { _, _, _ in
+        recorder.record()
+        return true
+      },
+      processPart: { part, _ in
+        if part == "hello there friend" {
+          // The visible pass's own single piece returns immediately — the visible run
+          // reaches Done well before the background pass below is even asked to clean
+          // anything up, which is the exact "Stop after Done" case #2810's addendum
+          // names: `stop()`'s `isRunning` guard makes this an EARLY RETURN before
+          // `generation` is bumped, so cancellation is the only signal left.
+          return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+        }
+        await turnGate.markArrived()
+        await turnGate.waitUntilOpen()
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    let visibleRunDone = await settleUntil { coordinator.state == .finished }
+    #expect(
+      visibleRunDone, "the visible run should reach Done before the background pass is exercised")
+
+    // Bounded, never an unconditional await of the very signal under test — a regression
+    // that stopped the background pass from ever starting must fail cleanly here instead
+    // of hanging the suite (found by chunk review round 3).
+    let backgroundInFlight = await settleUntil { await turnGate.arrivedSoFar() }
+    #expect(backgroundInFlight, "the background pass never started its per-turn cleanup")
+    #expect(coordinator.isEngineHeld, "the background pass's own claim must be genuinely held")
+
+    coordinator.stop()
+
+    // The claim must not be released until the in-flight call ACTUALLY returns —
+    // `Task.cancel()` alone cannot interrupt an `await` with no cooperative check inside it.
+    #expect(coordinator.isEngineHeld, "the claim was released before the in-flight call returned")
+
+    await turnGate.open()
+    let released = await settleUntil { coordinator.isEngineHeld == false }
+    #expect(released, "the claim was never released once the in-flight call returned")
+    #expect(recorder.callCount == 0, "a partial pass was persisted after Stop")
+  }
+
+  @Test(
+    "the background hold re-prepares the frozen import polisher under its own claim, and reacts to its OWN readiness result even when it differs from the visible run's"
+  )
+  func backgroundHoldRePreparesAndReactsToItsOwnReadiness() async {
+    @MainActor final class PrepareRecorder {
+      private(set) var callCount = 0
+      func record() { callCount += 1 }
+    }
+    @MainActor final class MergeRecorder {
+      private(set) var callCount = 0
+      func record() { callCount += 1 }
+    }
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportTurnsOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportTurnsOutcome) { outcomes.append(outcome) }
+    }
+    let prepareRecorder = PrepareRecorder()
+    let mergeRecorder = MergeRecorder()
+    let telemetry = TelemetryRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      mergeSpeakerFields: { _, _, _ in
+        mergeRecorder.record()
+        return true
+      },
+      emitTurnTelemetry: { outcome, _, _ in telemetry.record(outcome) },
+      prepareLocalPolish: { _ in
+        prepareRecorder.record()
+        // First call: the visible run's own `start()`. Every call after that is the
+        // background hold's SEPARATE claim — simulating the shared engine's provider
+        // having moved on in between, exactly the case #2810's addendum names.
+        return prepareRecorder.callCount == 1
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    let finished = await settleUntil { coordinator.state == .finished }
+    #expect(
+      finished,
+      "the visible run must succeed on the FIRST preparation, independent of what the background pass later sees"
+    )
+
+    let reactedToItsOwnFailure = await settleUntil {
+      telemetry.outcomes.contains(.polisherNotReady)
+    }
+    #expect(
+      reactedToItsOwnFailure, "the background pass never reported its own re-preparation failure")
+    #expect(
+      prepareRecorder.callCount >= 2,
+      "the background pass must re-prepare under its own claim rather than reusing the visible run's readiness"
+    )
+    #expect(
+      mergeRecorder.callCount == 0,
+      "a write must never happen once the background pass's own preparation fails")
   }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -447,56 +447,6 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(turnCleanupArrived, "turn-cleanup should have started once the visible pass finished")
   }
 
-  @Test(
-    "a superseded generation's completion gate still resolves when its run is stopped, never hangs")
-  func supersededGenerationGateStillResolves() async {
-    let documentGate = ManualGate()
-    let coordinator = makeCoordinator(
-      lease: EngineLease(),
-      transcribedText: "hello there friend",
-      wordTimings: Self.twoSpeakerWordTimings(),
-      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
-      processPart: { part, _ in
-        await documentGate.markArrived()
-        await documentGate.waitUntilOpen()
-        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
-      })
-
-    coordinator.choose(url: Self.anyURL)
-    _ = await settleUntil {
-      if case .ready = coordinator.state { return true } else { return false }
-    }
-    coordinator.start()
-    await documentGate.waitUntilArrived()
-
-    // Stop while the visible pass's own part call is still held open. `stop()` cancels the
-    // run task and bumps `generation`, but the blocked `processPart` call itself does not
-    // return until the gate opens — `Task.cancel()` alone cannot interrupt an in-flight
-    // `await` with no cooperative check inside it.
-    coordinator.stop()
-    let stopped = await settleUntil { coordinator.state == .stopped }
-    #expect(stopped)
-
-    // NOW let the stale call return. `polishAll`'s own generation guard sees a superseded
-    // generation and returns early — its `defer` must still settle the completion gate for
-    // that generation, so anything that had been waiting on it (or would wait on it later)
-    // is never left hanging forever.
-    await documentGate.open()
-
-    // If the gate were broken (never settled on this exit path), a background task still
-    // waiting on this exact generation would hang. Prove it resolves within a bounded
-    // window by driving a SECOND run and confirming ITS OWN turn-cleanup still completes
-    // normally — a wedged gate implementation (e.g. one that leaked a waiter into the wrong
-    // bucket) would show up as the second run's own sequencing breaking.
-    coordinator.choose(url: Self.anyURL)
-    _ = await settleUntil {
-      if case .ready = coordinator.state { return true } else { return false }
-    }
-    coordinator.start()
-    let secondFinished = await settleUntil { coordinator.state == .finished }
-    #expect(secondFinished, "a fresh run after a superseded generation must complete normally")
-  }
-
   @Test("a labeled outcome with real word timings persists turns via mergeSpeakerFields")
   func labeledOutcomeWithWordTimingsPersistsTurns() async {
     @MainActor final class MergeRecorder {

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -515,6 +515,44 @@ struct FileImportCoordinatorSpeakerTests {
   }
 
   @Test(
+    "word timings that never bind to any segment (a space-free script) merge as a failure, never a self-contradictory labeled-but-all-unknown row"
+  )
+  func allUnknownTurnsMergeAsFailureNotContradictoryLabeled() async {
+    @MainActor final class MergeRecorder {
+      private(set) var analysis: TranscriptSpeakerAnalysis?
+      func record(_ analysis: TranscriptSpeakerAnalysis) { self.analysis = analysis }
+    }
+    let recorder = MergeRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      // Mimics exactly what `WordTimingRangeMapper` produces for a space-free script: one
+      // untimed entry spanning the whole transcript, since there is no whitespace to
+      // tokenize on and no engine word can bind to the single resulting text run.
+      wordTimings: [
+        ASRWordTiming(word: "hello there friend", range: 0..<19, startMs: nil, endMs: nil)
+      ],
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      mergeSpeakerFields: { _, analysis, turns in
+        recorder.record(analysis)
+        #expect(
+          turns == nil, "a contradictory labeled-with-all-unknown-turns row must never be stored")
+        return true
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+
+    let recorded = await settleUntil { recorder.analysis != nil }
+    #expect(recorded)
+    #expect(recorder.analysis == .failed(.noWordTimings))
+  }
+
+  @Test(
     "a write failure on the silent (already-reported) path still reports saveFailed, never disappearing"
   )
   func silentPathReportsSaveFailedWhenMergeThrows() async {
@@ -867,5 +905,55 @@ struct FileImportCoordinatorSpeakerTests {
     let lastRow = recorder.rows.last
     #expect(lastRow?.speakerAnalysis != nil, "re-polish reset the speaker analysis back to nil")
     #expect(lastRow?.turns?.isEmpty == false, "re-polish reset the turns back to nil")
+  }
+
+  @Test(
+    "pressing Clean it again WHILE the background speaker pass is still in flight does not discard that pass's only analysis"
+  )
+  func rePolishDuringInFlightSpeakerAnalysisStillPersists() async {
+    @MainActor final class MergeRecorder {
+      private(set) var analyses: [TranscriptSpeakerAnalysis] = []
+      func record(_ analysis: TranscriptSpeakerAnalysis) { analyses.append(analysis) }
+    }
+    let recorder = MergeRecorder()
+    let speakerGate = ManualGate()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        // Blocks BEFORE `runSpeakerStep` ever reaches its own document-identity guard — the
+        // exact window `rePolish()` can land in (found by cloud review).
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      },
+      mergeSpeakerFields: { _, analysis, _ in
+        recorder.record(analysis)
+        return true
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    let visibleRunDone = await settleUntil { coordinator.state == .finished }
+    #expect(visibleRunDone)
+    await speakerGate.waitUntilArrived()
+
+    // "Clean it again" — bumps `generation` for the SAME document WITHOUT cancelling or
+    // restarting the still-blocked speaker pass above.
+    coordinator.rePolish()
+    let rePolishFinished = await settleUntil { coordinator.state == .finished }
+    #expect(rePolishFinished, "the re-polish itself must still complete normally")
+
+    // NOW let the original, still-in-flight speaker pass return its outcome.
+    await speakerGate.open()
+    let persisted = await settleUntil { recorder.analyses.contains(.labeled(count: 2)) }
+    #expect(
+      persisted,
+      "a re-polish of the SAME document must never discard the only speaker analysis this document will ever get"
+    )
   }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -109,6 +109,7 @@ struct FileImportCoordinatorSpeakerTests {
     wordTimingCoverage: ASRWordTimingCoverage? = nil,
     speakerLabeler: @escaping @MainActor ([Float], TimeInterval) async -> SpeakerAnalysis,
     saveToHistory: @escaping @MainActor (Transcript) throws -> Void = { _ in },
+    updateHistoryRow: @escaping @MainActor (Transcript) throws -> Bool = { _ in true },
     mergeSpeakerFields: @escaping @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?) throws ->
       Bool = { _, _, _ in true },
     emitSpeakerTelemetry: @escaping @MainActor (
@@ -145,7 +146,7 @@ struct FileImportCoordinatorSpeakerTests {
       },
       prepareLocalPolish: prepareLocalPolish,
       saveToHistory: saveToHistory,
-      updateHistoryRow: { _ in true },
+      updateHistoryRow: updateHistoryRow,
       mergeSpeakerFields: mergeSpeakerFields,
       historyRowExists: { _ in true },
       processPart: processPart)
@@ -865,5 +866,56 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(
       mergeRecorder.callCount == 0,
       "a write must never happen once the background pass's own preparation fails")
+  }
+
+  @Test(
+    "re-polishing (Clean it again) after turn storage has already run preserves the persisted speaker fields, never resetting them to nil"
+  )
+  func rePolishPreservesAlreadyPersistedSpeakerFields() async {
+    @MainActor final class UpdateRecorder {
+      private(set) var rows: [Transcript] = []
+      func record(_ row: Transcript) { rows.append(row) }
+    }
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportTurnsOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportTurnsOutcome) { outcomes.append(outcome) }
+    }
+    let recorder = UpdateRecorder()
+    let telemetry = TelemetryRecorder()
+    let coordinator = makeCoordinator(
+      lease: EngineLease(),
+      transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      updateHistoryRow: { row in
+        recorder.record(row)
+        return true
+      },
+      emitTurnTelemetry: { outcome, _, _ in telemetry.record(outcome) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    // Wait for the BACKGROUND turn-storage pass to actually REPORT a stored write, not
+    // just for `isEngineHeld` to read false — that flag starts false too, so checking it
+    // right after the visible run finishes can observe "not yet started" and "already
+    // finished" as the exact same value (a race this test itself had before this fix).
+    let stored = await settleUntil { telemetry.outcomes.contains(.stored) }
+    #expect(stored, "the background turn-storage pass never reported a stored outcome")
+
+    coordinator.rePolish()
+    let rePolishFinished = await settleUntil { coordinator.state == .finished }
+    #expect(rePolishFinished)
+
+    // The LAST row `rePolish`'s own `savePolishedToHistory` wrote must still carry the
+    // speaker fields the background pass persisted earlier. `withImportResult` never
+    // touches them — this only holds if `originalHistoryRow` learned about that earlier
+    // write, which is exactly what the whole-diff review found missing.
+    let lastRow = recorder.rows.last
+    #expect(lastRow?.speakerAnalysis != nil, "re-polish reset the speaker analysis back to nil")
+    #expect(lastRow?.turns?.isEmpty == false, "re-polish reset the turns back to nil")
   }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -117,6 +117,7 @@ struct FileImportCoordinatorTests {
       // success is the explicit statement of that, not a default.
       saveToHistory: { _ in },
       updateHistoryRow: { _ in true },
+      mergeSpeakerFields: { _, _, _ in true },
       historyRowExists: { _ in true },
       processPart: { part, _ in try await processPart(part) })
   }

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -86,6 +86,7 @@ struct FileImportHistoryTests {
       prepareLocalPolish: { _ in polisherStarts },
       saveToHistory: { try spy.save($0) },
       updateHistoryRow: { try spy.update($0) },
+      mergeSpeakerFields: { _, _, _ in true },
       historyRowExists: { spy.exists($0) },
       processPart: { _, _ in
         onPart?()
@@ -555,6 +556,7 @@ struct FileImportHistoryTests {
       },
       saveToHistory: { try spy.save($0) },
       updateHistoryRow: { try spy.update($0) },
+      mergeSpeakerFields: { _, _, _ in true },
       historyRowExists: { spy.exists($0) },
       // Every part comes back with NO polished text, which is what a bypassed or entirely
       // failed polish produces.

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
@@ -1,0 +1,188 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+@testable import EnviousWisprStorage
+
+/// `TranscriptCoordinator.mergeSpeakerFields` (#2810 addendum §3 E, phase 3 of #2807) — the
+/// one write path the turn-cleanup pass and a future phase-4 rename share. Driven against a
+/// REAL `TranscriptStore(directory:)` under a temp directory, no fakes: the contract that
+/// matters is what actually lands on disk and in the coordinator's own in-memory list.
+@MainActor
+@Suite("TranscriptCoordinator.mergeSpeakerFields (#2810)", .tags(.productOutcome))
+struct TranscriptCoordinatorMergeTests {
+
+  private static func makeTempDir() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("2810-merge-\(UUID().uuidString)", isDirectory: true)
+  }
+
+  private static func makeTranscript(id: UUID = UUID(), text: String = "hello") -> Transcript {
+    Transcript(id: id, text: text, processingTime: 0.1, backendType: .parakeet, createdAt: Date())
+  }
+
+  private static func makeTurns(speaker: String = "A") -> [Turn] {
+    [Turn(id: "0-5", speakerId: speaker, startMs: 0, endMs: 100, originalTextRange: 0..<5)]
+  }
+
+  private func row(_ coordinator: TranscriptCoordinator, _ id: UUID) -> Transcript? {
+    coordinator.filteredTranscripts.first { $0.id == id }
+  }
+
+  private func freshlyLoaded(from dir: URL) async -> TranscriptCoordinator {
+    let coordinator = TranscriptCoordinator(store: TranscriptStore(directory: dir))
+    coordinator.load()
+    await coordinator.waitForLoadForTesting()
+    return coordinator
+  }
+
+  @Test("merging into an existing row persists to disk and to the in-memory list")
+  func mergeSucceedsAgainstExistingRow() async throws {
+    let dir = Self.makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+    let original = Self.makeTranscript()
+    try coordinator.saveAndShow(original)
+
+    let saved = try coordinator.mergeSpeakerFields(
+      id: original.id, analysis: .labeled(count: 1), turns: Self.makeTurns())
+    #expect(saved)
+    #expect(row(coordinator, original.id)?.speakerAnalysis == .labeled(count: 1))
+
+    // Round-trip through a FRESH coordinator loading from disk, proving this is a real
+    // persisted write, not just an in-memory mutation.
+    let reloaded = await freshlyLoaded(from: dir)
+    let reloadedRow = row(reloaded, original.id)
+    #expect(reloadedRow?.speakerAnalysis == .labeled(count: 1))
+    #expect(reloadedRow?.turns?.first?.speakerId == "A")
+  }
+
+  @Test(
+    "merging into a row deleted since the write was requested returns false and resurrects nothing")
+  func mergeAfterDeletionReturnsFalse() async throws {
+    let dir = Self.makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+    let original = Self.makeTranscript()
+    try coordinator.saveAndShow(original)
+    coordinator.delete(original)
+
+    let saved = try coordinator.mergeSpeakerFields(
+      id: original.id, analysis: .labeled(count: 1), turns: Self.makeTurns())
+    #expect(saved == false)
+
+    let reloaded = await freshlyLoaded(from: dir)
+    #expect(row(reloaded, original.id) == nil, "a deleted row must never be resurrected")
+  }
+
+  @Test("a cleanup merge and an explicit rename compose: the rename survives a later cleanup pass")
+  func cleanupMergeAndExplicitRenameCompose() throws {
+    let dir = Self.makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+    let original = Self.makeTranscript()
+    try coordinator.saveAndShow(original)
+
+    // First cleanup pass: default name.
+    _ = try coordinator.mergeSpeakerFields(
+      id: original.id, analysis: .labeled(count: 1), turns: Self.makeTurns())
+    #expect(row(coordinator, original.id)?.speakerNames == ["A": "Speaker 1"])
+
+    // An explicit rename (phase 4, simulated here at the storage layer).
+    _ = try coordinator.mergeSpeakerFields(
+      id: original.id, analysis: .labeled(count: 1), turns: Self.makeTurns(),
+      explicitRename: ("A", "Zach"))
+    #expect(row(coordinator, original.id)?.speakerNames == ["A": "Zach"])
+
+    // A LATER cleanup pass (e.g. a retry) over the SAME surviving speakerId must not
+    // clobber the rename back to a freshly-computed default — this is the exact race the
+    // addendum's "delayed cleanup vs. explicit rename" contract exists to prevent.
+    _ = try coordinator.mergeSpeakerFields(
+      id: original.id, analysis: .labeled(count: 1), turns: Self.makeTurns())
+    #expect(row(coordinator, original.id)?.speakerNames == ["A": "Zach"])
+  }
+
+  @Test("a real store write failure throws and leaves the existing row completely unchanged")
+  func mergeThrowsAndPreservesExistingRowOnRealStoreFailure() async throws {
+    let dir = Self.makeTempDir()
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+      try? FileManager.default.removeItem(at: dir)
+    }
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+    let original = Self.makeTranscript()
+    try coordinator.saveAndShow(original)
+
+    // `.sortedKeys`: `JSONEncoder`'s default key order is UNSPECIFIED and varies between
+    // separate `encode()` calls for equal values (confirmed by running this test through
+    // the real Xcode gate: two encodes of the identical content produced different byte
+    // orderings), so a byte-for-byte comparison across independent encodes needs a forced
+    // deterministic order or it is comparing noise, not content (found by chunk review
+    // round 3's own "byte-for-byte" ask surfacing a latent bug in the proof itself).
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let fileURL = dir.appendingPathComponent("\(original.id.uuidString).json")
+    let originalEncoded = try encoder.encode(original)
+    let bytesBeforeFailure = try Data(contentsOf: fileURL)
+
+    // Force a REAL write failure — strip write permission from the transcripts directory
+    // itself, so the store's own temp-file-then-rename write throws, never a fake
+    // simulating one (found by chunk review round 2).
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+
+    #expect(throws: (any Error).self) {
+      try coordinator.mergeSpeakerFields(
+        id: original.id, analysis: .labeled(count: 1), turns: Self.makeTurns())
+    }
+
+    // Restored before reading anything back — the directory's own listing needs it too.
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+
+    // `updateExistingRow` calls `store.save` BEFORE mutating `transcripts`, so a failed
+    // write must never half-apply. Proven BYTE-FOR-BYTE against the original's own encoding
+    // — checking that two optional fields stayed `nil` would also pass if the row vanished
+    // or were rebuilt from a bare default (found by chunk review round 3).
+    let inMemoryRow = row(coordinator, original.id)
+    #expect(inMemoryRow != nil, "the row must still exist in memory after a failed write")
+    if let inMemoryRow {
+      #expect(try encoder.encode(inMemoryRow) == originalEncoded)
+    }
+
+    // And the ON-DISK bytes are equally untouched — the literal file contents, not merely
+    // the same decoded shape.
+    let bytesAfterFailure = try Data(contentsOf: fileURL)
+    #expect(
+      bytesAfterFailure == bytesBeforeFailure, "the on-disk file changed despite the write throwing"
+    )
+
+    let reloaded = await freshlyLoaded(from: dir)
+    let reloadedRow = row(reloaded, original.id)
+    #expect(reloadedRow != nil, "a fresh reload must still find the row")
+    if let reloadedRow {
+      #expect(try encoder.encode(reloadedRow) == originalEncoded)
+    }
+  }
+
+  @Test("a relaunch after an interrupted pass sees the row exactly as it was last durably written")
+  func relaunchAfterInterruptedPassSeesLastDurableState() async throws {
+    let dir = Self.makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = TranscriptStore(directory: dir)
+    let coordinator = TranscriptCoordinator(store: store)
+    let original = Self.makeTranscript()
+    try coordinator.saveAndShow(original)
+    // No merge call at all — simulates a turn-cleanup pass that never got to write because
+    // the app quit mid-pass. The row must simply stay at its pre-#2810 shape: `nil` speaker
+    // fields, never a half-written one, because `mergeSpeakerFields` makes exactly one
+    // atomic write per call and this scenario never called it.
+    let reloaded = await freshlyLoaded(from: dir)
+    let reloadedRow = row(reloaded, original.id)
+    #expect(reloadedRow?.speakerAnalysis == nil)
+    #expect(reloadedRow?.turns == nil)
+  }
+}

--- a/Tests/EnviousWisprTests/Core/TranscriptSpeakerFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Core/TranscriptSpeakerFieldsTests.swift
@@ -86,6 +86,35 @@ struct TranscriptSpeakerFieldsTests {
     #expect(second.speakerNames == ["B": "Speaker 1"])
   }
 
+  @Test(
+    "a retry that keeps one speaker and adds another never hands the new one a number the surviving one already holds"
+  )
+  func retryNeverCollidesADefaultWithASurvivingName() {
+    // First pass: A and B, named "Speaker 1" and "Speaker 2".
+    let firstTurns = [
+      Turn(id: "0-1", speakerId: "A", startMs: 0, endMs: 100, originalTextRange: 0..<1),
+      Turn(id: "2-3", speakerId: "B", startMs: 200, endMs: 300, originalTextRange: 2..<3),
+    ]
+    let first = Transcript(text: "x").mergingSpeakerFields(
+      analysis: .labeled(count: 2), turns: firstTurns)
+    #expect(first.speakerNames == ["A": "Speaker 1", "B": "Speaker 2"])
+
+    // A retry: "A" retires, "B" survives (keeping its "Speaker 2"), "C" is newly appearing.
+    // A naive re-numbering by first-appearance order in THIS pass alone would call B
+    // "Speaker 1" and C "Speaker 2" — colliding with B's own preserved name (found by
+    // cloud review). C must get a number nobody currently visible already holds.
+    let secondTurns = [
+      Turn(id: "0-1", speakerId: "B", startMs: 0, endMs: 100, originalTextRange: 0..<1),
+      Turn(id: "2-3", speakerId: "C", startMs: 200, endMs: 300, originalTextRange: 2..<3),
+    ]
+    let second = first.mergingSpeakerFields(analysis: .labeled(count: 2), turns: secondTurns)
+    #expect(second.speakerNames?["B"] == "Speaker 2", "B's preserved name must survive untouched")
+    #expect(
+      second.speakerNames?["C"] != "Speaker 2",
+      "C must never collide with B's preserved name")
+    #expect(second.speakerNames?["C"] != nil, "C still needs a name of its own")
+  }
+
   @Test("an explicit rename overwrites exactly the named speakerId, preserving the rest")
   func explicitRenameOverwritesOneID() {
     let turns = [

--- a/Tests/EnviousWisprTests/Core/TranscriptSpeakerFieldsTests.swift
+++ b/Tests/EnviousWisprTests/Core/TranscriptSpeakerFieldsTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// `Transcript` gains optional `speakerAnalysis` / `speakerNames` / `turns` (#2810, phase 3 of
+/// #2807). Decode-safety matches the established pattern (#1063, #1408, #2087, #2772): a
+/// pre-#2810 row must still decode, with the new fields nil. `mergingSpeakerFields` is the
+/// single write-time enforcement point for the cross-field invariant a decode cannot check,
+/// and it computes its own default names (never takes one from the caller) so a surviving
+/// speakerId can never be silently dropped from `speakerNames` (found by chunk review).
+@Suite("Transcript speaker fields (#2810)", .tags(.productOutcome))
+struct TranscriptSpeakerFieldsTests {
+
+  @Test("a pre-#2810 JSON row decodes with the new fields nil")
+  func legacyJSONDecodes() throws {
+    let id = UUID().uuidString
+    let legacy = """
+      {"id":"\(id)","text":"hello world","duration":1.5,"processingTime":0.2,\
+      "backendType":"parakeet","createdAt":12345.0}
+      """
+    let transcript = try JSONDecoder().decode(Transcript.self, from: Data(legacy.utf8))
+    #expect(transcript.speakerAnalysis == nil)
+    #expect(transcript.speakerNames == nil)
+    #expect(transcript.turns == nil)
+  }
+
+  @Test("a non-labeled outcome clears turns and names")
+  func nonLabeledClearsTurnsAndNames() {
+    let labeled = Transcript(text: "x").mergingSpeakerFields(
+      analysis: .labeled(count: 2),
+      turns: [Turn(id: "0-1", speakerId: "A", startMs: 0, endMs: 100, originalTextRange: 0..<1)])
+    let single = labeled.mergingSpeakerFields(analysis: .single, turns: nil)
+    #expect(single.speakerAnalysis == .single)
+    #expect(single.turns == nil)
+    #expect(single.speakerNames == nil)
+  }
+
+  @Test("a fresh labeled merge fills every surviving speakerId's name, excluding unknown")
+  func freshMergeFillsEveryName() {
+    // Two real speakers plus "unknown" — no existing names, no caller-supplied defaults
+    // possible (the parameter is gone): every real speakerId must still get a name.
+    let turns = [
+      Turn(id: "0-1", speakerId: "A", startMs: 0, endMs: 100, originalTextRange: 0..<1),
+      Turn(id: "2-3", speakerId: "unknown", startMs: nil, endMs: nil, originalTextRange: 2..<3),
+      Turn(id: "4-5", speakerId: "B", startMs: 200, endMs: 300, originalTextRange: 4..<5),
+    ]
+    let merged = Transcript(text: "x").mergingSpeakerFields(
+      analysis: .labeled(count: 2), turns: turns)
+    #expect(merged.speakerNames == ["A": "Speaker 1", "B": "Speaker 2"])
+    #expect(merged.speakerNames?["unknown"] == nil)
+  }
+
+  @Test("a retry preserves an existing name for a surviving speakerId")
+  func retryPreservesExistingName() {
+    let firstTurns = [
+      Turn(id: "0-1", speakerId: "A", startMs: 0, endMs: 100, originalTextRange: 0..<1)
+    ]
+    let first = Transcript(text: "x").mergingSpeakerFields(
+      analysis: .labeled(count: 1), turns: firstTurns)
+    // Simulate a rename having already happened to this row (phase 4, out of this phase's
+    // scope to trigger, but the merge function must not clobber it on a later cleanup pass).
+    let renamed = first.mergingSpeakerFields(
+      analysis: .labeled(count: 1), turns: firstTurns, explicitRename: ("A", "Zach"))
+    #expect(renamed.speakerNames == ["A": "Zach"])
+
+    // A later retry with the SAME surviving speakerId must not overwrite "Zach" back to a
+    // freshly-computed default.
+    let retried = renamed.mergingSpeakerFields(analysis: .labeled(count: 1), turns: firstTurns)
+    #expect(retried.speakerNames == ["A": "Zach"])
+  }
+
+  @Test("a retry removes a name whose speakerId no longer appears, and fills a new one")
+  func retryRetiresAndFills() {
+    let firstTurns = [
+      Turn(id: "0-1", speakerId: "A", startMs: 0, endMs: 100, originalTextRange: 0..<1)
+    ]
+    let first = Transcript(text: "x").mergingSpeakerFields(
+      analysis: .labeled(count: 1), turns: firstTurns)
+
+    // A fresh TurnAssembler pass reshuffles which ids appear: "A" is gone, "B" is new.
+    let secondTurns = [
+      Turn(id: "0-1", speakerId: "B", startMs: 0, endMs: 100, originalTextRange: 0..<1)
+    ]
+    let second = first.mergingSpeakerFields(analysis: .labeled(count: 1), turns: secondTurns)
+    #expect(second.speakerNames == ["B": "Speaker 1"])
+  }
+
+  @Test("an explicit rename overwrites exactly the named speakerId, preserving the rest")
+  func explicitRenameOverwritesOneID() {
+    let turns = [
+      Turn(id: "0-1", speakerId: "A", startMs: 0, endMs: 100, originalTextRange: 0..<1),
+      Turn(id: "2-3", speakerId: "B", startMs: 200, endMs: 300, originalTextRange: 2..<3),
+    ]
+    let merged = Transcript(text: "x").mergingSpeakerFields(
+      analysis: .labeled(count: 2), turns: turns, explicitRename: ("A", "Zach"))
+    #expect(merged.speakerNames == ["A": "Zach", "B": "Speaker 2"])
+  }
+
+  @Test("a legacy-JSON transcript's new fields round-trip through Codable")
+  func newFieldsRoundTrip() throws {
+    let original = Transcript(text: "x").mergingSpeakerFields(
+      analysis: .labeled(count: 1),
+      turns: [Turn(id: "0-1", speakerId: "A", startMs: 0, endMs: 100, originalTextRange: 0..<1)])
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(Transcript.self, from: data)
+    #expect(decoded.speakerAnalysis == .labeled(count: 1))
+    #expect(decoded.speakerNames == ["A": "Speaker 1"])
+    #expect(decoded.turns?.first?.id == "0-1")
+  }
+
+  @Test("SpeakerAnalysis maps exhaustively to the persisted TranscriptSpeakerAnalysis")
+  func speakerAnalysisMapsExhaustively() {
+    #expect(SpeakerAnalysis.single(segments: []).asStorageAnalysis == .single)
+    #expect(SpeakerAnalysis.labeled(count: 3, segments: []).asStorageAnalysis == .labeled(count: 3))
+    #expect(
+      SpeakerAnalysis.failed(.modelsUnavailable).asStorageAnalysis == .failed(.modelsUnavailable))
+    #expect(
+      SpeakerAnalysis.failed(.analyzerThrew("boom")).asStorageAnalysis == .failed(.analyzerThrew))
+    #expect(
+      SpeakerAnalysis.failed(.noSpeakerSegments).asStorageAnalysis == .failed(.noSpeakerSegments))
+    #expect(SpeakerAnalysis.failed(.cancelled).asStorageAnalysis == .failed(.cancelled))
+    #expect(SpeakerAnalysis.timedOut(afterMs: 20_000).asStorageAnalysis == .failed(.timedOut))
+  }
+
+  @Test("analyzerThrew's diagnostic string is stripped before persisting")
+  func analyzerThrewStripsDiagnosticText() {
+    let mapped = SpeakerFailure.analyzerThrew("a very specific crash string").asStorageReason
+    #expect(mapped == .analyzerThrew)
+  }
+}

--- a/Tests/EnviousWisprTests/Core/TurnAssemblerTests.swift
+++ b/Tests/EnviousWisprTests/Core/TurnAssemblerTests.swift
@@ -1,0 +1,313 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprCore
+
+/// #2810 chunk 1: what fails when these fail is a real user-visible defect once phase 4
+/// renders turns — a word attributed to the wrong speaker, dropped, or duplicated.
+@Suite("TurnAssembler", .tags(.productOutcome))
+struct TurnAssemblerTests {
+
+  private func entry(_ word: String, _ lower: Int, _ upper: Int, _ start: Int?, _ end: Int?)
+    -> ASRWordTiming
+  {
+    ASRWordTiming(word: word, range: lower..<upper, startMs: start, endMs: end)
+  }
+
+  /// UTF-16-offset slicing, matching how `TurnCleanupRunner` reads a turn's raw text —
+  /// `Range(_:in:)` does not accept a bare `Range<Int>`.
+  private func slice(_ range: Range<Int>, of text: String) -> String {
+    let lower = String.Index(utf16Offset: range.lowerBound, in: text)
+    let upper = String.Index(utf16Offset: range.upperBound, in: text)
+    return String(text[lower..<upper])
+  }
+
+  @Test("every entry lands in exactly one turn, in order, with no loss or duplication")
+  func noLostOrReassignedWords() {
+    let entries = [
+      entry("hello", 0, 5, 0, 200), entry("there", 6, 11, 200, 500),
+      entry("hi", 12, 14, 600, 800), entry("back", 15, 19, 800, 1000),
+    ]
+    let segments = [
+      SpeakerSegment(speakerId: "A", startMs: 0, endMs: 500, quality: 1),
+      SpeakerSegment(speakerId: "B", startMs: 600, endMs: 1000, quality: 1),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.count == 2)
+    #expect(turns[0].speakerId == "A")
+    #expect(turns[1].speakerId == "B")
+    // Every original entry accounted for: the two turns' ranges cover exactly the
+    // entries' own spans, first-to-last, with none dropped or duplicated.
+    #expect(turns[0].originalTextRange == 0..<11)
+    #expect(turns[1].originalTextRange == 12..<19)
+  }
+
+  @Test(
+    "a mixed A-to-B-to-A fixture with punctuation, numerals and an untimed span: every entry attributed exactly once, no forbidden regrouping"
+  )
+  func mixedFixtureNoRegroupingAcrossSpeakerChanges() {
+    let text = "Hi, I'm 24. Well, nice to meet you. Yeah, likewise."
+    // Entries: "Hi," / "I'm" / "24." (speaker A) — "Well," / "nice" (speaker B) — "to"
+    // (untimed, so always "unknown" — this correctly SPLITS the B turn, an untimed word in
+    // the middle of a speaker's turn is not smoothed over) — "meet" / "you." (speaker B
+    // again, a SEPARATE turn from the first B turn since "unknown" sits between them) —
+    // "Yeah," (unknown, beyond tolerance) — "likewise." (speaker A again, must NOT merge
+    // back into the FIRST A turn just because the speaker recurs).
+    let entries: [ASRWordTiming] = [
+      entry("Hi,", 0, 3, 0, 300),
+      entry("I'm", 4, 7, 300, 500),
+      entry("24.", 8, 11, 500, 700),
+      entry("Well,", 12, 17, 5000, 5300),
+      entry("nice", 18, 22, 5300, 5600),
+      entry("to", 23, 25, nil, nil),  // untimed span
+      entry("meet", 26, 30, 5900, 6100),
+      entry("you.", 31, 35, 6100, 6400),
+      entry("Yeah,", 36, 41, 50_000, 50_200),
+      entry("likewise.", 42, 51, 900, 1100),
+    ]
+    let segments = [
+      SpeakerSegment(speakerId: "A", startMs: 0, endMs: 700, quality: 1),
+      SpeakerSegment(speakerId: "B", startMs: 5000, endMs: 6400, quality: 1),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+
+    // Every entry belongs to exactly one turn, under its expected speaker, in original order.
+    let bySpeaker = turns.map(\.speakerId)
+    #expect(bySpeaker == ["A", "B", "unknown", "B", "unknown", "A"])
+    // The A speaker (and B speaker) recurring later must NOT merge back into an earlier
+    // same-speaker turn once a different speaker (even "unknown") has intervened — no word
+    // moves across an established speaker change (addendum §3 C).
+    #expect(turns.count == 6)
+
+    // Each turn's raw-text slice equals exactly its member entries' span, whitespace
+    // included, sliced from the SAME text the entries' ranges were computed against.
+    #expect(slice(turns[0].originalTextRange, of: text) == "Hi, I'm 24.")
+    #expect(slice(turns[1].originalTextRange, of: text) == "Well, nice")
+    #expect(slice(turns[2].originalTextRange, of: text) == "to")
+    #expect(slice(turns[3].originalTextRange, of: text) == "meet you.")
+    #expect(slice(turns[4].originalTextRange, of: text) == "Yeah,")
+    #expect(slice(turns[5].originalTextRange, of: text) == "likewise.")
+
+    // No entry lost or duplicated: every entry's range appears inside exactly one turn's
+    // range, and the union of all turn ranges accounts for every entry.
+    var coveredEntries = 0
+    for entry in entries {
+      let owners = turns.filter {
+        $0.originalTextRange.lowerBound <= entry.range.lowerBound
+          && entry.range.upperBound <= $0.originalTextRange.upperBound
+      }
+      #expect(owners.count == 1, "entry \(entry.word) must belong to exactly one turn")
+      coveredEntries += 1
+    }
+    #expect(coveredEntries == entries.count)
+  }
+
+  @Test("adjacent same-speaker entries group into one turn; a speaker change starts a new one")
+  func adjacencyGrouping() {
+    let entries = [
+      entry("a", 0, 1, 0, 100), entry("b", 2, 3, 100, 200), entry("c", 4, 5, 100_100, 100_200),
+    ]
+    let segments = [
+      SpeakerSegment(speakerId: "A", startMs: 0, endMs: 200, quality: 1),
+      SpeakerSegment(speakerId: "B", startMs: 100_000, endMs: 100_300, quality: 1),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["A", "B"])
+    #expect(turns[0].originalTextRange == 0..<3)
+    #expect(turns[1].originalTextRange == 4..<5)
+  }
+
+  @Test("greatest overlap wins over a segment the entry merely touches")
+  func greatestOverlapWins() {
+    // Entry spans 100-300ms. Segment A covers 90-150 (60ms overlap); segment B covers
+    // 140-400 (160ms overlap). B has the larger overlap and must win.
+    let entries = [entry("word", 0, 4, 100, 300)]
+    let segments = [
+      SpeakerSegment(speakerId: "A", startMs: 90, endMs: 150, quality: 1),
+      SpeakerSegment(speakerId: "B", startMs: 140, endMs: 400, quality: 1),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["B"])
+  }
+
+  @Test(
+    "a tie breaks deterministically by lowest segment start, then lowest speakerId, regardless of array order"
+  )
+  func deterministicTieBreak() {
+    // Two segments each overlap the entry by exactly 100ms; same start, so speakerId decides.
+    let entries = [entry("word", 0, 4, 100, 300)]
+    let segments = [
+      SpeakerSegment(speakerId: "Z", startMs: 100, endMs: 300, quality: 1),
+      SpeakerSegment(speakerId: "A", startMs: 100, endMs: 300, quality: 1),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["A"])
+
+    // Reversed array order must not change the outcome — the tie-break is a property of
+    // the segments themselves, never of how the caller happened to order them.
+    let reversedTurns = TurnAssembler.assemble(entries: entries, segments: segments.reversed())
+    #expect(reversedTurns.map(\.speakerId) == ["A"])
+  }
+
+  @Test("the earliest segment start wins a tie even when it is not first in the array")
+  func earliestStartWinsTieRegardlessOfArrayPosition() {
+    // Both segments overlap the entry by 100ms, but "B" starts earlier — "B" must win the
+    // tie even though "A" (the later start) is listed first and would win on speakerId alone.
+    let entries = [entry("word", 0, 4, 100, 300)]
+    let segments = [
+      SpeakerSegment(speakerId: "A", startMs: 150, endMs: 300, quality: 1),
+      SpeakerSegment(speakerId: "B", startMs: 50, endMs: 250, quality: 1),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["B"])
+  }
+
+  @Test("zero overlap within tolerance assigns to the nearest segment")
+  func nearestSegmentFallbackWithinTolerance() {
+    // Entry at 1000-1100ms; nearest segment ends at 900ms, 100ms away (<= 250ms tolerance).
+    let entries = [entry("word", 0, 4, 1000, 1100)]
+    let segments = [SpeakerSegment(speakerId: "A", startMs: 200, endMs: 900, quality: 1)]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["A"])
+  }
+
+  @Test("the tolerance boundary is exact: 250ms away assigns, 251ms away is unknown")
+  func exactToleranceBoundary() {
+    // Segment ends at 900ms. An entry starting at 1150ms is exactly 250ms away (within
+    // tolerance); one starting at 1151ms is 251ms away (beyond it).
+    let segments = [SpeakerSegment(speakerId: "A", startMs: 200, endMs: 900, quality: 1)]
+
+    let atBoundary = TurnAssembler.assemble(
+      entries: [entry("word", 0, 4, 1150, 1250)], segments: segments)
+    #expect(atBoundary.map(\.speakerId) == ["A"])
+
+    let overBoundary = TurnAssembler.assemble(
+      entries: [entry("word", 0, 4, 1151, 1251)], segments: segments)
+    #expect(overBoundary.map(\.speakerId) == ["unknown"])
+  }
+
+  @Test("beyond tolerance, and with no segments at all, the entry is unknown")
+  func beyondToleranceAndNoSegmentsAreUnknown() {
+    let entries = [entry("word", 0, 4, 5000, 5100)]
+    let segments = [SpeakerSegment(speakerId: "A", startMs: 200, endMs: 900, quality: 1)]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["unknown"])
+
+    let noSegmentTurns = TurnAssembler.assemble(entries: entries, segments: [])
+    #expect(noSegmentTurns.map(\.speakerId) == ["unknown"])
+  }
+
+  @Test("an untimed entry (nil bounds) is unknown regardless of segments present")
+  func untimedEntryIsUnknown() {
+    let entries = [entry("word", 0, 4, nil, nil)]
+    let segments = [SpeakerSegment(speakerId: "A", startMs: 0, endMs: 100, quality: 1)]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["unknown"])
+    #expect(turns[0].startMs == nil)
+    #expect(turns[0].endMs == nil)
+  }
+
+  @Test("a turn's bounds are the min/max among ALL its timed members, not just one")
+  func minMaxAmongMultipleTimedMembers() {
+    // Three entries, all falling beyond tolerance so they group as one "unknown" turn:
+    // bounds must be the overall min start and max end across all three, not the first
+    // or last member's own bounds.
+    let entries = [
+      entry("a", 0, 1, 9500, 9600), entry("b", 2, 3, 9000, 9200), entry("c", 4, 5, 9800, 10_000),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: [])
+    #expect(turns.count == 1)
+    #expect(turns[0].startMs == 9000)
+    #expect(turns[0].endMs == 10_000)
+  }
+
+  @Test("a turn's bounds are the min/max among its TIMED members, even if one member is untimed")
+  func mixedTimedAndUntimedBoundsWithinOneTurn() {
+    // Both fall outside any segment's tolerance, so both are "unknown" and group together —
+    // one is timed, one is not. Bounds must reflect only the timed one.
+    let entries = [entry("a", 0, 1, 9000, 9100), entry("b", 2, 3, nil, nil)]
+    let turns = TurnAssembler.assemble(entries: entries, segments: [])
+    #expect(turns.count == 1)
+    #expect(turns[0].startMs == 9000)
+    #expect(turns[0].endMs == 9100)
+  }
+
+  @Test("a turn made entirely of untimed entries has nil bounds")
+  func allUntimedTurnHasNilBounds() {
+    let entries = [entry("a", 0, 1, nil, nil), entry("b", 2, 3, nil, nil)]
+    let turns = TurnAssembler.assemble(entries: entries, segments: [])
+    #expect(turns.count == 1)
+    #expect(turns[0].startMs == nil)
+    #expect(turns[0].endMs == nil)
+  }
+
+  @Test("a space-free script groups by adjacency exactly like a spaced one")
+  func spaceFreeScript() {
+    // Simulates CJK text: WordTimingRangeMapper still produces per-glyph-run entries;
+    // TurnAssembler does not care about whitespace at all, only entry order and timing.
+    let entries = [
+      entry("你好", 0, 2, 0, 200), entry("世界", 2, 4, 200, 400),
+      entry("再见", 4, 6, 5000, 5200),
+    ]
+    let segments = [
+      SpeakerSegment(speakerId: "A", startMs: 0, endMs: 400, quality: 1),
+      SpeakerSegment(speakerId: "B", startMs: 4900, endMs: 5300, quality: 1),
+    ]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["A", "B"])
+    #expect(turns[0].originalTextRange == 0..<4)
+    #expect(turns[1].originalTextRange == 4..<6)
+  }
+
+  @Test("empty input produces no turns")
+  func emptyInput() {
+    #expect(TurnAssembler.assemble(entries: [], segments: []).isEmpty)
+  }
+
+  @Test("default speaker names are assigned in first-appearance order, excluding unknown")
+  func defaultSpeakerNamesExcludeUnknown() {
+    let entries = [
+      entry("a", 0, 1, 0, 100), entry("b", 2, 3, nil, nil), entry("c", 4, 5, 9000, 9100),
+    ]
+    let segments = [SpeakerSegment(speakerId: "Z", startMs: 0, endMs: 100, quality: 1)]
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    // "Z" appears first, "unknown" (from the untimed entry) groups separately, then the
+    // beyond-tolerance entry is also "unknown" but adjacent so it merges with the prior
+    // unknown group only if immediately adjacent — here it is not (Z, unknown, unknown are
+    // three distinct adjacency groups only if speaker changes between them; unknown ==
+    // unknown so entries 2 and 3 merge into ONE unknown turn).
+    let names = TurnAssembler.defaultSpeakerNames(for: turns)
+    #expect(names["Z"] == "Speaker 1")
+    #expect(names["unknown"] == nil)
+  }
+
+  @Test("multiple recurring real speakers get one stable name each, in first-appearance order")
+  func multipleRecurringSpeakersGetOneNameEach() {
+    let entries = [
+      entry("a", 0, 1, 0, 100), entry("b", 2, 3, 9000, 9100), entry("c", 4, 5, 100, 200),
+    ]
+    let segments = [
+      SpeakerSegment(speakerId: "B", startMs: 0, endMs: 200, quality: 1),
+      SpeakerSegment(speakerId: "A", startMs: 9000, endMs: 9200, quality: 1),
+    ]
+    // Turn order: B (entry a), A (entry b), B again (entry c) — three turns, two speakers.
+    let turns = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(turns.map(\.speakerId) == ["B", "A", "B"])
+    let names = TurnAssembler.defaultSpeakerNames(for: turns)
+    // "B" appeared first (turn 0), so it gets "Speaker 1" even though it recurs later;
+    // "A" appeared second, gets "Speaker 2"; exactly two entries, not three.
+    #expect(names == ["B": "Speaker 1", "A": "Speaker 2"])
+  }
+
+  @Test("a fresh assembly over identical input reproduces identical, range-derived turn ids")
+  func repeatedAssemblyProducesStableIDs() {
+    let entries = [
+      entry("hello", 0, 5, 0, 200), entry("there", 6, 11, 200, 500),
+    ]
+    let segments = [SpeakerSegment(speakerId: "A", startMs: 0, endMs: 500, quality: 1)]
+    let first = TurnAssembler.assemble(entries: entries, segments: segments)
+    let second = TurnAssembler.assemble(entries: entries, segments: segments)
+    #expect(first.map(\.id) == second.map(\.id))
+    #expect(first.first?.id == "0-11")
+  }
+}

--- a/Tests/EnviousWisprTests/Core/TurnAssemblerTests.swift
+++ b/Tests/EnviousWisprTests/Core/TurnAssemblerTests.swift
@@ -310,4 +310,22 @@ struct TurnAssemblerTests {
     #expect(first.map(\.id) == second.map(\.id))
     #expect(first.first?.id == "0-11")
   }
+
+  @Test(
+    "assemble stops at the first entry when its own Task is already cancelled, never fabricating a result for cancelled work"
+  )
+  func assembleStopsWhenCancelled() async {
+    let entries = [
+      entry("hello", 0, 5, 0, 200), entry("there", 6, 11, 200, 500),
+    ]
+    let segments = [SpeakerSegment(speakerId: "A", startMs: 0, endMs: 500, quality: 1)]
+    let task = Task {
+      TurnAssembler.assemble(entries: entries, segments: segments)
+    }
+    // Cancelled BEFORE the task's body has a chance to run — cancellation is a monotonic
+    // flag, so this is deterministic, never a race against the task's own scheduling.
+    task.cancel()
+    let turns = await task.value
+    #expect(turns.isEmpty, "a cancelled task must not process any entries")
+  }
 }

--- a/Tests/EnviousWisprTests/Pipeline/TurnCleanupRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TurnCleanupRunnerTests.swift
@@ -1,0 +1,161 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprPipeline
+
+/// #2810 addendum §3 D: the background turn-safe cleanup pass. What fails when these fail is
+/// a stored turn showing the wrong text, silently dropping a part's cleaned output, or
+/// running a part after the caller was told to stop.
+@MainActor
+@Suite("TurnCleanupRunner", .tags(.productOutcome))
+struct TurnCleanupRunnerTests {
+
+  private func turn(_ id: String, _ speaker: String, _ range: Range<Int>) -> Turn {
+    Turn(id: id, speakerId: speaker, startMs: 0, endMs: 100, originalTextRange: range)
+  }
+
+  @Test("a single-part turn's processedText is the part's displayText, wasPolished true")
+  func singlePartTurnJoinsCleanly() async {
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        FileImportRunner.PartOutcome(text: part, polishedText: "CLEANED: \(part)", polishError: nil)
+      })
+    let turns = [turn("0-5", "A", 0..<5)]
+    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "hello", engineLanguage: nil)
+    #expect(result.count == 1)
+    #expect(fallbackCount == 0)
+    #expect(result[0].processedText == "CLEANED: hello")
+    #expect(result[0].wasPolished == true)
+  }
+
+  @Test("a turn split into multiple parts joins them in order with a blank-line separator")
+  func multiPartTurnJoinsInOrder() async {
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        FileImportRunner.PartOutcome(text: part, polishedText: "[\(part)]", polishError: nil)
+      },
+      split: { text in text.split(separator: " ").map(String.init) })
+    let turns = [turn("0-11", "A", 0..<11)]
+    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "hello world", engineLanguage: nil)
+    #expect(result[0].processedText == "[hello]\n\n[world]")
+    #expect(result[0].wasPolished == true)
+    #expect(fallbackCount == 0)
+  }
+
+  @Test(
+    "mixed success: one part polished, one fell back — joins both, wasPolished true, counts as fallback"
+  )
+  func mixedSuccessJoin() async {
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        if part == "good" {
+          return FileImportRunner.PartOutcome(text: part, polishedText: "GOOD", polishError: nil)
+        }
+        // The deterministic floor: no polishedText, matching a real polish failure.
+        return FileImportRunner.PartOutcome(text: part, polishedText: nil, polishError: "boom")
+      },
+      split: { text in text.split(separator: " ").map(String.init) })
+    let turns = [turn("0-8", "A", 0..<8)]
+    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "good bad", engineLanguage: nil)
+    #expect(result[0].processedText == "GOOD\n\nbad")
+    #expect(result[0].wasPolished == true, "any part polishing makes the whole turn wasPolished")
+    #expect(fallbackCount == 1, "a turn with any fallback part counts, even if it also has a polished part")
+  }
+
+  @Test("every part failing to polish leaves wasPolished false")
+  func everyPartFailingLeavesUnpolished() async {
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        FileImportRunner.PartOutcome(text: part, polishedText: nil, polishError: "boom")
+      })
+    let turns = [turn("0-5", "A", 0..<5)]
+    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "hello", engineLanguage: nil)
+    #expect(result[0].processedText == "hello")
+    #expect(result[0].wasPolished == false)
+    #expect(fallbackCount == 1)
+  }
+
+  @Test("multiple turns are processed in order, each independently")
+  func multipleTurnsProcessedInOrder() async {
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        FileImportRunner.PartOutcome(text: part, polishedText: part.uppercased(), polishError: nil)
+      })
+    let turns = [turn("0-5", "A", 0..<5), turn("6-11", "B", 6..<11)]
+    let (result, _) = await runner.run(turns: turns, rawText: "hello world", engineLanguage: nil)
+    #expect(result.map(\.processedText) == ["HELLO", "WORLD"])
+    #expect(result.map(\.id) == ["0-5", "6-11"])
+  }
+
+  @Test("cancellation between turns leaves the remaining turns untouched, never mid-part")
+  func cancellationBetweenTurnsNeverMidPart() async {
+    // A gate that deterministically holds the first part's call open until the test has
+    // cancelled the task, ruling out any race between "turn 1 finished" and "turn 2 started."
+    actor Gate {
+      private(set) var calls: [String] = []
+      private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+      private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+      private var isReleased = false
+
+      func recordAndWaitForRelease(_ part: String) async {
+        calls.append(part)
+        for waiter in arrivalWaiters { waiter.resume() }
+        arrivalWaiters = []
+        if isReleased { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+      }
+
+      func waitForFirstArrival() async {
+        if !calls.isEmpty { return }
+        await withCheckedContinuation { arrivalWaiters.append($0) }
+      }
+
+      func release() {
+        isReleased = true
+        for waiter in releaseWaiters { waiter.resume() }
+        releaseWaiters = []
+      }
+    }
+    let gate = Gate()
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        await gate.recordAndWaitForRelease(part)
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      })
+
+    let task = Task { @MainActor in
+      await runner.run(
+        turns: [turn("0-5", "A", 0..<5), turn("6-11", "B", 6..<11)], rawText: "hello world",
+        engineLanguage: nil)
+    }
+    // The first part is confirmed in flight and BLOCKED before turn 2 can possibly start.
+    await gate.waitForFirstArrival()
+    task.cancel()
+    // Only now let the first part's call return — `run()`'s cancellation check happens at
+    // the TOP of the next loop iteration, after this call completes, so cancelling first
+    // guarantees turn 2 is never reached.
+    await gate.release()
+    let (result, _) = await task.value
+
+    let calls = await gate.calls
+    #expect(calls == ["hello"], "only the first turn's part should have run before cancellation")
+    #expect(result.count == 2, "the result still contains every turn, even uncleaned ones")
+    #expect(result[0].processedText == "hello", "the turn already processed keeps its result")
+    #expect(
+      result[1].processedText == nil, "the turn never reached stays unprocessed, not half-written")
+  }
+
+  @Test(
+    "a range mismatch against the supplied rawText leaves the turn untouched rather than crashing")
+  func rangeMismatchLeavesTurnUntouched() async {
+    let runner = TurnCleanupRunner(processPart: { part, _ in
+      FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+    })
+    // originalTextRange far beyond the supplied rawText's own length.
+    let turns = [turn("100-200", "A", 100..<200)]
+    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "short", engineLanguage: nil)
+    #expect(result == turns, "an out-of-bounds range must not crash or fabricate text")
+    #expect(fallbackCount == 0)
+  }
+}

--- a/Tests/EnviousWisprTests/Pipeline/TurnCleanupRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TurnCleanupRunnerTests.swift
@@ -172,6 +172,62 @@ struct TurnCleanupRunnerTests {
   }
 
   @Test(
+    "cancellation during a multi-part turn stops the remaining parts of THAT turn too, not only between turns"
+  )
+  func cancellationDuringMultiPartTurnStopsRemainingParts() async {
+    actor Gate {
+      private(set) var calls: [String] = []
+      private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+      private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+      private var isReleased = false
+
+      func recordAndWaitForRelease(_ part: String) async {
+        calls.append(part)
+        for waiter in arrivalWaiters { waiter.resume() }
+        arrivalWaiters = []
+        if isReleased { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+      }
+
+      func waitForFirstArrival() async {
+        if !calls.isEmpty { return }
+        await withCheckedContinuation { arrivalWaiters.append($0) }
+      }
+
+      func release() {
+        isReleased = true
+        for waiter in releaseWaiters { waiter.resume() }
+        releaseWaiters = []
+      }
+    }
+    let gate = Gate()
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        await gate.recordAndWaitForRelease(part)
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      },
+      split: { text in text.split(separator: " ").map(String.init) })
+
+    let task = Task { @MainActor in
+      await runner.run(
+        turns: [turn("0-11", "A", 0..<11)], rawText: "hello world", engineLanguage: nil)
+    }
+    // The turn's FIRST part is confirmed in flight and blocked before its second part can
+    // possibly start.
+    await gate.waitForFirstArrival()
+    task.cancel()
+    // `cleaned()`'s own cancellation check happens at the top of the NEXT part iteration,
+    // after this call completes, so cancelling first guarantees "world" is never reached.
+    await gate.release()
+    _ = await task.value
+
+    let calls = await gate.calls
+    #expect(
+      calls == ["hello"],
+      "only the first part of the turn should have run before cancellation stopped the rest")
+  }
+
+  @Test(
     "a range mismatch against the supplied rawText leaves the turn untouched rather than crashing")
   func rangeMismatchLeavesTurnUntouched() async {
     let runner = TurnCleanupRunner(processPart: { part, _ in

--- a/Tests/EnviousWisprTests/Pipeline/TurnCleanupRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/TurnCleanupRunnerTests.swift
@@ -22,7 +22,8 @@ struct TurnCleanupRunnerTests {
         FileImportRunner.PartOutcome(text: part, polishedText: "CLEANED: \(part)", polishError: nil)
       })
     let turns = [turn("0-5", "A", 0..<5)]
-    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "hello", engineLanguage: nil)
+    let (result, fallbackCount) = await runner.run(
+      turns: turns, rawText: "hello", engineLanguage: nil)
     #expect(result.count == 1)
     #expect(fallbackCount == 0)
     #expect(result[0].processedText == "CLEANED: hello")
@@ -37,7 +38,8 @@ struct TurnCleanupRunnerTests {
       },
       split: { text in text.split(separator: " ").map(String.init) })
     let turns = [turn("0-11", "A", 0..<11)]
-    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "hello world", engineLanguage: nil)
+    let (result, fallbackCount) = await runner.run(
+      turns: turns, rawText: "hello world", engineLanguage: nil)
     #expect(result[0].processedText == "[hello]\n\n[world]")
     #expect(result[0].wasPolished == true)
     #expect(fallbackCount == 0)
@@ -57,10 +59,13 @@ struct TurnCleanupRunnerTests {
       },
       split: { text in text.split(separator: " ").map(String.init) })
     let turns = [turn("0-8", "A", 0..<8)]
-    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "good bad", engineLanguage: nil)
+    let (result, fallbackCount) = await runner.run(
+      turns: turns, rawText: "good bad", engineLanguage: nil)
     #expect(result[0].processedText == "GOOD\n\nbad")
     #expect(result[0].wasPolished == true, "any part polishing makes the whole turn wasPolished")
-    #expect(fallbackCount == 1, "a turn with any fallback part counts, even if it also has a polished part")
+    #expect(
+      fallbackCount == 1,
+      "a turn with any fallback part counts, even if it also has a polished part")
   }
 
   @Test("every part failing to polish leaves wasPolished false")
@@ -70,10 +75,30 @@ struct TurnCleanupRunnerTests {
         FileImportRunner.PartOutcome(text: part, polishedText: nil, polishError: "boom")
       })
     let turns = [turn("0-5", "A", 0..<5)]
-    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "hello", engineLanguage: nil)
+    let (result, fallbackCount) = await runner.run(
+      turns: turns, rawText: "hello", engineLanguage: nil)
     #expect(result[0].processedText == "hello")
     #expect(result[0].wasPolished == false)
     #expect(fallbackCount == 1)
+  }
+
+  @Test(
+    "a part where no polisher was ever asked for is neither polished nor a fallback"
+  )
+  func noPolishAttemptedIsNeitherPolishedNorFallback() async {
+    let runner = TurnCleanupRunner(
+      processPart: { part, _ in
+        // The user picked no polisher, or an intentional bypass for a short part — this is
+        // not a failure, so `fallback_turn_count` must never see it (found by cloud review).
+        FileImportRunner.PartOutcome(
+          text: part, polishedText: nil, polishError: nil, polishAttempted: false)
+      })
+    let turns = [turn("0-5", "A", 0..<5)]
+    let (result, fallbackCount) = await runner.run(
+      turns: turns, rawText: "hello", engineLanguage: nil)
+    #expect(result[0].processedText == "hello")
+    #expect(result[0].wasPolished == false)
+    #expect(fallbackCount == 0, "no polisher was ever asked for — this is not a fallback")
   }
 
   @Test("multiple turns are processed in order, each independently")
@@ -154,7 +179,8 @@ struct TurnCleanupRunnerTests {
     })
     // originalTextRange far beyond the supplied rawText's own length.
     let turns = [turn("100-200", "A", 100..<200)]
-    let (result, fallbackCount) = await runner.run(turns: turns, rawText: "short", engineLanguage: nil)
+    let (result, fallbackCount) = await runner.run(
+      turns: turns, rawText: "short", engineLanguage: nil)
     #expect(result == turns, "an out-of-bounds range must not crash or fabricate text")
     #expect(fallbackCount == 0)
   }


### PR DESCRIPTION
Closes #2810. Phase 3 of the multi-phase epic tracked separately.

## What this ships

Ships DORMANT — no user-visible change. Builds the turn-safe cleanup and storage layer speaker labels will render on top of in a later phase:

- **Turn assembly**: each ASR word is assigned to the speaker segment it overlaps most, with a deterministic tie-break and a bounded nearest-segment fallback. Every original word is kept; adjacent same-speaker words group into one turn.
- **Turn-safe background cleanup**: each turn is cleaned independently, splitting oversized turns the same way the existing pipeline already does, reassembling by identity rather than position. Speaker names never enter the model's prompt or output.
- **Storage**: the History row gains optional speaker-analysis state, speaker names, and turns. A single, update-only write path persists them, never resurrecting a deleted row and never overwriting a newer name with a stale default.

## Review history

- Build reached CHUNK-CLEAN across all three chunks (Core / Pipeline / AppKit-Storage) after four review rounds on the storage-wiring chunk.
- A whole-diff review found and this branch fixes a real regression: re-polishing an already-cleaned-up import used to silently erase the speaker data that had just been saved.
- A fresh second-pass behavioral review removed one test that proved the wrong thing (kept the stronger replacement already in the suite) and flagged a known limitation for phase 4's rename UI, documented as a code comment rather than built speculatively now.

## Testing

- `swift test` (informal): 212/212 across 11 relevant suites, run repeatedly through the fix cycles above.
- `scripts/xcode-test.sh` (the real gate): green except one pre-existing, unrelated failure (`RenderedPillFreezeTests`, a UI snapshot test with zero overlap with this diff — reproduced identically before and after this branch's changes).
- Local Dev build (`EnviousWispr-Dev`) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF9Bb42yHkgffHPuRzdBL2
