### PR TITLE
perf(website): first-frame header layout, hero preload, deferred chat, heading outline

### DIFF
--- a/website/scripts/check-features.mjs
+++ b/website/scripts/check-features.mjs
@@ -301,7 +301,10 @@ else {
 // header stylesheet must key its enhanced layout on that flag, never on the
 // data-nav-ready the module stamps later. Either regression paints the open
 // link lists and then jumps the whole page when the module collapses them.
-const navFlag = /<script>document\.documentElement\.dataset\.navJs\s*=\s*''[;\s]*<\/script>/;
+// The same inline script must also clear the flag on load when the header
+// never became ready, or a nav module that failed to load would leave the
+// phone navigation hidden with nothing able to open it.
+const navFlag = /<script>\s*document\.documentElement\.dataset\.navJs\s*=\s*'';\s*addEventListener\('load',[\s\S]*?data-nav-ready[\s\S]*?delete document\.documentElement\.dataset\.navJs[\s\S]*?<\/script>/;
 for (const [route, html] of pages) {
   if (!tags(html).some((t) => t.name === 'header' && (t.attrs.class ?? '').split(/\s+/).includes('chrome-header'))) problems.push(`${route}: shared header missing`);
   if (!tags(html).some((t) => t.name === 'footer' && (t.attrs.class ?? '').split(/\s+/).includes('chrome-footer'))) problems.push(`${route}: shared footer missing`);

--- a/website/scripts/check-features.mjs
+++ b/website/scripts/check-features.mjs
@@ -296,9 +296,26 @@ else {
   linksChecked += checkLinks('/', home, 'homepage');
 }
 
+// The header must be laid out collapsed from the FIRST frame: the inline
+// pre-paint flag (SiteHead.astro) has to precede the first stylesheet, and the
+// header stylesheet must key its enhanced layout on that flag, never on the
+// data-nav-ready the module stamps later. Either regression paints the open
+// link lists and then jumps the whole page when the module collapses them.
+const navFlag = /<script>document\.documentElement\.dataset\.navJs\s*=\s*''[;\s]*<\/script>/;
 for (const [route, html] of pages) {
   if (!tags(html).some((t) => t.name === 'header' && (t.attrs.class ?? '').split(/\s+/).includes('chrome-header'))) problems.push(`${route}: shared header missing`);
   if (!tags(html).some((t) => t.name === 'footer' && (t.attrs.class ?? '').split(/\s+/).includes('chrome-footer'))) problems.push(`${route}: shared footer missing`);
+  const flagAt = html.search(navFlag);
+  const firstStylesheet = html.search(/<link[^>]*rel=["']?stylesheet/i);
+  if (flagAt < 0) problems.push(`${route}: nav pre-paint flag script missing from <head>`);
+  else if (firstStylesheet >= 0 && firstStylesheet < flagAt) problems.push(`${route}: a stylesheet precedes the nav pre-paint flag`);
+}
+const headerSheets = fs.readdirSync(path.join(dist, '_astro')).filter((f) => f.endsWith('.css') && fs.readFileSync(path.join(dist, '_astro', f), 'utf8').includes('.chrome-header'));
+if (headerSheets.length === 0) problems.push('no built stylesheet styles .chrome-header');
+for (const f of headerSheets) {
+  const css = fs.readFileSync(path.join(dist, '_astro', f), 'utf8');
+  if (/\.chrome-header\[data-nav-ready\]/.test(css)) problems.push(`_astro/${f}: header layout keyed on data-nav-ready instead of html[data-nav-js]`);
+  if (!css.includes('html[data-nav-js] .chrome-header')) problems.push(`_astro/${f}: no html[data-nav-js] header layout rules`);
 }
 if (missing.length) problems.push(`launch routes missing from the build: ${missing.join(', ')}`);
 if (unexpected.length) problems.push(`launch routes built but not in the catalog: ${unexpected.join(', ')}`);

--- a/website/src/components/SiteHead.astro
+++ b/website/src/components/SiteHead.astro
@@ -24,6 +24,10 @@ const {
 // The inline script below runs before first paint and tells site-header.css
 // that site-nav.js will run, so the header is laid out collapsed from the
 // first frame instead of flashing its open link lists (see that stylesheet).
+// site-nav.js clears the flag itself when it cannot install; the load-event
+// fallback here covers the cases that module can never reach (it failed to
+// download, or failed to parse), so a header that is still not enhanced once
+// the page has loaded returns to its plain visible-lists layout.
 const siteUrl = 'https://enviouswispr.com';
 const canonical = canonicalPath ? `${siteUrl}${canonicalPath}` : Astro.url.href;
 const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`;
@@ -31,7 +35,12 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
 
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<script is:inline>document.documentElement.dataset.navJs = '';</script>
+<script is:inline>
+  document.documentElement.dataset.navJs = '';
+  addEventListener('load', function () {
+    if (!document.querySelector('.chrome-header[data-nav-ready]')) delete document.documentElement.dataset.navJs;
+  });
+</script>
 <title>{title}</title>
 <meta name="description" content={description} />
 <meta name="robots" content={noindex ? 'noindex, nofollow' : 'index, follow'} />

--- a/website/src/components/SiteHead.astro
+++ b/website/src/components/SiteHead.astro
@@ -21,6 +21,9 @@ const {
   noindex = false,
 } = Astro.props;
 
+// The inline script below runs before first paint and tells site-header.css
+// that site-nav.js will run, so the header is laid out collapsed from the
+// first frame instead of flashing its open link lists (see that stylesheet).
 const siteUrl = 'https://enviouswispr.com';
 const canonical = canonicalPath ? `${siteUrl}${canonicalPath}` : Astro.url.href;
 const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`;
@@ -28,6 +31,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`
 
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<script is:inline>document.documentElement.dataset.navJs = '';</script>
 <title>{title}</title>
 <meta name="description" content={description} />
 <meta name="robots" content={noindex ? 'noindex, nofollow' : 'index, follow'} />

--- a/website/src/components/SiteHeader.astro
+++ b/website/src/components/SiteHeader.astro
@@ -5,6 +5,8 @@
 // lists and the two triggers are ordinary links. site-nav.js upgrades the
 // triggers to buttons, collapses the panels, and only then stamps
 // data-nav-ready on the header. A failed script leaves working links.
+// SiteHead.astro stamps html[data-nav-js] before first paint so the visible
+// lists never flash on a browser that is about to collapse them.
 import Logo from './home/Logo.astro';
 import SiteIcon from './SiteIcon.astro';
 import { menuProducts, menuFoot, headerLinks, resources, downloadUrl } from '../data/site-navigation.js';

--- a/website/src/components/SiteServices.astro
+++ b/website/src/components/SiteServices.astro
@@ -1,4 +1,4 @@
-<!-- PostHog Analytics (deferred until after LCP to avoid contention) -->
+<!-- PostHog Analytics and Crisp chat (both deferred until after LCP to avoid contention) -->
 <script>
   let postHogLoaded = false;
   function loadPostHog() {
@@ -54,16 +54,35 @@
       autocapture: true,
     });
   }
+  // Crisp chat: its loader pulls ~400 KB of script and opens a socket, so it
+  // waits for the same trigger as PostHog instead of competing with the page's
+  // own stylesheet, fonts and hero image on a cold visit. The queue and site id
+  // are set up front so nothing that pushes to $crisp before load is lost.
+  window.$crisp = [];
+  window.CRISP_WEBSITE_ID = '6cfca684-ab92-4927-a1a3-6bf97eac13f9';
+  let crispLoaded = false;
+  function loadCrisp() {
+    if (crispLoaded) return;
+    crispLoaded = true;
+    const s = document.createElement('script');
+    s.src = 'https://client.crisp.chat/l.js';
+    s.async = true;
+    document.head.appendChild(s);
+  }
+  function loadServices() {
+    loadPostHog();
+    loadCrisp();
+  }
   // Wait for first user interaction OR a 5-second backstop, whichever comes first.
-  // This guarantees PostHog initialization happens AFTER LCP on cold visits while
-  // still firing reliably on visitors who never scroll or move (e.g. bounce).
+  // This guarantees third-party initialization happens AFTER LCP on cold visits
+  // while still firing reliably on visitors who never scroll or move (e.g. bounce).
   const events = ['pointermove', 'scroll', 'touchstart', 'keydown'];
   function trigger() {
     events.forEach((e) => window.removeEventListener(e, trigger));
-    loadPostHog();
+    loadServices();
   }
   events.forEach((e) => window.addEventListener(e, trigger, { once: true, passive: true }));
-  setTimeout(loadPostHog, 5000);
+  setTimeout(loadServices, 5000);
 </script>
 <!-- Download click tracking with source attribution -->
 <script>
@@ -83,16 +102,4 @@
       page: window.location.pathname,
     });
   });
-</script>
-<!-- Crisp Chat Widget -->
-<script>
-  window.$crisp = [];
-  window.CRISP_WEBSITE_ID = '6cfca684-ab92-4927-a1a3-6bf97eac13f9';
-  (function () {
-    var d = document,
-      s = d.createElement('script');
-    s.src = 'https://client.crisp.chat/l.js';
-    s.async = 1;
-    d.getElementsByTagName('head')[0].appendChild(s);
-  })();
 </script>

--- a/website/src/components/features/FileDemo.astro
+++ b/website/src/components/features/FileDemo.astro
@@ -20,7 +20,7 @@ const formats = ['MP3', 'M4A', 'WAV', 'AIFF', 'CAF', 'FLAC', 'MP4', 'MOV'];
   </div>
   <div class="fd-stage" aria-hidden="true">
     <section class="fd-scene fd-upload is-active">
-      <h3>Your recording.<br />Drop it right in.</h3>
+      <div class="scene-title">Your recording.<br />Drop it right in.</div>
       <div class="fd-drop">
         <span class="fd-drop-icon"><DemoIcon name="document" strokeWidth="1.6" /></span><strong>Audio or video</strong><span class="fd-drop-hint">Drag a recording here</span>
         <div class="fd-file">
@@ -30,7 +30,7 @@ const formats = ['MP3', 'M4A', 'WAV', 'AIFF', 'CAF', 'FLAC', 'MP4', 'MOV'];
       <div class="fd-formats">{formats.map((f) => <span>{f}</span>)}</div>
     </section>
     <section class="fd-scene fd-engines">
-      <h3>Your engines.<br />Your choice.</h3>
+      <div class="scene-title">Your engines.<br />Your choice.</div>
       <span class="fd-label">Transcription</span>
       <div class="fd-options fd-asr">
         <div class="fd-choice fd-parakeet"><span class="fd-engine-glyph">≋</span><span><b>Parakeet</b><small>Speech to text</small></span><i><DemoIcon name="check" strokeWidth="1.6" /></i></div>
@@ -44,7 +44,7 @@ const formats = ['MP3', 'M4A', 'WAV', 'AIFF', 'CAF', 'FLAC', 'MP4', 'MOV'];
       <div class="fd-ready"><DemoIcon name="lock" strokeWidth="1.6" /><span>Parakeet + EG-1. Entirely on your Mac.</span></div>
     </section>
     <section class="fd-scene fd-process">
-      <div class="fd-process-heading"><span class="fd-label">JRE #1470.m4a</span><h3 data-fd-process>Transcribing your recording.</h3></div>
+      <div class="fd-process-heading"><span class="fd-label">JRE #1470.m4a</span><div class="scene-title" data-fd-process>Transcribing your recording.</div></div>
       <div class="fd-workspace">
         <div class="fd-wave">{waveform.map((w) => <i style={`--bar:${w.bar}px;--delay:${w.delay}s`} />)}</div>
         <div class="fd-passage-grid">
@@ -70,7 +70,7 @@ const formats = ['MP3', 'M4A', 'WAV', 'AIFF', 'CAF', 'FLAC', 'MP4', 'MOV'];
     <section class="fd-scene fd-done">
       <div class="fd-check"><DemoIcon name="check" strokeWidth="1.6" /></div>
       <span class="fd-label">Your transcript is ready</span>
-      <h3>Hours of audio.<br />Polished in minutes.</h3>
+      <div class="scene-title">Hours of audio.<br />Polished in minutes.</div>
       <div class="fd-result-document"><span><DemoIcon name="document" strokeWidth="1.6" /><b>JRE #1470</b><small>Polished with EG-1</small></span><i></i><i></i><i></i></div>
       <div class="fd-stats">
         <div><strong>{words}</strong><small>Words transcribed</small></div>
@@ -82,7 +82,7 @@ const formats = ['MP3', 'M4A', 'WAV', 'AIFF', 'CAF', 'FLAC', 'MP4', 'MOV'];
     <section class="fd-scene fd-brand">
       <LoopLips glowId="file-lip-glow" />
       <span class="fd-label">Powered by</span>
-      <h3>EnviousWispr</h3>
+      <div class="scene-title">EnviousWispr</div>
       <p>Your voice.<br />A clearer read.</p>
     </section>
   </div>

--- a/website/src/components/features/HistoryFilm.astro
+++ b/website/src/components/features/HistoryFilm.astro
@@ -9,7 +9,7 @@ const bars = Array.from({ length: 23 }, (_, i) => ({ h: 15 + ((i * 13) % 36), d:
   <div class="history-film-stage" aria-hidden="true">
     <section class="hs hs-speaking active">
       <span class="history-kicker">You have the perfect wording.</span>
-      <h3>The thought is flowing.</h3>
+      <div class="scene-title">The thought is flowing.</div>
       <div class="history-voice">
         <div class="history-wave">{bars.map((b) => <i style={`--h:${b.h}px;--d:${b.d}s`} />)}</div>
         <p data-history-words>Let’s move the meeting to Friday.</p>
@@ -19,7 +19,7 @@ const bars = Array.from({ length: 23 }, (_, i) => ({ h: 15 + ((i * 13) % 36), d:
     <section class="hs hs-oops">
       <span class="history-kicker">Then, one wrong key.</span>
       <div class="history-key">esc</div>
-      <h3>Wait.<br />Did I just lose that?</h3>
+      <div class="scene-title">Wait.<br />Did I just lose that?</div>
       <span class="history-key-note">Recording cancelled with Escape</span>
     </section>
     <section class="hs hs-panic">
@@ -41,12 +41,12 @@ const bars = Array.from({ length: 23 }, (_, i) => ({ h: 15 + ((i * 13) % 36), d:
           stroke="#39303d"
           stroke-width="2"></ellipse></svg
       >
-      <h3>…</h3>
+      <div class="scene-title">…</div>
       <p>That split-second panic.</p>
     </section>
     <section class="hs hs-history">
       <span class="history-kicker">Open History.</span>
-      <h3>There are your words.</h3>
+      <div class="scene-title">There are your words.</div>
       <div class="history-rescued">
         <div><b>Just now</b><span>Kept</span></div>
         <p>Let’s move the meeting to Friday.</p>
@@ -56,7 +56,7 @@ const bars = Array.from({ length: 23 }, (_, i) => ({ h: 15 + ((i * 13) % 36), d:
     </section>
     <section class="hs hs-relief">
       <div class="relief-face">😮‍💨</div>
-      <h3>A breath of relief.</h3>
+      <div class="scene-title">A breath of relief.</div>
       <p>Your thought is saved.<br />Get back to what you were doing.</p>
       <span class="history-copy-result">✓ Text copied</span>
     </section>

--- a/website/src/components/features/PrivacyFilm.astro
+++ b/website/src/components/features/PrivacyFilm.astro
@@ -18,7 +18,7 @@ const art = `<svg class="privacy-scene-art" viewBox="0 0 360 340"><g class="priv
     <div class="privacy-cloud-story">
       <div class="privacy-local-mark"><LoopLips glowId="privacy-lip-glow" plain /></div>
       <Fragment set:html={art} />
-      <h3 data-privacy-story>Your words are<br /><span class="privacy-money">$$$</span> for corporations.</h3>
+      <div class="scene-title" data-privacy-story>Your words are<br /><span class="privacy-money">$$$</span> for corporations.</div>
     </div>
   </div>
   <div class="privacy-film-foot"><span data-privacy-caption>Your words are sent to a server.</span></div>

--- a/website/src/components/features/RecordingDeck.astro
+++ b/website/src/components/features/RecordingDeck.astro
@@ -43,7 +43,7 @@ const encoded = JSON.stringify(cases.map(({ name, title, duration, kind, video, 
       <div class="recording-body">
         <div>
           <div id="case-video" class="case-video">
-            <button type="button" class="case-load" data-load-video aria-label={`Play ${first.name} source video`} disabled data-enables>
+            <button type="button" class="case-load" data-load-video disabled data-enables>
               <img class="case-thumbnail" src={`https://i.ytimg.com/vi/${first.video}/hqdefault.jpg`} alt="" loading="lazy" width="480" height="360" />
               <span class="case-play">▶</span><strong>Watch and follow the transcript</strong><small>Click to load YouTube</small>
             </button>

--- a/website/src/components/home/Evidence.astro
+++ b/website/src/components/home/Evidence.astro
@@ -62,7 +62,6 @@ const evidence = [
           href={proof[0].url}
           target="_blank"
           rel="noopener"
-          aria-label="Watch Mostly Mac’s EnviousWispr review from 6 minutes 25 seconds"
           ><Image
             src={frame}
             alt="Frame from Mostly Mac demonstrating EnviousWispr"

--- a/website/src/components/home/Hero.astro
+++ b/website/src/components/home/Hero.astro
@@ -1,19 +1,10 @@
 ---
-import { getImage } from 'astro:assets';
-import light from '../../assets/home/hero-light.png';
-import dark from '../../assets/home/hero-dark.png';
 import examples from '../../data/home/hero.json';
 import { downloadUrl } from '../../data/home/site.js';
+import { heroArt } from '../../utils/home/hero-art.js';
 import AppDemo from './AppDemo.astro';
-const widths = [720, 1440, 2160];
-const sources = await Promise.all(
-  [light, dark].map((src) =>
-    Promise.all(widths.map((width) => getImage({ src, width, format: 'webp', quality: 85 }))),
-  ),
-);
-const sets = sources.map((group) =>
-  group.map((image, i) => image.src + ' ' + widths[i] + 'w').join(', '),
-);
+const art = await heroArt();
+const sources = [art.light, art.dark];
 ---
 
 <section class="screen-hero" id="opening" data-phase="finished" aria-labelledby="hero-title">

--- a/website/src/components/home/HeroArtPreload.astro
+++ b/website/src/components/home/HeroArtPreload.astro
@@ -1,0 +1,19 @@
+---
+// Preload the hero background (#2816 follow-up): it is the homepage's largest
+// paint, but as a CSS background the browser cannot request it until the
+// stylesheet has been fetched and parsed. These links let it start with the
+// HTML. The media attributes mirror hero.css so only one file is fetched;
+// a stored theme override (rare) preloads the system-theme variant instead.
+import { heroArt, variantMedia } from '../../utils/home/hero-art.js';
+const art = await heroArt();
+const links = [];
+for (const [theme, set] of Object.entries(art)) {
+  set.forEach((image, index) => {
+    for (const media of variantMedia[index]) {
+      links.push({ href: image.src, media: `${media} and (prefers-color-scheme: ${theme})` });
+    }
+  });
+}
+---
+
+{links.map((link) => <link rel="preload" as="image" href={link.href} media={link.media} fetchpriority="high" />)}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -13,6 +13,7 @@ import Comparisons from '../components/home/Comparisons.astro';
 import Founder from '../components/home/Founder.astro';
 import Download from '../components/home/Download.astro';
 import StructuredData from '../components/home/StructuredData.astro';
+import HeroArtPreload from '../components/home/HeroArtPreload.astro';
 ---
 
 <ThemedLayout
@@ -22,6 +23,7 @@ import StructuredData from '../components/home/StructuredData.astro';
   canonicalPath="/"
 >
   <StructuredData slot="head" />
+  <HeroArtPreload slot="head" />
   <Hero />
   <CompatibleApps />
   <Workflow />

--- a/website/src/scripts/features/transcript-player.js
+++ b/website/src/scripts/features/transcript-player.js
@@ -227,7 +227,6 @@ export function init(host, motion, scope) {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'case-load';
-    button.setAttribute('aria-label', 'Play ' + item.name + ' source video');
     button.innerHTML = '<span class="case-play">▶</span><strong>Watch and follow the transcript</strong><small>Click to load YouTube</small>';
     const img = document.createElement('img');
     img.className = 'case-thumbnail';

--- a/website/src/scripts/home/motion.js
+++ b/website/src/scripts/home/motion.js
@@ -66,14 +66,18 @@ export function createMotionController(env = globalThis) {
           ? 'Play motion'
           : 'Pause motion';
       button.setAttribute('aria-pressed', String(paused || reduced.matches));
-      button.setAttribute(
-        'aria-label',
-        reduced.matches
-          ? 'Reduced motion enabled'
-          : paused
-            ? 'Play page animations'
-            : 'Pause page animations',
-      );
+      // Only the icon buttons need a spoken name; a text button's own label is
+      // its name, and a differing aria-label would hide that text from speech users.
+      if (button.classList.contains('icon-button'))
+        button.setAttribute(
+          'aria-label',
+          reduced.matches
+            ? 'Reduced motion enabled'
+            : paused
+              ? 'Play page animations'
+              : 'Pause page animations',
+        );
+      else button.removeAttribute('aria-label');
     }
     for (const task of tasks) {
       if (task.failed) continue;

--- a/website/src/scripts/site-nav.js
+++ b/website/src/scripts/site-nav.js
@@ -8,15 +8,20 @@
 // data-nav-ready only after every binding succeeded. If anything throws the
 // mutations are rolled back, so a failure leaves the no-script header exactly
 // as it was delivered.
+//
+// An inline script in SiteHead.astro stamps html[data-nav-js] before first
+// paint so the stylesheet draws the collapsed header from the first frame.
+// Every path that does not end in data-nav-ready removes that flag, which
+// returns the header to its visible-lists layout.
 function install() {
   const header = document.querySelector('.chrome-header');
-  if (!header || header.dataset.navReady) return;
+  if (!header || header.dataset.navReady) return Boolean(header);
 
   // 1. Query and validate. Nothing is mutated in this phase.
   const nav = header.querySelector('.main-nav');
   const mobileLink = header.querySelector('[data-nav-mobile-trigger]');
   const parents = [...header.querySelectorAll('[data-nav-parent]')];
-  if (!nav || !nav.id || !mobileLink || parents.length !== 2) return;
+  if (!nav || !nav.id || !mobileLink || parents.length !== 2) return false;
   const groups = parents.map((parent) => {
     const link = parent.querySelector('[data-nav-trigger]');
     const panel = parent.querySelector('[data-nav-panel]');
@@ -133,6 +138,7 @@ function install() {
       { signal },
     );
     header.dataset.navReady = 'true';
+    return true;
   } catch (error) {
     controller.abort();
     for (const undo of applied.reverse()) undo();
@@ -142,8 +148,10 @@ function install() {
   }
 }
 
+let installed = false;
 try {
-  install();
+  installed = install();
 } catch (error) {
   console.error('Site navigation enhancement unavailable; plain links remain.', error);
 }
+if (!installed) delete document.documentElement.dataset.navJs;

--- a/website/src/styles/features/file-demo.css
+++ b/website/src/styles/features/file-demo.css
@@ -11,7 +11,7 @@
 .fd-stage{position:relative;height:477px;overflow:hidden;background:radial-gradient(ellipse at 50% 25%,var(--soft),transparent 75%)}
 .fd-scene{position:absolute;inset:0;padding:30px 28px;opacity:0;transform:translateY(15px) scale(.985);transition:opacity .55s ease,transform .65s cubic-bezier(.2,.65,.2,1);visibility:hidden;pointer-events:none;display:flex;flex-direction:column}
 .fd-scene.is-active{opacity:1;transform:none;visibility:visible}
-.fd-scene h3{font-size:31px;line-height:1.18;letter-spacing:-1px;font-weight:650;margin:0 0 24px;color:var(--ink)}
+.fd-scene .scene-title{font-size:31px;line-height:1.18;letter-spacing:-1px;font-weight:650;margin:0 0 24px;color:var(--ink)}
 .fd-scene p{font-size:16px;line-height:1.6;color:var(--body);margin:0}
 .fd-scene svg{width:24px;height:24px}
 .fd-label{font-size:12px;letter-spacing:.02em;color:var(--muted);display:block;margin-bottom:10px}
@@ -33,7 +33,7 @@
 .file-demo[data-dropped=true] .fd-drop{border-color:var(--accent);background:var(--soft)}
 .fd-formats{display:flex;gap:6px;flex-wrap:wrap;margin:23px 0 0;justify-content:center}
 .fd-formats>span{font-size:10px;color:var(--muted);padding:5px 7px;border-radius:5px;background:var(--card);border:1px solid var(--line)}
-.fd-engines h3{margin-bottom:25px}
+.fd-engines .scene-title{margin-bottom:25px}
 .fd-options{display:flex;gap:10px;margin-bottom:21px}
 .fd-asr>.fd-choice{flex:1;min-width:0}
 .fd-choice{display:flex;gap:9px;align-items:center;padding:16px 12px;border:1px solid var(--line);background:var(--card);border-radius:13px;transition:background .35s,border-color .35s,box-shadow .35s}
@@ -53,7 +53,7 @@
 .fd-ready{display:flex;gap:8px;color:var(--muted);font-size:11px;align-items:center;opacity:0;transition:opacity .4s}
 .fd-ready svg{width:14px;height:14px}
 .file-demo[data-selected=both] .fd-ready{opacity:1}
-.fd-process-heading h3{min-height:75px;margin-bottom:15px}
+.fd-process-heading .scene-title{min-height:75px;margin-bottom:15px}
 .fd-workspace{position:relative;height:203px;border:1px solid var(--line);border-radius:15px;background:var(--card);overflow:hidden}
 .fd-wave{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:5px;transition:opacity .45s,transform .6s}
 .fd-wave i{height:var(--bar);width:4px;border-radius:6px;background:var(--accent);animation:fd-wave 1s ease-in-out var(--delay) infinite}
@@ -77,7 +77,7 @@
 .fd-check{display:grid;place-items:center;width:57px;height:57px;background:var(--demo-green-soft);color:var(--demo-green);border:1px solid var(--demo-green);border-radius:50%;margin:0 0 18px}
 .fd-check svg{width:29px;height:29px}
 .fd-done .fd-label{font-size:11px}
-.fd-done h3{font-size:29px;margin:7px 0 22px}
+.fd-done .scene-title{font-size:29px;margin:7px 0 22px}
 .fd-result-document{width:100%;border:1px solid var(--line);background:var(--card);padding:16px 19px;border-radius:12px;text-align:left}
 .fd-result-document>span{display:flex;gap:7px;align-items:center;margin-bottom:18px}
 .fd-result-document svg{width:17px;height:17px;color:var(--accent)}
@@ -92,7 +92,7 @@
 .fd-pending{font-size:10px;color:var(--muted)}
 .fd-brand{justify-content:center}
 .fd-brand .loop-lips{width:235px;height:235px;margin:-25px 0 5px}
-.fd-brand h3{font-size:37px;margin:6px 0 14px}
+.fd-brand .scene-title{font-size:37px;margin:6px 0 14px}
 .fd-brand .fd-label{font-size:12px}
 .fd-bottom{padding:14px 22px 12px;font-size:11px;color:var(--muted);border-top:1px solid var(--line)}
 .fd-bottom button{display:grid;place-items:center;width:33px;height:33px;flex:none;background:var(--card);border:1px solid var(--line);border-radius:50%;color:var(--accent);cursor:pointer;font-size:15px}
@@ -102,5 +102,5 @@
 .fd-accessible{position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%)}
 .file-demo[data-animate=paused] *,.file-demo[data-playing=false] *{animation-play-state:paused!important}
 @keyframes fd-wave{50%{transform:scaleY(.55)}}
-@media(max-width:650px){.fd-top{padding:15px 18px}.fd-stage{height:478px}.fd-scene{padding:26px 20px}.fd-scene h3{font-size:28px}.fd-asr{gap:8px}.fd-choice{padding:14px 9px;gap:6px}.fd-engine-glyph{display:none}.fd-choice b{font-size:13px}.fd-choice small{font-size:9px}.fd-done h3{font-size:27px}.fd-done .fd-pending{font-size:9px}.fd-wave{gap:4px}.fd-wave i{width:3px}}
+@media(max-width:650px){.fd-top{padding:15px 18px}.fd-stage{height:478px}.fd-scene{padding:26px 20px}.fd-scene .scene-title{font-size:28px}.fd-asr{gap:8px}.fd-choice{padding:14px 9px;gap:6px}.fd-engine-glyph{display:none}.fd-choice b{font-size:13px}.fd-choice small{font-size:9px}.fd-done .scene-title{font-size:27px}.fd-done .fd-pending{font-size:9px}.fd-wave{gap:4px}.fd-wave i{width:3px}}
 @media(prefers-reduced-motion:reduce){.file-demo *{animation:none!important;transition:none!important}}

--- a/website/src/styles/features/history-demo.css
+++ b/website/src/styles/features/history-demo.css
@@ -7,7 +7,7 @@
 .history-film-stage{height:420px;position:relative;background:radial-gradient(ellipse at 50% 20%,var(--soft),transparent 80%)}
 .hs{position:absolute;inset:0;padding:32px 26px;opacity:0;visibility:hidden;transform:translateY(12px);transition:opacity .4s,transform .5s;display:flex;flex-direction:column;justify-content:center}
 .hs.active{opacity:1;visibility:visible;transform:none}
-.hs h3{font-size:32px;line-height:1.2;letter-spacing:-1px;margin:14px 0 25px;color:var(--ink)}
+.hs .scene-title{font-size:32px;font-weight:500;line-height:1.2;letter-spacing:-1px;margin:14px 0 25px;color:var(--ink)}
 .history-kicker{font-size:12px;color:var(--muted)}
 .history-voice{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:23px;margin-top:10px}
 .history-wave{display:flex;align-items:center;justify-content:center;gap:5px;height:45px;color:var(--accent)}
@@ -18,7 +18,7 @@
 .history-key{width:87px;height:78px;display:grid;place-items:center;background:var(--card);border:1px solid var(--line);border-bottom:5px solid var(--line);border-radius:15px;font-size:27px;color:var(--accent);margin:24px 0 8px}
 .history-key-note{font-size:12px;color:var(--muted)}
 .surprise-face{width:225px;height:220px;filter:drop-shadow(0 12px 22px #0002)}
-.hs-panic h3{margin:8px 0;font-size:37px}
+.hs-panic .scene-title{margin:8px 0;font-size:37px}
 .hs-panic p,.hs-relief p{font-size:17px;line-height:1.7;color:var(--body)}
 .history-rescued{padding:24px;background:var(--card);border:1px solid var(--line);border-radius:16px}
 .history-rescued>div:first-child{display:flex;justify-content:space-between;align-items:center;gap:15px;font-size:12px}
@@ -52,6 +52,6 @@
 .recovery-example{background:var(--surface);padding:35px}
 .history-film[data-playing=false] *,.history-film[data-animate=paused] *{animation-play-state:paused!important}
 @keyframes history-wave{50%{transform:scaleY(.5)}}
-@media(max-width:750px){.history-safety{grid-template-columns:1fr;gap:30px;padding-top:45px;padding-bottom:45px}.history-benefits{grid-template-columns:1fr;gap:30px}.history-film-stage{height:410px}.hs{padding:25px 20px}.hs h3{font-size:28px}.history-voice p{font-size:22px}.history-rescued{padding:20px}.history-rescued>p{font-size:23px}.history-clock-card{padding:28px}.history-clock-card>strong{font-size:86px}.history-safety>div>p,.history-library .history-benefits p{font-size:16px}.history-library{padding-top:30px;padding-bottom:40px}}
+@media(max-width:750px){.history-safety{grid-template-columns:1fr;gap:30px;padding-top:45px;padding-bottom:45px}.history-benefits{grid-template-columns:1fr;gap:30px}.history-film-stage{height:410px}.hs{padding:25px 20px}.hs .scene-title{font-size:28px}.history-voice p{font-size:22px}.history-rescued{padding:20px}.history-rescued>p{font-size:23px}.history-clock-card{padding:28px}.history-clock-card>strong{font-size:86px}.history-safety>div>p,.history-library .history-benefits p{font-size:16px}.history-library{padding-top:30px;padding-bottom:40px}}
 @media(prefers-reduced-motion:reduce){.history-film *{animation:none!important;transition:none!important}}
 .history-a11y{position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%);white-space:nowrap}

--- a/website/src/styles/features/privacy-demo.css
+++ b/website/src/styles/features/privacy-demo.css
@@ -7,7 +7,7 @@
 .privacy-cloud-story{position:absolute;inset:0;padding:20px 25px;display:flex;align-items:center;justify-content:center;flex-direction:column;opacity:0;visibility:hidden;transition:opacity .5s,transform .5s;transform:translateY(10px);text-align:center}
 .privacy-film[data-scene="0"] .privacy-cloud-story,.privacy-film[data-scene="1"] .privacy-cloud-story,.privacy-film[data-scene="2"] .privacy-introduce{opacity:1;visibility:visible;transform:none}
 .privacy-scene-art{width:100%;max-width:330px;height:310px;overflow:visible}
-.privacy-cloud-story h3{font-size:27px;letter-spacing:-.8px;line-height:1.2;margin:10px 0;color:var(--ink)}
+.privacy-cloud-story .scene-title{font-size:27px;font-weight:500;letter-spacing:-.8px;line-height:1.2;margin:10px 0;color:var(--ink)}
 .cloud-exec{animation:privacy-laugh .65s var(--delay) ease-in-out infinite;transform-box:fill-box;transform-origin:center}
 .privacy-cloud{transition:opacity .5s,transform .7s}
 .privacy-introduce .loop-lips{width:210px;height:210px;margin-bottom:6px}
@@ -26,7 +26,7 @@
 .offline-choice small{display:block;color:var(--muted);font-size:12px;line-height:1.7;margin-top:20px}
 @keyframes privacy-words{0%{opacity:0;transform:translateY(35px)}20%,70%{opacity:1}100%{opacity:0;transform:translateY(-30px)}}
 @keyframes privacy-laugh{50%{translate:0 -3px}}
-@media(max-width:750px){.offline-simple{grid-template-columns:1fr;gap:35px;padding-top:45px;padding-bottom:45px}.offline-simple>div{border-top:1px solid var(--line);padding-top:25px}.offline-simple h2{font-size:27px}.offline-simple p,.offline-choice>p{font-size:16px}.privacy-stage{height:455px}.privacy-cloud-story{padding:20px}.privacy-scene-art{height:285px}.privacy-cloud-story h3{font-size:25px}.offline-choice{padding-top:40px;padding-bottom:40px}}
+@media(max-width:750px){.offline-simple{grid-template-columns:1fr;gap:35px;padding-top:45px;padding-bottom:45px}.offline-simple>div{border-top:1px solid var(--line);padding-top:25px}.offline-simple h2{font-size:27px}.offline-simple p,.offline-choice>p{font-size:16px}.privacy-stage{height:455px}.privacy-cloud-story{padding:20px}.privacy-scene-art{height:285px}.privacy-cloud-story .scene-title{font-size:25px}.offline-choice{padding-top:40px;padding-bottom:40px}}
 @media(prefers-reduced-motion:reduce){.privacy-film *{animation:none!important;transition:none!important}}
 .word-packet{opacity:0;will-change:transform,opacity}
 .word-packet rect{fill:var(--surface);stroke:var(--line)}
@@ -74,4 +74,4 @@
 .privacy-final-name{color:var(--ink);font-size:clamp(29px,7cqw,37px);letter-spacing:-1.3px;line-height:1.2}
 .privacy-final-promise{display:inline-block;color:var(--accent);font-size:26px;margin-top:8px;letter-spacing:-.7px}
 @media(max-width:750px){.privacy-local-mark{top:32px;width:150px;height:150px}.privacy-final-name{font-size:30px}.privacy-final-promise{font-size:24px}}
-.privacy-cloud-story h3{height:84px;min-height:84px;width:100%}
+.privacy-cloud-story .scene-title{height:84px;min-height:84px;width:100%}

--- a/website/src/styles/site-header.css
+++ b/website/src/styles/site-header.css
@@ -323,9 +323,16 @@ html[data-theme='dark'] .site-chrome {
   height: 20px;
 }
 
-/* No script yet (or none at all): the panels are plain visible lists and the
- * triggers are links. Nothing here floats. */
-.chrome-header:not([data-nav-ready]) .main-nav {
+/* Scripts off (or the nav module failed): the panels are plain visible lists
+ * and the triggers are links. Nothing here floats.
+ *
+ * `html[data-nav-js]` is stamped by an inline script in the document head
+ * BEFORE first paint (SiteHead.astro), so a browser that will run site-nav.js
+ * lays the header out in its collapsed shape from the first frame instead of
+ * painting the open lists and jumping ~1000px when the module collapses them.
+ * site-nav.js removes the flag if it cannot install, which restores this
+ * layout. */
+html:not([data-nav-js]) .chrome-header .main-nav {
   display: flex;
   flex-direction: column;
   flex-basis: 100%;
@@ -335,25 +342,28 @@ html[data-theme='dark'] .site-chrome {
   margin-left: 0;
   padding-bottom: 8px;
 }
-.chrome-header:not([data-nav-ready]) .mega-menu,
-.chrome-header:not([data-nav-ready]) .resources-menu {
+html:not([data-nav-js]) .chrome-header .mega-menu,
+html:not([data-nav-js]) .chrome-header .resources-menu {
   position: static;
   width: 100%;
   margin: 4px 0 10px;
   box-shadow: none;
 }
-.chrome-header:not([data-nav-ready]) .nav-trigger,
-.chrome-header:not([data-nav-ready]) .nav-link {
+html:not([data-nav-js]) .chrome-header .nav-trigger,
+html:not([data-nav-js]) .chrome-header .nav-link {
   font-size: 16px;
   padding: 10px 5px;
 }
-.chrome-header:not([data-nav-ready]) .chrome-inner {
+html:not([data-nav-js]) .chrome-header .chrome-inner {
   height: auto;
   min-height: 80px;
   flex-wrap: wrap;
   padding-block: 14px;
 }
-.chrome-header:not([data-nav-ready]) .chrome-mobile-trigger {
+html:not([data-nav-js]) .chrome-header .chrome-mobile-trigger {
+  display: none;
+}
+html[data-nav-js] .chrome-header:not([data-nav-ready]) [data-nav-panel] {
   display: none;
 }
 
@@ -418,30 +428,30 @@ html[data-theme='dark'] .site-chrome {
     background: var(--nav-card);
     box-shadow: 0 8px 28px #2714380a;
   }
-  .chrome-header[data-nav-ready] .main-nav {
+  html[data-nav-js] .chrome-header .main-nav {
     flex: 1;
     justify-content: center;
     gap: 36px;
     margin-left: 0;
     font-size: 16px;
   }
-  .chrome-header[data-nav-ready] .nav-trigger,
-  .chrome-header[data-nav-ready] .nav-link {
+  html[data-nav-js] .chrome-header .nav-trigger,
+  html[data-nav-js] .chrome-header .nav-link {
     font-size: 18px;
     font-weight: 600;
     color: var(--nav-ink);
     white-space: nowrap;
     position: relative;
   }
-  .chrome-header[data-nav-ready] .nav-link.active,
-  .chrome-header[data-nav-ready] .nav-link:hover,
-  .chrome-header[data-nav-ready] .nav-trigger.active,
-  .chrome-header[data-nav-ready] .nav-trigger:hover,
-  .chrome-header[data-nav-ready] .nav-trigger[aria-expanded='true'] {
+  html[data-nav-js] .chrome-header .nav-link.active,
+  html[data-nav-js] .chrome-header .nav-link:hover,
+  html[data-nav-js] .chrome-header .nav-trigger.active,
+  html[data-nav-js] .chrome-header .nav-trigger:hover,
+  html[data-nav-js] .chrome-header .nav-trigger[aria-expanded='true'] {
     color: var(--nav-accent);
   }
-  .chrome-header[data-nav-ready] .nav-link.active::after,
-  .chrome-header[data-nav-ready] .nav-trigger.active::after {
+  html[data-nav-js] .chrome-header .nav-link.active::after,
+  html[data-nav-js] .chrome-header .nav-trigger.active::after {
     content: '';
     position: absolute;
     left: 0;
@@ -460,11 +470,11 @@ html[data-theme='dark'] .site-chrome {
   }
 }
 @media (min-width: 1000px) and (max-width: 1190px) {
-  .chrome-header[data-nav-ready] .main-nav {
+  html[data-nav-js] .chrome-header .main-nav {
     gap: 22px;
   }
-  .chrome-header[data-nav-ready] .nav-trigger,
-  .chrome-header[data-nav-ready] .nav-link {
+  html[data-nav-js] .chrome-header .nav-trigger,
+  html[data-nav-js] .chrome-header .nav-link {
     font-size: 16px;
   }
 }
@@ -499,7 +509,7 @@ html[data-theme='dark'] .site-chrome {
   .chrome-header .chrome-inner {
     position: relative;
   }
-  .chrome-header[data-nav-ready] .main-nav {
+  html[data-nav-js] .chrome-header .main-nav {
     display: none;
     position: absolute;
     top: 88px;
@@ -518,7 +528,7 @@ html[data-theme='dark'] .site-chrome {
     background: var(--nav-card);
     box-shadow: var(--nav-shadow);
   }
-  .chrome-header[data-nav-ready] .main-nav.open {
+  html[data-nav-js] .chrome-header .main-nav.open {
     display: flex;
   }
   .chrome-header .menu-parent,
@@ -550,14 +560,14 @@ html[data-theme='dark'] .site-chrome {
     width: 100%;
     box-shadow: none;
   }
-  .chrome-header[data-nav-ready] .chrome-actions .chrome-button {
+  html[data-nav-js] .chrome-header .chrome-actions .chrome-button {
     display: none;
   }
   .chrome-header .chrome-actions {
     order: 2;
     margin-left: auto;
   }
-  .chrome-header[data-nav-ready] .chrome-mobile-trigger {
+  html[data-nav-js] .chrome-header .chrome-mobile-trigger {
     display: grid;
     order: 3;
     margin: 0;
@@ -607,7 +617,7 @@ html[data-theme='dark'] .site-chrome {
     width: 18px;
     height: 18px;
   }
-  .chrome-header[data-nav-ready] .main-nav {
+  html[data-nav-js] .chrome-header .main-nav {
     top: 78px;
     gap: 3px;
     max-height: calc(100dvh - 105px);

--- a/website/src/utils/home/hero-art.js
+++ b/website/src/utils/home/hero-art.js
@@ -1,0 +1,28 @@
+// The homepage hero background, shared by Hero.astro (which paints it through
+// CSS custom properties) and HeroArtPreload.astro (which preloads it from the
+// document head). One source of truth for the variants, so the preloaded file
+// is byte-for-byte the one hero.css selects.
+import { getImage } from 'astro:assets';
+import light from '../../assets/home/hero-light.png';
+import dark from '../../assets/home/hero-dark.png';
+
+export const widths = [720, 1440, 2160];
+
+// Mirrors the selection in hero.css: index 0 under 600px wide, index 2 on a
+// hi-dpi or ≥1600px viewport, index 1 otherwise. The `or` between the two
+// index-2 conditions is expressed as two preload links because Safari 17
+// (macOS 14, the oldest supported Mac) does not parse `or` inside a media query.
+export const variantMedia = [
+  ['(max-width: 600px)'],
+  ['(min-width: 601px) and (max-width: 1599px) and (max-resolution: 1.49dppx)'],
+  ['(min-width: 601px) and (min-resolution: 1.5dppx)', '(min-width: 1600px)'],
+];
+
+export async function heroArt() {
+  const [lightSet, darkSet] = await Promise.all(
+    [light, dark].map((src) =>
+      Promise.all(widths.map((width) => getImage({ src, width, format: 'webp', quality: 85 }))),
+    ),
+  );
+  return { light: lightSet, dark: darkSet };
+}


### PR DESCRIPTION
## Summary

Performance and SEO hygiene pass over the home page, the features pages and `/why-offline/`, measured against the built output (Lighthouse mobile preset on a local preview, plus headless Chrome probes). Lane: Content (`website/**`), plus the `check-features.mjs` build check.

### Header: laid out collapsed on the first frame (every page)

The shared header ships as visible link lists that `site-nav.js` collapses after parsing. In the window between first paint and that module the header is 1075px tall on a phone and 890px on desktop, and the whole page jumps up by that much when the module runs. Lighthouse recorded a 0.92 layout shift on `/features/dictation/` in one of four runs.

An inline script in `<head>` now stamps `html[data-nav-js]` before first paint and `site-header.css` keys the collapsed layout on that flag. Pre-script header height is now 70px/82px, identical to the ready state. The flag is removed by `site-nav.js` on any path that does not reach `data-nav-ready`, and by a `load` listener in the same inline script when the module never ran (failed download or parse), so the no-script and script-failed layouts are unchanged: probed with the nav module stripped from the served page, the header returns to its visible-lists layout with 11 panel links tappable.

`check-features.mjs` fails if the flag script is missing or follows a stylesheet on any page, lacks the load fallback, or if a built header stylesheet is keyed on `data-nav-ready` again. Two-way control: it fails on the previous build and passes on this one.

### Home hero image: discoverable from the HTML

The largest paint is a CSS background, so its request could not start until the stylesheet had loaded and parsed (1350ms resource load delay on the mobile run). Eight `<link rel="preload" as="image">` tags with media attributes mirroring `hero.css` (light/dark x three widths) let it start with the document. Probed across 8 scheme/width/DPR combinations: exactly one hero file is fetched and it is the one the stylesheet selects; no unused-preload warnings.

Mobile: LCP 2.7s to 2.0s, performance 93 to 99. Desktop was 100 and stays 100. The variant list moved to `src/utils/home/hero-art.js` so `Hero.astro` and the preload share one source; an unused `sets` array in `Hero.astro` is gone.

### Crisp chat deferred

The chat loader was injected at page load on every page and pulls 412KB of script plus a socket before the visitor does anything (measured on production). It now waits for the same first-interaction-or-5s trigger PostHog uses. `$crisp` and `CRISP_WEBSITE_ID` are still set at load; nothing else on the site references `$crisp`.

### Accessible names

axe `label-content-name-mismatch` on `/` and `/features/file-transcription/`: the review link and the video-load button drop `aria-label`s that hid their visible text; the footer motion toggle keeps its `aria-label` only on the icon variant.

### Heading outline

The history, privacy and file-transcription demo films used `<h3>` for scene captions ("Wait.", "…", "A breath of relief."), so those pages went h1 to h3 before the first h2 and crawlers saw captions as sections. They are `<div class="scene-title">` now with the same computed styles. Page screenshots on both builds are byte-identical at desktop and phone widths for `/`, `/why-offline/`, `/features/`, `/features/dictation/`, `/blog/`, `/help/`.

## Validation

- `npm run build`, `npm run check:help` (routes 71/71, search 47/47, features 9/9, 329 links, 143 pages), `npm run test:home` (13/13).
- Lighthouse after: home mobile 99/100/100/100, `/features/file-transcription/` 100/100/100/100.
- Local Codex `review --base origin/main`: round 1 found the script-failed fallback gap (fixed, reproduced by stripping the module); round 2 clean.
- The new check in `check-features.mjs` is a build-output guard, not a Swift test, so no mutation recipe applies; its two-way control is recorded above.

## Not changed, for the record

- PostHog loads `surveys.js` (34KB) and `dead-clicks-autocapture.js` (9KB) after the trigger. Turning those features off in the init config would drop ~43KB per visit; left alone because both are analytics product choices.
- The on-page SEO ceiling was measured on 2026-08-23 (`seo-work-tracker.md` FACT: seo-strategic-verdict) at ~5 clicks per 28 days; this PR is speed and code quality, not a traffic lever.
