### PR TITLE
feat(appkit): shared turn document view and speaker labels go live (#2811)

### DIFF
--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -706,9 +706,13 @@ final class FileImportCoordinator {
     // Same rule as `startOver`: a different file is a different row (#2772).
     originalHistoryRow = nil
     documentView = .cleaned
+    timesOn = true
     markedUpCache = nil
     markedUpWorker?.task.cancel()
     markedUpWorker = nil
+    turnDiffCache = nil
+    turnDiffWorker?.task.cancel()
+    turnDiffWorker = nil
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []
@@ -850,6 +854,12 @@ final class FileImportCoordinator {
   /// way to check it is a promise the product does not keep. Found by Codex.
   var documentView: DocumentView = .cleaned
 
+  /// Times on/off for turn-labeled rendering and export (#2811, phase 4 of #2807). A
+  /// per-view-session UI toggle, never a persisted preference (plan §2.2 non-goal) —
+  /// defaults ON and resets at the same points `documentView` itself resets, matching that
+  /// property's own "screen-local, not carried across documents" contract.
+  var timesOn = true
+
   /// Which words the Done screen shows (#2773). Copy, Save and Share follow Cleaned and
   /// Original; the marked-up view has no plain-text form, so it exports the CLEANED text.
   enum DocumentView: Equatable, Sendable {
@@ -972,10 +982,32 @@ final class FileImportCoordinator {
   var screenShowsRawWords: Bool { documentView == .original || parts.isEmpty }
 
   /// What Copy and Save hand over, which is always what the screen is showing.
+  ///
+  /// Turn-labeled documents route through the presenter FIRST (#2811, phase 4 of #2807) —
+  /// its own `exportText` returns `nil` for `turns == nil`/empty, which is exactly when this
+  /// falls through to the EXISTING selection below, unchanged (plan §9: "each screen keeps
+  /// calling its OWN existing fallback UNCHANGED"). Never both: the presenter's fallback for
+  /// `.markedUp` is the CLEANED text, not `markedUpKeptText`, since a turn's own
+  /// `processedText` is what cleanup actually produced for that turn.
   var exportText: String {
+    if let turns,
+      let result = TranscriptDocumentPresenter.exportText(
+        turns: turns, rawText: rawTranscript, speakerNames: speakerNames, timesOn: timesOn,
+        mode: documentView)
+    {
+      return result.text
+    }
     if screenShowsRawWords { return rawTranscript }
     if documentView == .markedUp { return markedUpKeptText }
     return documentText
+  }
+
+  /// Copy/Save/Share titles. The founder's export rule (plan §2.1) is general, not scoped to
+  /// turn-labeled documents: `exportText` above already substitutes the CLEANED text for
+  /// `.markedUp` on every document, turn-labeled or not, so the label disclosure applies
+  /// uniformly too — never gated on `turns != nil`.
+  var exportButtonLabels: (copy: String, save: String, share: String) {
+    TranscriptDocumentPresenter.exportButtonLabels(mode: documentView)
   }
 
   /// What the marked-up view presents as KEPT: the cleaned passages, then every passage the
@@ -1109,9 +1141,13 @@ final class FileImportCoordinator {
     // same property that makes the raw-then-polished pair an update rather than a duplicate.
     originalHistoryRow = nil
     documentView = .cleaned
+    timesOn = true
     markedUpCache = nil
     markedUpWorker?.task.cancel()
     markedUpWorker = nil
+    turnDiffCache = nil
+    turnDiffWorker?.task.cancel()
+    turnDiffWorker = nil
     savedHistoryRow = nil
     historySaveFailure = nil
     pendingPieces = []
@@ -1180,6 +1216,85 @@ final class FileImportCoordinator {
     _ = speakerFieldsRevision
     guard let historyID else { return [:] }
     return currentHistoryRow(historyID)?.speakerNames ?? [:]
+  }
+
+  /// One turn's original/cleaned pair, computed once per `turnDiffInput` build. Wrapped in a
+  /// struct rather than a tuple because a tuple array is neither `Equatable` nor usable as an
+  /// `Equatable` cache key.
+  struct TurnDiffPair: Equatable, Sendable {
+    let id: String
+    let original: String
+    let cleaned: String
+  }
+
+  struct TurnDiffInput: Equatable, Sendable {
+    let pairs: [TurnDiffPair]
+    let language: String?
+  }
+
+  /// The current turns' own original/cleaned pairs, mirroring `markedUpInput`'s role but for
+  /// per-turn Marked-up rendering (#2811, phase 4 of #2807) — the presenter's `render` never
+  /// computes `WordDiff` itself (chunk-1 review), so this is the CALLER-side preparation it
+  /// consumes via `diffLookup`.
+  var turnDiffInput: TurnDiffInput {
+    guard let turns else { return TurnDiffInput(pairs: [], language: engineReportedLanguage) }
+    let text = rawTranscript
+    let pairs = turns.map { turn -> TurnDiffPair in
+      let original = Self.slice(text, turn.originalTextRange)
+      return TurnDiffPair(id: turn.id, original: original, cleaned: turn.processedText ?? original)
+    }
+    return TurnDiffInput(pairs: pairs, language: engineReportedLanguage)
+  }
+
+  private var turnDiffCache: (input: TurnDiffInput, results: [String: WordDiff.Result])?
+
+  /// `nil` while `prepareTurnDiffs` is still running or the input has moved — same OBSERVED
+  /// contract as `markedUp`.
+  var turnDiffs: [String: WordDiff.Result]? {
+    guard let cached = turnDiffCache, cached.input == turnDiffInput else { return nil }
+    return cached.results
+  }
+
+  /// Computes every current turn's diff OFF the main actor in ONE batched pass, exactly
+  /// mirroring `prepareMarkedUp`'s single-flight, cancel-on-mismatch shape — never per-turn
+  /// caching, which would multiply that machinery by the turn count for no benefit, since all
+  /// of a document's turns become stale together (a new analysis pass, a retry, or a
+  /// `processedText` change replaces the whole array at once).
+  func prepareTurnDiffs() async {
+    let input = turnDiffInput
+    guard turnDiffs == nil, !input.pairs.isEmpty else { return }
+    if let inFlight = turnDiffWorker, inFlight.input != input {
+      inFlight.task.cancel()
+      turnDiffWorker = nil
+    }
+    let task: Task<[String: WordDiff.Result], Never>
+    if let inFlight = turnDiffWorker {
+      task = inFlight.task
+    } else {
+      task = Task.detached(priority: .userInitiated) {
+        var results: [String: WordDiff.Result] = [:]
+        for pair in input.pairs {
+          results[pair.id] = WordDiff.compare(
+            original: pair.original, cleaned: pair.cleaned, language: input.language)
+        }
+        return results
+      }
+      turnDiffWorker = (input, task)
+    }
+    let result = await task.value
+    guard turnDiffInput == input else { return }
+    if turnDiffWorker?.input == input { turnDiffWorker = nil }
+    turnDiffCache = (input, result)
+  }
+
+  @ObservationIgnored private var turnDiffWorker:
+    (input: TurnDiffInput, task: Task<[String: WordDiff.Result], Never>)?
+
+  private static func slice(_ text: String, _ range: Range<Int>) -> String {
+    let lower = String.Index(utf16Offset: range.lowerBound, in: text)
+    let upper = String.Index(utf16Offset: range.upperBound, in: text)
+    guard lower <= upper, upper <= text.endIndex else { return "" }
+    return String(text[lower..<upper])
   }
 
   /// The in-flight speaker step, run detached from `run()`'s own completion — it touches

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1155,6 +1155,33 @@ final class FileImportCoordinator {
   private var retainedWordTimings: [ASRWordTiming]?
   private var retainedWordTimingCoverage: ASRWordTimingCoverage?
 
+  /// Bumped only by a successful `renameSpeaker` (#2811, phase 4 of #2807). `turns`/
+  /// `speakerNames` below read through `currentHistoryRow`, a plain closure the `@Observable`
+  /// macro cannot see into — so nothing tells a view depending on them to re-render after a
+  /// rename lands anywhere else (the wizard's own popover, or History's). Reading this
+  /// alongside them inside their own getters gives Observation a real stored-property
+  /// dependency to invalidate on. A background turn-storage pass or a retry needs no such
+  /// bump: both already flip the genuinely-tracked `speakerStepState`, which a view showing
+  /// "Finding speakers" already depends on.
+  private(set) var speakerFieldsRevision = 0
+
+  /// The wizard's own document turns, read fresh from the live store on every access — this
+  /// coordinator never caches them itself, so a background pass finishing, a retry, or a
+  /// rename is always reflected. `nil` under the exact same conditions
+  /// `TranscriptDocumentPresenter.render` treats as "nothing turn-shaped to show."
+  var turns: [Turn]? {
+    _ = speakerFieldsRevision
+    guard let historyID else { return nil }
+    return currentHistoryRow(historyID)?.turns
+  }
+
+  /// `speakerId -> display name` for the current document, read fresh alongside `turns`.
+  var speakerNames: [String: String] {
+    _ = speakerFieldsRevision
+    guard let historyID else { return [:] }
+    return currentHistoryRow(historyID)?.speakerNames ?? [:]
+  }
+
   /// The in-flight speaker step, run detached from `run()`'s own completion — it touches
   /// no ASR engine and must never add its own deadline (20s minimum) to the user-visible
   /// polish latency every import already pays (found by cloud review: awaiting it inline
@@ -1520,7 +1547,12 @@ final class FileImportCoordinator {
     outcome: SpeakerAnalysis, wordTimings: [ASRWordTiming]?, rawText: String,
     generationAtStart: Int, historyIDAtStart: UUID?
   ) async {
-    guard let historyID else { return }
+    // NEVER named `historyID` — that would SHADOW the live computed property for the rest of
+    // this function, turning every `historyIDAtStart == historyID` guard below into a
+    // comparison of two constants that can never diverge, silently neutering the staleness
+    // check they exist to perform (found by chunk review, in the sibling `retrySpeakerAnalysis`
+    // this pattern was copied into — fixed here too since the class is the same).
+    guard let historyIDForWrite = historyID else { return }
     let passStart = CFAbsoluteTimeGetCurrent()
 
     // Waits for the visible document's own cleanup FIRST, uniformly for EVERY branch below
@@ -1542,7 +1574,7 @@ final class FileImportCoordinator {
 
     guard
       let (assembledTurns, labeledCount) = await assembleTurnsOrPersistTerminal(
-        outcome: outcome, wordTimings: wordTimings, historyID: historyID,
+        outcome: outcome, wordTimings: wordTimings, historyIDForWrite: historyIDForWrite,
         historyIDAtStart: historyIDAtStart, passStart: passStart)
     else { return }
     guard historyIDAtStart == historyID, !Task.isCancelled else { return }
@@ -1590,7 +1622,7 @@ final class FileImportCoordinator {
     guard historyIDAtStart == historyID, !Task.isCancelled else { return }
 
     await mergeAndReport(
-      historyID: historyID, analysis: .labeled(count: labeledCount), turns: cleanedTurns,
+      historyID: historyIDForWrite, analysis: .labeled(count: labeledCount), turns: cleanedTurns,
       outcome: .stored, turnCount: cleanedTurns.count, fallbackTurnCount: fallbackTurnCount,
       passStart: passStart)
   }
@@ -1606,9 +1638,12 @@ final class FileImportCoordinator {
   /// caller must stop, writing nothing further. Non-nil hands back turns ready for EITHER
   /// cleanup (the ordinary path) or direct persistence (retry, which skips cleanup).
   private func assembleTurnsOrPersistTerminal(
-    outcome: SpeakerAnalysis, wordTimings: [ASRWordTiming]?, historyID: UUID,
+    outcome: SpeakerAnalysis, wordTimings: [ASRWordTiming]?, historyIDForWrite: UUID,
     historyIDAtStart: UUID?, passStart: CFAbsoluteTime
   ) async -> (turns: [Turn], labeledCount: Int)? {
+    // `historyIDForWrite`, NEVER `historyID` — that name would SHADOW the live computed
+    // property for this whole function, turning every `historyIDAtStart == historyID` guard
+    // below into a comparison of two constants that can never diverge (found by chunk review).
     // Non-labeled outcomes map directly through the one exhaustive mapping (chunk 1) and
     // never touch turn assembly. A missing `wordTimings` matters ONLY when assembly is
     // actually needed — checking it before the outcome type would let a merge-input gap
@@ -1622,13 +1657,13 @@ final class FileImportCoordinator {
       let turnsOutcome: TelemetryService.FileImportTurnsOutcome? =
         if case .single = outcome { .singleNoTurns } else { nil }
       await mergeAndReport(
-        historyID: historyID, analysis: outcome.asStorageAnalysis, turns: nil,
+        historyID: historyIDForWrite, analysis: outcome.asStorageAnalysis, turns: nil,
         outcome: turnsOutcome, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
       return nil
     }
     guard let wordTimings else {
       await mergeAndReport(
-        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
+        historyID: historyIDForWrite, analysis: .failed(.noWordTimings), turns: nil,
         outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
       return nil
     }
@@ -1654,7 +1689,9 @@ final class FileImportCoordinator {
     )
     // A stale/cancelled pass writes NOTHING here, matching every other staleness guard in
     // this file — the caller must not fall through to the all-unknown check below and
-    // persist a failure on behalf of a document nobody is watching anymore.
+    // persist a failure on behalf of a document nobody is watching anymore. Compares against
+    // the LIVE `historyID` property, never `historyIDForWrite` — a value captured once at
+    // entry cannot detect a document swap that happened during this `await`.
     guard historyIDAtStart == historyID, !Task.isCancelled else { return nil }
 
     // A space-free script (Chinese, Japanese, ...) makes the production word-timing mapper
@@ -1670,7 +1707,7 @@ final class FileImportCoordinator {
     guard assembledTurns.contains(where: { $0.speakerId != TurnAssembler.unknownSpeakerID })
     else {
       await mergeAndReport(
-        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
+        historyID: historyIDForWrite, analysis: .failed(.noWordTimings), turns: nil,
         outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
       return nil
     }
@@ -1702,20 +1739,36 @@ final class FileImportCoordinator {
   /// silently re-run cleanup, but it MUST still persist its result"). Shares the
   /// analysis/assembly PREFIX with the ordinary pass via `assembleTurnsOrPersistTerminal`;
   /// the CLEANUP SUFFIX, which stays "Clean it again" (`rePolish()`), is never reached here.
-  func retrySpeakerAnalysis() async {
-    guard canRetrySpeakerAnalysis, let historyID else { return }
+  ///
+  /// Synchronous and task-owning, matching `rePolish()`'s own shape (found by chunk review:
+  /// an `async` entry point that never assigned `speakerStepTask` ran in the CALLER's task,
+  /// so `stop()`/`choose()`/`startOver()`'s existing `speakerStepTask?.cancel()` targeted the
+  /// PREVIOUS pass and never touched a running retry at all).
+  func retrySpeakerAnalysis() {
+    guard canRetrySpeakerAnalysis, let historyIDAtStart = historyID else { return }
     let analysisSamples = retainedAnalysisSamples
     let wordTimings = retainedWordTimings
     let wordTimingCoverage = retainedWordTimingCoverage
-    // No retained `rawText`: retry never reaches `TurnCleanupRunner`, the only consumer of
-    // raw text in this pipeline, so there is nothing here that would use it.
-    let historyIDAtStart = historyID
     speakerStepState = .inProgress
+    speakerStepTask = Task { [weak self] in
+      await self?.runRetryAnalysis(
+        analysisSamples: analysisSamples, wordTimings: wordTimings,
+        wordTimingCoverage: wordTimingCoverage, historyIDAtStart: historyIDAtStart)
+    }
+  }
+
+  private func runRetryAnalysis(
+    analysisSamples: [Float], wordTimings: [ASRWordTiming]?,
+    wordTimingCoverage: ASRWordTimingCoverage?, historyIDAtStart: UUID
+  ) async {
+    // Every comparison below reads the LIVE `historyID` property — never a locally-bound
+    // value of the same name, which would shadow it and neuter the staleness check (the
+    // exact defect found by chunk review in an earlier version of this function).
+    defer { if historyIDAtStart == historyID { speakerStepState = .finished } }
     let durationSeconds = file?.seconds ?? 0
     let analysisStart = CFAbsoluteTimeGetCurrent()
     let outcome = await speakerLabeler(analysisSamples, durationSeconds)
     let analysisMs = Int(((CFAbsoluteTimeGetCurrent() - analysisStart) * 1000).rounded())
-    defer { if historyIDAtStart == historyID { speakerStepState = .finished } }
     guard historyIDAtStart == historyID, !Task.isCancelled else { return }
     speakerAnalysis = outcome
     await AppLogger.shared.log(
@@ -1727,10 +1780,11 @@ final class FileImportCoordinator {
     // shape (`analysisStart` for the analyzer alone, `passStart` for everything after) — so
     // this pass's `ms=` reads the same way as the ordinary pass's, minus the cleanup it skips.
     let passStart = CFAbsoluteTimeGetCurrent()
+    guard let historyIDForWrite = historyID, historyIDForWrite == historyIDAtStart else { return }
 
     guard
       let (assembledTurns, labeledCount) = await assembleTurnsOrPersistTerminal(
-        outcome: outcome, wordTimings: wordTimings, historyID: historyID,
+        outcome: outcome, wordTimings: wordTimings, historyIDForWrite: historyIDForWrite,
         historyIDAtStart: historyIDAtStart, passStart: passStart)
     else { return }
     guard historyIDAtStart == historyID, !Task.isCancelled else { return }
@@ -1738,9 +1792,9 @@ final class FileImportCoordinator {
     // turns persist AS-IS, exactly as they came out of analysis, matching the epic's own
     // "cleanup stays 'Clean it again'" requirement.
     await mergeAndReport(
-      historyID: historyID, analysis: .labeled(count: labeledCount), turns: assembledTurns,
-      outcome: .stored, turnCount: assembledTurns.count, fallbackTurnCount: 0,
-      passStart: passStart)
+      historyID: historyIDForWrite, analysis: .labeled(count: labeledCount),
+      turns: assembledTurns, outcome: .stored, turnCount: assembledTurns.count,
+      fallbackTurnCount: 0, passStart: passStart)
   }
 
   /// Renames a speaker id across every turn showing it (#2811, phase 4 of #2807). Re-fetches
@@ -1750,17 +1804,23 @@ final class FileImportCoordinator {
   /// Design correction 2). Callable from either screen; both are ordinary, symmetric callers
   /// of the same underlying write.
   func renameSpeaker(id: String, name: String) async -> RenameFailure? {
-    guard let historyID, let current = currentHistoryRow(historyID), current.turns != nil,
-      let analysis = current.speakerAnalysis
+    guard let historyIDForWrite = historyID, let current = currentHistoryRow(historyIDForWrite),
+      current.turns != nil, let analysis = current.speakerAnalysis
     else {
       return RenameFailure(message: "Couldn't save the name.", currentName: nil)
     }
     do {
-      let saved = try writeExplicitRename(historyID, analysis, current.turns, (id, name))
+      let saved = try writeExplicitRename(
+        historyIDForWrite, analysis, current.turns, (id, name))
       guard saved else {
         return RenameFailure(
           message: "This recording was removed from History.", currentName: nil)
       }
+      // Neither `turns` nor `speakerNames` below is itself an `@Observable`-tracked stored
+      // property — they read through `currentHistoryRow`, a closure Observation cannot see
+      // into — so nothing would tell a view to re-render after a successful rename without
+      // this. Bumping it is what makes "every turn showing that speaker id re-renders" true.
+      speakerFieldsRevision += 1
       return nil
     } catch {
       return RenameFailure(

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -346,11 +346,16 @@ final class FileImportCoordinator {
   private let emitTurnTelemetry:
     @MainActor (TelemetryService.FileImportTurnsOutcome, Int?, Int) -> Void
 
-  /// Shape-only telemetry for a rename attempt and a "Try again" press (#2811, phase 4 of
-  /// #2807 §3e) — No-op defaults, same as every other telemetry-shaped closure in this app.
+  /// Shape-only telemetry for a rename attempt, a "Try again" press, and the first time this
+  /// screen draws a turn view for a document (#2811, phase 4 of #2807 §3e) — No-op defaults,
+  /// same as every other telemetry-shaped closure in this app.
   private let emitRenameTelemetry: @MainActor (TelemetryService.FileImportRenameOutcome) -> Void
   private let emitSpeakerRetryTelemetry:
     @MainActor (TelemetryService.FileImportSpeakerRetryOutcome) -> Void
+  private let emitTurnsDisplayedTelemetry: @MainActor () -> Void
+  /// Documents this wizard has already reported as displayed, so a Done step that re-appears
+  /// (view mode flip, window re-open) reports each document once per launch, never per draw.
+  private var displayedTurnHistoryIDs: Set<UUID> = []
 
   /// Fires the instant `waitForVisibleCleanup(generation:)` actually returns for that
   /// generation — never on a timeout, never on a guess. No-op default. Exists purely so a
@@ -627,6 +632,7 @@ final class FileImportCoordinator {
     emitSpeakerRetryTelemetry: @escaping @MainActor (
       TelemetryService.FileImportSpeakerRetryOutcome
     ) -> Void = { _ in },
+    emitTurnsDisplayedTelemetry: @escaping @MainActor () -> Void = {},
     onVisibleCleanupWaitResolved: @escaping @MainActor (Int) -> Void = { _ in },
     engineAdmission: EngineAdmissionAccess,
     polishOllamaLocalityNow: @escaping @MainActor () -> Bool? = { false },
@@ -672,6 +678,7 @@ final class FileImportCoordinator {
     self.emitTurnTelemetry = emitTurnTelemetry
     self.emitRenameTelemetry = emitRenameTelemetry
     self.emitSpeakerRetryTelemetry = emitSpeakerRetryTelemetry
+    self.emitTurnsDisplayedTelemetry = emitTurnsDisplayedTelemetry
     self.onVisibleCleanupWaitResolved = onVisibleCleanupWaitResolved
     self.engineAdmission = engineAdmission
     self.beginRun = beginRun
@@ -1889,14 +1896,18 @@ final class FileImportCoordinator {
       // Read AFTER the retry's own write, from the STORED outcome (§3 Design "failure
       // authority" correction) — never the in-memory analyzer-only `speakerAnalysis`, and
       // never assumed from whether `runRetryAnalysis` itself returned normally, since a
-      // stale/cancelled retry also returns normally having written nothing.
-      guard let self, historyIDAtStart == self.historyID,
+      // stale/cancelled retry also returns normally having written nothing. Both staleness
+      // signals are required (found by chunk review): Stop cancels this task but leaves
+      // `historyID` in place, so the identity check alone would read the untouched failed
+      // row as "still failed" and blame the analyzer for a retry the user abandoned.
+      guard let self, !Task.isCancelled, historyIDAtStart == self.historyID,
         let current = self.currentHistoryRow(historyIDAtStart)
       else { return }
-      if case .labeled = current.speakerAnalysis {
-        self.emitSpeakerRetryTelemetry(.recovered)
-      } else {
-        self.emitSpeakerRetryTelemetry(.stillFailed)
+      switch current.speakerAnalysis {
+      // The same two outcomes that clear `speakerNoticeReason`: a one-voice result is a
+      // successful analysis too, not a failure the user needs to retry.
+      case .single, .labeled: self.emitSpeakerRetryTelemetry(.recovered)
+      case .failed, .unanalyzed, nil: self.emitSpeakerRetryTelemetry(.stillFailed)
       }
     }
   }
@@ -1974,6 +1985,19 @@ final class FileImportCoordinator {
       return RenameFailure(
         message: "Couldn't save the name.", currentName: current.speakerNames?[id])
     }
+  }
+
+  /// The rename popover closed on Escape or a blank name (plan §3d). Telemetry only; nothing
+  /// to write and nothing to revert, since neither path ever reached `renameSpeaker`.
+  func noteRenameCancelled() {
+    emitRenameTelemetry(.cancelled)
+  }
+
+  /// The Done step's turn view just appeared for the current document (#2811 §3e). Reported
+  /// once per document per launch; a re-appearance for the same row is not a new fact.
+  func noteTurnsDisplayed() {
+    guard let historyID, displayedTurnHistoryIDs.insert(historyID).inserted else { return }
+    emitTurnsDisplayedTelemetry()
   }
 
   private static func elapsedMs(since start: CFAbsoluteTime) -> Int {

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1242,11 +1242,27 @@ final class FileImportCoordinator {
 
   /// Frees the retained retry inputs once the CURRENT document's stored outcome is one no
   /// retry could change. Reads the stored field, never the in-memory analyzer property, so
-  /// a save that threw (row still at its previous retryable outcome) keeps them.
+  /// a save that threw (row still at its previous retryable outcome) keeps them. A row that
+  /// no longer exists is terminal too (cloud review of PR #2846, round 2): a retry has
+  /// nothing to write against, and `canRetrySpeakerAnalysis` already reads false for it.
   private func releaseRetryInputsIfNoLongerRetryable() {
-    guard let historyID, let current = currentHistoryRow(historyID),
-      !retryCouldChange(current.speakerAnalysis)
-    else { return }
+    guard let historyID else { return }
+    if let current = currentHistoryRow(historyID), retryCouldChange(current.speakerAnalysis) {
+      return
+    }
+    releaseRetryInputs()
+  }
+
+  /// History deleted a row (wired from `TranscriptCoordinator.onRowDeleted`). Only a deletion
+  /// AFTER the speaker pass settled needs this; one during the pass is caught by the pass's
+  /// own completion above. A row the user later resurrects with "Clean it again" comes back
+  /// without speaker fields and without a retry: the audio for it is gone, on purpose.
+  func noteHistoryRowDeleted(_ id: UUID) {
+    guard id == historyID else { return }
+    releaseRetryInputs()
+  }
+
+  private func releaseRetryInputs() {
     retainedAnalysisSamples = []
     retainedWordTimings = nil
     retainedWordTimingCoverage = nil

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1467,7 +1467,13 @@ final class FileImportCoordinator {
     // exactly that situation. A direct Stop press must behave the same way, or it becomes
     // the one "user moves on" path that leaves a background engine hold with no way to end
     // it. Cancelling a nil or already-finished task is a documented no-op.
+    //
+    // `runTask` joins it here (#2811, found by confirming review): "Clean it again" now
+    // re-cleans the stored turns on `runTask` AFTER the visible document reaches Done, so
+    // `isRunning` is already false while that re-clean is still writing. `runTask` only
+    // ever holds a run (`start()`/`rePolish()`), so cancelling it outside a run is a no-op.
     speakerStepTask?.cancel()
+    runTask?.cancel()
     guard isRunning else { return }
     generation += 1
     state = .stopped
@@ -1491,8 +1497,8 @@ final class FileImportCoordinator {
     // and Stop leaves `.stopped`, `canRetry` requires a rejection about the
     // ENGINE, and a re-polish reads `rawTranscript`. Nothing left can want it.
     releaseDecodedAudio()
-    runTask?.cancel()
-    // speakerStepTask is already cancelled unconditionally above, before this guard.
+    // `runTask` and `speakerStepTask` are both already cancelled unconditionally above,
+    // before this guard.
   }
 
   /// Re-runs the cleanup under the current settings, from the transcript already

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -714,6 +714,9 @@ final class FileImportCoordinator {
     // file's speaker step is still quietly running in the background must stop it
     // itself, not rely on Stop having already done so.
     speakerStepTask?.cancel()
+    // And the run task (found by cloud review, round 3): after Done it can still be
+    // running the turn re-clean under the engine claim, which `isRunning` no longer covers.
+    runTask?.cancel()
     let name = url.lastPathComponent
     // Bumped HERE too, not only when a run starts. Picking a second file while
     // the first is still decoding is an ordinary thing to do, and without this
@@ -1156,6 +1159,9 @@ final class FileImportCoordinator {
     retainedWordTimings = nil
     retainedWordTimingCoverage = nil
     speakerStepTask?.cancel()
+    // And the run task (found by cloud review, round 3): after Done it can still be
+    // running the turn re-clean under the engine claim, which `isRunning` no longer covers.
+    runTask?.cancel()
     forgetSaveOutcome()
     // A new file is a NEW History row. Carrying the id forward would make the next import
     // overwrite the last one's words, because the store names its file by id — which is the
@@ -1273,13 +1279,17 @@ final class FileImportCoordinator {
     releaseRetryInputs()
   }
 
-  /// History deleted a row (wired from `TranscriptCoordinator.onRowDeleted`). Only a deletion
-  /// AFTER the speaker pass settled needs this; one during the pass is caught by the pass's
-  /// own completion above. A row the user later resurrects with "Clean it again" comes back
-  /// without speaker fields and without a retry: the audio for it is gone, on purpose.
+  /// History deleted a row (wired from `TranscriptCoordinator.onRowDeleted`). Drops the retry
+  /// audio and stops the background speaker work still aimed at that row: the speaker pass,
+  /// and a post-Done turn re-clean on `runTask` (never a visible run in flight, whose own
+  /// save already refuses a deleted row). A row the user later resurrects with "Clean it
+  /// again" comes back without speaker fields and without a retry: the audio for it is gone,
+  /// on purpose.
   func noteHistoryRowDeleted(_ id: UUID) {
     guard id == historyID else { return }
     releaseRetryInputs()
+    speakerStepTask?.cancel()
+    if !isRunning { runTask?.cancel() }
   }
 
   private func releaseRetryInputs() {
@@ -1630,6 +1640,10 @@ final class FileImportCoordinator {
       guard generationAtStart == generation else { return }
       await polishAll(
         TranscriptSplitter.split(rawTranscript), generationAtStart: generationAtStart)
+      // `polishAll` has already shown the polisher-not-ready rejection and cleaned nothing;
+      // re-cleaning the turns against the same unavailable polisher would only burn the
+      // claim and hand back their raw text (found by cloud review, round 3).
+      guard localPolisherIsReady else { return }
       // Still under THIS run's engine claim (the defer above releases it only after this
       // returns), and after the visible document has already reached Done, exactly as the
       // first import's own turn cleanup runs behind its Done step.

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1240,7 +1240,7 @@ final class FileImportCoordinator {
     guard let turns else { return TurnDiffInput(pairs: [], language: engineReportedLanguage) }
     let text = rawTranscript
     let pairs = turns.map { turn -> TurnDiffPair in
-      let original = Self.slice(text, turn.originalTextRange)
+      let original = TranscriptDocumentPresenter.slice(text, turn.originalTextRange)
       return TurnDiffPair(id: turn.id, original: original, cleaned: turn.processedText ?? original)
     }
     return TurnDiffInput(pairs: pairs, language: engineReportedLanguage)
@@ -1289,13 +1289,6 @@ final class FileImportCoordinator {
 
   @ObservationIgnored private var turnDiffWorker:
     (input: TurnDiffInput, task: Task<[String: WordDiff.Result], Never>)?
-
-  private static func slice(_ text: String, _ range: Range<Int>) -> String {
-    let lower = String.Index(utf16Offset: range.lowerBound, in: text)
-    let upper = String.Index(utf16Offset: range.upperBound, in: text)
-    guard lower <= upper, upper <= text.endIndex else { return "" }
-    return String(text[lower..<upper])
-  }
 
   /// The in-flight speaker step, run detached from `run()`'s own completion — it touches
   /// no ASR engine and must never add its own deadline (20s minimum) to the user-visible

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1136,6 +1136,13 @@ final class FileImportCoordinator {
   ///   the step you are already on.
   func jump(to target: Step, advancing: Bool = false) {
     guard canGo(to: target, advancing: advancing) else { return }
+    // Leaving Done ends a post-Done turn re-clean (#2811, found by cloud review, round 8):
+    // after "Clean it again" the visible run is finished, so `isRunning` is false while
+    // `runTask` may still be re-cleaning turns under the engine claim; walking to Polish
+    // ("Change"), Back, or the step bar would otherwise leave it running with no Stop in
+    // sight and refuse the next run as engine-busy. This is the one mover every such path
+    // goes through; `choose`, `startOver` and `stop` cancel on their own.
+    if step == .done, target != .done, !isRunning { runTask?.cancel() }
     step = target
   }
 

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -346,6 +346,12 @@ final class FileImportCoordinator {
   private let emitTurnTelemetry:
     @MainActor (TelemetryService.FileImportTurnsOutcome, Int?, Int) -> Void
 
+  /// Shape-only telemetry for a rename attempt and a "Try again" press (#2811, phase 4 of
+  /// #2807 §3e) — No-op defaults, same as every other telemetry-shaped closure in this app.
+  private let emitRenameTelemetry: @MainActor (TelemetryService.FileImportRenameOutcome) -> Void
+  private let emitSpeakerRetryTelemetry:
+    @MainActor (TelemetryService.FileImportSpeakerRetryOutcome) -> Void
+
   /// Fires the instant `waitForVisibleCleanup(generation:)` actually returns for that
   /// generation — never on a timeout, never on a guess. No-op default. Exists purely so a
   /// test can prove the underlying `CheckedContinuation` was genuinely resumed rather than
@@ -615,6 +621,12 @@ final class FileImportCoordinator {
     ) -> Void = { _, _, _, _ in },
     emitTurnTelemetry: @escaping @MainActor (TelemetryService.FileImportTurnsOutcome, Int?, Int) ->
       Void = { _, _, _ in },
+    emitRenameTelemetry: @escaping @MainActor (TelemetryService.FileImportRenameOutcome) -> Void = {
+      _ in
+    },
+    emitSpeakerRetryTelemetry: @escaping @MainActor (
+      TelemetryService.FileImportSpeakerRetryOutcome
+    ) -> Void = { _ in },
     onVisibleCleanupWaitResolved: @escaping @MainActor (Int) -> Void = { _ in },
     engineAdmission: EngineAdmissionAccess,
     polishOllamaLocalityNow: @escaping @MainActor () -> Bool? = { false },
@@ -658,6 +670,8 @@ final class FileImportCoordinator {
     self.speakerLabeler = speakerLabeler
     self.emitSpeakerTelemetry = emitSpeakerTelemetry
     self.emitTurnTelemetry = emitTurnTelemetry
+    self.emitRenameTelemetry = emitRenameTelemetry
+    self.emitSpeakerRetryTelemetry = emitSpeakerRetryTelemetry
     self.onVisibleCleanupWaitResolved = onVisibleCleanupWaitResolved
     self.engineAdmission = engineAdmission
     self.beginRun = beginRun
@@ -1872,6 +1886,18 @@ final class FileImportCoordinator {
       await self?.runRetryAnalysis(
         analysisSamples: analysisSamples, wordTimings: wordTimings,
         wordTimingCoverage: wordTimingCoverage, historyIDAtStart: historyIDAtStart)
+      // Read AFTER the retry's own write, from the STORED outcome (§3 Design "failure
+      // authority" correction) — never the in-memory analyzer-only `speakerAnalysis`, and
+      // never assumed from whether `runRetryAnalysis` itself returned normally, since a
+      // stale/cancelled retry also returns normally having written nothing.
+      guard let self, historyIDAtStart == self.historyID,
+        let current = self.currentHistoryRow(historyIDAtStart)
+      else { return }
+      if case .labeled = current.speakerAnalysis {
+        self.emitSpeakerRetryTelemetry(.recovered)
+      } else {
+        self.emitSpeakerRetryTelemetry(.stillFailed)
+      }
     }
   }
 
@@ -1925,12 +1951,14 @@ final class FileImportCoordinator {
     guard let historyIDForWrite = historyID, let current = currentHistoryRow(historyIDForWrite),
       current.turns != nil, let analysis = current.speakerAnalysis
     else {
+      emitRenameTelemetry(.failed)
       return RenameFailure(message: "Couldn't save the name.", currentName: nil)
     }
     do {
       let saved = try writeExplicitRename(
         historyIDForWrite, analysis, current.turns, (id, name))
       guard saved else {
+        emitRenameTelemetry(.failed)
         return RenameFailure(
           message: "This recording was removed from History.", currentName: nil)
       }
@@ -1939,8 +1967,10 @@ final class FileImportCoordinator {
       // into — so nothing would tell a view to re-render after a successful rename without
       // this. Bumping it is what makes "every turn showing that speaker id re-renders" true.
       speakerFieldsRevision += 1
+      emitRenameTelemetry(.saved)
       return nil
     } catch {
+      emitRenameTelemetry(.failed)
       return RenameFailure(
         message: "Couldn't save the name.", currentName: current.speakerNames?[id])
     }

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1339,6 +1339,16 @@ final class FileImportCoordinator {
     let language: String?
   }
 
+  /// The id of both screens' diff task: the input AND whether Marked up is the selected view,
+  /// so the per-turn diffs are computed only while something would show them (found by
+  /// cloud review, round 7: a long labeled recording opened in Cleaned mode diffed every turn
+  /// at user-initiated priority for nothing). Switching to Marked up changes the id and starts
+  /// the work then; switching away cancels it.
+  struct TurnDiffRequest: Equatable, Sendable {
+    let input: TurnDiffInput
+    let markedUp: Bool
+  }
+
   /// The current turns' own original/cleaned pairs, mirroring `markedUpInput`'s role but for
   /// per-turn Marked-up rendering (#2811, phase 4 of #2807) — the presenter's `render` never
   /// computes `WordDiff` itself (chunk-1 review), so this is the CALLER-side preparation it

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1205,12 +1205,52 @@ final class FileImportCoordinator {
   /// Retained PCM for a possible "Try again" (#2811 §3 Design "retained retry state"
   /// correction): a genuinely NEW retention this phase adds, since `releaseDecodedAudio()`
   /// already clears `decodedSamples` immediately after transcription, well before a retry
-  /// would exist to need it. Cleared at the exact points `decodedSamples` itself resets
+  /// would exist to need it. Cleared at the points `decodedSamples` itself resets
   /// (`choose(url:)`, `startOver()`), so a stale retry can never fire against a replaced
-  /// document.
+  /// document, AND as soon as a pass settles on an outcome no retry could change
+  /// (`releaseRetryInputsIfNoLongerRetryable`, found by cloud review of PR #2846): this
+  /// coordinator lives for the process, and a multi-hour import's buffer is hundreds of
+  /// megabytes to hold behind a screen the user has left.
   private var retainedAnalysisSamples: [Float] = []
   private var retainedWordTimings: [ASRWordTiming]?
   private var retainedWordTimingCoverage: ASRWordTimingCoverage?
+
+  /// Test-facing: whether a "Try again" still has audio to run against.
+  var retainsRetryInputs: Bool { !retainedAnalysisSamples.isEmpty }
+
+  /// Whether the retained timing data could ever bind a speaker: `nil` timings, or a
+  /// coverage with zero timed entries (a space-free script, #2838), can only reach
+  /// `.failed(.noWordTimings)` again however the analyzer segments the audio, since a retry
+  /// reruns the analyzer and never the ASR or the timing mapper. A present-but-partial
+  /// coverage stays retryable: assembly binds whatever entries ARE timed, and a different
+  /// segmentation can bind them differently.
+  private var retainedTimingsCanBindSpeakers: Bool {
+    guard retainedWordTimings != nil else { return false }
+    if let coverage = retainedWordTimingCoverage, coverage.timed == 0 { return false }
+    return true
+  }
+
+  /// The one reading of "could a retry change this stored outcome", shared by the button
+  /// and by the release of the retained audio, so the two can never disagree.
+  private func retryCouldChange(_ analysis: TranscriptSpeakerAnalysis?) -> Bool {
+    switch analysis {
+    case .single, .labeled: return false
+    case .failed(.noWordTimings): return retainedTimingsCanBindSpeakers
+    case .failed, .unanalyzed, nil: return true
+    }
+  }
+
+  /// Frees the retained retry inputs once the CURRENT document's stored outcome is one no
+  /// retry could change. Reads the stored field, never the in-memory analyzer property, so
+  /// a save that threw (row still at its previous retryable outcome) keeps them.
+  private func releaseRetryInputsIfNoLongerRetryable() {
+    guard let historyID, let current = currentHistoryRow(historyID),
+      !retryCouldChange(current.speakerAnalysis)
+    else { return }
+    retainedAnalysisSamples = []
+    retainedWordTimings = nil
+    retainedWordTimingCoverage = nil
+  }
 
   /// Bumped only by a successful `renameSpeaker` (#2811, phase 4 of #2807). `turns`/
   /// `speakerNames` below read through `currentHistoryRow`, a plain closure the `@Observable`
@@ -1647,7 +1687,8 @@ final class FileImportCoordinator {
       // #2811, phase 4: retained for a possible "Try again," a genuinely NEW retention this
       // phase adds — `analysisSamples` itself is a local (freed once this function returns),
       // and `wordTimings`/`wordTimingCoverage` were never stored at all before. Cleared at the
-      // same points `decodedSamples` itself resets.
+      // points `decodedSamples` itself resets, and once the pass settles on an outcome no
+      // retry could change (see the declaration).
       retainedAnalysisSamples = analysisSamples
       retainedWordTimings = result.wordTimings
       retainedWordTimingCoverage = result.wordTimingCoverage
@@ -1683,7 +1724,12 @@ final class FileImportCoordinator {
     analysisSamples: [Float], generationAtStart: Int, historyIDAtStart: UUID?, rawText: String,
     wordTimings: [ASRWordTiming]?, wordTimingCoverage: ASRWordTimingCoverage?
   ) async {
-    defer { if historyIDAtStart == historyID { speakerStepState = .finished } }
+    defer {
+      if historyIDAtStart == historyID {
+        speakerStepState = .finished
+        releaseRetryInputsIfNoLongerRetryable()
+      }
+    }
     let durationSeconds = file?.seconds ?? 0
     let analysisStart = CFAbsoluteTimeGetCurrent()
     let outcome = await speakerLabeler(analysisSamples, durationSeconds)
@@ -1899,7 +1945,10 @@ final class FileImportCoordinator {
   enum SpeakerNoticeReason: Equatable, Sendable { case none, failed, unresolved }
 
   var speakerNoticeReason: SpeakerNoticeReason {
-    guard speakerStepState == .finished, !retainedAnalysisSamples.isEmpty, let historyID,
+    // No retained-audio guard here (cloud review of PR #2846): a notice can be owed for an
+    // outcome no retry could change, whose audio has already been released. `choose`/
+    // `startOver` reset both the step and the document identity, so no notice survives them.
+    guard speakerStepState == .finished, let historyID,
       let current = currentHistoryRow(historyID)
     else { return .none }
     switch current.speakerAnalysis {
@@ -1913,9 +1962,17 @@ final class FileImportCoordinator {
     }
   }
 
-  /// Whether "Try again" should be offered right now — true for either notice reason above,
-  /// since both are genuinely retry-eligible per §4's invariant (only the WORDING differs).
-  var canRetrySpeakerAnalysis: Bool { speakerNoticeReason != .none }
+  /// Whether "Try again" should be offered right now: a notice is showing, the audio to run
+  /// against is still held, and the stored outcome is one a retry could change. Both notice
+  /// reasons are eligible in principle (§4's invariant); the one exception is a
+  /// `.noWordTimings` failure whose timing data can never bind a speaker, where a retry
+  /// would only reach the same failure again (cloud review of PR #2846).
+  var canRetrySpeakerAnalysis: Bool {
+    guard speakerNoticeReason != .none, !retainedAnalysisSamples.isEmpty, let historyID,
+      let current = currentHistoryRow(historyID)
+    else { return false }
+    return retryCouldChange(current.speakerAnalysis)
+  }
 
   /// Re-runs speaker analysis and turn assembly from retained state, then PERSISTS that
   /// result — but skips `TurnCleanupRunner` entirely (#2811 §3 Design "retry must not
@@ -1963,7 +2020,12 @@ final class FileImportCoordinator {
     // Every comparison below reads the LIVE `historyID` property — never a locally-bound
     // value of the same name, which would shadow it and neuter the staleness check (the
     // exact defect found by chunk review in an earlier version of this function).
-    defer { if historyIDAtStart == historyID { speakerStepState = .finished } }
+    defer {
+      if historyIDAtStart == historyID {
+        speakerStepState = .finished
+        releaseRetryInputsIfNoLongerRetryable()
+      }
+    }
     let durationSeconds = file?.seconds ?? 0
     let analysisStart = CFAbsoluteTimeGetCurrent()
     let outcome = await speakerLabeler(analysisSamples, durationSeconds)

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1375,7 +1375,11 @@ final class FileImportCoordinator {
       turnDiffWorker = nil
     }
     let task: Task<[String: WordDiff.Result], Never>
-    if let inFlight = turnDiffWorker {
+    // A worker that was cancelled (the Done view left mid-batch) returns a PARTIAL dictionary;
+    // reusing it would cache that partial result for good, and the missing turns would show
+    // unmarked cleaned text forever (found by cloud review, round 6). Only a live worker is
+    // shared; a cancelled one is replaced.
+    if let inFlight = turnDiffWorker, !inFlight.task.isCancelled {
       task = inFlight.task
     } else {
       task = Task.detached(priority: .userInitiated) {
@@ -1400,8 +1404,10 @@ final class FileImportCoordinator {
       operation: { await task.value },
       onCancel: { task.cancel() }
     )
-    guard !Task.isCancelled, turnDiffInput == input else { return }
+    // Released on EVERY return path, cancelled included, so the next visit with the same
+    // input starts a fresh worker instead of adopting this one's partial result.
     if turnDiffWorker?.input == input { turnDiffWorker = nil }
+    guard !Task.isCancelled, turnDiffInput == input else { return }
     turnDiffCache = (input, result)
   }
 

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1202,6 +1202,26 @@ final class FileImportCoordinator {
   enum SpeakerStepState: Equatable, Sendable { case notStarted, inProgress, finished }
   private(set) var speakerStepState: SpeakerStepState = .notStarted
 
+  /// How far the per-turn cleanup is, while one is running (the ordinary pass after Done,
+  /// or a re-clean after "Clean it again"); nil otherwise.
+  struct TurnCleanupProgress: Equatable, Sendable {
+    let done: Int
+    let total: Int
+  }
+  private(set) var turnCleanupProgress: TurnCleanupProgress?
+
+  /// The ONE line the Done step shows for background speaker work, or nil for none. Says
+  /// what is actually happening (founder UAT, 2026-09-13: "it's still stuck on finding
+  /// speakers" over a 490 s turn cleanup that had found the speakers in 17 s): the analysis
+  /// itself, or the per-turn cleanup with its count. The Working step shows nothing for
+  /// this: its bar is the one status there.
+  var speakerStatusLabel: String? {
+    if let progress = turnCleanupProgress {
+      return "Cleaning speaker turns: \(progress.done) of \(progress.total)"
+    }
+    return speakerStepState == .inProgress ? "Finding speakers" : nil
+  }
+
   /// Retained PCM for a possible "Try again" (#2811 §3 Design "retained retry state"
   /// correction): a genuinely NEW retention this phase adds, since `releaseDecodedAudio()`
   /// already clears `decodedSamples` immediately after transcription, well before a retry
@@ -1637,8 +1657,14 @@ final class FileImportCoordinator {
       let storedTurns = current.turns, !storedTurns.isEmpty
     else { return }
     let passStart = CFAbsoluteTimeGetCurrent()
+    defer { turnCleanupProgress = nil }
     let (cleanedTurns, fallbackTurnCount) = await TurnCleanupRunner(processPart: processPart)
-      .run(turns: storedTurns, rawText: rawTranscript, engineLanguage: engineReportedLanguage)
+      .run(
+        turns: storedTurns, rawText: rawTranscript, engineLanguage: engineReportedLanguage,
+        onProgress: { [weak self] done, total in
+          guard let self, historyIDForWrite == self.historyID else { return }
+          self.turnCleanupProgress = TurnCleanupProgress(done: done, total: total)
+        })
     guard historyIDForWrite == historyID, generationAtStart == generation, !Task.isCancelled
     else { return }
     await mergeAndReport(
@@ -1852,8 +1878,14 @@ final class FileImportCoordinator {
       return
     }
 
+    defer { turnCleanupProgress = nil }
     let (cleanedTurns, fallbackTurnCount) = await TurnCleanupRunner(processPart: processPart)
-      .run(turns: assembledTurns, rawText: rawText, engineLanguage: engineReportedLanguage)
+      .run(
+        turns: assembledTurns, rawText: rawText, engineLanguage: engineReportedLanguage,
+        onProgress: { [weak self] done, total in
+          guard let self, historyIDAtStart == self.historyID else { return }
+          self.turnCleanupProgress = TurnCleanupProgress(done: done, total: total)
+        })
     guard historyIDAtStart == historyID, !Task.isCancelled else { return }
 
     await mergeAndReport(

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1381,6 +1381,10 @@ final class FileImportCoordinator {
       task = Task.detached(priority: .userInitiated) {
         var results: [String: WordDiff.Result] = [:]
         for pair in input.pairs {
+          // Between compares, never mid-compare: an obsolete document's worker (file
+          // replaced, retry changed the turns, Start Over) stops at the next turn instead of
+          // diffing every remaining one (found by cloud review, round 4).
+          guard !Task.isCancelled else { break }
           results[pair.id] = WordDiff.compare(
             original: pair.original, cleaned: pair.cleaned, language: input.language)
         }
@@ -1388,8 +1392,15 @@ final class FileImportCoordinator {
       }
       turnDiffWorker = (input, task)
     }
-    let result = await task.value
-    guard turnDiffInput == input else { return }
+    // `Task.detached` is UNSTRUCTURED: cancelling THIS caller (`.task(id:)` on an input change)
+    // does not reach the worker by itself, same as `assembleTurnsOrPersistTerminal`'s own
+    // assembly task. The handler forwards it; the worker is single-flight per input, so the
+    // only caller awaiting it is the one whose input just went stale.
+    let result = await withTaskCancellationHandler(
+      operation: { await task.value },
+      onCancel: { task.cancel() }
+    )
+    guard !Task.isCancelled, turnDiffInput == input else { return }
     if turnDiffWorker?.input == input { turnDiffWorker = nil }
     turnDiffCache = (input, result)
   }

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1518,6 +1518,7 @@ final class FileImportCoordinator {
 
     generation += 1
     let generationAtStart = generation
+    let historyIDAtStart = historyID
     parts = []
     // #2772 finding 14: the OLD queue must not be shown as the current one while this run
     // is still preparing. Cleared here and republished by `polishAll` from the new split.
@@ -1547,7 +1548,44 @@ final class FileImportCoordinator {
       guard generationAtStart == generation else { return }
       await polishAll(
         TranscriptSplitter.split(rawTranscript), generationAtStart: generationAtStart)
+      // Still under THIS run's engine claim (the defer above releases it only after this
+      // returns), and after the visible document has already reached Done, exactly as the
+      // first import's own turn cleanup runs behind its Done step.
+      await reCleanStoredTurns(
+        generationAtStart: generationAtStart, historyIDAtStart: historyIDAtStart)
     }
+  }
+
+  /// "Clean it again" for the TURNS (#2811, found by whole-diff review). `polishAll` above
+  /// re-cleans only the whole document, but once a row is `.labeled` both screens draw and
+  /// export the stored turns, so without this the new cleanup never reached the screen: the
+  /// turns kept their previous `processedText`, and after a "Try again" retry (which skips
+  /// cleanup by design, so that cleanup stays "Clean it again") they stayed raw for good.
+  /// Re-runs the same `TurnCleanupRunner` over the row's CURRENT turns, from the raw text,
+  /// so speaker ids and every explicit rename survive (`mergeSpeakerFields` preserves names
+  /// for surviving ids). Skipped while the ordinary storage pass is still in flight: that
+  /// pass is about to write freshly cleaned turns of its own, and racing it would only
+  /// write the same thing twice. `outcome: nil` because `file_import_turns` is a
+  /// once-per-import event (plan §3e) and a re-clean is not a new import.
+  private func reCleanStoredTurns(generationAtStart: Int, historyIDAtStart: UUID?) async {
+    guard let historyIDForWrite = historyIDAtStart, historyIDForWrite == historyID,
+      generationAtStart == generation, !Task.isCancelled, speakerStepState == .finished,
+      let current = currentHistoryRow(historyIDForWrite),
+      case .labeled(let labeledCount) = current.speakerAnalysis,
+      let storedTurns = current.turns, !storedTurns.isEmpty
+    else { return }
+    let passStart = CFAbsoluteTimeGetCurrent()
+    let (cleanedTurns, fallbackTurnCount) = await TurnCleanupRunner(processPart: processPart)
+      .run(turns: storedTurns, rawText: rawTranscript, engineLanguage: engineReportedLanguage)
+    guard historyIDForWrite == historyID, generationAtStart == generation, !Task.isCancelled
+    else { return }
+    await mergeAndReport(
+      historyID: historyIDForWrite, analysis: .labeled(count: labeledCount), turns: cleanedTurns,
+      outcome: nil, turnCount: cleanedTurns.count, fallbackTurnCount: fallbackTurnCount,
+      passStart: passStart)
+    await AppLogger.shared.log(
+      "[TurnCleanup] outcome=recleaned turns=\(cleanedTurns.count) fallback=\(fallbackTurnCount) ms=\(Self.elapsedMs(since: passStart))",
+      level: .info, category: "FileImportCoordinator")
   }
 
   // MARK: - The run

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -525,12 +525,33 @@ final class FileImportCoordinator {
   private let mergeSpeakerFields:
     @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?) throws -> Bool
 
+  /// The rename write (#2811, phase 4 of #2807) — a SEPARATE closure from `mergeSpeakerFields`
+  /// rather than a widened one, so every existing turn-storage call site (which never renames)
+  /// stays untouched. Backed by the SAME `TranscriptCoordinator.mergeSpeakerFields
+  /// (explicitRename:)` method underneath (no new coordinator method, per §4's contract
+  /// delta) — this coordinator's own rename entry point re-reads the row's current analysis
+  /// and turns via `currentHistoryRow` immediately before calling this, never reusing a value
+  /// captured when a popover opened. Defaults to a harmless failure so tests that do not
+  /// exercise rename need not wire it.
+  private let writeExplicitRename:
+    @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?, (speakerId: String, name: String))
+      throws -> Bool
+
   /// Whether the import's row is in History RIGHT NOW. Every "saved" answer on this page
   /// goes through it, because a remembered write is not a row: the user can delete the row
   /// from History at any moment after either write, including after a Stop that ends the
   /// run before the cleaned write would have noticed. Found by the cloud review of PR #2786,
   /// the second route to the same defect.
   private let historyRowExists: @MainActor (UUID) -> Bool
+
+  /// The row's CURRENT state, read fresh at call time — never `originalHistoryRow`'s own
+  /// cached copy (#2811, phase 4 of #2807). Two callers need this: `savePolishedToHistory`'s
+  /// rename-safety fix (carries the live speaker fields forward rather than reverting them to
+  /// a stale snapshot) and this coordinator's own rename/retry entry points, which must read
+  /// the row's current analysis and turns TOGETHER, atomically, rather than reusing a value
+  /// captured earlier (§3 Design correction). Defaults to "no row" so tests that do not
+  /// exercise rename/retry need not wire it.
+  private let currentHistoryRow: @MainActor (UUID) -> Transcript?
 
   /// The row this import first wrote, kept whole rather than as an id.
   ///
@@ -613,6 +634,14 @@ final class FileImportCoordinator {
     updateHistoryRow: @escaping @MainActor (Transcript) throws -> Bool,
     mergeSpeakerFields:
       @escaping @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?) throws -> Bool,
+    // Defaulted, unlike the four closures above (#2772's "no defaults" rule protects the
+    // MAIN import write path — every new import always calls those four; rename and retry
+    // are opt-in UI actions most tests never exercise, so a harmless default here does not
+    // risk a silently-wrong "saved" answer the way defaulting the core writes would).
+    writeExplicitRename: @escaping @MainActor (
+      UUID, TranscriptSpeakerAnalysis, [Turn]?, (speakerId: String, name: String)
+    ) throws -> Bool = { _, _, _, _ in false },
+    currentHistoryRow: @escaping @MainActor (UUID) -> Transcript? = { _ in nil },
     historyRowExists: @escaping @MainActor (UUID) -> Bool,
     processPart:
       @escaping @MainActor (String, String?) async throws -> FileImportRunner.PartOutcome
@@ -636,6 +665,8 @@ final class FileImportCoordinator {
     self.saveToHistory = saveToHistory
     self.updateHistoryRow = updateHistoryRow
     self.mergeSpeakerFields = mergeSpeakerFields
+    self.writeExplicitRename = writeExplicitRename
+    self.currentHistoryRow = currentHistoryRow
     self.historyRowExists = historyRowExists
     self.processPart = processPart
   }
@@ -652,6 +683,12 @@ final class FileImportCoordinator {
     // Same reason as `startOver`: a different file must not read as though the LAST
     // file's speaker analysis was about this one (found by second-pass review).
     speakerAnalysis = nil
+    // #2811, phase 4: same reason, and the same points `decodedSamples` itself resets — a
+    // retained retry from the LAST file must never fire against this one.
+    speakerStepState = .notStarted
+    retainedAnalysisSamples = []
+    retainedWordTimings = nil
+    retainedWordTimingCoverage = nil
     // Detached from `runTask` (see `run()`), so choosing a new file while a PRIOR
     // file's speaker step is still quietly running in the background must stop it
     // itself, not rely on Stop having already done so.
@@ -1060,6 +1097,11 @@ final class FileImportCoordinator {
     // A different file is a different speaker analysis — the prior file's outcome must
     // not survive to be read against this one (found by second-pass review).
     speakerAnalysis = nil
+    // #2811, phase 4: same reason, same reset point as `decodedSamples`.
+    speakerStepState = .notStarted
+    retainedAnalysisSamples = []
+    retainedWordTimings = nil
+    retainedWordTimingCoverage = nil
     speakerStepTask?.cancel()
     forgetSaveOutcome()
     // A new file is a NEW History row. Carrying the id forward would make the next import
@@ -1084,9 +1126,34 @@ final class FileImportCoordinator {
   /// The in-flight read, so replacing or clearing the file can stop it.
   private var decodeTask: Task<Void, Never>?
 
-  /// The dormant speaker step's outcome, held in memory for telemetry and the log only
-  /// (#2809 addendum §3 B3). Not persisted, not read by any view in phase 2.
+  /// The speaker step's ANALYZER outcome, held in memory for telemetry and the log
+  /// (#2809 addendum §3 B3). This is the in-memory, analyzer-only value — phase 4's UI reads
+  /// the STORED outcome instead (via `currentHistoryRow`/`speakerStepState` together), since
+  /// several branches downstream of this (missing timings, admission refusal, polisher
+  /// unavailable) either downgrade or never touch what gets persisted (§3 Design "failure
+  /// authority" correction). Kept for telemetry/log continuity, not read directly by any view.
   private(set) var speakerAnalysis: SpeakerAnalysis?
+
+  /// UI-facing lifecycle signal for the phase-3 speaker/turn-storage pass (#2811 §4 contract
+  /// deltas): "is the invisible step currently running," nothing about its outcome. Neither
+  /// `speakerAnalysis` (analyzer-only) nor the stored `speakerAnalysis` field alone can
+  /// distinguish not-started from in-progress from a `.single` result with nothing to say, so
+  /// this is tracked explicitly. Transitions exactly once per run/retry:
+  /// `.notStarted` → `.inProgress` → `.finished`, whatever the outcome (success, failure, or
+  /// Stop all reach `.finished`); reset to `.notStarted` at the same points `speakerAnalysis`
+  /// itself resets.
+  enum SpeakerStepState: Equatable, Sendable { case notStarted, inProgress, finished }
+  private(set) var speakerStepState: SpeakerStepState = .notStarted
+
+  /// Retained PCM for a possible "Try again" (#2811 §3 Design "retained retry state"
+  /// correction): a genuinely NEW retention this phase adds, since `releaseDecodedAudio()`
+  /// already clears `decodedSamples` immediately after transcription, well before a retry
+  /// would exist to need it. Cleared at the exact points `decodedSamples` itself resets
+  /// (`choose(url:)`, `startOver()`), so a stale retry can never fire against a replaced
+  /// document.
+  private var retainedAnalysisSamples: [Float] = []
+  private var retainedWordTimings: [ASRWordTiming]?
+  private var retainedWordTimingCoverage: ASRWordTimingCoverage?
 
   /// The in-flight speaker step, run detached from `run()`'s own completion — it touches
   /// no ASR engine and must never add its own deadline (20s minimum) to the user-visible
@@ -1377,6 +1444,14 @@ final class FileImportCoordinator {
       // get (found by cloud review). `choose`/`startOver` still invalidate this correctly:
       // both reset `originalHistoryRow` before any later save gives it a new id.
       let historyIDAtStart = historyID
+      // #2811, phase 4: retained for a possible "Try again," a genuinely NEW retention this
+      // phase adds — `analysisSamples` itself is a local (freed once this function returns),
+      // and `wordTimings`/`wordTimingCoverage` were never stored at all before. Cleared at the
+      // same points `decodedSamples` itself resets.
+      retainedAnalysisSamples = analysisSamples
+      retainedWordTimings = result.wordTimings
+      retainedWordTimingCoverage = result.wordTimingCoverage
+      speakerStepState = .inProgress
       speakerStepTask = Task { [weak self] in
         await self?.runSpeakerStep(
           analysisSamples: analysisSamples, generationAtStart: generationAtStart,
@@ -1399,12 +1474,16 @@ final class FileImportCoordinator {
 
   /// The phase-2 speaker step, now feeding phase-3 turn assembly and storage (#2810
   /// addendum §3 C-E). Runs the bounded, cancellable analysis on the captured PCM, guards
-  /// on DOCUMENT IDENTITY once more before recording anything, and never surfaces a UI
-  /// signal on any outcome — `speakerAnalysis` is read only by telemetry and the log.
+  /// on DOCUMENT IDENTITY once more before recording anything. `speakerAnalysis` (in-memory,
+  /// analyzer-only) is read only by telemetry and the log; `speakerStepState` (#2811, phase 4)
+  /// is the UI-facing signal, set to `.finished` here on EVERY exit path via `defer` — success,
+  /// an early return, or cancellation — but only for the document this pass was FOR, so a
+  /// stale completion can never mark a NEWER document's own in-progress pass as finished.
   private func runSpeakerStep(
     analysisSamples: [Float], generationAtStart: Int, historyIDAtStart: UUID?, rawText: String,
     wordTimings: [ASRWordTiming]?, wordTimingCoverage: ASRWordTimingCoverage?
   ) async {
+    defer { if historyIDAtStart == historyID { speakerStepState = .finished } }
     let durationSeconds = file?.seconds ?? 0
     let analysisStart = CFAbsoluteTimeGetCurrent()
     let outcome = await speakerLabeler(analysisSamples, durationSeconds)
@@ -1461,68 +1540,12 @@ final class FileImportCoordinator {
     onVisibleCleanupWaitResolved(generationAtStart)
     guard historyIDAtStart == historyID, !Task.isCancelled else { return }
 
-    // Non-labeled outcomes map directly through the one exhaustive mapping (chunk 1) and
-    // never touch turn assembly. A missing `wordTimings` matters ONLY when assembly is
-    // actually needed — checking it before the outcome type would let a merge-input gap
-    // silently override a perfectly good `.single`/`.failed`/`.timedOut` result that has
-    // nothing to do with timings (found by chunk review).
-    guard case .labeled(let labeledCount, let segments) = outcome else {
-      // `.single` is the one non-labeled outcome worth a turn-storage telemetry event of
-      // its own (there is genuinely nothing to store, by design). `.failed`/`.timedOut`/
-      // `.cancelled` are ANALYZER outcomes `emitSpeakerTelemetry` already reported moments
-      // earlier — `nil` here means "write silently, do not double-report."
-      let turnsOutcome: TelemetryService.FileImportTurnsOutcome? =
-        if case .single = outcome { .singleNoTurns } else { nil }
-      await mergeAndReport(
-        historyID: historyID, analysis: outcome.asStorageAnalysis, turns: nil,
-        outcome: turnsOutcome, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
-      return
-    }
-    guard let wordTimings else {
-      await mergeAndReport(
-        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
-        outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
-      return
-    }
-
-    // Off the main actor: a multi-hour, highly segmented recording's O(words × segments)
-    // scan would otherwise run synchronously on this MainActor-isolated method and freeze
-    // the UI before the background cleanup even claims the engine (found by cloud review).
-    // `entries`/`segments`/`Turn` are all `Sendable` value types, so handing the pure
-    // computation to a detached task changes nothing about its result.
-    //
-    // `Task.detached` is UNSTRUCTURED: cancelling THIS task (e.g. `stop()`'s unconditional
-    // `speakerStepTask?.cancel()`) would not by itself cancel the detached child, leaving it
-    // to run the full scan to completion and this task waiting on it the whole time
-    // (found by cloud review). `withTaskCancellationHandler` propagates cancellation into
-    // the child explicitly; `TurnAssembler.assemble`'s own loop checks `Task.isCancelled`
-    // per entry so the propagated cancellation actually shortens the scan.
-    let assemblyTask = Task.detached(priority: .utility) {
-      TurnAssembler.assemble(entries: wordTimings, segments: segments)
-    }
-    let assembledTurns = await withTaskCancellationHandler(
-      operation: { await assemblyTask.value },
-      onCancel: { assemblyTask.cancel() }
-    )
+    guard
+      let (assembledTurns, labeledCount) = await assembleTurnsOrPersistTerminal(
+        outcome: outcome, wordTimings: wordTimings, historyID: historyID,
+        historyIDAtStart: historyIDAtStart, passStart: passStart)
+    else { return }
     guard historyIDAtStart == historyID, !Task.isCancelled else { return }
-
-    // A space-free script (Chinese, Japanese, ...) makes the production word-timing mapper
-    // (`WordTimingRangeMapper`, #2809) return exactly one untimed entry for the whole
-    // transcript — there is no whitespace to tokenize on, so no engine word can bind to any
-    // text run. Every entry then resolves to "unknown" here, and persisting `.labeled(count:)`
-    // alongside turns that are ALL "unknown" would store a self-contradictory row: the
-    // analysis claims real speakers while the turns say none were ever found (found by cloud
-    // review). Treated the same as `noWordTimings` — from turn assembly's own perspective,
-    // timings that never bind to anything are exactly "nothing to merge against," matching
-    // that reason's own documented scope. The real fix (a mapper that can tokenize a
-    // space-free script) belongs to `WordTimingRangeMapper` itself, out of this phase's scope.
-    guard assembledTurns.contains(where: { $0.speakerId != TurnAssembler.unknownSpeakerID })
-    else {
-      await mergeAndReport(
-        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
-        outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
-      return
-    }
 
     let token: EngineLease.Token
     switch engineAdmission.claim() {
@@ -1570,6 +1593,179 @@ final class FileImportCoordinator {
       historyID: historyID, analysis: .labeled(count: labeledCount), turns: cleanedTurns,
       outcome: .stored, turnCount: cleanedTurns.count, fallbackTurnCount: fallbackTurnCount,
       passStart: passStart)
+  }
+
+  /// The analysis/assembly PREFIX shared by the ordinary post-import pass
+  /// (`runTurnStorage`) and a "Try again" retry (#2811 §3 Design: "the two entry points share
+  /// the analysis/assembly PREFIX and the persistence step; only the cleanup SUFFIX
+  /// differs"). Extracted rather than duplicated, since a future fix to any of these three
+  /// branches (non-labeled, missing timings, all-unknown) would otherwise need applying twice.
+  ///
+  /// `nil` means a terminal outcome was already persisted by THIS call (non-labeled, missing
+  /// timings, or all-unknown), or the pass went stale/cancelled mid-assembly — either way the
+  /// caller must stop, writing nothing further. Non-nil hands back turns ready for EITHER
+  /// cleanup (the ordinary path) or direct persistence (retry, which skips cleanup).
+  private func assembleTurnsOrPersistTerminal(
+    outcome: SpeakerAnalysis, wordTimings: [ASRWordTiming]?, historyID: UUID,
+    historyIDAtStart: UUID?, passStart: CFAbsoluteTime
+  ) async -> (turns: [Turn], labeledCount: Int)? {
+    // Non-labeled outcomes map directly through the one exhaustive mapping (chunk 1) and
+    // never touch turn assembly. A missing `wordTimings` matters ONLY when assembly is
+    // actually needed — checking it before the outcome type would let a merge-input gap
+    // silently override a perfectly good `.single`/`.failed`/`.timedOut` result that has
+    // nothing to do with timings (found by chunk review).
+    guard case .labeled(let labeledCount, let segments) = outcome else {
+      // `.single` is the one non-labeled outcome worth a turn-storage telemetry event of
+      // its own (there is genuinely nothing to store, by design). `.failed`/`.timedOut`/
+      // `.cancelled` are ANALYZER outcomes `emitSpeakerTelemetry` already reported moments
+      // earlier — `nil` here means "write silently, do not double-report."
+      let turnsOutcome: TelemetryService.FileImportTurnsOutcome? =
+        if case .single = outcome { .singleNoTurns } else { nil }
+      await mergeAndReport(
+        historyID: historyID, analysis: outcome.asStorageAnalysis, turns: nil,
+        outcome: turnsOutcome, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
+      return nil
+    }
+    guard let wordTimings else {
+      await mergeAndReport(
+        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
+        outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
+      return nil
+    }
+
+    // Off the main actor: a multi-hour, highly segmented recording's O(words × segments)
+    // scan would otherwise run synchronously on this MainActor-isolated method and freeze
+    // the UI before the background cleanup even claims the engine (found by cloud review).
+    // `entries`/`segments`/`Turn` are all `Sendable` value types, so handing the pure
+    // computation to a detached task changes nothing about its result.
+    //
+    // `Task.detached` is UNSTRUCTURED: cancelling THIS task (e.g. `stop()`'s unconditional
+    // `speakerStepTask?.cancel()`) would not by itself cancel the detached child, leaving it
+    // to run the full scan to completion and this task waiting on it the whole time
+    // (found by cloud review). `withTaskCancellationHandler` propagates cancellation into
+    // the child explicitly; `TurnAssembler.assemble`'s own loop checks `Task.isCancelled`
+    // per entry so the propagated cancellation actually shortens the scan.
+    let assemblyTask = Task.detached(priority: .utility) {
+      TurnAssembler.assemble(entries: wordTimings, segments: segments)
+    }
+    let assembledTurns = await withTaskCancellationHandler(
+      operation: { await assemblyTask.value },
+      onCancel: { assemblyTask.cancel() }
+    )
+    // A stale/cancelled pass writes NOTHING here, matching every other staleness guard in
+    // this file — the caller must not fall through to the all-unknown check below and
+    // persist a failure on behalf of a document nobody is watching anymore.
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return nil }
+
+    // A space-free script (Chinese, Japanese, ...) makes the production word-timing mapper
+    // (`WordTimingRangeMapper`, #2809) return exactly one untimed entry for the whole
+    // transcript — there is no whitespace to tokenize on, so no engine word can bind to any
+    // text run. Every entry then resolves to "unknown" here, and persisting `.labeled(count:)`
+    // alongside turns that are ALL "unknown" would store a self-contradictory row: the
+    // analysis claims real speakers while the turns say none were ever found (found by cloud
+    // review). Treated the same as `noWordTimings` — from turn assembly's own perspective,
+    // timings that never bind to anything are exactly "nothing to merge against," matching
+    // that reason's own documented scope. The real fix (a mapper that can tokenize a
+    // space-free script) belongs to `WordTimingRangeMapper` itself, out of this phase's scope.
+    guard assembledTurns.contains(where: { $0.speakerId != TurnAssembler.unknownSpeakerID })
+    else {
+      await mergeAndReport(
+        historyID: historyID, analysis: .failed(.noWordTimings), turns: nil,
+        outcome: .noWordTimings, turnCount: nil, fallbackTurnCount: 0, passStart: passStart)
+      return nil
+    }
+    return (assembledTurns, labeledCount)
+  }
+
+  /// Whether "Try again" should be offered right now (#2811 §4 invariant): the STORED outcome
+  /// is `.failed`, or `speakerStepState` reached `.finished` with the row STILL unanalyzed
+  /// (admission-refused/polisher-unavailable write nothing at all, leaving the row exactly as
+  /// it was — read the STORED field, never the in-memory analyzer-only `speakerAnalysis`, per
+  /// the §3 Design "failure authority" correction). Never while a pass is `.inProgress`, and
+  /// never for `.single`/`.labeled`, which have nothing to retry.
+  var canRetrySpeakerAnalysis: Bool {
+    guard speakerStepState == .finished, !retainedAnalysisSamples.isEmpty, let historyID,
+      let current = currentHistoryRow(historyID)
+    else { return false }
+    switch current.speakerAnalysis {
+    // `.unanalyzed`/`nil` both mean "no outcome ever landed" — `nil` is a pre-#2810 legacy
+    // row's decode default (Transcript.swift's own documented reading), `.unanalyzed` is the
+    // enum's own explicit spelling of the same fact; neither is ever chosen over the other by
+    // this codebase's own writers, so both must be treated identically here.
+    case .failed, .unanalyzed, nil: return true
+    case .single, .labeled: return false
+    }
+  }
+
+  /// Re-runs speaker analysis and turn assembly from retained state, then PERSISTS that
+  /// result — but skips `TurnCleanupRunner` entirely (#2811 §3 Design "retry must not
+  /// silently re-run cleanup, but it MUST still persist its result"). Shares the
+  /// analysis/assembly PREFIX with the ordinary pass via `assembleTurnsOrPersistTerminal`;
+  /// the CLEANUP SUFFIX, which stays "Clean it again" (`rePolish()`), is never reached here.
+  func retrySpeakerAnalysis() async {
+    guard canRetrySpeakerAnalysis, let historyID else { return }
+    let analysisSamples = retainedAnalysisSamples
+    let wordTimings = retainedWordTimings
+    let wordTimingCoverage = retainedWordTimingCoverage
+    // No retained `rawText`: retry never reaches `TurnCleanupRunner`, the only consumer of
+    // raw text in this pipeline, so there is nothing here that would use it.
+    let historyIDAtStart = historyID
+    speakerStepState = .inProgress
+    let durationSeconds = file?.seconds ?? 0
+    let analysisStart = CFAbsoluteTimeGetCurrent()
+    let outcome = await speakerLabeler(analysisSamples, durationSeconds)
+    let analysisMs = Int(((CFAbsoluteTimeGetCurrent() - analysisStart) * 1000).rounded())
+    defer { if historyIDAtStart == historyID { speakerStepState = .finished } }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
+    speakerAnalysis = outcome
+    await AppLogger.shared.log(
+      "[SpeakerLabeler] outcome=\(Self.speakerLogOutcome(outcome)) speakers=\(Self.speakerLogCount(outcome)) ms=\(analysisMs) retry=true",
+      level: .info, category: "FileImportCoordinator")
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
+    emitSpeakerTelemetry(outcome, durationSeconds, analysisMs, wordTimingCoverage)
+    // A fresh timer for the turn-storage phase, matching `runTurnStorage`'s own two-timer
+    // shape (`analysisStart` for the analyzer alone, `passStart` for everything after) — so
+    // this pass's `ms=` reads the same way as the ordinary pass's, minus the cleanup it skips.
+    let passStart = CFAbsoluteTimeGetCurrent()
+
+    guard
+      let (assembledTurns, labeledCount) = await assembleTurnsOrPersistTerminal(
+        outcome: outcome, wordTimings: wordTimings, historyID: historyID,
+        historyIDAtStart: historyIDAtStart, passStart: passStart)
+    else { return }
+    guard historyIDAtStart == historyID, !Task.isCancelled else { return }
+    // The cleanup suffix (`TurnCleanupRunner`) is deliberately never reached — the assembled
+    // turns persist AS-IS, exactly as they came out of analysis, matching the epic's own
+    // "cleanup stays 'Clean it again'" requirement.
+    await mergeAndReport(
+      historyID: historyID, analysis: .labeled(count: labeledCount), turns: assembledTurns,
+      outcome: .stored, turnCount: assembledTurns.count, fallbackTurnCount: 0,
+      passStart: passStart)
+  }
+
+  /// Renames a speaker id across every turn showing it (#2811, phase 4 of #2807). Re-fetches
+  /// the row's CURRENT analysis and turns TOGETHER, atomically, immediately before writing —
+  /// never a value captured when a popover opened, which the plan's own grounded review
+  /// found unsafe against a rename or a background turn-storage pass racing this one (§3
+  /// Design correction 2). Callable from either screen; both are ordinary, symmetric callers
+  /// of the same underlying write.
+  func renameSpeaker(id: String, name: String) async -> RenameFailure? {
+    guard let historyID, let current = currentHistoryRow(historyID), current.turns != nil,
+      let analysis = current.speakerAnalysis
+    else {
+      return RenameFailure(message: "Couldn't save the name.", currentName: nil)
+    }
+    do {
+      let saved = try writeExplicitRename(historyID, analysis, current.turns, (id, name))
+      guard saved else {
+        return RenameFailure(
+          message: "This recording was removed from History.", currentName: nil)
+      }
+      return nil
+    } catch {
+      return RenameFailure(
+        message: "Couldn't save the name.", currentName: current.speakerNames?[id])
+    }
   }
 
   private static func elapsedMs(since start: CFAbsoluteTime) -> Int {
@@ -1810,11 +2006,22 @@ final class FileImportCoordinator {
     // Same question the Done header's credit asks, and the same answer: `wasPolished`, not
     // the frozen configuration. A row that credits an engine for a clean that never ran is
     // the on-screen defect, persisted.
-    let polished = originalHistoryRow.withImportResult(
+    var polished = originalHistoryRow.withImportResult(
       documentText,
       wasPolished: parts.contains(where: \.wasPolished),
       llmProvider: runConfiguration?.polishProvider.rawValue,
       llmModel: runConfiguration?.polishModel)
+    // #2811, phase 4: `originalHistoryRow` is this coordinator's own cached snapshot, and
+    // `withImportResult` never touches speaker fields — it carries whatever `originalHistoryRow`
+    // already had forward VERBATIM. A rename (from either this wizard or History) or a
+    // background turn-storage write landing on the live row AFTER this snapshot was taken
+    // would otherwise be silently reverted by this write. Re-reading the live row and
+    // carrying ITS speaker fields forward instead closes that gap regardless of which surface
+    // wrote most recently (§3 Design "revised fix" — a single fix at the one place that
+    // performs this write, not a per-writer patch).
+    if let historyID, let liveRow = currentHistoryRow(historyID) {
+      polished = polished.carryingSpeakerFields(from: liveRow)
+    }
     do {
       guard try updateHistoryRow(polished) else {
         // The user deleted this import from History while it was being cleaned. Their

--- a/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/FileImportCoordinator.swift
@@ -1829,25 +1829,35 @@ final class FileImportCoordinator {
     return (assembledTurns, labeledCount)
   }
 
-  /// Whether "Try again" should be offered right now (#2811 §4 invariant): the STORED outcome
-  /// is `.failed`, or `speakerStepState` reached `.finished` with the row STILL unanalyzed
-  /// (admission-refused/polisher-unavailable write nothing at all, leaving the row exactly as
-  /// it was — read the STORED field, never the in-memory analyzer-only `speakerAnalysis`, per
-  /// the §3 Design "failure authority" correction). Never while a pass is `.inProgress`, and
-  /// never for `.single`/`.labeled`, which have nothing to retry.
-  var canRetrySpeakerAnalysis: Bool {
+  /// Why the Done screen should show a speaker-analysis notice right now, if at all (#2811 §4
+  /// invariant, refined by chunk review): `.failed` (a real analyzer failure) and
+  /// `.unresolved` (admission-refused/polisher-unavailable, which write NOTHING at all,
+  /// leaving the row exactly as it was) are DISTINCT stored outcomes and must read as
+  /// distinct notices — collapsing them into one generic message is exactly the "success
+  /// transitions straight to a silently-unresolved state" gap the §3 Design "failure
+  /// authority" correction exists to close. Reads the STORED field via `currentHistoryRow`,
+  /// never the in-memory analyzer-only `speakerAnalysis`. `.none` while a pass is
+  /// `.inProgress`, and for `.single`/`.labeled`, which have nothing to retry.
+  enum SpeakerNoticeReason: Equatable, Sendable { case none, failed, unresolved }
+
+  var speakerNoticeReason: SpeakerNoticeReason {
     guard speakerStepState == .finished, !retainedAnalysisSamples.isEmpty, let historyID,
       let current = currentHistoryRow(historyID)
-    else { return false }
+    else { return .none }
     switch current.speakerAnalysis {
+    case .failed: return .failed
     // `.unanalyzed`/`nil` both mean "no outcome ever landed" — `nil` is a pre-#2810 legacy
     // row's decode default (Transcript.swift's own documented reading), `.unanalyzed` is the
     // enum's own explicit spelling of the same fact; neither is ever chosen over the other by
-    // this codebase's own writers, so both must be treated identically here.
-    case .failed, .unanalyzed, nil: return true
-    case .single, .labeled: return false
+    // this codebase's own writers, so both read as the same `.unresolved` notice.
+    case .unanalyzed, nil: return .unresolved
+    case .single, .labeled: return .none
     }
   }
+
+  /// Whether "Try again" should be offered right now — true for either notice reason above,
+  /// since both are genuinely retry-eligible per §4's invariant (only the WORDING differs).
+  var canRetrySpeakerAnalysis: Bool { speakerNoticeReason != .none }
 
   /// Re-runs speaker analysis and turn assembly from retained state, then PERSISTS that
   /// result — but skips `TurnCleanupRunner` entirely (#2811 §3 Design "retry must not

--- a/Sources/EnviousWisprAppKit/App/MenuBarController.swift
+++ b/Sources/EnviousWisprAppKit/App/MenuBarController.swift
@@ -402,6 +402,17 @@ final class MenuBarController: NSObject {
       result: state.quickAdd.selectionResult, context: state.quickAddContext)
     menu.addItem(quickAddItem)
 
+    // Transcribe a File (#2772): the founder asked for it in the first UAT round of the
+    // import wizard. Opens the unified window on that page; the page itself does the rest.
+    // Sits with the other two ways to get words in (#2811, founder 2026-09-12), above the
+    // divider, not with the Settings group below it.
+    let transcribeFileItem = NSMenuItem(
+      title: "Transcribe a File...", action: #selector(openTranscribeFileAction), keyEquivalent: "")
+    transcribeFileItem.image = NSImage(
+      systemSymbolName: "doc.badge.plus", accessibilityDescription: "Transcribe a File")
+    transcribeFileItem.target = self
+    menu.addItem(transcribeFileItem)
+
     // Auto-stop on silence indicator
     if state.vadAutoStop {
       let autoStopTitle =
@@ -446,15 +457,6 @@ final class MenuBarController: NSObject {
     }
 
     menu.addItem(.separator())
-
-    // Transcribe a File (#2772): the founder asked for it in the first UAT round of the
-    // import wizard. Opens the unified window on that page; the page itself does the rest.
-    let transcribeFileItem = NSMenuItem(
-      title: "Transcribe a File...", action: #selector(openTranscribeFileAction), keyEquivalent: "")
-    transcribeFileItem.image = NSImage(
-      systemSymbolName: "doc.badge.plus", accessibilityDescription: "Transcribe a File")
-    transcribeFileItem.target = self
-    menu.addItem(transcribeFileItem)
 
     // Settings (opens unified window to Speech Engine tab)
     let settingsItem = NSMenuItem(

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -819,6 +819,32 @@ final class TranscriptCoordinator {
     transcripts.first { $0.id == id }
   }
 
+  /// Renames a speaker id across every turn showing it, for a row History renders directly
+  /// (#2811, phase 4 of #2807) — the History-side twin of `FileImportCoordinator
+  /// .renameSpeaker`, both ordinary, symmetric callers of `mergeSpeakerFields` above. Re-reads
+  /// the row's CURRENT analysis and turns TOGETHER, atomically, immediately before writing —
+  /// never a value captured when a popover opened (§3 Design correction 2).
+  func renameSpeaker(id transcriptID: UUID, speakerId: String, name: String) -> RenameFailure? {
+    guard let current = currentRow(id: transcriptID), current.turns != nil,
+      let analysis = current.speakerAnalysis
+    else {
+      return RenameFailure(message: "Couldn't save the name.", currentName: nil)
+    }
+    do {
+      let saved = try mergeSpeakerFields(
+        id: transcriptID, analysis: analysis, turns: current.turns,
+        explicitRename: (speakerId, name))
+      guard saved else {
+        return RenameFailure(
+          message: "This recording was removed from History.", currentName: nil)
+      }
+      return nil
+    } catch {
+      return RenameFailure(
+        message: "Couldn't save the name.", currentName: current.speakerNames?[speakerId])
+    }
+  }
+
   /// Counts writes, so a disk read that began earlier can be told it is stale.
   ///
   /// `load()` prefers the DISK row whenever an id already exists, which is right for a

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -140,9 +140,16 @@ final class TranscriptCoordinator {
       // for a meeting they transcribed types, so it is searchable. Searching "marketing" for
       // `marketing_sync.wav` removed the row while its badge said the word. Found by the
       // cloud review of PR #2786.
+      // #2811, phase 4 of #2807: a renamed speaker's name does not enter `displayText` — the
+      // epic's own "find the row with 'Zach, Ariana' on it" walkthrough needs an explicit
+      // match against the speaker names themselves, a genuinely new gap this phase closes
+      // (plan §6 downstream consumer matrix).
       $0.escapeRecoveredAt == nil
         && ($0.displayText.localizedCaseInsensitiveContains(searchQuery)
-          || ($0.importedFileName?.localizedCaseInsensitiveContains(searchQuery) ?? false))
+          || ($0.importedFileName?.localizedCaseInsensitiveContains(searchQuery) ?? false)
+          || ($0.speakerNames?.values.contains {
+            $0.localizedCaseInsensitiveContains(searchQuery)
+          } ?? false))
     }
   }
 

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -1036,7 +1036,11 @@ final class TranscriptCoordinator {
   func deleteAll() {
     do {
       try store.deleteAll()
+      let removedIDs = transcripts.map(\.id)
       transcripts.removeAll()
+      // The same announcement `delete(_:)` makes, per row, after the list is already empty
+      // (found by cloud review, round 3: this route bypassed it).
+      for id in removedIDs { onRowDeleted?(id) }
       selectedTranscriptID = nil
       // #2807: an empty History shows nothing, whatever the live pipeline last produced.
       liveFallbackSuppressed = true

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -94,6 +94,9 @@ final class TranscriptCoordinator {
   private let emitEscapeRecoveryExpired: (_ ageMs: Int, _ takeID: String) -> Void
   private let emitEscapeRecoveryRestoredFromHistory: (_ ageMs: Int, _ takeID: String) -> Void
   private let recordEscapeRecoveryKeep: @MainActor (_ outcome: String, _ takeID: String?) -> Void
+  /// #2811, phase 4 of #2807 §3e — same seam-not-direct-call reason as the escape-recovery
+  /// emitters above.
+  private let emitRenameTelemetry: (_ outcome: TelemetryService.FileImportRenameOutcome) -> Void
   private var loadTask: Task<Void, Never>?
   private var pulseTask: Task<Void, Never>?
 
@@ -436,7 +439,8 @@ final class TranscriptCoordinator {
     emitEscapeRecoveryKept: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
     emitEscapeRecoveryExpired: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
     emitEscapeRecoveryRestoredFromHistory: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
-    recordEscapeRecoveryKeep: (@MainActor (_ outcome: String, _ takeID: String?) -> Void)? = nil
+    recordEscapeRecoveryKeep: (@MainActor (_ outcome: String, _ takeID: String?) -> Void)? = nil,
+    emitRenameTelemetry: ((_ outcome: TelemetryService.FileImportRenameOutcome) -> Void)? = nil
   ) {
     self.store = store
     self.pendingPulseInterval = pendingPulseInterval
@@ -458,6 +462,9 @@ final class TranscriptCoordinator {
           source: .history, ageMs: ageMs, pasteResult: .pasted, takeID: takeID)
       }
     self.recordEscapeRecoveryKeep = recordEscapeRecoveryKeep ?? Self.logKeep
+    self.emitRenameTelemetry =
+      emitRenameTelemetry
+      ?? { outcome in TelemetryService.shared.trackFileImportRename(outcome: outcome) }
   }
 
   /// Report that a HELD recovery was pasted from History (#2087).
@@ -835,6 +842,7 @@ final class TranscriptCoordinator {
     guard let current = currentRow(id: transcriptID), current.turns != nil,
       let analysis = current.speakerAnalysis
     else {
+      emitRenameTelemetry(.failed)
       return RenameFailure(message: "Couldn't save the name.", currentName: nil)
     }
     do {
@@ -842,11 +850,14 @@ final class TranscriptCoordinator {
         id: transcriptID, analysis: analysis, turns: current.turns,
         explicitRename: (speakerId, name))
       guard saved else {
+        emitRenameTelemetry(.failed)
         return RenameFailure(
           message: "This recording was removed from History.", currentName: nil)
       }
+      emitRenameTelemetry(.saved)
       return nil
     } catch {
+      emitRenameTelemetry(.failed)
       return RenameFailure(
         message: "Couldn't save the name.", currentName: current.speakerNames?[speakerId])
     }

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -102,6 +102,11 @@ final class TranscriptCoordinator {
   private let emitTurnsDisplayedTelemetry: () -> Void
   /// Documents whose turn view History has already drawn this launch (#2811 §3e).
   private var displayedTurnIDs: Set<UUID> = []
+  /// Called after a row is deleted here, with its id. Set by the bootstrapper once both
+  /// coordinators exist, since this one is built first: the file-import coordinator uses it
+  /// to drop the audio it holds for a possible speaker retry on that row (#2811). Nothing
+  /// else observes a deletion; the coordinator's own deleted-row notice stays derived.
+  @ObservationIgnored var onRowDeleted: (@MainActor (UUID) -> Void)?
   private var loadTask: Task<Void, Never>?
   private var pulseTask: Task<Void, Never>?
 
@@ -897,6 +902,7 @@ final class TranscriptCoordinator {
       let displayed = filteredTranscripts
       try store.delete(id: transcript.id)
       transcripts.removeAll { $0.id == transcript.id }
+      onRowDeleted?(transcript.id)
       if selectedTranscriptID == transcript.id {
         // The next row in the same filter, else the previous one, else nothing — and
         // nothing means the status view, never the live fallback (the setter arms that).

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -810,6 +810,15 @@ final class TranscriptCoordinator {
     transcripts.contains { $0.id == id }
   }
 
+  /// The CURRENT row, read fresh from `transcripts` at call time — never a snapshot (#2811,
+  /// phase 4 of #2807). Mirrors `hasRow(id:)`'s own "the in-memory list is the oracle"
+  /// contract: a caller about to carry another writer's speaker fields forward, or decide
+  /// whether a rename/retry is eligible, must read this rather than trust a value it captured
+  /// earlier.
+  func currentRow(id: UUID) -> Transcript? {
+    transcripts.first { $0.id == id }
+  }
+
   /// Counts writes, so a disk read that began earlier can be told it is stale.
   ///
   /// `load()` prefers the DISK row whenever an id already exists, which is right for a

--- a/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptCoordinator.swift
@@ -95,8 +95,13 @@ final class TranscriptCoordinator {
   private let emitEscapeRecoveryRestoredFromHistory: (_ ageMs: Int, _ takeID: String) -> Void
   private let recordEscapeRecoveryKeep: @MainActor (_ outcome: String, _ takeID: String?) -> Void
   /// #2811, phase 4 of #2807 §3e — same seam-not-direct-call reason as the escape-recovery
-  /// emitters above.
+  /// emitters above, but with NO-OP defaults rather than a fallback to the shared service:
+  /// these mirror `FileImportCoordinator`'s emitters for the same feature, and both screens'
+  /// production wiring lives side by side in `WisprBootstrapper` (found by chunk review).
   private let emitRenameTelemetry: (_ outcome: TelemetryService.FileImportRenameOutcome) -> Void
+  private let emitTurnsDisplayedTelemetry: () -> Void
+  /// Documents whose turn view History has already drawn this launch (#2811 §3e).
+  private var displayedTurnIDs: Set<UUID> = []
   private var loadTask: Task<Void, Never>?
   private var pulseTask: Task<Void, Never>?
 
@@ -440,7 +445,9 @@ final class TranscriptCoordinator {
     emitEscapeRecoveryExpired: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
     emitEscapeRecoveryRestoredFromHistory: ((_ ageMs: Int, _ takeID: String) -> Void)? = nil,
     recordEscapeRecoveryKeep: (@MainActor (_ outcome: String, _ takeID: String?) -> Void)? = nil,
-    emitRenameTelemetry: ((_ outcome: TelemetryService.FileImportRenameOutcome) -> Void)? = nil
+    emitRenameTelemetry: @escaping (_ outcome: TelemetryService.FileImportRenameOutcome) -> Void =
+      { _ in },
+    emitTurnsDisplayedTelemetry: @escaping () -> Void = {}
   ) {
     self.store = store
     self.pendingPulseInterval = pendingPulseInterval
@@ -462,9 +469,8 @@ final class TranscriptCoordinator {
           source: .history, ageMs: ageMs, pasteResult: .pasted, takeID: takeID)
       }
     self.recordEscapeRecoveryKeep = recordEscapeRecoveryKeep ?? Self.logKeep
-    self.emitRenameTelemetry =
-      emitRenameTelemetry
-      ?? { outcome in TelemetryService.shared.trackFileImportRename(outcome: outcome) }
+    self.emitRenameTelemetry = emitRenameTelemetry
+    self.emitTurnsDisplayedTelemetry = emitTurnsDisplayedTelemetry
   }
 
   /// Report that a HELD recovery was pasted from History (#2087).
@@ -861,6 +867,18 @@ final class TranscriptCoordinator {
       return RenameFailure(
         message: "Couldn't save the name.", currentName: current.speakerNames?[speakerId])
     }
+  }
+
+  /// The rename popover closed on Escape or a blank name (plan §3d). Telemetry only.
+  func noteRenameCancelled() {
+    emitRenameTelemetry(.cancelled)
+  }
+
+  /// History's detail view just drew a turn view for `id` (#2811 §3e). Reported once per
+  /// document per launch; re-selecting the same row is not a new fact.
+  func noteTurnsDisplayed(id: UUID) {
+    guard displayedTurnIDs.insert(id).inserted else { return }
+    emitTurnsDisplayedTelemetry()
   }
 
   /// Counts writes, so a disk read that began earlier can be told it is stale.

--- a/Sources/EnviousWisprAppKit/App/TranscriptDocumentPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptDocumentPresenter.swift
@@ -125,7 +125,11 @@ enum TranscriptDocumentPresenter {
     return speakerNames[speakerId]
   }
 
-  private static func slice(_ text: String, _ range: Range<Int>) -> String {
+  /// Internal, not private (#2811, phase 4 of #2807): both callers preparing a turn's diff
+  /// input off-main — `FileImportCoordinator.turnDiffInput` and `TranscriptDetailView`'s own
+  /// equivalent — need the SAME slice this type uses for rendering, so this is the one owner
+  /// rather than a third private copy.
+  static func slice(_ text: String, _ range: Range<Int>) -> String {
     let lower = String.Index(utf16Offset: range.lowerBound, in: text)
     let upper = String.Index(utf16Offset: range.upperBound, in: text)
     guard lower <= upper, upper <= text.endIndex else { return "" }

--- a/Sources/EnviousWisprAppKit/App/TranscriptDocumentPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptDocumentPresenter.swift
@@ -11,36 +11,31 @@ import Foundation
 /// different inputs feeding the SAME turn-rendering/export decision once turns are in hand.
 /// Each caller keeps its OWN existing plain-text fallback for the `turns == nil` case; this
 /// type answers only "given real turns, what do they look like and what gets exported."
-public enum TranscriptDocumentPresenter {
+///
+/// Module-internal, matching `FileImportCoordinator`/`TranscriptDetailView`'s own convention
+/// — both this type's callers live in `EnviousWisprAppKit`, so nothing here needs to be
+/// `public`.
+enum TranscriptDocumentPresenter {
 
-  /// Mirrors `FileImportCoordinator.DocumentView` — the SAME three states, reused rather than
-  /// redeclared. History gets its own instance of this identical enum for its own
-  /// screen-local mode state; the two screens never share a mutable mode owner.
-  public enum ViewMode: Equatable, Sendable {
-    case cleaned, markedUp, original
-  }
+  /// Reuses `FileImportCoordinator.DocumentView` directly rather than redeclaring an
+  /// equivalent enum (found by chunk review) — History gets its own LOCAL `@State` of this
+  /// SAME type for its own screen-local mode; the two screens never share a mutable owner.
+  typealias ViewMode = FileImportCoordinator.DocumentView
 
   /// One turn ready to render. `content` carries either plain text or a diff — `.markedUp`
   /// needs styled segments (removed/changed/added), the other two modes do not.
-  public struct RenderedTurn: Equatable, Sendable {
-    public let speakerId: String
+  struct RenderedTurn: Equatable, Sendable {
+    let speakerId: String
     /// `nil` for `"unknown"` — a classification outcome, never a named speaker (#2810).
     /// Callers must never attach a rename control when this is `nil`.
-    public let speakerName: String?
+    let speakerName: String?
     /// `nil` when times are off, or the turn has no timing at all.
-    public let timeLabel: String?
-    public let content: Content
+    let timeLabel: String?
+    let content: Content
 
-    public enum Content: Equatable, Sendable {
+    enum Content: Equatable, Sendable {
       case plain(String)
       case markedUp(WordDiff.Result)
-    }
-
-    public init(speakerId: String, speakerName: String?, timeLabel: String?, content: Content) {
-      self.speakerId = speakerId
-      self.speakerName = speakerName
-      self.timeLabel = timeLabel
-      self.content = content
     }
   }
 
@@ -49,9 +44,17 @@ public enum TranscriptDocumentPresenter {
   /// — `nil` and `[]` collapse to the SAME "fall back to plain text" outcome, never
   /// distinguished by a caller). `rawText` is the SAME text `turn.originalTextRange` indexes
   /// into (`Transcript.text` for History, the wizard's own `rawTranscript` for a live run).
-  public static func render(
+  ///
+  /// `diffLookup` supplies an ALREADY-PREPARED `WordDiff.Result` for `.markedUp` mode — this
+  /// function never calls `WordDiff.compare` itself (found by chunk review: `WordDiff`'s own
+  /// doc comment measures up to ~3 seconds at pathological input sizes, so computing it
+  /// synchronously inside a rendering call would stall the caller; the plan's own corrected
+  /// §3 requires the SAME off-main, cached preparation `prepareMarkedUp` already uses). A
+  /// turn with no cached diff yet (still preparing) renders `nil` from the lookup and this
+  /// falls back to that turn's cleaned text rather than blocking.
+  static func render(
     turns: [Turn]?, rawText: String, speakerNames: [String: String], mode: ViewMode,
-    timesOn: Bool, engineLanguage: String?
+    timesOn: Bool, diffLookup: (Turn) -> WordDiff.Result?
   ) -> [RenderedTurn]? {
     guard let turns, !turns.isEmpty else { return nil }
     return turns.map { turn in
@@ -62,8 +65,11 @@ public enum TranscriptDocumentPresenter {
       case .cleaned: content = .plain(cleaned)
       case .original: content = .plain(original)
       case .markedUp:
-        content = .markedUp(
-          WordDiff.compare(original: original, cleaned: cleaned, language: engineLanguage))
+        if let diff = diffLookup(turn) {
+          content = .markedUp(diff)
+        } else {
+          content = .plain(cleaned)
+        }
       }
       return RenderedTurn(
         speakerId: turn.speakerId,
@@ -78,7 +84,7 @@ public enum TranscriptDocumentPresenter {
   /// callers use `isCleanedFallback` to relabel their buttons ("Copy cleaned", etc.).
   /// `nil` under the exact same condition as `render` — a caller with no turns to render
   /// has no turn-shaped text to export either, and falls back to its OWN existing export.
-  public static func exportText(
+  static func exportText(
     turns: [Turn]?, rawText: String, speakerNames: [String: String], timesOn: Bool, mode: ViewMode
   ) -> (text: String, isCleanedFallback: Bool)? {
     guard let turns, !turns.isEmpty else { return nil }
@@ -102,9 +108,7 @@ public enum TranscriptDocumentPresenter {
   /// Button titles for the three export actions. `.markedUp` relabels to disclose the
   /// substitution (founder's export rule, #2811 §2.1); the other two modes keep the
   /// wizard's own existing titles unchanged.
-  public static func exportButtonLabels(mode: ViewMode) -> (
-    copy: String, save: String, share: String
-  ) {
+  static func exportButtonLabels(mode: ViewMode) -> (copy: String, save: String, share: String) {
     mode == .markedUp
       ? ("Copy cleaned", "Save cleaned as…", "Share cleaned…")
       : ("Copy everything", "Save as…", "Share…")

--- a/Sources/EnviousWisprAppKit/App/TranscriptDocumentPresenter.swift
+++ b/Sources/EnviousWisprAppKit/App/TranscriptDocumentPresenter.swift
@@ -1,0 +1,136 @@
+import EnviousWisprCore
+import Foundation
+
+/// Renders a labeled transcript's turns and decides what export actions hand over (#2811,
+/// phase 4 of #2807). Stateless: every call recomputes from its own inputs, the same
+/// discipline `WordDiff` already uses, so two independent consumers (the wizard's Done step,
+/// History's detail view) can share this one decision point without sharing any state.
+///
+/// Deliberately narrower than "one function over a persisted `Transcript`": the wizard's own
+/// live rendering (`parts`, cached diffs) and History's persisted rendering are genuinely
+/// different inputs feeding the SAME turn-rendering/export decision once turns are in hand.
+/// Each caller keeps its OWN existing plain-text fallback for the `turns == nil` case; this
+/// type answers only "given real turns, what do they look like and what gets exported."
+public enum TranscriptDocumentPresenter {
+
+  /// Mirrors `FileImportCoordinator.DocumentView` — the SAME three states, reused rather than
+  /// redeclared. History gets its own instance of this identical enum for its own
+  /// screen-local mode state; the two screens never share a mutable mode owner.
+  public enum ViewMode: Equatable, Sendable {
+    case cleaned, markedUp, original
+  }
+
+  /// One turn ready to render. `content` carries either plain text or a diff — `.markedUp`
+  /// needs styled segments (removed/changed/added), the other two modes do not.
+  public struct RenderedTurn: Equatable, Sendable {
+    public let speakerId: String
+    /// `nil` for `"unknown"` — a classification outcome, never a named speaker (#2810).
+    /// Callers must never attach a rename control when this is `nil`.
+    public let speakerName: String?
+    /// `nil` when times are off, or the turn has no timing at all.
+    public let timeLabel: String?
+    public let content: Content
+
+    public enum Content: Equatable, Sendable {
+      case plain(String)
+      case markedUp(WordDiff.Result)
+    }
+
+    public init(speakerId: String, speakerName: String?, timeLabel: String?, content: Content) {
+      self.speakerId = speakerId
+      self.speakerName = speakerName
+      self.timeLabel = timeLabel
+      self.content = content
+    }
+  }
+
+  /// `nil` when there is nothing turn-shaped to render: `turns == nil`, OR `turns.isEmpty`
+  /// (`TurnAssembler.assemble` genuinely can return `[]` for empty input or a cancelled pass
+  /// — `nil` and `[]` collapse to the SAME "fall back to plain text" outcome, never
+  /// distinguished by a caller). `rawText` is the SAME text `turn.originalTextRange` indexes
+  /// into (`Transcript.text` for History, the wizard's own `rawTranscript` for a live run).
+  public static func render(
+    turns: [Turn]?, rawText: String, speakerNames: [String: String], mode: ViewMode,
+    timesOn: Bool, engineLanguage: String?
+  ) -> [RenderedTurn]? {
+    guard let turns, !turns.isEmpty else { return nil }
+    return turns.map { turn in
+      let original = slice(rawText, turn.originalTextRange)
+      let cleaned = turn.processedText ?? original
+      let content: RenderedTurn.Content
+      switch mode {
+      case .cleaned: content = .plain(cleaned)
+      case .original: content = .plain(original)
+      case .markedUp:
+        content = .markedUp(
+          WordDiff.compare(original: original, cleaned: cleaned, language: engineLanguage))
+      }
+      return RenderedTurn(
+        speakerId: turn.speakerId,
+        speakerName: displayName(for: turn.speakerId, in: speakerNames),
+        timeLabel: timesOn ? timeLabel(for: turn) : nil,
+        content: content)
+    }
+  }
+
+  /// What Copy/Save/Share hand over for a turn-labeled document, and whether that is the
+  /// CLEANED text standing in for a mode with no export form of its own (`.markedUp`) —
+  /// callers use `isCleanedFallback` to relabel their buttons ("Copy cleaned", etc.).
+  /// `nil` under the exact same condition as `render` — a caller with no turns to render
+  /// has no turn-shaped text to export either, and falls back to its OWN existing export.
+  public static func exportText(
+    turns: [Turn]?, rawText: String, speakerNames: [String: String], timesOn: Bool, mode: ViewMode
+  ) -> (text: String, isCleanedFallback: Bool)? {
+    guard let turns, !turns.isEmpty else { return nil }
+    let isCleanedFallback = mode == .markedUp
+    let effectiveMode: ViewMode = isCleanedFallback ? .cleaned : mode
+    let blocks = turns.map { turn -> String in
+      let original = slice(rawText, turn.originalTextRange)
+      let text = effectiveMode == .original ? original : (turn.processedText ?? original)
+      let name = displayName(for: turn.speakerId, in: speakerNames) ?? "Unknown speaker"
+      let header: String
+      if timesOn, let label = timeLabel(for: turn) {
+        header = "\(name) (\(label))"
+      } else {
+        header = name
+      }
+      return "\(header)\n\(text)"
+    }
+    return (blocks.joined(separator: "\n\n"), isCleanedFallback)
+  }
+
+  /// Button titles for the three export actions. `.markedUp` relabels to disclose the
+  /// substitution (founder's export rule, #2811 §2.1); the other two modes keep the
+  /// wizard's own existing titles unchanged.
+  public static func exportButtonLabels(mode: ViewMode) -> (
+    copy: String, save: String, share: String
+  ) {
+    mode == .markedUp
+      ? ("Copy cleaned", "Save cleaned as…", "Share cleaned…")
+      : ("Copy everything", "Save as…", "Share…")
+  }
+
+  /// `nil` for `"unknown"`; otherwise the caller-supplied name, or `nil` if the speaker has
+  /// none yet (a caller showing a rendered turn is responsible for its own "unnamed" default
+  /// — this type never invents one, matching `mergingSpeakerFields`'s own discipline of
+  /// never silently dropping or guessing a surviving speaker's name).
+  private static func displayName(for speakerId: String, in speakerNames: [String: String])
+    -> String?
+  {
+    guard speakerId != TurnAssembler.unknownSpeakerID else { return nil }
+    return speakerNames[speakerId]
+  }
+
+  private static func slice(_ text: String, _ range: Range<Int>) -> String {
+    let lower = String.Index(utf16Offset: range.lowerBound, in: text)
+    let upper = String.Index(utf16Offset: range.upperBound, in: text)
+    guard lower <= upper, upper <= text.endIndex else { return "" }
+    return String(text[lower..<upper])
+  }
+
+  private static func timeLabel(for turn: Turn) -> String? {
+    guard let startMs = turn.startMs else { return nil }
+    let totalSeconds = startMs / 1000
+    return String(format: "%d:%02d", totalSeconds / 60, totalSeconds % 60)
+  }
+}

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1442,6 +1442,12 @@ package final class WisprBootstrapper {
         TelemetryService.shared.trackFileImportTurns(
           outcome: outcome, turnCount: turnCount, fallbackTurnCount: fallbackTurnCount)
       },
+      emitRenameTelemetry: { outcome in
+        TelemetryService.shared.trackFileImportRename(outcome: outcome)
+      },
+      emitSpeakerRetryTelemetry: { outcome in
+        TelemetryService.shared.trackFileImportSpeakerRetry(outcome: outcome)
+      },
       // The third workload, claiming the same one-slot engine as a dictation and
       // a crash replay.
       engineAdmission: .live(lease: engineLease, as: .fileImport),

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -289,7 +289,16 @@ package final class WisprBootstrapper {
     let llmDiscovery = LLMModelDiscoveryCoordinator(keychainManager: keychainManager)
 
     let transcriptStore = TranscriptStore()
-    let transcriptCoordinator = TranscriptCoordinator(store: transcriptStore)
+    // The History half of #2811's turn-label telemetry; the wizard half is wired on
+    // `FileImportCoordinator` below, and both emit the same shape-only events.
+    let transcriptCoordinator = TranscriptCoordinator(
+      store: transcriptStore,
+      emitRenameTelemetry: { outcome in
+        TelemetryService.shared.trackFileImportRename(outcome: outcome)
+      },
+      emitTurnsDisplayedTelemetry: {
+        TelemetryService.shared.trackFileImportTurnsDisplayed(screen: .history)
+      })
 
     // #832/#913 PR8: app-owned output-safety classifier holder. Created before
     // the polish service + both kernel drivers so all three receive the same
@@ -1447,6 +1456,9 @@ package final class WisprBootstrapper {
       },
       emitSpeakerRetryTelemetry: { outcome in
         TelemetryService.shared.trackFileImportSpeakerRetry(outcome: outcome)
+      },
+      emitTurnsDisplayedTelemetry: {
+        TelemetryService.shared.trackFileImportTurnsDisplayed(screen: .wizard)
       },
       // The third workload, claiming the same one-slot engine as a dictation and
       // a crash replay.

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1601,6 +1601,13 @@ package final class WisprBootstrapper {
       mergeSpeakerFields: { [transcriptCoordinator] id, analysis, turns in
         try transcriptCoordinator.mergeSpeakerFields(id: id, analysis: analysis, turns: turns)
       },
+      // The rename write (#2811, phase 4) — same underlying method, an explicit rename pair
+      // this time.
+      writeExplicitRename: { [transcriptCoordinator] id, analysis, turns, explicitRename in
+        try transcriptCoordinator.mergeSpeakerFields(
+          id: id, analysis: analysis, turns: turns, explicitRename: explicitRename)
+      },
+      currentHistoryRow: { [transcriptCoordinator] id in transcriptCoordinator.currentRow(id: id) },
       historyRowExists: { [transcriptCoordinator] id in transcriptCoordinator.hasRow(id: id) },
       processPart: { [fileImportRunner] part, language in
         try await fileImportRunner.process(part: part, engineLanguage: language)

--- a/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
+++ b/Sources/EnviousWisprAppKit/App/WisprBootstrapper.swift
@@ -1630,6 +1630,12 @@ package final class WisprBootstrapper {
       processPart: { [fileImportRunner] part, language in
         try await fileImportRunner.process(part: part, engineLanguage: language)
       })
+    // History announces a deleted row; the wizard drops the retry audio it holds for that
+    // row (#2811, cloud review of PR #2846). Late-bound because History's coordinator is
+    // built first.
+    transcriptCoordinator.onRowDeleted = { [weak fileImportCoordinator] id in
+      fileImportCoordinator?.noteHistoryRowDeleted(id)
+    }
     fileImportCoordinatorForGates = fileImportCoordinator
     self.fileImportCoordinator = fileImportCoordinator
     self.transcriptCoordinator = transcriptCoordinator

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -79,6 +79,8 @@ struct TranscriptDetailView: View {
                   transcriptCoordinator.renameSpeaker(
                     id: transcript.id, speakerId: id, name: name)
                 },
+                onRenameCancelled: { transcriptCoordinator.noteRenameCancelled() },
+                onTurnsDisplayed: { transcriptCoordinator.noteTurnsDisplayed(id: transcript.id) },
                 fallback: { EmptyView() }
               )
             }

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -84,7 +84,13 @@ struct TranscriptDetailView: View {
                 fallback: { EmptyView() }
               )
             }
-            .task(id: turnDiffInput) { await prepareTurnDiffs() }
+            .task(
+              id: FileImportCoordinator.TurnDiffRequest(
+                input: turnDiffInput, markedUp: documentView == .markedUp)
+            ) {
+              guard documentView == .markedUp else { return }
+              await prepareTurnDiffs()
+            }
             // Gives the WHOLE turn-rendering subtree — including every `TurnRowView`'s own
             // rename-popover `@State` — a fresh identity per document (found by chunk
             // review): `HistoryContentView` reuses this view across row selections at a

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -432,14 +432,23 @@ struct TranscriptDetailView: View {
   private func prepareTurnDiffs() async {
     let input = turnDiffInput
     guard turnDiffs == nil, !input.pairs.isEmpty else { return }
-    let computed = await Task.detached(priority: .userInitiated) {
+    let worker = Task.detached(priority: .userInitiated) {
       var results: [String: WordDiff.Result] = [:]
       for pair in input.pairs {
+        // Between compares: selecting another row cancels this `.task(id:)` invocation, and
+        // the handler below forwards that to the worker, which stops at the next turn
+        // instead of diffing a long transcript nobody is looking at (found by cloud review,
+        // round 4). `Task.detached` does not inherit the caller's cancellation on its own.
+        guard !Task.isCancelled else { break }
         results[pair.id] = WordDiff.compare(
           original: pair.original, cleaned: pair.cleaned, language: input.language)
       }
       return results
-    }.value
+    }
+    let computed = await withTaskCancellationHandler(
+      operation: { await worker.value },
+      onCancel: { worker.cancel() }
+    )
     guard !Task.isCancelled, turnDiffInput == input else { return }
     turnDiffCache = (input, computed)
   }

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -1,6 +1,8 @@
+import CoreTransferable
 import EnviousWisprCore
 import EnviousWisprServices
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Detail view for a single transcript: an action bar, a titled header with
 /// metadata chips, and the polished/original text each in its own card (mockup
@@ -20,7 +22,11 @@ struct TranscriptDetailView: View {
   /// `@State` across a mere value change at the same tree position (§5 E2E audit).
   @State private var documentView: FileImportCoordinator.DocumentView = .cleaned
   @State private var timesOn = true
-  @State private var turnDiffs: [String: WordDiff.Result] = [:]
+  @State private var turnDiffCache:
+    (input: FileImportCoordinator.TurnDiffInput, results: [String: WordDiff.Result])?
+  /// Surfaced via `.alert` rather than swallowed by `try?` (found by chunk review) — a failed
+  /// disk write must not look identical to a successful one.
+  @State private var saveError: String?
 
   /// #2087: the two actions this feature adds stand down while a dictation is
   /// in flight — Paste on a HELD recovery, and Keep.
@@ -62,18 +68,28 @@ struct TranscriptDetailView: View {
         VStack(alignment: .leading, spacing: 20) {
           header
 
-          if transcript.turns != nil {
+          if let renderedTurns {
             transcriptSection(kindWord, icon: "doc.text") {
+              // `fallback` is genuinely unreachable here — `renderedTurns` is already known
+              // non-nil — so it carries no risk of the double-card nesting a reachable
+              // `plainTextSections` would produce inside this same `transcriptSection`.
               TurnDocumentView(
                 turns: renderedTurns,
                 onRename: { id, name in
                   transcriptCoordinator.renameSpeaker(
                     id: transcript.id, speakerId: id, name: name)
                 },
-                fallback: { plainTextSections }
+                fallback: { EmptyView() }
               )
             }
             .task(id: turnDiffInput) { await prepareTurnDiffs() }
+            // Gives the WHOLE turn-rendering subtree — including every `TurnRowView`'s own
+            // rename-popover `@State` — a fresh identity per document (found by chunk
+            // review): `HistoryContentView` reuses this view across row selections at a
+            // fixed tree position, and `ForEach`'s own `id: \.offset` can otherwise let a
+            // rename popover opened on document A's turn survive into document B if B has a
+            // turn at the same position, committing a rename against the wrong document.
+            .id(transcript.id)
           } else {
             plainTextSections
           }
@@ -85,7 +101,16 @@ struct TranscriptDetailView: View {
     .onChange(of: transcript.id) {
       documentView = .cleaned
       timesOn = true
-      turnDiffs = [:]
+      turnDiffCache = nil
+    }
+    .alert(
+      "Couldn't save the file",
+      isPresented: Binding(
+        get: { saveError != nil }, set: { if !$0 { saveError = nil } })
+    ) {
+      Button("OK") { saveError = nil }
+    } message: {
+      Text(saveError ?? "")
     }
   }
 
@@ -116,7 +141,15 @@ struct TranscriptDetailView: View {
       .disabled(exportText == nil)
       .help("Save as a text file")
 
-      ShareLink(item: exportText ?? "") {
+      // `DeliverableText`, never a plain `String` item (found by chunk review): a share sheet
+      // can sit open far longer than Save's modal, and a bare `String` freezes `exportText`
+      // at THIS body evaluation — a row that expires (the escape-recovery 24-hour promise)
+      // while the sheet is still open would still hand over its text. The closure defers the
+      // read to whenever the system actually asks for the data.
+      ShareLink(
+        item: DeliverableText(resolve: { exportText }),
+        preview: SharePreview(kindWord)
+      ) {
         Label(exportButtonLabels.share, systemImage: "square.and.arrow.up")
       }
       .disabled(exportText == nil || exportText?.isEmpty == true)
@@ -224,7 +257,11 @@ struct TranscriptDetailView: View {
         }
 
         // View mode + Times (#2811 §2.1) — only meaningful once there are turns to show.
-        if transcript.turns != nil {
+        // `hasRenderableTurns`, never a bare `!= nil` (found by chunk review): `turns == []`
+        // is a real, reachable state (`TurnAssembler.assemble` can return it) that must
+        // collapse to "nothing to show" exactly like `nil`, or these controls appear with
+        // nothing for them to control.
+        if hasRenderableTurns {
           HStack(spacing: 10) {
             Picker(
               "View", selection: $documentView
@@ -338,12 +375,19 @@ struct TranscriptDetailView: View {
     }
   }
 
+  /// `TurnAssembler.assemble` can return `[]` — collapses to the SAME "nothing to render"
+  /// outcome as `nil` everywhere this view branches on turns, never just `!= nil`.
+  private var hasRenderableTurns: Bool {
+    guard let turns = transcript.turns else { return false }
+    return !turns.isEmpty
+  }
+
   private var renderedTurns: [TranscriptDocumentPresenter.RenderedTurn]? {
     let diffs = turnDiffs
     return TranscriptDocumentPresenter.render(
       turns: transcript.turns, rawText: transcript.text,
       speakerNames: transcript.speakerNames ?? [:], mode: documentView, timesOn: timesOn,
-      diffLookup: { diffs[$0.id] })
+      diffLookup: { diffs?[$0.id] })
   }
 
   /// Mirrors `FileImportCoordinator.turnDiffInput`, reusing its own `TurnDiffPair`/
@@ -363,14 +407,24 @@ struct TranscriptDetailView: View {
     return FileImportCoordinator.TurnDiffInput(pairs: pairs, language: transcript.language)
   }
 
+  /// `nil` while `prepareTurnDiffs` is still running or the input has moved — same
+  /// input-matches-cache contract as `FileImportCoordinator.turnDiffs` (found by chunk
+  /// review: an unkeyed dictionary can go on describing OLDER text after this row's own
+  /// turns change under it — a retry or a background pass replacing `processedText` while
+  /// this row happens to still be selected — even though the turn ids themselves survive).
+  private var turnDiffs: [String: WordDiff.Result]? {
+    guard let cached = turnDiffCache, cached.input == turnDiffInput else { return nil }
+    return cached.results
+  }
+
   /// Off the main actor, same reason as the wizard's own `prepareTurnDiffs` (chunk-1 review:
   /// `WordDiff` can take ~3 seconds on worst-case inputs). `.task(id:)` already cancels a
-  /// stale computation when `transcript`/`documentView`/`timesOn` moves — the explicit
-  /// `Task.isCancelled` check below is what stops that stale result from still landing in
-  /// `@State` after cancellation, since the write happens AFTER the `await` returns.
+  /// stale computation when `turnDiffInput` moves — the explicit re-check below is what stops
+  /// a stale result from still landing in `@State` after cancellation, since the write
+  /// happens AFTER the `await` returns.
   private func prepareTurnDiffs() async {
     let input = turnDiffInput
-    guard !input.pairs.isEmpty else { return }
+    guard turnDiffs == nil, !input.pairs.isEmpty else { return }
     let computed = await Task.detached(priority: .userInitiated) {
       var results: [String: WordDiff.Result] = [:]
       for pair in input.pairs {
@@ -379,8 +433,8 @@ struct TranscriptDetailView: View {
       }
       return results
     }.value
-    guard !Task.isCancelled else { return }
-    turnDiffs = computed
+    guard turnDiffInput == input else { return }
+    turnDiffCache = (input, computed)
   }
 
   /// What Copy/Save/Share hand over. Turn-labeled documents route through the presenter
@@ -405,12 +459,35 @@ struct TranscriptDetailView: View {
     TranscriptDocumentPresenter.exportButtonLabels(mode: documentView)
   }
 
+  /// `exportText` is read AFTER the modal returns, never before it (found by chunk review):
+  /// `NSSavePanel.runModal()` blocks for as long as the user takes, and a row can expire
+  /// (the escape-recovery 24-hour promise) or be deleted in that window — writing a value
+  /// captured before the panel opened would export text the user was told had gone.
   private func saveDocument() {
-    guard let text = exportText else { return }
     let panel = NSSavePanel()
     panel.allowedContentTypes = [.plainText]
     panel.nameFieldStringValue = kindWord
     guard panel.runModal() == .OK, let url = panel.url else { return }
-    try? text.write(to: url, atomically: true, encoding: .utf8)
+    guard let text = exportText else { return }
+    do {
+      try text.write(to: url, atomically: true, encoding: .utf8)
+    } catch {
+      saveError = String(describing: error)
+    }
+  }
+}
+
+/// Defers reading the export text to whenever the system actually asks for the data, rather
+/// than whenever SwiftUI last evaluated `body` (found by chunk review) — `resolve` closes
+/// over `transcriptCoordinator` (a reference) and re-reads `exportText`'s own live,
+/// expiry-checked selection at that later point, the same delivery-time validation Save gets
+/// from being read after its modal returns.
+private struct DeliverableText: Transferable, Sendable {
+  let resolve: @Sendable () -> String?
+
+  static var transferRepresentation: some TransferRepresentation {
+    DataRepresentation(exportedContentType: .plainText) { deliverable in
+      Data((deliverable.resolve() ?? "").utf8)
+    }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -418,10 +418,15 @@ struct TranscriptDetailView: View {
   }
 
   /// Off the main actor, same reason as the wizard's own `prepareTurnDiffs` (chunk-1 review:
-  /// `WordDiff` can take ~3 seconds on worst-case inputs). `.task(id:)` already cancels a
-  /// stale computation when `turnDiffInput` moves — the explicit re-check below is what stops
-  /// a stale result from still landing in `@State` after cancellation, since the write
-  /// happens AFTER the `await` returns.
+  /// `WordDiff` can take ~3 seconds on worst-case inputs). `View` is a VALUE type, so this
+  /// `async` method runs against a `self` FROZEN at the moment `.task(id:)` invoked it —
+  /// `turnDiffInput` inside this function keeps reading THAT frozen `transcript` forever, so
+  /// it can never observe a row-selection change on its own (found by chunk review: two
+  /// selections whose diffs finish OUT OF ORDER — A's slow computation outliving a switch to
+  /// B, then landing after B's own already has — would otherwise let A silently overwrite B's
+  /// cache, since the input comparison alone always reads true against itself). `Task
+  /// .isCancelled` is the one signal that DOES observe it: `.task(id:)` cancels the previous
+  /// invocation's Task the instant the id changes, which is exactly A's task in that repro.
   private func prepareTurnDiffs() async {
     let input = turnDiffInput
     guard turnDiffs == nil, !input.pairs.isEmpty else { return }
@@ -433,7 +438,7 @@ struct TranscriptDetailView: View {
       }
       return results
     }.value
-    guard turnDiffInput == input else { return }
+    guard !Task.isCancelled, turnDiffInput == input else { return }
     turnDiffCache = (input, computed)
   }
 
@@ -485,9 +490,16 @@ struct TranscriptDetailView: View {
 private struct DeliverableText: Transferable, Sendable {
   let resolve: @Sendable () -> String?
 
+  /// A `nil` resolve must REFUSE delivery, never substitute empty content (found by chunk
+  /// review): `Data("".utf8)` reads to the receiving app as a successful, if empty, export —
+  /// exactly the silent "expiry reads as success" failure `textForDelivery`'s own contract
+  /// exists to prevent.
+  struct ExpiredError: Error {}
+
   static var transferRepresentation: some TransferRepresentation {
     DataRepresentation(exportedContentType: .plainText) { deliverable in
-      Data((deliverable.resolve() ?? "").utf8)
+      guard let text = deliverable.resolve() else { throw ExpiredError() }
+      return Data(text.utf8)
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -448,11 +448,19 @@ struct TranscriptDetailView: View {
   /// FIRST, exactly mirroring `FileImportCoordinator.exportText`'s own fallback contract —
   /// its `nil` for `turns == nil`/empty falls through to `textForDelivery`'s existing,
   /// expiry-checked selection, UNCHANGED.
+  ///
+  /// Reads the LIVE row, never `self.transcript` (found by second-pass review): this view's
+  /// value is a snapshot from when the row was selected, while Save's panel and Share's
+  /// sheet can stay open across a "Clean it again" landing new turns, or across the row
+  /// being deleted. `nil` for a row that no longer exists, so nothing is delivered for a
+  /// recording the user was told is gone.
   private var exportText: String? {
-    guard let base = transcriptCoordinator.textForDelivery(transcript) else { return nil }
-    if let turns = transcript.turns,
+    guard let live = transcriptCoordinator.currentRow(id: transcript.id),
+      let base = transcriptCoordinator.textForDelivery(live)
+    else { return nil }
+    if let turns = live.turns,
       let result = TranscriptDocumentPresenter.exportText(
-        turns: turns, rawText: transcript.text, speakerNames: transcript.speakerNames ?? [:],
+        turns: turns, rawText: live.text, speakerNames: live.speakerNames ?? [:],
         timesOn: timesOn, mode: documentView)
     {
       return result.text

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptDetailView.swift
@@ -13,6 +13,15 @@ struct TranscriptDetailView: View {
   @Environment(TranscriptCoordinator.self) private var transcriptCoordinator
   @Environment(LiveRecordingState.self) private var liveRecordingState
 
+  /// Screen-local, per-row UI state (#2811, phase 4 of #2807) — History has no persisted view
+  /// mode today, and this phase does not add one (plan §2.2 non-goal). Reset on row change
+  /// via `.onChange(of: transcript.id)`: without it, a stale Marked-up selection from one
+  /// file would leak onto the next file's detail view, since SwiftUI otherwise preserves
+  /// `@State` across a mere value change at the same tree position (§5 E2E audit).
+  @State private var documentView: FileImportCoordinator.DocumentView = .cleaned
+  @State private var timesOn = true
+  @State private var turnDiffs: [String: WordDiff.Result] = [:]
+
   /// #2087: the two actions this feature adds stand down while a dictation is
   /// in flight — Paste on a HELD recovery, and Keep.
   ///
@@ -53,44 +62,31 @@ struct TranscriptDetailView: View {
         VStack(alignment: .leading, spacing: 20) {
           header
 
-          // #2772: a THIRD rung. An import whose polish was bypassed or failed everywhere
-          // still has a derived document worth showing — numbers formatted, saved words
-          // corrected — and it must not be labelled as AI-polished. Falling back to the raw
-          // words instead would silently discard that work.
-          // #2807: the section names say what the TEXT is (polished, processed, original);
-          // the title above says what the row is (a dictation or a transcript).
-          if let output = transcript.polishedText ?? transcript.processedText {
-            transcriptSection(
-              transcript.polishedText == nil ? "Processed" : "Polished",
-              icon: transcript.polishedText == nil ? "doc.text" : "sparkles"
-            ) {
-              Text(output)
-                .font(.system(size: 16))
-                .lineSpacing(3)
-                .foregroundStyle(.stTextPrimary)
-                .textSelection(.enabled)
-            }
-            transcriptSection("Original", icon: "doc.text") {
-              Text(transcript.text)
-                .font(.system(size: 15))
-                .lineSpacing(3)
-                .foregroundStyle(.stTextBody)
-                .textSelection(.enabled)
-            }
-          } else {
+          if transcript.turns != nil {
             transcriptSection(kindWord, icon: "doc.text") {
-              Text(transcript.text)
-                .font(.system(size: 16))
-                .lineSpacing(3)
-                .foregroundStyle(.stTextPrimary)
-                .textSelection(.enabled)
+              TurnDocumentView(
+                turns: renderedTurns,
+                onRename: { id, name in
+                  transcriptCoordinator.renameSpeaker(
+                    id: transcript.id, speakerId: id, name: name)
+                },
+                fallback: { plainTextSections }
+              )
             }
+            .task(id: turnDiffInput) { await prepareTurnDiffs() }
+          } else {
+            plainTextSections
           }
         }
         .padding(20)
       }
     }
     .background(Color.stPageBg)
+    .onChange(of: transcript.id) {
+      documentView = .cleaned
+      timesOn = true
+      turnDiffs = [:]
+    }
   }
 
   // MARK: - Action bar
@@ -98,16 +94,32 @@ struct TranscriptDetailView: View {
   private var actionBar: some View {
     HStack(spacing: 8) {
       Button {
-        // #2087: asked for by id rather than taken from the rendered row. A held
-        // recovery can lapse between this row appearing and the press, and
-        // copying the snapshot would hand back text the user was told had gone.
-        // Returns the text unchanged for an ordinary dictation.
-        guard let text = transcriptCoordinator.textForDelivery(transcript) else { return }
+        // #2087: `exportText` reads `textForDelivery` fresh by id rather than taking the
+        // rendered row's own snapshot. A held recovery can lapse between this row appearing
+        // and the press, and copying a snapshot would hand back text the user was told had
+        // gone. Returns the text unchanged for an ordinary dictation.
+        guard let text = exportText else { return }
         PasteService.copyToClipboard(text)
       } label: {
-        Label("Copy", systemImage: "doc.on.doc")
+        Label(exportButtonLabels.copy, systemImage: "doc.on.doc")
       }
       .help("Copy to clipboard")
+
+      // #2811, phase 4: History gains Save and Share, which did not exist before this phase
+      // (plan §6 downstream consumer matrix) — reusing `exportText`'s SAME expiry-checked
+      // selection as Copy, never a separate one.
+      Button {
+        saveDocument()
+      } label: {
+        Label(exportButtonLabels.save, systemImage: "square.and.arrow.down")
+      }
+      .disabled(exportText == nil)
+      .help("Save as a text file")
+
+      ShareLink(item: exportText ?? "") {
+        Label(exportButtonLabels.share, systemImage: "square.and.arrow.up")
+      }
+      .disabled(exportText == nil || exportText?.isEmpty == true)
 
       Button {
         if permissions.accessibilityGranted {
@@ -210,6 +222,27 @@ struct TranscriptDetailView: View {
             metaChip("AI Polished", icon: nil, accent: true)
           }
         }
+
+        // View mode + Times (#2811 §2.1) — only meaningful once there are turns to show.
+        if transcript.turns != nil {
+          HStack(spacing: 10) {
+            Picker(
+              "View", selection: $documentView
+            ) {
+              Text("Cleaned").tag(FileImportCoordinator.DocumentView.cleaned)
+              Text("Marked up").tag(FileImportCoordinator.DocumentView.markedUp)
+              Text("Original").tag(FileImportCoordinator.DocumentView.original)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .controlSize(.small)
+            .fixedSize()
+            .accessibilityLabel("Which words to show")
+            Toggle("Times", isOn: $timesOn)
+              .controlSize(.small)
+              .toggleStyle(.switch)
+          }
+        }
       }
       Spacer(minLength: 0)
     }
@@ -261,5 +294,123 @@ struct TranscriptDetailView: View {
             .strokeBorder(Color.stDivider, lineWidth: 1)
         )
     }
+  }
+
+  // MARK: - Turn-labeled rendering (#2811, phase 4 of #2807)
+
+  /// Today's own rendering, UNCHANGED — `TurnDocumentView`'s fallback, structurally
+  /// unreachable here since the call site already gates on `transcript.turns != nil`, exactly
+  /// mirroring the wizard's own `legacyTranscriptContent` shape.
+  @ViewBuilder
+  private var plainTextSections: some View {
+    // #2772: a THIRD rung. An import whose polish was bypassed or failed everywhere
+    // still has a derived document worth showing — numbers formatted, saved words
+    // corrected — and it must not be labelled as AI-polished. Falling back to the raw
+    // words instead would silently discard that work.
+    // #2807: the section names say what the TEXT is (polished, processed, original);
+    // the title above says what the row is (a dictation or a transcript).
+    if let output = transcript.polishedText ?? transcript.processedText {
+      transcriptSection(
+        transcript.polishedText == nil ? "Processed" : "Polished",
+        icon: transcript.polishedText == nil ? "doc.text" : "sparkles"
+      ) {
+        Text(output)
+          .font(.system(size: 16))
+          .lineSpacing(3)
+          .foregroundStyle(.stTextPrimary)
+          .textSelection(.enabled)
+      }
+      transcriptSection("Original", icon: "doc.text") {
+        Text(transcript.text)
+          .font(.system(size: 15))
+          .lineSpacing(3)
+          .foregroundStyle(.stTextBody)
+          .textSelection(.enabled)
+      }
+    } else {
+      transcriptSection(kindWord, icon: "doc.text") {
+        Text(transcript.text)
+          .font(.system(size: 16))
+          .lineSpacing(3)
+          .foregroundStyle(.stTextPrimary)
+          .textSelection(.enabled)
+      }
+    }
+  }
+
+  private var renderedTurns: [TranscriptDocumentPresenter.RenderedTurn]? {
+    let diffs = turnDiffs
+    return TranscriptDocumentPresenter.render(
+      turns: transcript.turns, rawText: transcript.text,
+      speakerNames: transcript.speakerNames ?? [:], mode: documentView, timesOn: timesOn,
+      diffLookup: { diffs[$0.id] })
+  }
+
+  /// Mirrors `FileImportCoordinator.turnDiffInput`, reusing its own `TurnDiffPair`/
+  /// `TurnDiffInput` types (chunk review found their FIRST duplicate; this would have been a
+  /// second) — the wizard and History prepare the same per-turn diff shape from different
+  /// live/persisted sources.
+  private var turnDiffInput: FileImportCoordinator.TurnDiffInput {
+    guard let turns = transcript.turns else {
+      return FileImportCoordinator.TurnDiffInput(pairs: [], language: transcript.language)
+    }
+    let text = transcript.text
+    let pairs = turns.map { turn -> FileImportCoordinator.TurnDiffPair in
+      let original = TranscriptDocumentPresenter.slice(text, turn.originalTextRange)
+      return FileImportCoordinator.TurnDiffPair(
+        id: turn.id, original: original, cleaned: turn.processedText ?? original)
+    }
+    return FileImportCoordinator.TurnDiffInput(pairs: pairs, language: transcript.language)
+  }
+
+  /// Off the main actor, same reason as the wizard's own `prepareTurnDiffs` (chunk-1 review:
+  /// `WordDiff` can take ~3 seconds on worst-case inputs). `.task(id:)` already cancels a
+  /// stale computation when `transcript`/`documentView`/`timesOn` moves — the explicit
+  /// `Task.isCancelled` check below is what stops that stale result from still landing in
+  /// `@State` after cancellation, since the write happens AFTER the `await` returns.
+  private func prepareTurnDiffs() async {
+    let input = turnDiffInput
+    guard !input.pairs.isEmpty else { return }
+    let computed = await Task.detached(priority: .userInitiated) {
+      var results: [String: WordDiff.Result] = [:]
+      for pair in input.pairs {
+        results[pair.id] = WordDiff.compare(
+          original: pair.original, cleaned: pair.cleaned, language: input.language)
+      }
+      return results
+    }.value
+    guard !Task.isCancelled else { return }
+    turnDiffs = computed
+  }
+
+  /// What Copy/Save/Share hand over. Turn-labeled documents route through the presenter
+  /// FIRST, exactly mirroring `FileImportCoordinator.exportText`'s own fallback contract —
+  /// its `nil` for `turns == nil`/empty falls through to `textForDelivery`'s existing,
+  /// expiry-checked selection, UNCHANGED.
+  private var exportText: String? {
+    guard let base = transcriptCoordinator.textForDelivery(transcript) else { return nil }
+    if let turns = transcript.turns,
+      let result = TranscriptDocumentPresenter.exportText(
+        turns: turns, rawText: transcript.text, speakerNames: transcript.speakerNames ?? [:],
+        timesOn: timesOn, mode: documentView)
+    {
+      return result.text
+    }
+    return base
+  }
+
+  /// Copy/Save/Share titles — the SAME general export rule as the wizard (plan §2.1), never
+  /// scoped to turn-labeled documents.
+  private var exportButtonLabels: (copy: String, save: String, share: String) {
+    TranscriptDocumentPresenter.exportButtonLabels(mode: documentView)
+  }
+
+  private func saveDocument() {
+    guard let text = exportText else { return }
+    let panel = NSSavePanel()
+    panel.allowedContentTypes = [.plainText]
+    panel.nameFieldStringValue = kindWord
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+    try? text.write(to: url, atomically: true, encoding: .utf8)
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TranscriptHistoryView.swift
@@ -228,6 +228,25 @@ struct TranscriptRowView: View {
           .accessibilityLabel("Imported from \(importedFileName)")
         }
 
+        if let speakerNames = transcript.speakerNames, !speakerNames.isEmpty {
+          // #2811, phase 4 of #2807: rendered/exported speaker names never enter
+          // `displayText`, so scanning the list is the OTHER half of the epic's own "find
+          // the row with 'Zach, Ariana' on it" walkthrough — the search predicate above is
+          // the first half. Sorted for a stable order across renders; a dictionary's own
+          // iteration order is not guaranteed.
+          HStack(spacing: 2) {
+            Image(systemName: "person.2")
+            Text(speakerNames.values.sorted().joined(separator: ", "))
+          }
+          .font(.caption2)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 2)
+          .background(Color.stTextSecondary.opacity(0.14), in: Capsule())
+          .foregroundStyle(.stTextSecondary)
+        }
+
         if transcript.isRecovered == true {
           // #1063 PR2 — marks a transcript reconstructed from a recovered recording
           // after an abnormal exit. Icon + text (never color-only).

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -32,9 +32,15 @@ struct TurnDocumentView<Fallback: View>: View {
   /// History's detail view alike. A nested `ScrollView` with no height of its own has nothing
   /// to size against and collapses instead of growing with the text, exactly the "renders
   /// exactly today's plain text" contract this view exists to preserve.
+  ///
+  /// `LazyVStack`, not `VStack` (found by cloud review, round 5): a multi-hour recording has
+  /// thousands of turns, each row carrying its own rename state and popover, and the eager
+  /// stack built and laid out every one of them at once inside the callers' scroll views.
+  /// Rows now materialise as they scroll into view; a rename popover only ever belongs to a
+  /// visible row, so the per-row state a lazy stack discards off-screen is never in use.
   var body: some View {
     if let turns {
-      VStack(alignment: .leading, spacing: 16) {
+      LazyVStack(alignment: .leading, spacing: 16) {
         ForEach(Array(turns.enumerated()), id: \.offset) { _, turn in
           TurnRowView(turn: turn, onRename: onRename, onRenameCancelled: onRenameCancelled)
         }

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -106,8 +106,11 @@ private struct TurnRowView: View {
     }
   }
 
-  /// On failure, the popover stays open (`isRenaming` was never cleared) showing the error and
-  /// the reverted name; on success it closes.
+  /// On failure, reopens (or keeps open) the popover showing the error and the reverted name;
+  /// on success it closes. `isRenaming = true` is required even when it is already true: an
+  /// outside-click commit has ALREADY dismissed the popover (SwiftUI cleared the binding before
+  /// `.onDisappear` fired), so without this the failure and restored name would land on an
+  /// already-gone view (found by chunk review r3).
   private func commitRename(_ name: String) {
     guard let id = renamingSpeakerId else {
       isRenaming = false
@@ -116,6 +119,7 @@ private struct TurnRowView: View {
     Task {
       if let failure = await onRename(id, name) {
         renameFailure = failure
+        isRenaming = true
       } else {
         renameFailure = nil
         isRenaming = false
@@ -161,12 +165,13 @@ private struct MarkedUpTurnText: View {
 /// dismiss through the same SwiftUI mechanism.
 ///
 /// `failure` renders inline when the caller's last commit attempt failed (plan §7) and reverts
-/// the field to the re-read current name (plan §9) — never the rejected input. Because a
-/// failure keeps `isRenaming` true, THIS SAME instance survives the failed attempt (found by
-/// chunk review r2: an instance that stayed alive kept `hasCommitted = true` from the failed
-/// Enter forever, so a following outside-click could never re-commit). `.onChange(of: failure)`
-/// resets both dismissal guards whenever a new failure arrives, so a retry behaves like a fresh
-/// attempt.
+/// the field to the re-read current name (plan §9) — never the rejected input. Two different
+/// recreation paths need two different fixes, both required (found across chunk review r2/r3):
+/// an Enter-triggered failure keeps `isRenaming` true, so THIS SAME instance survives and
+/// `.onChange(of: failure)` resets the dismissal guards on it; an outside-click-triggered
+/// failure has ALREADY dismissed the popover before the write's result comes back, so its retry
+/// reopens a BRAND NEW instance, for which `.onChange` never fires on the value it was created
+/// with — that path is covered instead by seeding `_name` from `failure.currentName` at `init`.
 private struct RenamePopoverView: View {
   let initialName: String
   let failure: RenameFailure?
@@ -185,7 +190,7 @@ private struct RenamePopoverView: View {
     self.failure = failure
     self.onCommit = onCommit
     self.onCancel = onCancel
-    self._name = State(initialValue: initialName)
+    self._name = State(initialValue: failure?.currentName ?? initialName)
   }
 
   var body: some View {

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -11,10 +11,12 @@ import SwiftUI
 /// turn-labeled case.
 struct TurnDocumentView<Fallback: View>: View {
   let turns: [TranscriptDocumentPresenter.RenderedTurn]?
-  /// Called with a speaker id and its CURRENT name (or `nil`) when the user commits a rename
-  /// from the popover. The caller re-fetches current analysis/turns and writes through
+  /// Called with a speaker id and its new name when the user commits a rename. Returns `nil`
+  /// on success, or an error message to show inline without dismissing the popover (plan §7:
+  /// "Rename write fails ... Popover shows an inline error, does not silently claim success").
+  /// The caller re-fetches current analysis/turns and writes through
   /// `mergeSpeakerFields(explicitRename:)` — this view never persists anything itself.
-  let onRename: (String, String) -> Void
+  let onRename: (String, String) async -> String?
   @ViewBuilder let fallback: () -> Fallback
 
   var body: some View {
@@ -35,9 +37,15 @@ struct TurnDocumentView<Fallback: View>: View {
 
 private struct TurnRowView: View {
   let turn: TranscriptDocumentPresenter.RenderedTurn
-  let onRename: (String, String) -> Void
+  let onRename: (String, String) async -> String?
   @State private var isRenaming = false
   @State private var draftName = ""
+  @State private var renameError: String?
+  /// Captured when the popover opens, never read live off `turn` at commit time: `ForEach`
+  /// keys rows by POSITION (`\.offset`), so the same row identity can be reused for a
+  /// different turn while a popover is still open (found by chunk review). Committing must
+  /// target the speaker the user actually opened the popover on.
+  @State private var renamingSpeakerId: String?
 
   var body: some View {
     VStack(alignment: .leading, spacing: 4) {
@@ -65,7 +73,9 @@ private struct TurnRowView: View {
         .foregroundStyle(.secondary)
     } else {
       Button {
+        renamingSpeakerId = turn.speakerId
         draftName = turn.speakerName ?? ""
+        renameError = nil
         isRenaming = true
       } label: {
         Text(displayName)
@@ -76,12 +86,31 @@ private struct TurnRowView: View {
       .accessibilityValue(displayName)
       .popover(isPresented: $isRenaming) {
         RenamePopoverView(
-          initialName: turn.speakerName ?? "",
-          onCommit: { name in
-            onRename(turn.speakerId, name)
+          initialName: draftName,
+          errorMessage: renameError,
+          onCommit: { name in commitRename(name) },
+          onCancel: {
+            renameError = nil
             isRenaming = false
-          },
-          onCancel: { isRenaming = false })
+          })
+      }
+    }
+  }
+
+  /// On failure, reopens the popover with the error message rather than letting the dismissal
+  /// already in flight (e.g. from an outside click) silently swallow the failed write.
+  private func commitRename(_ name: String) {
+    guard let id = renamingSpeakerId else {
+      isRenaming = false
+      return
+    }
+    Task {
+      if let error = await onRename(id, name) {
+        renameError = error
+        isRenaming = true
+      } else {
+        renameError = nil
+        isRenaming = false
       }
     }
   }
@@ -121,9 +150,12 @@ private struct MarkedUpTurnText: View {
 /// this distinguishes the two via a flag Escape sets before dismissal, and treats ANY OTHER
 /// disappearance (`.onDisappear`, which fires for outside-click dismissal too) as a commit
 /// attempt. Escape's own flag makes it read as a cancel instead, even though both paths
-/// dismiss through the same SwiftUI mechanism.
+/// dismiss through the same SwiftUI mechanism. `errorMessage` renders inline when the
+/// caller's last commit attempt failed (plan §7) — the popover is a fresh instance each time
+/// it reopens after a failure, so `hasCommitted`/`didCancelExplicitly` correctly reset.
 private struct RenamePopoverView: View {
   let initialName: String
+  let errorMessage: String?
   let onCommit: (String) -> Void
   let onCancel: () -> Void
   @State private var name: String
@@ -131,34 +163,41 @@ private struct RenamePopoverView: View {
   @State private var hasCommitted = false
   private static let maxLength = 60
 
-  init(initialName: String, onCommit: @escaping (String) -> Void, onCancel: @escaping () -> Void) {
+  init(
+    initialName: String, errorMessage: String?, onCommit: @escaping (String) -> Void,
+    onCancel: @escaping () -> Void
+  ) {
     self.initialName = initialName
+    self.errorMessage = errorMessage
     self.onCommit = onCommit
     self.onCancel = onCancel
     self._name = State(initialValue: initialName)
   }
 
   var body: some View {
-    TextField("Speaker name", text: $name)
-      .textFieldStyle(.roundedBorder)
-      .frame(width: 200)
-      .padding(8)
-      .onSubmit { commit() }
-      .onExitCommand {
-        didCancelExplicitly = true
-        onCancel()
+    VStack(alignment: .leading, spacing: 4) {
+      TextField("Speaker name", text: $name)
+        .textFieldStyle(.roundedBorder)
+        .frame(width: 200)
+        .onSubmit { commit() }
+        .onExitCommand {
+          didCancelExplicitly = true
+          onCancel()
+        }
+        .onChange(of: name) { _, newValue in
+          if newValue.count > Self.maxLength { name = String(newValue.prefix(Self.maxLength)) }
+        }
+      if let errorMessage {
+        Text(errorMessage)
+          .font(.caption)
+          .foregroundStyle(.red)
       }
-      .onChange(of: name) { _, newValue in
-        if newValue.count > Self.maxLength { name = String(newValue.prefix(Self.maxLength)) }
-      }
-      .onDisappear {
-        // Enter already committed and dismissed the popover from the PARENT, which triggers
-        // THIS disappearance too — without the guard, a single Enter press would commit
-        // twice. Escape is excluded by `didCancelExplicitly`; only an outside-click dismissal
-        // (neither flag set) should still trigger a commit here.
-        guard !didCancelExplicitly, !hasCommitted else { return }
-        commit()
-      }
+    }
+    .padding(8)
+    .onDisappear {
+      guard !didCancelExplicitly, !hasCommitted else { return }
+      commit()
+    }
   }
 
   private func commit() {

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -19,15 +19,17 @@ struct TurnDocumentView<Fallback: View>: View {
   let onRename: (String, String) async -> RenameFailure?
   @ViewBuilder let fallback: () -> Fallback
 
+  /// No `ScrollView` of its own (found by chunk review): both callers already embed this
+  /// view inside a container that scrolls the WHOLE page — the wizard's Done step and
+  /// History's detail view alike. A nested `ScrollView` with no height of its own has nothing
+  /// to size against and collapses instead of growing with the text, exactly the "renders
+  /// exactly today's plain text" contract this view exists to preserve.
   var body: some View {
     if let turns {
-      ScrollView {
-        VStack(alignment: .leading, spacing: 16) {
-          ForEach(Array(turns.enumerated()), id: \.offset) { _, turn in
-            TurnRowView(turn: turn, onRename: onRename)
-          }
+      VStack(alignment: .leading, spacing: 16) {
+        ForEach(Array(turns.enumerated()), id: \.offset) { _, turn in
+          TurnRowView(turn: turn, onRename: onRename)
         }
-        .padding()
       }
     } else {
       fallback()

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -17,6 +17,14 @@ struct TurnDocumentView<Fallback: View>: View {
   /// The caller re-fetches current analysis/turns and writes through
   /// `mergeSpeakerFields(explicitRename:)` — this view never persists anything itself.
   let onRename: (String, String) async -> RenameFailure?
+  /// Called when a rename popover closes WITHOUT a commit: Escape, or a blank name reverting
+  /// (plan §3d). An outside click commits and never reaches this. Shape-only telemetry is the
+  /// only consumer (#2811 §3e `cancelled`); the view keeps nothing.
+  var onRenameCancelled: () -> Void = {}
+  /// Called each time the turn branch below APPEARS, i.e. `turns` became non-nil for this
+  /// view identity. The caller decides whether that is new for the document (#2811 §3e
+  /// `file_import_turns_displayed`, deduplicated per document in each coordinator).
+  var onTurnsDisplayed: () -> Void = {}
   @ViewBuilder let fallback: () -> Fallback
 
   /// No `ScrollView` of its own (found by chunk review): both callers already embed this
@@ -28,9 +36,10 @@ struct TurnDocumentView<Fallback: View>: View {
     if let turns {
       VStack(alignment: .leading, spacing: 16) {
         ForEach(Array(turns.enumerated()), id: \.offset) { _, turn in
-          TurnRowView(turn: turn, onRename: onRename)
+          TurnRowView(turn: turn, onRename: onRename, onRenameCancelled: onRenameCancelled)
         }
       }
+      .onAppear(perform: onTurnsDisplayed)
     } else {
       fallback()
     }
@@ -49,6 +58,7 @@ struct RenameFailure: Equatable, Sendable {
 private struct TurnRowView: View {
   let turn: TranscriptDocumentPresenter.RenderedTurn
   let onRename: (String, String) async -> RenameFailure?
+  let onRenameCancelled: () -> Void
   @State private var isRenaming = false
   @State private var draftName = ""
   @State private var renameFailure: RenameFailure?
@@ -103,6 +113,7 @@ private struct TurnRowView: View {
           onCancel: {
             renameFailure = nil
             isRenaming = false
+            onRenameCancelled()
           })
       }
     }

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -1,0 +1,173 @@
+import EnviousWisprCore
+import SwiftUI
+
+/// Renders a `TranscriptDocumentPresenter.RenderedTurn` list, or falls through to a caller's
+/// own plain-text view when there is nothing turn-shaped to show (#2811, phase 4 of #2807).
+///
+/// Shared by the file-import wizard's Done step and History's detail view — the two places
+/// that replace their own independent renderers with this one (epic §3b). Each caller keeps
+/// its OWN plain-text fallback (`fallback`), since the wizard's and History's existing
+/// unlabeled behavior are NOT identical (#2811 addendum §3 Design) — this view only owns the
+/// turn-labeled case.
+struct TurnDocumentView<Fallback: View>: View {
+  let turns: [TranscriptDocumentPresenter.RenderedTurn]?
+  /// Called with a speaker id and its CURRENT name (or `nil`) when the user commits a rename
+  /// from the popover. The caller re-fetches current analysis/turns and writes through
+  /// `mergeSpeakerFields(explicitRename:)` — this view never persists anything itself.
+  let onRename: (String, String) -> Void
+  @ViewBuilder let fallback: () -> Fallback
+
+  var body: some View {
+    if let turns {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+          ForEach(Array(turns.enumerated()), id: \.offset) { _, turn in
+            TurnRowView(turn: turn, onRename: onRename)
+          }
+        }
+        .padding()
+      }
+    } else {
+      fallback()
+    }
+  }
+}
+
+private struct TurnRowView: View {
+  let turn: TranscriptDocumentPresenter.RenderedTurn
+  let onRename: (String, String) -> Void
+  @State private var isRenaming = false
+  @State private var draftName = ""
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 6) {
+        speakerLabel
+        if let timeLabel = turn.timeLabel {
+          Text(timeLabel)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+      content
+    }
+  }
+
+  /// A real `Button`, never a bare tap gesture (per `accessibility-semantic-controls`) — it
+  /// inherits AX role, keyboard activation, and focus order. `"unknown"` never gets one:
+  /// `turn.speakerName == nil` is the same signal for BOTH "unnamed real speaker" and
+  /// "unknown classification," so the tap target is gated on `speakerId`, not on the name.
+  @ViewBuilder private var speakerLabel: some View {
+    let displayName = turn.speakerName ?? "Unknown speaker"
+    if turn.speakerId == TurnAssembler.unknownSpeakerID {
+      Text(displayName)
+        .font(.subheadline.bold())
+        .foregroundStyle(.secondary)
+    } else {
+      Button {
+        draftName = turn.speakerName ?? ""
+        isRenaming = true
+      } label: {
+        Text(displayName)
+          .font(.subheadline.bold())
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Rename speaker")
+      .accessibilityValue(displayName)
+      .popover(isPresented: $isRenaming) {
+        RenamePopoverView(
+          initialName: turn.speakerName ?? "",
+          onCommit: { name in
+            onRename(turn.speakerId, name)
+            isRenaming = false
+          },
+          onCancel: { isRenaming = false })
+      }
+    }
+  }
+
+  @ViewBuilder private var content: some View {
+    switch turn.content {
+    case .plain(let text):
+      Text(text)
+    case .markedUp(let diff):
+      MarkedUpTurnText(result: diff)
+    }
+  }
+}
+
+/// One turn's worth of marked-up text — struck-through removals, highlighted changes/adds.
+/// Mirrors the wizard's existing whole-document marked-up rendering, applied per turn.
+private struct MarkedUpTurnText: View {
+  let result: WordDiff.Result
+
+  var body: some View {
+    result.segments.enumerated().reduce(Text("")) { text, element in
+      let (_, segment) = element
+      var piece = Text(segment.text + segment.trailing)
+      switch segment.kind {
+      case .same: break
+      case .removed: piece = piece.strikethrough()
+      case .changed, .added: piece = piece.foregroundColor(.orange)
+      }
+      return text + piece
+    }
+  }
+}
+
+/// Blank reverts; duplicate names allowed; 60-character cap; Enter commits, Escape cancels,
+/// dismissing by clicking outside ALSO commits (#2811 addendum §3d). SwiftUI has no direct
+/// "dismissed by outside click" event — only `.onExitCommand` for Escape specifically — so
+/// this distinguishes the two via a flag Escape sets before dismissal, and treats ANY OTHER
+/// disappearance (`.onDisappear`, which fires for outside-click dismissal too) as a commit
+/// attempt. Escape's own flag makes it read as a cancel instead, even though both paths
+/// dismiss through the same SwiftUI mechanism.
+private struct RenamePopoverView: View {
+  let initialName: String
+  let onCommit: (String) -> Void
+  let onCancel: () -> Void
+  @State private var name: String
+  @State private var didCancelExplicitly = false
+  @State private var hasCommitted = false
+  private static let maxLength = 60
+
+  init(initialName: String, onCommit: @escaping (String) -> Void, onCancel: @escaping () -> Void) {
+    self.initialName = initialName
+    self.onCommit = onCommit
+    self.onCancel = onCancel
+    self._name = State(initialValue: initialName)
+  }
+
+  var body: some View {
+    TextField("Speaker name", text: $name)
+      .textFieldStyle(.roundedBorder)
+      .frame(width: 200)
+      .padding(8)
+      .onSubmit { commit() }
+      .onExitCommand {
+        didCancelExplicitly = true
+        onCancel()
+      }
+      .onChange(of: name) { _, newValue in
+        if newValue.count > Self.maxLength { name = String(newValue.prefix(Self.maxLength)) }
+      }
+      .onDisappear {
+        // Enter already committed and dismissed the popover from the PARENT, which triggers
+        // THIS disappearance too — without the guard, a single Enter press would commit
+        // twice. Escape is excluded by `didCancelExplicitly`; only an outside-click dismissal
+        // (neither flag set) should still trigger a commit here.
+        guard !didCancelExplicitly, !hasCommitted else { return }
+        commit()
+      }
+  }
+
+  private func commit() {
+    hasCommitted = true
+    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      onCancel()
+      return
+    }
+    onCommit(trimmed)
+  }
+}

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -190,7 +190,10 @@ private struct RenamePopoverView: View {
     self.failure = failure
     self.onCommit = onCommit
     self.onCancel = onCancel
-    self._name = State(initialValue: failure?.currentName ?? initialName)
+    // `failure?.currentName ?? initialName` is WRONG when a failure exists but its re-read
+    // name is itself nil (a still-unnamed speaker): that reads as "no failure" and wrongly
+    // restores the stale opening name instead of blank (found by chunk review r4).
+    self._name = State(initialValue: failure.map { $0.currentName ?? "" } ?? initialName)
   }
 
   var body: some View {

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -140,12 +140,20 @@ private struct TurnRowView: View {
     }
   }
 
+  /// Selectable in both modes, as every passage this view replaces already was on both
+  /// screens (found by whole-diff review): a user copies one sentence of one turn as freely
+  /// as before, not only the whole document through Copy.
   @ViewBuilder private var content: some View {
     switch turn.content {
     case .plain(let text):
       Text(text)
+        .textSelection(.enabled)
     case .markedUp(let diff):
       MarkedUpTurnText(result: diff)
+        .textSelection(.enabled)
+        // The marks are visual; a screen reader gets the wizard's own spoken form instead,
+        // the same helper its whole-document marked-up view uses (found by whole-diff review).
+        .accessibilityLabel(TranscribeFileView.markedUpAccessibilityText(diff.segments))
     }
   }
 }

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -12,11 +12,11 @@ import SwiftUI
 struct TurnDocumentView<Fallback: View>: View {
   let turns: [TranscriptDocumentPresenter.RenderedTurn]?
   /// Called with a speaker id and its new name when the user commits a rename. Returns `nil`
-  /// on success, or an error message to show inline without dismissing the popover (plan §7:
+  /// on success, or a `RenameFailure` to show inline without dismissing the popover (plan §7:
   /// "Rename write fails ... Popover shows an inline error, does not silently claim success").
   /// The caller re-fetches current analysis/turns and writes through
   /// `mergeSpeakerFields(explicitRename:)` — this view never persists anything itself.
-  let onRename: (String, String) async -> String?
+  let onRename: (String, String) async -> RenameFailure?
   @ViewBuilder let fallback: () -> Fallback
 
   var body: some View {
@@ -35,12 +35,21 @@ struct TurnDocumentView<Fallback: View>: View {
   }
 }
 
+/// A failed rename write. `currentName` is the re-read, currently-saved name (plan §9: "Revert
+/// popover's TextField to the LAST KNOWN GOOD name ... re-read, not the value the user typed"),
+/// `nil` if the speaker still has no name — the caller performs the actual re-read; this type
+/// only carries the result back into the popover.
+struct RenameFailure: Equatable, Sendable {
+  let message: String
+  let currentName: String?
+}
+
 private struct TurnRowView: View {
   let turn: TranscriptDocumentPresenter.RenderedTurn
-  let onRename: (String, String) async -> String?
+  let onRename: (String, String) async -> RenameFailure?
   @State private var isRenaming = false
   @State private var draftName = ""
-  @State private var renameError: String?
+  @State private var renameFailure: RenameFailure?
   /// Captured when the popover opens, never read live off `turn` at commit time: `ForEach`
   /// keys rows by POSITION (`\.offset`), so the same row identity can be reused for a
   /// different turn while a popover is still open (found by chunk review). Committing must
@@ -75,7 +84,7 @@ private struct TurnRowView: View {
       Button {
         renamingSpeakerId = turn.speakerId
         draftName = turn.speakerName ?? ""
-        renameError = nil
+        renameFailure = nil
         isRenaming = true
       } label: {
         Text(displayName)
@@ -87,29 +96,28 @@ private struct TurnRowView: View {
       .popover(isPresented: $isRenaming) {
         RenamePopoverView(
           initialName: draftName,
-          errorMessage: renameError,
+          failure: renameFailure,
           onCommit: { name in commitRename(name) },
           onCancel: {
-            renameError = nil
+            renameFailure = nil
             isRenaming = false
           })
       }
     }
   }
 
-  /// On failure, reopens the popover with the error message rather than letting the dismissal
-  /// already in flight (e.g. from an outside click) silently swallow the failed write.
+  /// On failure, the popover stays open (`isRenaming` was never cleared) showing the error and
+  /// the reverted name; on success it closes.
   private func commitRename(_ name: String) {
     guard let id = renamingSpeakerId else {
       isRenaming = false
       return
     }
     Task {
-      if let error = await onRename(id, name) {
-        renameError = error
-        isRenaming = true
+      if let failure = await onRename(id, name) {
+        renameFailure = failure
       } else {
-        renameError = nil
+        renameFailure = nil
         isRenaming = false
       }
     }
@@ -150,12 +158,18 @@ private struct MarkedUpTurnText: View {
 /// this distinguishes the two via a flag Escape sets before dismissal, and treats ANY OTHER
 /// disappearance (`.onDisappear`, which fires for outside-click dismissal too) as a commit
 /// attempt. Escape's own flag makes it read as a cancel instead, even though both paths
-/// dismiss through the same SwiftUI mechanism. `errorMessage` renders inline when the
-/// caller's last commit attempt failed (plan §7) — the popover is a fresh instance each time
-/// it reopens after a failure, so `hasCommitted`/`didCancelExplicitly` correctly reset.
+/// dismiss through the same SwiftUI mechanism.
+///
+/// `failure` renders inline when the caller's last commit attempt failed (plan §7) and reverts
+/// the field to the re-read current name (plan §9) — never the rejected input. Because a
+/// failure keeps `isRenaming` true, THIS SAME instance survives the failed attempt (found by
+/// chunk review r2: an instance that stayed alive kept `hasCommitted = true` from the failed
+/// Enter forever, so a following outside-click could never re-commit). `.onChange(of: failure)`
+/// resets both dismissal guards whenever a new failure arrives, so a retry behaves like a fresh
+/// attempt.
 private struct RenamePopoverView: View {
   let initialName: String
-  let errorMessage: String?
+  let failure: RenameFailure?
   let onCommit: (String) -> Void
   let onCancel: () -> Void
   @State private var name: String
@@ -164,11 +178,11 @@ private struct RenamePopoverView: View {
   private static let maxLength = 60
 
   init(
-    initialName: String, errorMessage: String?, onCommit: @escaping (String) -> Void,
+    initialName: String, failure: RenameFailure?, onCommit: @escaping (String) -> Void,
     onCancel: @escaping () -> Void
   ) {
     self.initialName = initialName
-    self.errorMessage = errorMessage
+    self.failure = failure
     self.onCommit = onCommit
     self.onCancel = onCancel
     self._name = State(initialValue: initialName)
@@ -187,13 +201,19 @@ private struct RenamePopoverView: View {
         .onChange(of: name) { _, newValue in
           if newValue.count > Self.maxLength { name = String(newValue.prefix(Self.maxLength)) }
         }
-      if let errorMessage {
-        Text(errorMessage)
+      if let failure {
+        Text(failure.message)
           .font(.caption)
           .foregroundStyle(.red)
       }
     }
     .padding(8)
+    .onChange(of: failure) { _, newValue in
+      guard let newValue else { return }
+      hasCommitted = false
+      didCancelExplicitly = false
+      name = newValue.currentName ?? ""
+    }
     .onDisappear {
       guard !didCancelExplicitly, !hasCommitted else { return }
       commit()

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -53,6 +53,11 @@ struct TurnDocumentView<Fallback: View>: View {
 struct RenameFailure: Equatable, Sendable {
   let message: String
   let currentName: String?
+  /// Two consecutive failures with the same message and name must still read as DIFFERENT
+  /// values, or `RenamePopoverView`'s `.onChange(of: failure)` never fires for the second
+  /// and its `hasCommitted` guard stays stuck, so an outside click no longer commits (found
+  /// by second-pass review).
+  let attemptID = UUID()
 }
 
 private struct TurnRowView: View {

--- a/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Main/TurnDocumentView.swift
@@ -112,7 +112,7 @@ private struct TurnRowView: View {
       .accessibilityValue(displayName)
       .popover(isPresented: $isRenaming) {
         RenamePopoverView(
-          initialName: draftName,
+          name: $draftName,
           failure: renameFailure,
           onCommit: { name in commitRename(name) },
           onCancel: {
@@ -136,6 +136,10 @@ private struct TurnRowView: View {
     }
     Task {
       if let failure = await onRename(id, name) {
+        // The field reverts to the re-read current name (plan §9), never the rejected input;
+        // seeded HERE on the row's own binding so it holds whether the popover instance
+        // survived (Enter) or is about to be recreated (outside click).
+        draftName = failure.currentName ?? ""
         renameFailure = failure
         isRenaming = true
       } else {
@@ -190,37 +194,24 @@ private struct MarkedUpTurnText: View {
 /// attempt. Escape's own flag makes it read as a cancel instead, even though both paths
 /// dismiss through the same SwiftUI mechanism.
 ///
-/// `failure` renders inline when the caller's last commit attempt failed (plan §7) and reverts
-/// the field to the re-read current name (plan §9) — never the rejected input. Two different
-/// recreation paths need two different fixes, both required (found across chunk review r2/r3):
-/// an Enter-triggered failure keeps `isRenaming` true, so THIS SAME instance survives and
-/// `.onChange(of: failure)` resets the dismissal guards on it; an outside-click-triggered
-/// failure has ALREADY dismissed the popover before the write's result comes back, so its retry
-/// reopens a BRAND NEW instance, for which `.onChange` never fires on the value it was created
-/// with — that path is covered instead by seeding `_name` from `failure.currentName` at `init`.
+/// The field is a BINDING to the row's draft, never a `@State` seeded in `init` (found by
+/// Live UAT, 2026-09-13: the popover opened EMPTY for "Speaker 1"). macOS builds a
+/// popover's content before it is first shown, and a `State(initialValue:)` set in `init`
+/// counts only for that first construction, so the field kept the empty draft it was built
+/// with. The row sets the draft on open and on a failed commit (plan §9's revert), and the
+/// two dismissal guards are reset on every appearance for the same reason: this instance
+/// can be reused across presentations, and a `hasCommitted` left over from the last one
+/// would turn the next outside click into a silent no-op.
+///
+/// `failure` renders inline when the caller's last commit attempt failed (plan §7).
 private struct RenamePopoverView: View {
-  let initialName: String
+  @Binding var name: String
   let failure: RenameFailure?
   let onCommit: (String) -> Void
   let onCancel: () -> Void
-  @State private var name: String
   @State private var didCancelExplicitly = false
   @State private var hasCommitted = false
   private static let maxLength = 60
-
-  init(
-    initialName: String, failure: RenameFailure?, onCommit: @escaping (String) -> Void,
-    onCancel: @escaping () -> Void
-  ) {
-    self.initialName = initialName
-    self.failure = failure
-    self.onCommit = onCommit
-    self.onCancel = onCancel
-    // `failure?.currentName ?? initialName` is WRONG when a failure exists but its re-read
-    // name is itself nil (a still-unnamed speaker): that reads as "no failure" and wrongly
-    // restores the stale opening name instead of blank (found by chunk review r4).
-    self._name = State(initialValue: failure.map { $0.currentName ?? "" } ?? initialName)
-  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 4) {
@@ -242,11 +233,14 @@ private struct RenamePopoverView: View {
       }
     }
     .padding(8)
-    .onChange(of: failure) { _, newValue in
-      guard let newValue else { return }
+    .onAppear {
       hasCommitted = false
       didCancelExplicitly = false
-      name = newValue.currentName ?? ""
+    }
+    .onChange(of: failure) { _, newValue in
+      guard newValue != nil else { return }
+      hasCommitted = false
+      didCancelExplicitly = false
     }
     .onDisappear {
       guard !didCancelExplicitly, !hasCommitted else { return }

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -381,7 +381,8 @@ struct TranscribeFileView: View {
     .padding(.vertical, 30)
     .padding(.horizontal, 20)
     .background(
-      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg)
+    )
     .overlay(
       RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
         .strokeBorder(Color.stDivider, style: StrokeStyle(lineWidth: 1.5, dash: [7, 5]))
@@ -617,7 +618,9 @@ struct TranscribeFileView: View {
       }
       .padding(14)
       .frame(maxWidth: .infinity, alignment: .leading)
-      .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+      .background(
+        RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg)
+      )
       .overlay(
         RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
           .strokeBorder(selected ? Color.stAccent : Color.stDivider)
@@ -873,7 +876,8 @@ struct TranscribeFileView: View {
     case true: return "The model you picked runs on Ollama's servers, so the text is sent there."
     case false: return "That model runs on this Mac, so nothing leaves it."
     case nil:
-      return "Checking whether that model runs here or on Ollama's servers. Start Ollama to find out."
+      return
+        "Checking whether that model runs here or on Ollama's servers. Start Ollama to find out."
     }
   }
 
@@ -916,7 +920,9 @@ struct TranscribeFileView: View {
       }
       .padding(12)
       .frame(maxWidth: .infinity, minHeight: 120, alignment: .topLeading)
-      .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+      .background(
+        RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg)
+      )
       .overlay(
         RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
           .strokeBorder(selected ? Color.stAccent : Color.stDivider)
@@ -1144,7 +1150,9 @@ struct TranscribeFileView: View {
     }
     .padding(14)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+    .background(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg)
+    )
     .overlay(
       RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).strokeBorder(Color.stDivider))
   }
@@ -1187,6 +1195,15 @@ struct TranscribeFileView: View {
       .padding(.horizontal, SettingsLayout.rowPaddingH)
       .padding(.vertical, SettingsLayout.rowPaddingV)
     }
+    // "Finding speakers" (#2811 §3 Design): Working already has its own Stop above, which
+    // `stop()` already cancels the phase-3 speaker/turn-storage pass unconditionally — this
+    // adds only the text, never a second Stop control.
+    if coordinator.speakerStepState == .inProgress {
+      HStack(spacing: 6) {
+        ProgressView().controlSize(.small)
+        Text("Finding speakers").foregroundStyle(Color.stTextSecondary)
+      }
+    }
     // Finished parts, then what is still waiting. NO raw-document fallback here: it renders
     // the WHOLE recording, so before the first part landed the highlighted current row
     // started below the entire transcript and the user read their meeting twice. My own fix
@@ -1226,10 +1243,12 @@ struct TranscribeFileView: View {
             .padding(.vertical, 10)
             .background(
               RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
-                .fill(isWorking ? Color.stAccentLight.opacity(0.35) : Color.stSectionBg))
+                .fill(isWorking ? Color.stAccentLight.opacity(0.35) : Color.stSectionBg)
+            )
             .overlay(
               RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius)
-                .strokeBorder(isWorking ? Color.stAccent : Color.stDivider))
+                .strokeBorder(isWorking ? Color.stAccent : Color.stDivider)
+            )
             .accessibilityLabel(
               isWorking
                 ? "Cleaning this part now. \(row.element)"
@@ -1242,71 +1261,104 @@ struct TranscribeFileView: View {
   /// The words themselves while the run goes: cleaned parts as they land, and
   /// the raw transcript until the first one does, so the page is never empty and
   /// never just a spinner.
+  ///
+  /// DONE only, and only when there are real turns to show (#2811, phase 4 of #2807):
+  /// `TurnDocumentView` takes over from the three branches below, which stay exactly as they
+  /// are for Working and for any document with nothing turn-shaped — "a solo memo looks
+  /// exactly like today" (plan §2.1).
   private var liveTranscript: some View {
     VStack(alignment: .leading, spacing: 14) {
-      // The original/cleaned toggle belongs to DONE. On Working there is nothing to toggle
-      // and honouring it there hid the finished parts during a re-polish.
-      ForEach(
-        coordinator.step == .done
-          && (coordinator.screenShowsRawWords || coordinator.documentView == .markedUp)
-          ? [] : coordinator.parts
-      ) { part in
-        VStack(alignment: .leading, spacing: 4) {
-          Text(part.text)
-            .lineSpacing(6)
-            .foregroundStyle(Color.stTextBody)
-            .textSelection(.enabled)
-          // Only a FAILED polish is marked. A document the user chose not to
-          // have polished is not a document with fourteen problems in it.
-          if part.isUnpolished {
-            Text("This passage could not be cleaned up. These are the raw words.")
-              .font(.stHelper)
-              .foregroundStyle(Color.stTextSecondary)
-          }
-        }
-      }
-      // DONE only, the marked-up view (#2773): the original words with the cleanup on them,
-      // and the counts that are the point. The marks are one attributed text so selection
-      // and copy behave like the other two views.
-      if coordinator.step == .done, coordinator.documentView == .markedUp,
-        !coordinator.parts.isEmpty
-      {
-        Group {
-          if let markedUp = coordinator.markedUp {
-            VStack(alignment: .leading, spacing: 8) {
-              Text(markedUp.legend)
-                .font(.stHelper)
-                .foregroundStyle(Color.stTextSecondary)
-                .accessibilityLabel("Cleanup summary: \(markedUp.legend)")
-              Text(Self.markedUpText(markedUp.segments))
-                .lineSpacing(6)
-                .textSelection(.enabled)
-                // The marks are visual; this is what a screen reader gets instead.
-                .accessibilityLabel(Self.markedUpAccessibilityText(markedUp.segments))
-            }
-          } else {
-            ProgressView("Comparing words")
-              .controlSize(.small)
-          }
-        }
-        .task(id: coordinator.markedUpInput) { await coordinator.prepareMarkedUp() }
-      }
-      // DONE only. This is the "Original" view and the empty-document floor, and both belong
-      // to the finished screen; on Working the queue shows the raw words.
-      if coordinator.step == .done,
-        coordinator.screenShowsRawWords,
-        !coordinator.rawTranscript.isEmpty
-      {
-        Text(coordinator.rawTranscript)
-          .lineSpacing(6)
-          .foregroundStyle(Color.stTextSecondary)
-          .textSelection(.enabled)
+      if coordinator.step == .done {
+        TurnDocumentView(
+          turns: renderedTurns,
+          onRename: { id, name in await coordinator.renameSpeaker(id: id, name: name) },
+          fallback: { legacyTranscriptContent }
+        )
+        .task(id: coordinator.turnDiffInput) { await coordinator.prepareTurnDiffs() }
+      } else {
+        legacyTranscriptContent
       }
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, 16)
     .padding(.vertical, 14)
-    .background(RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+    .background(
+      RoundedRectangle(cornerRadius: SettingsLayout.sectionRadius).fill(Color.stSectionBg))
+  }
+
+  /// `TurnDocumentView`'s `diffLookup` reads whatever `prepareTurnDiffs` has cached so far —
+  /// `nil` for a turn not yet diffed falls back to that turn's cleaned text (chunk-1's own
+  /// contract), never blocking.
+  private var renderedTurns: [TranscriptDocumentPresenter.RenderedTurn]? {
+    TranscriptDocumentPresenter.render(
+      turns: coordinator.turns, rawText: coordinator.rawTranscript,
+      speakerNames: coordinator.speakerNames, mode: coordinator.documentView,
+      timesOn: coordinator.timesOn,
+      diffLookup: { turn in coordinator.turnDiffs?[turn.id] })
+  }
+
+  /// Today's own plain-text rendering, UNCHANGED — `TurnDocumentView`'s fallback for
+  /// `turns == nil`, and the whole of `liveTranscript` while Working.
+  @ViewBuilder
+  private var legacyTranscriptContent: some View {
+    // The original/cleaned toggle belongs to DONE. On Working there is nothing to toggle
+    // and honouring it there hid the finished parts during a re-polish.
+    ForEach(
+      coordinator.step == .done
+        && (coordinator.screenShowsRawWords || coordinator.documentView == .markedUp)
+        ? [] : coordinator.parts
+    ) { part in
+      VStack(alignment: .leading, spacing: 4) {
+        Text(part.text)
+          .lineSpacing(6)
+          .foregroundStyle(Color.stTextBody)
+          .textSelection(.enabled)
+        // Only a FAILED polish is marked. A document the user chose not to
+        // have polished is not a document with fourteen problems in it.
+        if part.isUnpolished {
+          Text("This passage could not be cleaned up. These are the raw words.")
+            .font(.stHelper)
+            .foregroundStyle(Color.stTextSecondary)
+        }
+      }
+    }
+    // DONE only, the marked-up view (#2773): the original words with the cleanup on them,
+    // and the counts that are the point. The marks are one attributed text so selection
+    // and copy behave like the other two views.
+    if coordinator.step == .done, coordinator.documentView == .markedUp,
+      !coordinator.parts.isEmpty
+    {
+      Group {
+        if let markedUp = coordinator.markedUp {
+          VStack(alignment: .leading, spacing: 8) {
+            Text(markedUp.legend)
+              .font(.stHelper)
+              .foregroundStyle(Color.stTextSecondary)
+              .accessibilityLabel("Cleanup summary: \(markedUp.legend)")
+            Text(Self.markedUpText(markedUp.segments))
+              .lineSpacing(6)
+              .textSelection(.enabled)
+              // The marks are visual; this is what a screen reader gets instead.
+              .accessibilityLabel(Self.markedUpAccessibilityText(markedUp.segments))
+          }
+        } else {
+          ProgressView("Comparing words")
+            .controlSize(.small)
+        }
+      }
+      .task(id: coordinator.markedUpInput) { await coordinator.prepareMarkedUp() }
+    }
+    // DONE only. This is the "Original" view and the empty-document floor, and both belong
+    // to the finished screen; on Working the queue shows the raw words.
+    if coordinator.step == .done,
+      coordinator.screenShowsRawWords,
+      !coordinator.rawTranscript.isEmpty
+    {
+      Text(coordinator.rawTranscript)
+        .lineSpacing(6)
+        .foregroundStyle(Color.stTextSecondary)
+        .textSelection(.enabled)
+    }
   }
 
   // MARK: - 6. Done
@@ -1330,6 +1382,24 @@ struct TranscribeFileView: View {
     // would alarm the first user and under-warn the second. Found by Codex.
     if let notice = coordinator.historySaveNotice {
       InsetNotice(text: notice, systemImage: "exclamationmark.triangle", tint: .orange)
+    }
+    // "Finding speakers" can outlive the visible Working step (#2811 §3 Design correction) —
+    // Done has no existing Stop button, so this notice carries its own.
+    if coordinator.speakerStepState == .inProgress {
+      HStack(spacing: 8) {
+        ProgressView().controlSize(.small)
+        Text("Finding speakers").foregroundStyle(Color.stTextSecondary)
+        Spacer(minLength: 12)
+        wizardSecondary("Stop") { coordinator.stop() }
+      }
+    }
+    // A generic message, honestly true whatever the failure reason (#2811 §3e: this must not
+    // imply a retry will fix a cause it cannot, such as #2838's CJK/space-free-script gap).
+    if coordinator.canRetrySpeakerAnalysis {
+      InsetNotice(
+        text: "Couldn't find distinct speakers in this recording.",
+        systemImage: "person.crop.circle.badge.questionmark", tint: .orange)
+      wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
     }
     // ONE row, which is finding 12. Founder, on the shipped two-row version: "You see how
     // cleaned up by EG-1 is on the wrong line and looks unpolished?" The prototype puts the
@@ -1364,12 +1434,14 @@ struct TranscribeFileView: View {
         // file — both of which destroy something the user had, to give them
         // nothing. Found enumerating (step, state) rather than by review.
         // No trailing arrow on any of these: the arrow means "this moves you forward a
-        // step", and copying, saving and starting over do not.
+        // step", and copying, saving and starting over do not. Titles relabel while Marked
+        // up is showing, disclosing that Copy/Save/Share hand over the CLEANED text instead
+        // (#2811 §2.1, generalized from the founder's existing export-substitution rule).
         wizardPrimary(
-          "Copy everything", isEnabled: coordinator.hasDocument, systemImage: "doc.on.doc",
-          showsArrow: false, action: { copyDocument() })
+          coordinator.exportButtonLabels.copy, isEnabled: coordinator.hasDocument,
+          systemImage: "doc.on.doc", showsArrow: false, action: { copyDocument() })
         wizardSecondary(
-          "Save as...", isEnabled: coordinator.hasDocument,
+          coordinator.exportButtonLabels.save, isEnabled: coordinator.hasDocument,
           systemImage: "square.and.arrow.down", action: { saveDocument() })
         // #2772 finding 10a: the prototype has FOUR buttons and this one was missing
         // entirely. Anchored to its own frame so the macOS picker points at the button the
@@ -1461,6 +1533,15 @@ struct TranscribeFileView: View {
         .controlSize(.small)
         .fixedSize()
         .accessibilityLabel("Which words to show")
+      }
+      // Times on/off (#2811 §2.1) — only meaningful once there are turns to time.
+      if coordinator.turns != nil {
+        Toggle(
+          "Times",
+          isOn: Binding(get: { coordinator.timesOn }, set: { coordinator.timesOn = $0 })
+        )
+        .controlSize(.small)
+        .toggleStyle(.switch)
       }
     }
   }
@@ -1624,8 +1705,9 @@ struct TranscribeFileView: View {
       Text(
         Self.footerDetail(
           step: coordinator.step, isCloudPolish: isCloudPolish,
-          provider: footerProvider))
-        .foregroundStyle(Color.stTextSecondary)
+          provider: footerProvider)
+      )
+      .foregroundStyle(Color.stTextSecondary)
       Spacer(minLength: 0)
     }
     .padding(.horizontal, 16)
@@ -1803,8 +1885,9 @@ struct TranscribeFileView: View {
   private var shareButton: some View {
     ShareLink(item: coordinator.exportText) {
       SettingsActionButton(
-        title: "Share...", isEnabled: coordinator.hasDocument, emphasis: .quiet,
-        shape: .roundedRect, size: .medium, systemImage: "square.and.arrow.up")
+        title: coordinator.exportButtonLabels.share, isEnabled: coordinator.hasDocument,
+        emphasis: .quiet, shape: .roundedRect, size: .medium,
+        systemImage: "square.and.arrow.up")
     }
     .buttonStyle(.plain)
     // Same rule as Copy and Save: nothing to hand over means no offer, rather than a sheet

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1271,7 +1271,13 @@ struct TranscribeFileView: View {
           onTurnsDisplayed: { coordinator.noteTurnsDisplayed() },
           fallback: { legacyTranscriptContent }
         )
-        .task(id: coordinator.turnDiffInput) { await coordinator.prepareTurnDiffs() }
+        .task(
+          id: FileImportCoordinator.TurnDiffRequest(
+            input: coordinator.turnDiffInput, markedUp: coordinator.documentView == .markedUp)
+        ) {
+          guard coordinator.documentView == .markedUp else { return }
+          await coordinator.prepareTurnDiffs()
+        }
       } else {
         legacyTranscriptContent
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1415,12 +1415,18 @@ struct TranscribeFileView: View {
       InsetNotice(
         text: "Couldn't add speaker labels to this recording.",
         systemImage: "person.crop.circle.badge.questionmark", tint: .orange)
-      wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
+      // Absent, not inert, when a retry could only reach the same failure (no usable word
+      // timings): offering it would promise what the retry cannot deliver (§3e).
+      if coordinator.canRetrySpeakerAnalysis {
+        wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
+      }
     case .unresolved:
       InsetNotice(
         text: "Speaker detection didn't finish for this recording.",
         systemImage: "person.crop.circle.badge.questionmark", tint: .orange)
-      wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
+      if coordinator.canRetrySpeakerAnalysis {
+        wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
+      }
     }
     // ONE row, which is finding 12. Founder, on the shipped two-row version: "You see how
     // cleaned up by EG-1 is on the wrong line and looks unpolished?" The prototype puts the

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1288,13 +1288,18 @@ struct TranscribeFileView: View {
 
   /// `TurnDocumentView`'s `diffLookup` reads whatever `prepareTurnDiffs` has cached so far —
   /// `nil` for a turn not yet diffed falls back to that turn's cleaned text (chunk-1's own
-  /// contract), never blocking.
+  /// contract), never blocking. `coordinator.turnDiffs` is read exactly ONCE here, outside
+  /// the closure `render` calls once per turn (found by chunk review): that getter validates
+  /// its cache against a freshly-rebuilt `turnDiffInput`, which itself re-slices every turn's
+  /// text — calling it per-turn made the whole render pass quadratic in turn count despite the
+  /// diffs themselves being cached.
   private var renderedTurns: [TranscriptDocumentPresenter.RenderedTurn]? {
-    TranscriptDocumentPresenter.render(
+    let diffs = coordinator.turnDiffs
+    return TranscriptDocumentPresenter.render(
       turns: coordinator.turns, rawText: coordinator.rawTranscript,
       speakerNames: coordinator.speakerNames, mode: coordinator.documentView,
       timesOn: coordinator.timesOn,
-      diffLookup: { turn in coordinator.turnDiffs?[turn.id] })
+      diffLookup: { turn in diffs?[turn.id] })
   }
 
   /// Today's own plain-text rendering, UNCHANGED — `TurnDocumentView`'s fallback for
@@ -1393,11 +1398,21 @@ struct TranscribeFileView: View {
         wizardSecondary("Stop") { coordinator.stop() }
       }
     }
-    // A generic message, honestly true whatever the failure reason (#2811 §3e: this must not
-    // imply a retry will fix a cause it cannot, such as #2838's CJK/space-free-script gap).
-    if coordinator.canRetrySpeakerAnalysis {
+    // Two distinct stored outcomes (found by chunk review), each with its own honestly-scoped
+    // wording (#2811 §3e: neither may imply a retry will fix a cause it cannot, such as
+    // #2838's CJK/space-free-script gap) — collapsing them into one message is exactly the
+    // "success transitions straight to a silently-unresolved state" gap §3 Design warns about.
+    switch coordinator.speakerNoticeReason {
+    case .none:
+      EmptyView()
+    case .failed:
       InsetNotice(
         text: "Couldn't find distinct speakers in this recording.",
+        systemImage: "person.crop.circle.badge.questionmark", tint: .orange)
+      wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
+    case .unresolved:
+      InsetNotice(
+        text: "Speaker detection didn't finish for this recording.",
         systemImage: "person.crop.circle.badge.questionmark", tint: .orange)
       wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
     }

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1195,15 +1195,10 @@ struct TranscribeFileView: View {
       .padding(.horizontal, SettingsLayout.rowPaddingH)
       .padding(.vertical, SettingsLayout.rowPaddingV)
     }
-    // "Finding speakers" (#2811 §3 Design): Working already has its own Stop above, which
-    // `stop()` already cancels the phase-3 speaker/turn-storage pass unconditionally — this
-    // adds only the text, never a second Stop control.
-    if coordinator.speakerStepState == .inProgress {
-      HStack(spacing: 6) {
-        ProgressView().controlSize(.small)
-        Text("Finding speakers").foregroundStyle(Color.stTextSecondary)
-      }
-    }
+    // No speaker line on Working (founder, 2026-09-13: the bar plus a separate "Finding
+    // speakers" spinner read as two jobs). The bar is the one status here; Working's own Stop
+    // already cancels the speaker pass too. Speaker work shows on Done, where nothing else
+    // is moving (`speakerStatusLabel`).
     // Finished parts, then what is still waiting. NO raw-document fallback here: it renders
     // the WHOLE recording, so before the first part landed the highlighted current row
     // started below the entire transcript and the user read their meeting twice. My own fix
@@ -1390,12 +1385,14 @@ struct TranscribeFileView: View {
     if let notice = coordinator.historySaveNotice {
       InsetNotice(text: notice, systemImage: "exclamationmark.triangle", tint: .orange)
     }
-    // "Finding speakers" can outlive the visible Working step (#2811 §3 Design correction) —
-    // Done has no existing Stop button, so this notice carries its own.
-    if coordinator.speakerStepState == .inProgress {
+    // Background speaker work outlives the visible Working step (#2811 §3 Design correction)
+    // and Done has no other Stop, so this one line carries its own. ONE line, saying what is
+    // happening ("Finding speakers", then "Cleaning speaker turns: 120 of 372"); the count
+    // is what a 48-minute file needs (founder UAT, 2026-09-13).
+    if let label = coordinator.speakerStatusLabel {
       HStack(spacing: 8) {
         ProgressView().controlSize(.small)
-        Text("Finding speakers").foregroundStyle(Color.stTextSecondary)
+        Text(label).foregroundStyle(Color.stTextSecondary)
         Spacer(minLength: 12)
         wizardSecondary("Stop") { coordinator.stop() }
       }

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1408,8 +1408,12 @@ struct TranscribeFileView: View {
     case .none:
       EmptyView()
     case .failed:
+      // Not "couldn't find distinct speakers": `.failed(.noWordTimings)` is reached when the
+      // analyzer DID find several and the word timings could not bind them (a space-free
+      // script, #2838), so that wording was false for one of this case's own reasons (found
+      // by second-pass review). This is true for every stored failure reason.
       InsetNotice(
-        text: "Couldn't find distinct speakers in this recording.",
+        text: "Couldn't add speaker labels to this recording.",
         systemImage: "person.crop.circle.badge.questionmark", tint: .orange)
       wizardSecondary("Try again") { coordinator.retrySpeakerAnalysis() }
     case .unresolved:

--- a/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/TranscribeFileView.swift
@@ -1272,6 +1272,8 @@ struct TranscribeFileView: View {
         TurnDocumentView(
           turns: renderedTurns,
           onRename: { id, name in await coordinator.renameSpeaker(id: id, name: name) },
+          onRenameCancelled: { coordinator.noteRenameCancelled() },
+          onTurnsDisplayed: { coordinator.noteTurnsDisplayed() },
           fallback: { legacyTranscriptContent }
         )
         .task(id: coordinator.turnDiffInput) { await coordinator.prepareTurnDiffs() }

--- a/Sources/EnviousWisprCore/Transcript.swift
+++ b/Sources/EnviousWisprCore/Transcript.swift
@@ -555,4 +555,20 @@ public struct Transcript: Codable, Identifiable, Sendable {
     copy.speakerNames = mergedNames
     return copy
   }
+
+  /// Adopts another row's speaker fields VERBATIM — no retire/fill logic, unlike
+  /// `mergingSpeakerFields`, because the caller already knows `other` holds the CURRENT,
+  /// correct values and is only carrying them onto a copy whose non-speaker fields (text,
+  /// polish credit) just changed (#2811, phase 4 of #2807). `FileImportCoordinator
+  /// .savePolishedToHistory` needs this: its own cached row snapshot can be stale relative to
+  /// a rename or a background turn-storage pass that landed on the live row since that
+  /// snapshot was taken, and `withImportResult` alone would silently carry the STALE fields
+  /// forward, reverting whatever the live row had just gained.
+  public func carryingSpeakerFields(from other: Transcript) -> Transcript {
+    var copy = self
+    copy.speakerAnalysis = other.speakerAnalysis
+    copy.speakerNames = other.speakerNames
+    copy.turns = other.turns
+    return copy
+  }
 }

--- a/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
+++ b/Sources/EnviousWisprPipeline/TurnCleanupRunner.swift
@@ -43,13 +43,19 @@ public struct TurnCleanupRunner: Sendable {
   /// "every part failed" — matches `Turn.wasPolished`'s own "true if ANY part polished").
   /// A cancellation partway through leaves the remaining turns' fields untouched (the caller
   /// must not persist a half-finished pass — this method makes no write of its own).
+  ///
+  /// `onProgress(done, total)` is called before the first turn (0 of N) and after each turn
+  /// lands, so a screen can say how far the pass is (#2811, founder UAT: a 48-minute file
+  /// spent 490 s here behind a bare spinner). Never called after a cancellation.
   @MainActor
   public func run(
-    turns: [Turn], rawText: String, engineLanguage: String?
+    turns: [Turn], rawText: String, engineLanguage: String?,
+    onProgress: @MainActor (Int, Int) -> Void = { _, _ in }
   ) async -> (turns: [Turn], fallbackTurnCount: Int) {
     var result: [Turn] = []
     result.reserveCapacity(turns.count)
     var fallbackTurnCount = 0
+    onProgress(0, turns.count)
     for turn in turns {
       guard !Task.isCancelled else {
         result.append(contentsOf: turns[result.count...])
@@ -59,6 +65,8 @@ public struct TurnCleanupRunner: Sendable {
         turn: turn, rawText: rawText, engineLanguage: engineLanguage)
       if hadFallbackPart { fallbackTurnCount += 1 }
       result.append(cleanedTurn)
+      guard !Task.isCancelled else { continue }
+      onProgress(result.count, turns.count)
     }
     return (result, fallbackTurnCount)
   }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -3206,6 +3206,38 @@ public final class TelemetryService {
     }
   }
 
+  // MARK: - File import turn labels: rename, retry (#2811, phase 4 of #2807)
+
+  /// Shape only, matching `trackFileImportTurns`'s own privacy floor: never a speaker's name,
+  /// never a document's text. `cancelled` (the popover's own blank-revert/Escape/outside-click
+  /// paths, which never call the write at all) is not tracked here — those paths never reach
+  /// either coordinator's rename entry point, so adding that outcome would need a NEW hook
+  /// through the shared, already-reviewed `TurnDocumentView` popover rather than a dimension
+  /// on an existing write path; left as a known, deliberate scope limit for this phase.
+  public enum FileImportRenameOutcome: String {
+    case saved
+    case failed
+  }
+
+  public func trackFileImportRename(outcome: FileImportRenameOutcome) {
+    PostHogSDK.shared.capture("file_import_turns_rename", properties: ["outcome": outcome.rawValue])
+  }
+
+  /// `recovered` reads the row's STORED outcome after the retry's own write (`.labeled`, per
+  /// the §3 Design "failure authority" correction — never the coordinator's in-memory
+  /// analyzer-only property); `stillFailed` covers every other outcome, including a stale/
+  /// cancelled retry that wrote nothing at all — from telemetry's perspective a retry that
+  /// did not recover is the only fact worth a dashboard, not why.
+  public enum FileImportSpeakerRetryOutcome: String {
+    case recovered
+    case stillFailed = "still_failed"
+  }
+
+  public func trackFileImportSpeakerRetry(outcome: FileImportSpeakerRetryOutcome) {
+    PostHogSDK.shared.capture(
+      "file_import_turns_retry", properties: ["outcome": outcome.rawValue])
+  }
+
   // MARK: - Update banner (issue #343)
 
   public func updateBannerShown(

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -3206,28 +3206,34 @@ public final class TelemetryService {
     }
   }
 
-  // MARK: - File import turn labels: rename, retry (#2811, phase 4 of #2807)
+  // MARK: - File import turn labels: rename, retry, displayed (#2811, phase 4 of #2807)
 
-  /// Shape only, matching `trackFileImportTurns`'s own privacy floor: never a speaker's name,
-  /// never a document's text. `cancelled` (the popover's own blank-revert/Escape/outside-click
-  /// paths, which never call the write at all) is not tracked here — those paths never reach
-  /// either coordinator's rename entry point, so adding that outcome would need a NEW hook
-  /// through the shared, already-reviewed `TurnDocumentView` popover rather than a dimension
-  /// on an existing write path; left as a known, deliberate scope limit for this phase.
+  /// Three sibling events under the `file_import_turns_` prefix, never new fields on
+  /// `file_import_turns` itself: that event fires exactly once per import from the storage
+  /// pass, before any screen draws a turn, so a per-attempt or render-time fact cannot ride
+  /// on it without inflating every count of it (plan §3e, chunk 4 correction). Shape only,
+  /// matching `trackFileImportTurns`'s own privacy floor: never a speaker's name, never a
+  /// document's text.
+  ///
+  /// `cancelled` is the rename popover's Escape and blank-revert paths, which share ONE
+  /// cancel hook in `TurnDocumentView`; an outside click COMMITS (plan §3d) and is never a
+  /// cancel.
   public enum FileImportRenameOutcome: String {
     case saved
     case failed
+    case cancelled
   }
 
   public func trackFileImportRename(outcome: FileImportRenameOutcome) {
     PostHogSDK.shared.capture("file_import_turns_rename", properties: ["outcome": outcome.rawValue])
   }
 
-  /// `recovered` reads the row's STORED outcome after the retry's own write (`.labeled`, per
-  /// the §3 Design "failure authority" correction — never the coordinator's in-memory
-  /// analyzer-only property); `stillFailed` covers every other outcome, including a stale/
-  /// cancelled retry that wrote nothing at all — from telemetry's perspective a retry that
-  /// did not recover is the only fact worth a dashboard, not why.
+  /// `recovered` reads the row's STORED outcome after the retry's own write (per the §3
+  /// Design "failure authority" correction, never the coordinator's in-memory analyzer-only
+  /// property) and is true for `.single` as well as `.labeled`: those are exactly the two
+  /// outcomes that clear the notice the user pressed "Try again" under. A retry that was
+  /// stopped or superseded by another file emits NOTHING, since it says nothing about the
+  /// analyzer; `stillFailed` is a retry that ran to its own write and left the row failed.
   public enum FileImportSpeakerRetryOutcome: String {
     case recovered
     case stillFailed = "still_failed"
@@ -3236,6 +3242,19 @@ public final class TelemetryService {
   public func trackFileImportSpeakerRetry(outcome: FileImportSpeakerRetryOutcome) {
     PostHogSDK.shared.capture(
       "file_import_turns_retry", properties: ["outcome": outcome.rawValue])
+  }
+
+  /// Which of the two screens drew a turn view. Replaces the plan's `labels_displayed` bool:
+  /// emitted by each coordinator at most once per document per screen per app launch, the
+  /// first time `TurnDocumentView`'s turn branch appears for that document.
+  public enum FileImportTurnsScreen: String {
+    case wizard
+    case history
+  }
+
+  public func trackFileImportTurnsDisplayed(screen: FileImportTurnsScreen) {
+    PostHogSDK.shared.capture(
+      "file_import_turns_displayed", properties: ["screen": screen.rawValue])
   }
 
   // MARK: - Update banner (issue #343)

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1150,6 +1150,54 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(store.current(historyID)?.speakerNames?["A"] == "Zach", "a rename must survive a re-clean")
   }
 
+  @Test("Stop pressed while Clean it again is re-cleaning the turns prevents that write (#2811)")
+  func stopDuringTurnRecleanPreventsWrite() async {
+    let store = FakeHistoryStore()
+    let cleaner = TaggedCleaner()
+    let turnGate = ManualGate()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      processPart: { part, _ in
+        // The re-clean's OWN per-turn calls (never the whole-document part, which is what
+        // the visible run cleans) block until the test has pressed Stop.
+        if cleaner.tag == "second", part != "hello there friend" {
+          await turnGate.markArrived()
+          await turnGate.waitUntilOpen()
+        }
+        return cleaner.outcome(part)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    let stored = await settleUntil {
+      store.current(historyID)?.turns != nil && coordinator.speakerStepState == .finished
+    }
+    #expect(stored)
+
+    cleaner.tag = "second"
+    coordinator.rePolish()
+    await turnGate.waitUntilArrived()
+    // The screen already reads Done (`isRunning` is false) while the re-clean is inside its
+    // first per-turn call; Stop here must still reach the task that owns the re-clean.
+    #expect(!coordinator.isRunning)
+    coordinator.stop()
+    await turnGate.open()
+    for _ in 0..<50 { await Task.yield() }
+
+    let untouched =
+      store.current(historyID)?.turns?.allSatisfy { $0.processedText?.hasSuffix("[first]") == true }
+    #expect(untouched == true, "a stopped re-clean must never persist its result")
+  }
+
   @Test("Clean it again cleans the raw turns a retry left behind (#2811)")
   func rePolishCleansTurnsLeftRawByRetry() async {
     let store = FakeHistoryStore()

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1095,6 +1095,114 @@ struct FileImportCoordinatorSpeakerTests {
     )
   }
 
+  /// A cleanup whose output the test can change between runs, so a re-clean is told apart
+  /// from the first clean by the text it wrote, never by a call count alone.
+  @MainActor private final class TaggedCleaner {
+    var tag = "first"
+    func outcome(_ part: String) -> FileImportRunner.PartOutcome {
+      FileImportRunner.PartOutcome(text: part, polishedText: "\(part) [\(tag)]", polishError: nil)
+    }
+  }
+
+  @Test("Clean it again re-cleans the stored turns and keeps an explicit rename (#2811)")
+  func rePolishRecleansStoredTurnsAndKeepsRename() async {
+    let store = FakeHistoryStore()
+    let cleaner = TaggedCleaner()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      processPart: { part, _ in cleaner.outcome(part) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    let stored = await settleUntil {
+      store.current(historyID)?.turns != nil && coordinator.speakerStepState == .finished
+    }
+    #expect(stored)
+    let firstCleaned =
+      store.current(historyID)?.turns?.allSatisfy { $0.processedText?.hasSuffix("[first]") == true }
+    #expect(firstCleaned == true, "the first pass should have cleaned every turn")
+
+    guard let liveRow = store.current(historyID), let analysis = liveRow.speakerAnalysis else {
+      Issue.record("no labeled row to rename against")
+      return
+    }
+    #expect(store.rename(historyID, analysis, liveRow.turns, (speakerId: "A", name: "Zach")))
+
+    cleaner.tag = "second"
+    coordinator.rePolish()
+    _ = await settleUntil { coordinator.state == .finished }
+    let recleaned = await settleUntil {
+      store.current(historyID)?.turns?.allSatisfy {
+        $0.processedText?.hasSuffix("[second]") == true
+      } ?? false
+    }
+    #expect(recleaned, "Clean it again must re-clean the stored turns, not only the document")
+    #expect(store.current(historyID)?.turns?.count == 2, "re-cleaning must not change the turn set")
+    #expect(store.current(historyID)?.speakerNames?["A"] == "Zach", "a rename must survive a re-clean")
+  }
+
+  @Test("Clean it again cleans the raw turns a retry left behind (#2811)")
+  func rePolishCleansTurnsLeftRawByRetry() async {
+    let store = FakeHistoryStore()
+    let cleaner = TaggedCleaner()
+    @MainActor final class AttemptCounter {
+      private(set) var count = 0
+      func next() -> Int {
+        count += 1
+        return count
+      }
+    }
+    let attempts = AttemptCounter()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        attempts.next() == 1
+          ? .failed(.analyzerThrew("boom")) : .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      },
+      processPart: { part, _ in cleaner.outcome(part) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    _ = await settleUntil {
+      if case .failed = store.current(historyID)?.speakerAnalysis { return true }
+      return false
+    }
+    coordinator.retrySpeakerAnalysis()
+    let retried = await settleUntil {
+      store.current(historyID)?.speakerAnalysis == .labeled(count: 2)
+        && coordinator.speakerStepState == .finished
+    }
+    #expect(retried)
+    let rawAfterRetry = store.current(historyID)?.turns?.allSatisfy { $0.processedText == nil }
+    #expect(rawAfterRetry == true, "retry skips cleanup by design, so its turns start raw")
+
+    coordinator.rePolish()
+    _ = await settleUntil { coordinator.state == .finished }
+    let cleaned = await settleUntil {
+      store.current(historyID)?.turns?.allSatisfy {
+        $0.processedText?.hasSuffix("[first]") == true
+      } ?? false
+    }
+    #expect(cleaned, "Clean it again is the one path that cleans a retry's raw turns")
+  }
+
   @Test("retrySpeakerAnalysis persists a labeled outcome without ever reaching cleanup")
   func retrySpeakerAnalysisSkipsCleanupButPersists() async {
     let store = FakeHistoryStore()

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -997,7 +997,8 @@ struct FileImportCoordinatorSpeakerTests {
   }
 
   private func makeStoreBackedCoordinator(
-    store: FakeHistoryStore, seconds: Double = 1.0, transcribedText: String = "hello there friend",
+    store: FakeHistoryStore, lease: EngineLease = EngineLease(), seconds: Double = 1.0,
+    transcribedText: String = "hello there friend",
     wordTimings: [ASRWordTiming]? = nil,
     speakerLabeler: @escaping @MainActor ([Float], TimeInterval) async -> SpeakerAnalysis,
     processPart: @escaping @MainActor (String, String?) async throws ->
@@ -1009,7 +1010,7 @@ struct FileImportCoordinatorSpeakerTests {
     ) -> Void = { _, _, _ in }
   ) -> FileImportCoordinator {
     makeCoordinator(
-      lease: EngineLease(), seconds: seconds, transcribedText: transcribedText,
+      lease: lease, seconds: seconds, transcribedText: transcribedText,
       wordTimings: wordTimings, speakerLabeler: speakerLabeler,
       saveToHistory: { store.save($0) },
       updateHistoryRow: { store.update($0) },
@@ -1403,5 +1404,53 @@ struct FileImportCoordinatorSpeakerTests {
     for turn in coordinator.turns ?? [] {
       #expect(diffs?[turn.id] != nil, "every turn should have its own diff entry")
     }
+  }
+
+  @Test(
+    "speakerNoticeReason distinguishes a real failure from an admission-refused pass that wrote nothing"
+  )
+  func speakerNoticeReasonDistinguishesFailedFromUnresolved() async {
+    let store = FakeHistoryStore()
+    let speakerGate = ManualGate()
+    let lease = EngineLease()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, lease: lease, transcribedText: "hello there friend",
+      wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        // Blocks AFTER the main run's own claim has already been released, so the test can
+        // claim the SAME lease itself in the exact window before turn-cleanup tries to —
+        // reproducing the admission-refused branch, which writes NOTHING at all.
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    let finished = await settleUntil { coordinator.state == .finished }
+    #expect(finished)
+    await speakerGate.waitUntilArrived()
+    #expect(coordinator.isEngineHeld == false)
+
+    guard case .granted = lease.admit(.dictation) else {
+      Issue.record("test setup: could not claim the lease to simulate contention")
+      return
+    }
+    await speakerGate.open()
+    let becameFinished = await settleUntil { coordinator.speakerStepState == .finished }
+    #expect(becameFinished)
+
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    #expect(
+      store.current(historyID)?.speakerAnalysis == nil,
+      "an admission-refused pass must write nothing at all")
+    #expect(coordinator.speakerNoticeReason == .unresolved)
+    #expect(coordinator.canRetrySpeakerAnalysis)
   }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1325,4 +1325,83 @@ struct FileImportCoordinatorSpeakerTests {
     let failure = await coordinator.renameSpeaker(id: "A", name: "Zach")
     #expect(failure != nil, "there is nothing to rename against a .single outcome")
   }
+
+  @Test("exportButtonLabels relabels for Marked up regardless of whether the document has turns")
+  func exportButtonLabelsRelabelForMarkedUpRegardlessOfTurns() async {
+    let store = FakeHistoryStore()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, speakerLabeler: { _, _ in .single(segments: []) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    #expect(coordinator.turns == nil, "a .single outcome has no turns")
+
+    #expect(coordinator.exportButtonLabels.copy == "Copy everything")
+    coordinator.documentView = .markedUp
+    #expect(
+      coordinator.exportButtonLabels.copy == "Copy cleaned",
+      "the export-rule relabel is general, not scoped to turn-labeled documents")
+    #expect(coordinator.exportButtonLabels.save == "Save cleaned as…")
+    #expect(coordinator.exportButtonLabels.share == "Share cleaned…")
+  }
+
+  @Test("exportText for a turn-labeled document routes through the presenter, honoring timesOn")
+  func exportTextForTurnLabeledDocumentRoutesThroughPresenter() async {
+    let store = FakeHistoryStore()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, transcribedText: "hello there friend", wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    let stored = await settleUntil { store.current(historyID)?.turns != nil }
+    #expect(stored)
+
+    coordinator.timesOn = true
+    #expect(
+      coordinator.exportText.contains(":"),
+      "with times on, a turn-labeled export should carry a time label")
+    coordinator.timesOn = false
+    #expect(
+      !coordinator.exportText.contains(":"),
+      "with times off, the export should carry no time label")
+  }
+
+  @Test("prepareTurnDiffs populates one diff per turn, off the main actor, matching prepareMarkedUp's shape")
+  func prepareTurnDiffsPopulatesOneDiffPerTurn() async {
+    let store = FakeHistoryStore()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, transcribedText: "hello there friend", wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    let stored = await settleUntil { coordinator.turns != nil }
+    #expect(stored)
+    #expect(coordinator.turnDiffs == nil, "nothing has computed a diff yet")
+
+    await coordinator.prepareTurnDiffs()
+
+    let diffs = coordinator.turnDiffs
+    #expect(diffs?.count == coordinator.turns?.count)
+    for turn in coordinator.turns ?? [] {
+      #expect(diffs?[turn.id] != nil, "every turn should have its own diff entry")
+    }
+  }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -122,6 +122,12 @@ struct FileImportCoordinatorSpeakerTests {
     emitTurnTelemetry: @escaping @MainActor (
       TelemetryService.FileImportTurnsOutcome, Int?, Int
     ) -> Void = { _, _, _ in },
+    emitRenameTelemetry: @escaping @MainActor (TelemetryService.FileImportRenameOutcome) -> Void = {
+      _ in
+    },
+    emitSpeakerRetryTelemetry: @escaping @MainActor (
+      TelemetryService.FileImportSpeakerRetryOutcome
+    ) -> Void = { _ in },
     onVisibleCleanupWaitResolved: @escaping @MainActor (Int) -> Void = { _ in },
     prepareLocalPolish: @escaping @MainActor (FileImportCoordinator.RunConfiguration) async ->
       Bool = { _ in true },
@@ -141,6 +147,8 @@ struct FileImportCoordinatorSpeakerTests {
       speakerLabeler: speakerLabeler,
       emitSpeakerTelemetry: emitSpeakerTelemetry,
       emitTurnTelemetry: emitTurnTelemetry,
+      emitRenameTelemetry: emitRenameTelemetry,
+      emitSpeakerRetryTelemetry: emitSpeakerRetryTelemetry,
       onVisibleCleanupWaitResolved: onVisibleCleanupWaitResolved,
       engineAdmission: .live(lease: lease, as: .fileImport),
       beginRun: {
@@ -1007,7 +1015,13 @@ struct FileImportCoordinatorSpeakerTests {
       },
     emitTurnTelemetry: @escaping @MainActor (
       TelemetryService.FileImportTurnsOutcome, Int?, Int
-    ) -> Void = { _, _, _ in }
+    ) -> Void = { _, _, _ in },
+    emitRenameTelemetry: @escaping @MainActor (TelemetryService.FileImportRenameOutcome) -> Void = {
+      _ in
+    },
+    emitSpeakerRetryTelemetry: @escaping @MainActor (
+      TelemetryService.FileImportSpeakerRetryOutcome
+    ) -> Void = { _ in }
   ) -> FileImportCoordinator {
     makeCoordinator(
       lease: lease, seconds: seconds, transcribedText: transcribedText,
@@ -1017,7 +1031,8 @@ struct FileImportCoordinatorSpeakerTests {
       mergeSpeakerFields: { store.mergeSpeakerFields($0, $1, $2) },
       writeExplicitRename: { store.rename($0, $1, $2, $3) },
       currentHistoryRow: { store.current($0) },
-      emitTurnTelemetry: emitTurnTelemetry, processPart: processPart)
+      emitTurnTelemetry: emitTurnTelemetry, emitRenameTelemetry: emitRenameTelemetry,
+      emitSpeakerRetryTelemetry: emitSpeakerRetryTelemetry, processPart: processPart)
   }
 
   @Test(
@@ -1452,5 +1467,92 @@ struct FileImportCoordinatorSpeakerTests {
       "an admission-refused pass must write nothing at all")
     #expect(coordinator.speakerNoticeReason == .unresolved)
     #expect(coordinator.canRetrySpeakerAnalysis)
+  }
+
+  @Test("renameSpeaker reports saved on success and failed when there is nothing to rename against")
+  func renameSpeakerTelemetryReportsSavedAndFailed() async {
+    let store = FakeHistoryStore()
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportRenameOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportRenameOutcome) { outcomes.append(outcome) }
+    }
+    let telemetry = TelemetryRecorder()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      emitRenameTelemetry: { telemetry.record($0) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    let stored = await settleUntil { coordinator.turns != nil }
+    #expect(stored)
+
+    _ = await coordinator.renameSpeaker(id: "A", name: "Zach")
+    #expect(telemetry.outcomes == [.saved])
+
+    let secondStore = FakeHistoryStore()
+    let secondCoordinator = makeStoreBackedCoordinator(
+      store: secondStore, speakerLabeler: { _, _ in .single(segments: []) },
+      emitRenameTelemetry: { telemetry.record($0) })
+    secondCoordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = secondCoordinator.state { return true } else { return false }
+    }
+    secondCoordinator.start()
+    _ = await settleUntil { secondCoordinator.state == .finished }
+
+    _ = await secondCoordinator.renameSpeaker(id: "A", name: "Ariana")
+    #expect(telemetry.outcomes == [.saved, .failed], "a .single outcome has nothing to rename against")
+  }
+
+  @Test("retrySpeakerAnalysis reports recovered on success and stillFailed otherwise (#2811 §3e)")
+  func retryTelemetryReportsRecoveredAndStillFailed() async {
+    let store = FakeHistoryStore()
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportSpeakerRetryOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportSpeakerRetryOutcome) {
+        outcomes.append(outcome)
+      }
+    }
+    let telemetry = TelemetryRecorder()
+    @MainActor final class AttemptCounter {
+      private(set) var count = 0
+      func next() -> Int {
+        count += 1
+        return count
+      }
+    }
+    let attempts = AttemptCounter()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        attempts.next() == 1
+          ? .failed(.analyzerThrew("boom")) : .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      }, emitSpeakerRetryTelemetry: { telemetry.record($0) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the first run")
+      return
+    }
+    let firstPassFailed = await settleUntil {
+      if case .failed = store.current(historyID)?.speakerAnalysis { return true }
+      return false
+    }
+    #expect(firstPassFailed)
+
+    coordinator.retrySpeakerAnalysis()
+    let recovered = await settleUntil { telemetry.outcomes.contains(.recovered) }
+    #expect(recovered, "a retry that reaches .labeled should report recovered")
+    #expect(!telemetry.outcomes.contains(.stillFailed))
   }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -112,6 +112,10 @@ struct FileImportCoordinatorSpeakerTests {
     updateHistoryRow: @escaping @MainActor (Transcript) throws -> Bool = { _ in true },
     mergeSpeakerFields: @escaping @MainActor (UUID, TranscriptSpeakerAnalysis, [Turn]?) throws ->
       Bool = { _, _, _ in true },
+    writeExplicitRename: @escaping @MainActor (
+      UUID, TranscriptSpeakerAnalysis, [Turn]?, (speakerId: String, name: String)
+    ) throws -> Bool = { _, _, _, _ in false },
+    currentHistoryRow: @escaping @MainActor (UUID) -> Transcript? = { _ in nil },
     emitSpeakerTelemetry: @escaping @MainActor (
       SpeakerAnalysis, TimeInterval, Int, ASRWordTimingCoverage?
     ) -> Void = { _, _, _, _ in },
@@ -148,6 +152,8 @@ struct FileImportCoordinatorSpeakerTests {
       saveToHistory: saveToHistory,
       updateHistoryRow: updateHistoryRow,
       mergeSpeakerFields: mergeSpeakerFields,
+      writeExplicitRename: writeExplicitRename,
+      currentHistoryRow: currentHistoryRow,
       historyRowExists: { _ in true },
       processPart: processPart)
   }
@@ -955,5 +961,247 @@ struct FileImportCoordinatorSpeakerTests {
       persisted,
       "a re-polish of the SAME document must never discard the only speaker analysis this document will ever get"
     )
+  }
+
+  // MARK: - Retry, rename, and the savePolishedToHistory race fix (#2811 phase 4 of #2807)
+
+  /// A live, mutable simulation of the History store — closer to `TranscriptCoordinator`'s own
+  /// "the in-memory list is the oracle" contract than four independent recorder closures, and
+  /// needed here specifically: these tests exist to prove a write reads back what ANOTHER
+  /// writer (an external rename) left behind, which four disconnected spies cannot represent.
+  @MainActor private final class FakeHistoryStore {
+    private(set) var rows: [UUID: Transcript] = [:]
+    func save(_ row: Transcript) { rows[row.id] = row }
+    func update(_ row: Transcript) -> Bool {
+      guard rows[row.id] != nil else { return false }
+      rows[row.id] = row
+      return true
+    }
+    func mergeSpeakerFields(_ id: UUID, _ analysis: TranscriptSpeakerAnalysis, _ turns: [Turn]?)
+      -> Bool
+    {
+      guard let existing = rows[id] else { return false }
+      rows[id] = existing.mergingSpeakerFields(analysis: analysis, turns: turns)
+      return true
+    }
+    func rename(
+      _ id: UUID, _ analysis: TranscriptSpeakerAnalysis, _ turns: [Turn]?,
+      _ explicitRename: (speakerId: String, name: String)
+    ) -> Bool {
+      guard let existing = rows[id] else { return false }
+      rows[id] = existing.mergingSpeakerFields(
+        analysis: analysis, turns: turns, explicitRename: explicitRename)
+      return true
+    }
+    func current(_ id: UUID) -> Transcript? { rows[id] }
+  }
+
+  private func makeStoreBackedCoordinator(
+    store: FakeHistoryStore, seconds: Double = 1.0, transcribedText: String = "hello there friend",
+    wordTimings: [ASRWordTiming]? = nil,
+    speakerLabeler: @escaping @MainActor ([Float], TimeInterval) async -> SpeakerAnalysis,
+    processPart: @escaping @MainActor (String, String?) async throws ->
+      FileImportRunner.PartOutcome = { part, _ in
+        FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      },
+    emitTurnTelemetry: @escaping @MainActor (
+      TelemetryService.FileImportTurnsOutcome, Int?, Int
+    ) -> Void = { _, _, _ in }
+  ) -> FileImportCoordinator {
+    makeCoordinator(
+      lease: EngineLease(), seconds: seconds, transcribedText: transcribedText,
+      wordTimings: wordTimings, speakerLabeler: speakerLabeler,
+      saveToHistory: { store.save($0) },
+      updateHistoryRow: { store.update($0) },
+      mergeSpeakerFields: { store.mergeSpeakerFields($0, $1, $2) },
+      writeExplicitRename: { store.rename($0, $1, $2, $3) },
+      currentHistoryRow: { store.current($0) },
+      emitTurnTelemetry: emitTurnTelemetry, processPart: processPart)
+  }
+
+  @Test(
+    "a re-polish's own write carries forward a rename that landed on the live row after this coordinator's own snapshot was taken"
+  )
+  func savePolishedToHistoryCarriesLiveSpeakerFieldsForward() async {
+    let store = FakeHistoryStore()
+    let telemetry = { @MainActor (
+      outcome: TelemetryService.FileImportTurnsOutcome, _: Int?, _: Int
+    ) in }
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      emitTurnTelemetry: telemetry)
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    // Waits for the background pass's OWN `speakerStepState` to reach `.finished`, not just
+    // for its write to land — the write and the telemetry both fire INSIDE `mergeAndReport`,
+    // strictly before that pass's own `defer` releases the shared engine claim. Gating only
+    // on the write risks `rePolish()`'s own claim being refused as busy a moment later
+    // (found while writing this test: `speakerStepState == .finished` is the one signal that
+    // is only set AFTER the whole pass, including its engine release, has unwound).
+    let stored = await settleUntil {
+      store.current(historyID)?.turns != nil && coordinator.speakerStepState == .finished
+    }
+    #expect(stored, "the background turn-storage pass never finished persisting turns")
+
+    // An EXTERNAL rename — simulating a write from History, or the wizard's own rename UI —
+    // landing directly on the live store, entirely bypassing this coordinator. Nothing in
+    // this coordinator's own `originalHistoryRow` snapshot learns about it.
+    guard let liveRow = store.current(historyID), let analysis = liveRow.speakerAnalysis else {
+      Issue.record("no labeled row to rename against")
+      return
+    }
+    let renamed = store.rename(historyID, analysis, liveRow.turns, (speakerId: "A", name: "Zach"))
+    #expect(renamed)
+
+    // "Clean it again" — its own `savePolishedToHistory` write must not revert the rename
+    // that landed on the live row while this coordinator's own cache was still stale.
+    coordinator.rePolish()
+    let rePolishFinished = await settleUntil { coordinator.state == .finished }
+    #expect(rePolishFinished)
+
+    #expect(
+      store.current(historyID)?.speakerNames?["A"] == "Zach",
+      "the re-polish's own write reverted a rename it never knew about — savePolishedToHistory must carry the LIVE row's speaker fields forward, not its own stale snapshot"
+    )
+  }
+
+  @Test("retrySpeakerAnalysis persists a labeled outcome without ever reaching cleanup")
+  func retrySpeakerAnalysisSkipsCleanupButPersists() async {
+    let store = FakeHistoryStore()
+    @MainActor final class CleanupCounter {
+      private(set) var count = 0
+      func increment() { count += 1 }
+    }
+    let cleanupCounter = CleanupCounter()
+    // Fails the FIRST attempt, succeeds the second — simulating whatever transient condition
+    // "Try again" exists to recover from.
+    @MainActor final class AttemptCounter {
+      private(set) var count = 0
+      func next() -> Int {
+        count += 1
+        return count
+      }
+    }
+    let attempts = AttemptCounter()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        attempts.next() == 1
+          ? .failed(.analyzerThrew("boom")) : .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      },
+      processPart: { part, _ in
+        // Only the WIZARD's own visible-document part ("hello there friend") is legitimate
+        // cleanup; anything sliced to a single speaker's words would mean turn cleanup ran.
+        if part != "hello there friend" { await cleanupCounter.increment() }
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    let firstPassFinished = await settleUntil {
+      if case .failed = store.current(historyID)?.speakerAnalysis { return true }
+      return false
+    }
+    #expect(firstPassFinished, "the first pass never persisted a failed outcome")
+    #expect(coordinator.canRetrySpeakerAnalysis, "a failed analysis should be retry-eligible")
+
+    await coordinator.retrySpeakerAnalysis()
+
+    let retried = await settleUntil {
+      store.current(historyID)?.speakerAnalysis == .labeled(count: 2)
+    }
+    #expect(retried, "retry never persisted the successful labeled outcome")
+    #expect(store.current(historyID)?.turns?.count == 2)
+    #expect(cleanupCounter.count == 0, "retry must never reach TurnCleanupRunner")
+  }
+
+  @Test("canRetrySpeakerAnalysis is false for a labeled or single outcome, and while in progress")
+  func canRetryFalseForLabeledOrSingleOrInProgress() async {
+    let store = FakeHistoryStore()
+    let speakerGate = ManualGate()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    await speakerGate.waitUntilArrived()
+    #expect(
+      !coordinator.canRetrySpeakerAnalysis, "must not be retry-eligible while still in progress")
+
+    await speakerGate.open()
+    let stored = await settleUntil {
+      store.current(coordinator.historyID ?? UUID())?.speakerAnalysis == .labeled(count: 2)
+    }
+    #expect(stored)
+    #expect(!coordinator.canRetrySpeakerAnalysis, "a labeled outcome has nothing to retry")
+  }
+
+  @Test("renameSpeaker re-reads the current row and writes through the explicit-rename path")
+  func renameSpeakerWritesThroughExplicitRenamePath() async {
+    let store = FakeHistoryStore()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    let stored = await settleUntil { store.current(historyID)?.turns != nil }
+    #expect(stored)
+
+    let failure = await coordinator.renameSpeaker(id: "A", name: "Zach")
+    #expect(failure == nil, "a rename against a real labeled row should not fail")
+    #expect(store.current(historyID)?.speakerNames?["A"] == "Zach")
+  }
+
+  @Test("renameSpeaker returns a failure, never crashing, when there are no turns to rename against")
+  func renameSpeakerFailsGracefullyWithNoTurns() async {
+    let store = FakeHistoryStore()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, speakerLabeler: { _, _ in .single(segments: []) })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+
+    let failure = await coordinator.renameSpeaker(id: "A", name: "Zach")
+    #expect(failure != nil, "there is nothing to rename against a .single outcome")
   }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -128,6 +128,7 @@ struct FileImportCoordinatorSpeakerTests {
     emitSpeakerRetryTelemetry: @escaping @MainActor (
       TelemetryService.FileImportSpeakerRetryOutcome
     ) -> Void = { _ in },
+    emitTurnsDisplayedTelemetry: @escaping @MainActor () -> Void = {},
     onVisibleCleanupWaitResolved: @escaping @MainActor (Int) -> Void = { _ in },
     prepareLocalPolish: @escaping @MainActor (FileImportCoordinator.RunConfiguration) async ->
       Bool = { _ in true },
@@ -149,6 +150,7 @@ struct FileImportCoordinatorSpeakerTests {
       emitTurnTelemetry: emitTurnTelemetry,
       emitRenameTelemetry: emitRenameTelemetry,
       emitSpeakerRetryTelemetry: emitSpeakerRetryTelemetry,
+      emitTurnsDisplayedTelemetry: emitTurnsDisplayedTelemetry,
       onVisibleCleanupWaitResolved: onVisibleCleanupWaitResolved,
       engineAdmission: .live(lease: lease, as: .fileImport),
       beginRun: {
@@ -1021,7 +1023,8 @@ struct FileImportCoordinatorSpeakerTests {
     },
     emitSpeakerRetryTelemetry: @escaping @MainActor (
       TelemetryService.FileImportSpeakerRetryOutcome
-    ) -> Void = { _ in }
+    ) -> Void = { _ in },
+    emitTurnsDisplayedTelemetry: @escaping @MainActor () -> Void = {}
   ) -> FileImportCoordinator {
     makeCoordinator(
       lease: lease, seconds: seconds, transcribedText: transcribedText,
@@ -1032,7 +1035,8 @@ struct FileImportCoordinatorSpeakerTests {
       writeExplicitRename: { store.rename($0, $1, $2, $3) },
       currentHistoryRow: { store.current($0) },
       emitTurnTelemetry: emitTurnTelemetry, emitRenameTelemetry: emitRenameTelemetry,
-      emitSpeakerRetryTelemetry: emitSpeakerRetryTelemetry, processPart: processPart)
+      emitSpeakerRetryTelemetry: emitSpeakerRetryTelemetry,
+      emitTurnsDisplayedTelemetry: emitTurnsDisplayedTelemetry, processPart: processPart)
   }
 
   @Test(
@@ -1163,6 +1167,7 @@ struct FileImportCoordinatorSpeakerTests {
       }
     }
     let attempts = AttemptCounter()
+    let retryTelemetry = RetryTelemetryRecorder()
     let coordinator = makeStoreBackedCoordinator(
       store: store, wordTimings: Self.twoSpeakerWordTimings(),
       speakerLabeler: { _, _ in
@@ -1173,7 +1178,7 @@ struct FileImportCoordinatorSpeakerTests {
         await speakerGate.markArrived()
         await speakerGate.waitUntilOpen()
         return .labeled(count: 2, segments: Self.twoSpeakerSegments)
-      })
+      }, emitSpeakerRetryTelemetry: { retryTelemetry.record($0) })
 
     coordinator.choose(url: Self.anyURL)
     _ = await settleUntil {
@@ -1211,6 +1216,9 @@ struct FileImportCoordinatorSpeakerTests {
       store.current(firstHistoryID)?.speakerAnalysis != .labeled(count: 2),
       "a stale retry must never persist a labeled outcome against a document the user already left"
     )
+    #expect(
+      retryTelemetry.outcomes == [],
+      "a superseded retry says nothing about the analyzer and must report neither outcome")
   }
 
   @Test("Stop pressed while a retry's own analyzer call is in flight prevents any further write")
@@ -1225,6 +1233,7 @@ struct FileImportCoordinatorSpeakerTests {
       }
     }
     let attempts = AttemptCounter()
+    let retryTelemetry = RetryTelemetryRecorder()
     let coordinator = makeStoreBackedCoordinator(
       store: store, wordTimings: Self.twoSpeakerWordTimings(),
       speakerLabeler: { _, _ in
@@ -1232,7 +1241,7 @@ struct FileImportCoordinatorSpeakerTests {
         await speakerGate.markArrived()
         await speakerGate.waitUntilOpen()
         return .labeled(count: 2, segments: Self.twoSpeakerSegments)
-      })
+      }, emitSpeakerRetryTelemetry: { retryTelemetry.record($0) })
 
     coordinator.choose(url: Self.anyURL)
     _ = await settleUntil {
@@ -1268,6 +1277,11 @@ struct FileImportCoordinatorSpeakerTests {
       store.current(historyID)?.speakerAnalysis != .labeled(count: 2),
       "Stop during a retry must prevent its result from ever being persisted"
     )
+    // Stop leaves `historyID` in place and the row still failed, so an identity-only guard
+    // would have blamed the analyzer for a retry the user abandoned (found by chunk review).
+    #expect(
+      retryTelemetry.outcomes == [],
+      "a stopped retry must report neither recovered nor still_failed")
   }
 
   @Test("canRetrySpeakerAnalysis is false for a labeled or single outcome, and while in progress")
@@ -1509,16 +1523,23 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(telemetry.outcomes == [.saved, .failed], "a .single outcome has nothing to rename against")
   }
 
-  @Test("retrySpeakerAnalysis reports recovered on success and stillFailed otherwise (#2811 §3e)")
-  func retryTelemetryReportsRecoveredAndStillFailed() async {
-    let store = FakeHistoryStore()
-    @MainActor final class TelemetryRecorder {
-      private(set) var outcomes: [TelemetryService.FileImportSpeakerRetryOutcome] = []
-      func record(_ outcome: TelemetryService.FileImportSpeakerRetryOutcome) {
-        outcomes.append(outcome)
-      }
+  /// Shared by the retry-telemetry tests and the two in-flight retry tests above, which
+  /// each prove a retry that never reached its own write reports NOTHING.
+  @MainActor final class RetryTelemetryRecorder {
+    private(set) var outcomes: [TelemetryService.FileImportSpeakerRetryOutcome] = []
+    func record(_ outcome: TelemetryService.FileImportSpeakerRetryOutcome) {
+      outcomes.append(outcome)
     }
-    let telemetry = TelemetryRecorder()
+  }
+
+  /// Runs one import whose first analyzer pass fails, then presses "Try again" once, and
+  /// returns the exact retry-telemetry sequence once the retry has settled (bounded yields
+  /// AFTER the step reads finished, so a duplicate emit would still be caught).
+  private func retryOutcomes(
+    afterRetryReturning retryOutcome: SpeakerAnalysis
+  ) async -> [TelemetryService.FileImportSpeakerRetryOutcome]? {
+    let store = FakeHistoryStore()
+    let telemetry = RetryTelemetryRecorder()
     @MainActor final class AttemptCounter {
       private(set) var count = 0
       func next() -> Int {
@@ -1530,8 +1551,7 @@ struct FileImportCoordinatorSpeakerTests {
     let coordinator = makeStoreBackedCoordinator(
       store: store, wordTimings: Self.twoSpeakerWordTimings(),
       speakerLabeler: { _, _ in
-        attempts.next() == 1
-          ? .failed(.analyzerThrew("boom")) : .labeled(count: 2, segments: Self.twoSpeakerSegments)
+        attempts.next() == 1 ? .failed(.analyzerThrew("boom")) : retryOutcome
       }, emitSpeakerRetryTelemetry: { telemetry.record($0) })
 
     coordinator.choose(url: Self.anyURL)
@@ -1542,17 +1562,94 @@ struct FileImportCoordinatorSpeakerTests {
     _ = await settleUntil { coordinator.state == .finished }
     guard let historyID = coordinator.historyID else {
       Issue.record("no historyID after the first run")
-      return
+      return nil
     }
     let firstPassFailed = await settleUntil {
       if case .failed = store.current(historyID)?.speakerAnalysis { return true }
       return false
     }
     #expect(firstPassFailed)
+    #expect(telemetry.outcomes == [], "the ordinary first pass is not a retry")
 
     coordinator.retrySpeakerAnalysis()
-    let recovered = await settleUntil { telemetry.outcomes.contains(.recovered) }
-    #expect(recovered, "a retry that reaches .labeled should report recovered")
-    #expect(!telemetry.outcomes.contains(.stillFailed))
+    let sawRetry = await settleUntil { attempts.count == 2 }
+    #expect(sawRetry)
+    _ = await settleUntil { coordinator.speakerStepState == .finished && !telemetry.outcomes.isEmpty }
+    for _ in 0..<50 { await Task.yield() }
+    return telemetry.outcomes
+  }
+
+  @Test("a retry whose write lands as labeled reports exactly one recovered (#2811 §3e)")
+  func retryTelemetryRecoveredForLabeled() async {
+    let outcomes = await retryOutcomes(
+      afterRetryReturning: .labeled(count: 2, segments: Self.twoSpeakerSegments))
+    #expect(outcomes == [.recovered])
+  }
+
+  @Test("a retry whose write lands as single reports recovered too, since that clears the notice")
+  func retryTelemetryRecoveredForSingle() async {
+    let outcomes = await retryOutcomes(afterRetryReturning: .single(segments: []))
+    #expect(outcomes == [.recovered])
+  }
+
+  @Test("a retry that runs to its own write and still fails reports exactly one still_failed")
+  func retryTelemetryStillFailed() async {
+    let outcomes = await retryOutcomes(afterRetryReturning: .failed(.modelsUnavailable))
+    #expect(outcomes == [.stillFailed])
+  }
+
+  @Test("noteRenameCancelled reports cancelled, and only that (#2811 §3e)")
+  func renameCancelledTelemetry() async {
+    let store = FakeHistoryStore()
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportRenameOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportRenameOutcome) { outcomes.append(outcome) }
+    }
+    let telemetry = TelemetryRecorder()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, speakerLabeler: { _, _ in .single(segments: []) },
+      emitRenameTelemetry: { telemetry.record($0) })
+    coordinator.noteRenameCancelled()
+    #expect(telemetry.outcomes == [.cancelled])
+  }
+
+  @Test("noteTurnsDisplayed reports once per document, and again for the next document")
+  func turnsDisplayedTelemetryOncePerDocument() async {
+    let store = FakeHistoryStore()
+    @MainActor final class Counter {
+      private(set) var count = 0
+      func bump() { count += 1 }
+    }
+    let displayed = Counter()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      emitTurnsDisplayedTelemetry: { displayed.bump() })
+
+    // Before any import there is no document, so a stray appear reports nothing.
+    coordinator.noteTurnsDisplayed()
+    #expect(displayed.count == 0)
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    #expect(coordinator.historyID != nil)
+
+    coordinator.noteTurnsDisplayed()
+    coordinator.noteTurnsDisplayed()
+    #expect(displayed.count == 1, "a view-mode flip re-appears the same document; not a new fact")
+
+    // A second import is a new document and reports once more.
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    coordinator.noteTurnsDisplayed()
+    #expect(displayed.count == 2)
   }
 }

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1419,6 +1419,11 @@ struct FileImportCoordinatorSpeakerTests {
       store.current(coordinator.historyID ?? UUID())?.speakerAnalysis == .labeled(count: 2)
     }
     #expect(stored)
+    // The write lands BEFORE the step reads finished; asserting on the write alone could
+    // pass while "in progress" was still what made the button absent (found by second-pass
+    // review). Wait for the whole pass, then the assertion is about the labeled outcome.
+    let finished = await settleUntil { coordinator.speakerStepState == .finished }
+    #expect(finished)
     #expect(!coordinator.canRetrySpeakerAnalysis, "a labeled outcome has nothing to retry")
   }
 

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1123,7 +1123,7 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(firstPassFinished, "the first pass never persisted a failed outcome")
     #expect(coordinator.canRetrySpeakerAnalysis, "a failed analysis should be retry-eligible")
 
-    await coordinator.retrySpeakerAnalysis()
+    coordinator.retrySpeakerAnalysis()
 
     let retried = await settleUntil {
       store.current(historyID)?.speakerAnalysis == .labeled(count: 2)
@@ -1131,6 +1131,127 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(retried, "retry never persisted the successful labeled outcome")
     #expect(store.current(historyID)?.turns?.count == 2)
     #expect(cleanupCounter.count == 0, "retry must never reach TurnCleanupRunner")
+  }
+
+  @Test(
+    "a retry whose analyzer call is still in flight when the document is replaced never persists against the old row"
+  )
+  func retryNeverPersistsAfterDocumentReplaced() async {
+    let store = FakeHistoryStore()
+    let speakerGate = ManualGate()
+    @MainActor final class AttemptCounter {
+      private(set) var count = 0
+      func next() -> Int {
+        count += 1
+        return count
+      }
+    }
+    let attempts = AttemptCounter()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        // Attempt 1: the ordinary first pass, which fails. Attempt 2: the retry, blocked
+        // until the test lets it through — exactly the window a document replacement (or a
+        // Stop, in the sibling test below) can land in.
+        if attempts.next() == 1 { return .failed(.analyzerThrew("boom")) }
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let firstHistoryID = coordinator.historyID else {
+      Issue.record("no historyID after the first run")
+      return
+    }
+    let firstPassFailed = await settleUntil {
+      if case .failed = store.current(firstHistoryID)?.speakerAnalysis { return true }
+      return false
+    }
+    #expect(firstPassFailed)
+    #expect(coordinator.canRetrySpeakerAnalysis)
+
+    coordinator.retrySpeakerAnalysis()
+    await speakerGate.waitUntilArrived()
+
+    // The user moves on to a DIFFERENT file while the retry's own analyzer call is still
+    // blocked — `choose(url:)` cancels `speakerStepTask` (which now owns the retry, per the
+    // chunk-2a review fix) and gives `historyID` a new value.
+    coordinator.choose(url: Self.anyURL)
+
+    await speakerGate.open()
+    let sawRetryAttempt = await settleUntil { attempts.count == 2 }
+    #expect(sawRetryAttempt, "the retry's own analyzer call should still have run to completion")
+    // A bounded settle for the (deliberately absent) write, not a wait for a signal that a
+    // correct implementation never sends.
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(
+      store.current(firstHistoryID)?.speakerAnalysis != .labeled(count: 2),
+      "a stale retry must never persist a labeled outcome against a document the user already left"
+    )
+  }
+
+  @Test("Stop pressed while a retry's own analyzer call is in flight prevents any further write")
+  func stopDuringRetryPreventsWrite() async {
+    let store = FakeHistoryStore()
+    let speakerGate = ManualGate()
+    @MainActor final class AttemptCounter {
+      private(set) var count = 0
+      func next() -> Int {
+        count += 1
+        return count
+      }
+    }
+    let attempts = AttemptCounter()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        if attempts.next() == 1 { return .failed(.analyzerThrew("boom")) }
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the first run")
+      return
+    }
+    let firstPassFailed = await settleUntil {
+      if case .failed = store.current(historyID)?.speakerAnalysis { return true }
+      return false
+    }
+    #expect(firstPassFailed)
+    #expect(coordinator.canRetrySpeakerAnalysis)
+
+    coordinator.retrySpeakerAnalysis()
+    await speakerGate.waitUntilArrived()
+
+    // Stop is unconditional, before `isRunning` (the visible screen already reads Done) —
+    // this is exactly the "background pass can outlive Done" case the retry task must now
+    // be reachable from, per the chunk-2a review fix (retry runs as `speakerStepTask`).
+    coordinator.stop()
+
+    await speakerGate.open()
+    let sawRetryAttempt = await settleUntil { attempts.count == 2 }
+    #expect(sawRetryAttempt, "the retry's own analyzer call should still have run to completion")
+    for _ in 0..<50 { await Task.yield() }
+
+    #expect(
+      store.current(historyID)?.speakerAnalysis != .labeled(count: 2),
+      "Stop during a retry must prevent its result from ever being persisted"
+    )
   }
 
   @Test("canRetrySpeakerAnalysis is false for a labeled or single outcome, and while in progress")

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1266,6 +1266,45 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(!coordinator.canRetrySpeakerAnalysis)
   }
 
+  @Test("the Done step's speaker line names the analysis, then counts turns, then goes away")
+  func speakerStatusLabelCountsTurns() async {
+    let store = FakeHistoryStore()
+    let speakerGate = ManualGate()
+    let firstTurnGate = ManualGate()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      },
+      processPart: { part, _ in
+        if part != "hello there friend" {
+          await firstTurnGate.markArrived()
+          await firstTurnGate.waitUntilOpen()
+        }
+        return FileImportRunner.PartOutcome(text: part, polishedText: part, polishError: nil)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await speakerGate.waitUntilArrived()
+    #expect(coordinator.speakerStatusLabel == "Finding speakers")
+
+    await speakerGate.open()
+    await firstTurnGate.waitUntilArrived()
+    #expect(coordinator.speakerStatusLabel == "Cleaning speaker turns: 0 of 2")
+
+    await firstTurnGate.open()
+    let cleared = await settleUntil { coordinator.speakerStepState == .finished }
+    #expect(cleared)
+    #expect(coordinator.turnCleanupProgress == nil)
+    #expect(coordinator.speakerStatusLabel == nil, "nothing to say once the labels are stored")
+  }
+
   @Test("no word timings: the notice shows, Try again does not, and the audio is released")
   func missingTimingsIsNotRetryable() async {
     let store = FakeHistoryStore()

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1324,6 +1324,81 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(coordinator.speakerStepState == .finished)
   }
 
+  @Test("choosing another file while Clean it again is re-cleaning the turns prevents that write")
+  func chooseDuringTurnRecleanPreventsWrite() async {
+    let store = FakeHistoryStore()
+    let cleaner = TaggedCleaner()
+    let turnGate = ManualGate()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      processPart: { part, _ in
+        if cleaner.tag == "second", part != "hello there friend" {
+          await turnGate.markArrived()
+          await turnGate.waitUntilOpen()
+        }
+        return cleaner.outcome(part)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    _ = await settleUntil {
+      store.current(historyID)?.turns != nil && coordinator.speakerStepState == .finished
+    }
+
+    cleaner.tag = "second"
+    coordinator.rePolish()
+    await turnGate.waitUntilArrived()
+    // Done already reads finished, so `choose` is allowed; it must reach the re-clean's task.
+    coordinator.choose(url: Self.anyURL)
+    await turnGate.open()
+    for _ in 0..<50 { await Task.yield() }
+
+    let untouched =
+      store.current(historyID)?.turns?.allSatisfy { $0.processedText?.hasSuffix("[first]") == true }
+    #expect(untouched == true, "a re-clean the user abandoned by choosing another file must not write")
+  }
+
+  @Test("deleting the row while speakers are being found stops that pass and drops the audio")
+  func deletedRowDuringSpeakerPassStopsIt() async {
+    let store = FakeHistoryStore()
+    let speakerGate = ManualGate()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in
+        await speakerGate.markArrived()
+        await speakerGate.waitUntilOpen()
+        return .labeled(count: 2, segments: Self.twoSpeakerSegments)
+      })
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    await speakerGate.waitUntilArrived()
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID once the speaker step is in flight")
+      return
+    }
+    #expect(coordinator.retainsRetryInputs)
+
+    coordinator.noteHistoryRowDeleted(historyID)
+    #expect(!coordinator.retainsRetryInputs)
+    await speakerGate.open()
+    for _ in 0..<50 { await Task.yield() }
+    #expect(
+      store.current(historyID)?.speakerAnalysis != .labeled(count: 2),
+      "a cancelled speaker pass must not persist against the deleted row")
+  }
+
   @Test("Clean it again cleans the raw turns a retry left behind (#2811)")
   func rePolishCleansTurnsLeftRawByRetry() async {
     let store = FakeHistoryStore()

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1324,6 +1324,50 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(coordinator.speakerStepState == .finished)
   }
 
+  @Test("Change (back to Polish) while Clean it again is re-cleaning the turns prevents that write")
+  func changePolisherDuringTurnRecleanPreventsWrite() async {
+    let store = FakeHistoryStore()
+    let cleaner = TaggedCleaner()
+    let turnGate = ManualGate()
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: Self.twoSpeakerWordTimings(),
+      speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) },
+      processPart: { part, _ in
+        if cleaner.tag == "second", part != "hello there friend" {
+          await turnGate.markArrived()
+          await turnGate.waitUntilOpen()
+        }
+        return cleaner.outcome(part)
+      })
+
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return
+    }
+    _ = await settleUntil {
+      store.current(historyID)?.turns != nil && coordinator.speakerStepState == .finished
+    }
+
+    cleaner.tag = "second"
+    coordinator.rePolish()
+    await turnGate.waitUntilArrived()
+    #expect(coordinator.step == .done)
+    coordinator.choosePolisherAgain()
+    #expect(coordinator.step == .polish, "Change must still be allowed after Done")
+    await turnGate.open()
+    for _ in 0..<50 { await Task.yield() }
+
+    let untouched =
+      store.current(historyID)?.turns?.allSatisfy { $0.processedText?.hasSuffix("[first]") == true }
+    #expect(untouched == true, "leaving Done for Polish must end the re-clean, not let it write")
+  }
+
   @Test("choosing another file while Clean it again is re-cleaning the turns prevents that write")
   func chooseDuringTurnRecleanPreventsWrite() async {
     let store = FakeHistoryStore()

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1198,6 +1198,75 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(untouched == true, "a stopped re-clean must never persist its result")
   }
 
+  /// Drives one import to `state == .finished` plus a settled speaker step, and returns the
+  /// coordinator and its history id; nil (with an issue recorded) if no row landed.
+  private func settledImport(
+    store: FakeHistoryStore, wordTimings: [ASRWordTiming]?,
+    speakerLabeler: @escaping @MainActor ([Float], TimeInterval) async -> SpeakerAnalysis
+  ) async -> (FileImportCoordinator, UUID)? {
+    let coordinator = makeStoreBackedCoordinator(
+      store: store, wordTimings: wordTimings, speakerLabeler: speakerLabeler)
+    coordinator.choose(url: Self.anyURL)
+    _ = await settleUntil {
+      if case .ready = coordinator.state { return true } else { return false }
+    }
+    coordinator.start()
+    _ = await settleUntil { coordinator.state == .finished }
+    guard let historyID = coordinator.historyID else {
+      Issue.record("no historyID after the visible run finished")
+      return nil
+    }
+    let settled = await settleUntil {
+      store.current(historyID)?.speakerAnalysis != nil
+        && coordinator.speakerStepState == .finished
+    }
+    #expect(settled, "the speaker step never settled")
+    return (coordinator, historyID)
+  }
+
+  @Test("the retained audio is released once the stored outcome is one no retry could change")
+  func retryInputsReleasedOnceSettled() async {
+    // A labeled success: nothing to retry, audio freed.
+    let labeledStore = FakeHistoryStore()
+    guard
+      let (labeled, _) = await settledImport(
+        store: labeledStore, wordTimings: Self.twoSpeakerWordTimings(),
+        speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) })
+    else { return }
+    #expect(!labeled.retainsRetryInputs, "a labeled outcome must not pin the audio")
+    #expect(!labeled.canRetrySpeakerAnalysis)
+
+    // A real analyzer failure: retry is offered, so the audio stays.
+    let failedStore = FakeHistoryStore()
+    guard
+      let (failed, _) = await settledImport(
+        store: failedStore, wordTimings: Self.twoSpeakerWordTimings(),
+        speakerLabeler: { _, _ in .failed(.modelsUnavailable) })
+    else { return }
+    #expect(failed.retainsRetryInputs, "a retryable failure keeps the audio for Try again")
+    #expect(failed.canRetrySpeakerAnalysis)
+    #expect(failed.speakerNoticeReason == .failed)
+  }
+
+  @Test("no word timings: the notice shows, Try again does not, and the audio is released")
+  func missingTimingsIsNotRetryable() async {
+    let store = FakeHistoryStore()
+    guard
+      let (coordinator, historyID) = await settledImport(
+        store: store, wordTimings: nil,
+        speakerLabeler: { _, _ in .labeled(count: 2, segments: Self.twoSpeakerSegments) })
+    else { return }
+    #expect(store.current(historyID)?.speakerAnalysis == .failed(.noWordTimings))
+    #expect(coordinator.speakerNoticeReason == .failed, "the user is still told labels failed")
+    #expect(
+      !coordinator.canRetrySpeakerAnalysis,
+      "a retry reruns only the analyzer against the same missing timings; it cannot help")
+    #expect(!coordinator.retainsRetryInputs, "nothing a retry could use is worth holding")
+    // And pressing it anyway is a no-op, never an empty-buffer analysis.
+    coordinator.retrySpeakerAnalysis()
+    #expect(coordinator.speakerStepState == .finished)
+  }
+
   @Test("Clean it again cleans the raw turns a retry left behind (#2811)")
   func rePolishCleansTurnsLeftRawByRetry() async {
     let store = FakeHistoryStore()

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -1248,6 +1248,24 @@ struct FileImportCoordinatorSpeakerTests {
     #expect(failed.speakerNoticeReason == .failed)
   }
 
+  @Test("a deleted History row releases the retry audio, for that row only")
+  func deletedRowReleasesRetryInputs() async {
+    let store = FakeHistoryStore()
+    guard
+      let (coordinator, historyID) = await settledImport(
+        store: store, wordTimings: Self.twoSpeakerWordTimings(),
+        speakerLabeler: { _, _ in .failed(.modelsUnavailable) })
+    else { return }
+    #expect(coordinator.retainsRetryInputs)
+
+    coordinator.noteHistoryRowDeleted(UUID())
+    #expect(coordinator.retainsRetryInputs, "another row's deletion is not this document's")
+
+    coordinator.noteHistoryRowDeleted(historyID)
+    #expect(!coordinator.retainsRetryInputs, "a retry has nothing to write against")
+    #expect(!coordinator.canRetrySpeakerAnalysis)
+  }
+
   @Test("no word timings: the notice shows, Try again does not, and the audio is released")
   func missingTimingsIsNotRetryable() async {
     let store = FakeHistoryStore()

--- a/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
+++ b/Tests/EnviousWisprTests/App/MenuBarControllerTests.swift
@@ -131,8 +131,8 @@ struct MenuBarControllerTests {
         "",  // separator
         "Start Recording",
         "Add Selected Word  \u{2303}\u{2325} W",  // #2412, disabled; the chord rides in the title
+        "Transcribe a File...",  // #2772, opens the window on that page; above the divider (#2811)
         "",  // separator
-        "Transcribe a File...",  // #2772, opens the window on that page
         "Settings...",
         "Appearance",  // #1047 submenu parent
         "",  // separator
@@ -145,7 +145,7 @@ struct MenuBarControllerTests {
     #expect(menu.items[1].isEnabled == false)
     // Separators are separators.
     #expect(menu.items[2].isSeparatorItem)
-    #expect(menu.items[5].isSeparatorItem)
+    #expect(menu.items[6].isSeparatorItem)
     #expect(menu.items[9].isSeparatorItem)
     // Settings carries the comma key-equivalent; Quit carries "q".
     #expect(item(menu, "Settings...")?.keyEquivalent == ",")

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorFilterTests.swift
@@ -109,6 +109,34 @@ struct TranscriptCoordinatorFilterTests {
     #expect(ids(coordinator.filteredTranscripts) == [t.id], "found by its file name")
   }
 
+  @Test("search matches a renamed speaker's name, which does not enter displayText (#2811)")
+  func searchMatchesSpeakerNames() throws {
+    let (coordinator, _) = makeCoordinator()
+    let labeled = Transcript(
+      text: "hello there friend", language: "en", duration: 61, backendType: .parakeet,
+      importedFileName: "interview.m4a", speakerAnalysis: .labeled(count: 2),
+      speakerNames: ["A": "Zach", "B": "Ariana"],
+      turns: [
+        Turn(id: "0-5", speakerId: "A", startMs: 0, endMs: 200, originalTextRange: 0..<5),
+        Turn(id: "6-18", speakerId: "B", startMs: 5000, endMs: 5400, originalTextRange: 6..<18),
+      ])
+    let unrelated = transcript("a totally different recording", file: "other.m4a")
+    try coordinator.saveAndShow(unrelated)
+    try coordinator.saveAndShow(labeled)
+
+    coordinator.searchQuery = "Zach"
+    #expect(
+      ids(coordinator.filteredTranscripts) == [labeled.id],
+      "a speaker's own name must be searchable even though it never enters displayText")
+
+    coordinator.searchQuery = "Ariana"
+    #expect(
+      ids(coordinator.filteredTranscripts) == [labeled.id], "every speaker name, not just one")
+
+    coordinator.searchQuery = "nobody named this"
+    #expect(coordinator.filteredTranscripts.isEmpty)
+  }
+
   @Test("a held recovery is listed under All and Dictations, never under Transcripts")
   func heldRowIsADictation() async throws {
     let (coordinator, store) = makeCoordinator()

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
@@ -213,5 +213,33 @@ struct TranscriptCoordinatorMergeTests {
     let secondFailure = coordinator.renameSpeaker(id: unlabeled.id, speakerId: "A", name: "Zach")
     #expect(secondFailure != nil, "a row with no turns has nothing to rename against")
     #expect(telemetry.outcomes == [.saved, .failed])
+
+    coordinator.noteRenameCancelled()
+    #expect(telemetry.outcomes == [.saved, .failed, .cancelled])
+  }
+
+  @Test("noteTurnsDisplayed reports once per document per launch, never per re-selection (#2811)")
+  func turnsDisplayedTelemetryOncePerDocument() throws {
+    let dir = Self.makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    @MainActor final class Counter {
+      private(set) var count = 0
+      func bump() { count += 1 }
+    }
+    let displayed = Counter()
+    let coordinator = TranscriptCoordinator(
+      store: TranscriptStore(directory: dir), emitTurnsDisplayedTelemetry: { displayed.bump() })
+    let first = Self.makeTranscript()
+    let second = Self.makeTranscript()
+    try coordinator.saveAndShow(first)
+    try coordinator.saveAndShow(second)
+
+    coordinator.noteTurnsDisplayed(id: first.id)
+    coordinator.noteTurnsDisplayed(id: first.id)
+    #expect(displayed.count == 1, "re-selecting the same row is not a new fact")
+    coordinator.noteTurnsDisplayed(id: second.id)
+    #expect(displayed.count == 2)
+    coordinator.noteTurnsDisplayed(id: first.id)
+    #expect(displayed.count == 2, "going back to a row already reported adds nothing")
   }
 }

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
@@ -235,6 +235,15 @@ struct TranscriptCoordinatorMergeTests {
     coordinator.delete(row)
     #expect(recorder.ids == [row.id])
     #expect(coordinator.currentRow(id: row.id) == nil)
+
+    // Delete All takes its own route to the store and must announce every row too.
+    let second = Self.makeTranscript()
+    let third = Self.makeTranscript()
+    try coordinator.saveAndShow(second)
+    try coordinator.saveAndShow(third)
+    coordinator.deleteAll()
+    #expect(Set(recorder.ids) == [row.id, second.id, third.id])
+    #expect(coordinator.currentRow(id: second.id) == nil)
   }
 
   @Test("noteTurnsDisplayed reports once per document per launch, never per re-selection (#2811)")

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
@@ -218,6 +218,25 @@ struct TranscriptCoordinatorMergeTests {
     #expect(telemetry.outcomes == [.saved, .failed, .cancelled])
   }
 
+  @Test("delete announces the deleted row's id, and nothing on a failed delete (#2811)")
+  func deleteAnnouncesTheRow() throws {
+    let dir = Self.makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let coordinator = TranscriptCoordinator(store: TranscriptStore(directory: dir))
+    @MainActor final class Recorder {
+      private(set) var ids: [UUID] = []
+      func record(_ id: UUID) { ids.append(id) }
+    }
+    let recorder = Recorder()
+    coordinator.onRowDeleted = { recorder.record($0) }
+    let row = Self.makeTranscript()
+    try coordinator.saveAndShow(row)
+
+    coordinator.delete(row)
+    #expect(recorder.ids == [row.id])
+    #expect(coordinator.currentRow(id: row.id) == nil)
+  }
+
   @Test("noteTurnsDisplayed reports once per document per launch, never per re-selection (#2811)")
   func turnsDisplayedTelemetryOncePerDocument() throws {
     let dir = Self.makeTempDir()

--- a/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptCoordinatorMergeTests.swift
@@ -1,4 +1,5 @@
 import EnviousWisprCore
+import EnviousWisprServices
 import Foundation
 import Testing
 
@@ -184,5 +185,33 @@ struct TranscriptCoordinatorMergeTests {
     let reloadedRow = row(reloaded, original.id)
     #expect(reloadedRow?.speakerAnalysis == nil)
     #expect(reloadedRow?.turns == nil)
+  }
+
+  @Test("renameSpeaker reports saved on success and failed against a row with no turns (#2811)")
+  func renameSpeakerTelemetryReportsSavedAndFailed() async throws {
+    let dir = Self.makeTempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = TranscriptStore(directory: dir)
+    @MainActor final class TelemetryRecorder {
+      private(set) var outcomes: [TelemetryService.FileImportRenameOutcome] = []
+      func record(_ outcome: TelemetryService.FileImportRenameOutcome) { outcomes.append(outcome) }
+    }
+    let telemetry = TelemetryRecorder()
+    let coordinator = TranscriptCoordinator(
+      store: store, emitRenameTelemetry: { telemetry.record($0) })
+    let labeled = Self.makeTranscript()
+    try coordinator.saveAndShow(labeled)
+    _ = try coordinator.mergeSpeakerFields(
+      id: labeled.id, analysis: .labeled(count: 1), turns: Self.makeTurns())
+
+    let failure = coordinator.renameSpeaker(id: labeled.id, speakerId: "A", name: "Zach")
+    #expect(failure == nil)
+    #expect(telemetry.outcomes == [.saved])
+
+    let unlabeled = Self.makeTranscript()
+    try coordinator.saveAndShow(unlabeled)
+    let secondFailure = coordinator.renameSpeaker(id: unlabeled.id, speakerId: "A", name: "Zach")
+    #expect(secondFailure != nil, "a row with no turns has nothing to rename against")
+    #expect(telemetry.outcomes == [.saved, .failed])
   }
 }

--- a/Tests/EnviousWisprTests/App/TranscriptDocumentPresenterTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptDocumentPresenterTests.swift
@@ -11,6 +11,8 @@ import Testing
 struct TranscriptDocumentPresenterTests {
 
   private static let rawText = "hello there friend"
+  private static func noDiff(_ turn: Turn) -> WordDiff.Result? { nil }
+
   private static func turn(
     _ id: String, _ speaker: String, _ range: Range<Int>, startMs: Int? = 0,
     processedText: String? = nil
@@ -24,7 +26,7 @@ struct TranscriptDocumentPresenterTests {
   func nilTurnsRendersNil() {
     let result = TranscriptDocumentPresenter.render(
       turns: nil, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     #expect(result == nil)
   }
 
@@ -32,7 +34,7 @@ struct TranscriptDocumentPresenterTests {
   func emptyTurnsRendersNilToo() {
     let result = TranscriptDocumentPresenter.render(
       turns: [], rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     #expect(result == nil)
   }
 
@@ -44,7 +46,7 @@ struct TranscriptDocumentPresenterTests {
     ]
     let result = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: ["A": "Zach"], mode: .cleaned,
-      timesOn: false, engineLanguage: nil)
+      timesOn: false, diffLookup: Self.noDiff)
     #expect(result?.count == 2)
     #expect(result?[0].content == .plain("Hello!"))
     #expect(
@@ -57,21 +59,31 @@ struct TranscriptDocumentPresenterTests {
     let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hello!")]
     let result = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .original, timesOn: false,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     #expect(result?[0].content == .plain("hello"))
   }
 
-  @Test("marked up mode produces a diff, not plain text")
-  func markedUpModeProducesADiff() {
+  @Test("marked up mode consumes the supplied diff, never computing its own")
+  func markedUpModeConsumesTheSuppliedDiff() {
     let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hi!")]
+    let suppliedDiff = WordDiff.compare(original: "hello", cleaned: "Hi!", language: nil)
     let result = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .markedUp, timesOn: false,
-      engineLanguage: nil)
+      diffLookup: { _ in suppliedDiff })
     guard case .markedUp(let diff) = result?[0].content else {
       Issue.record("expected a .markedUp content case")
       return
     }
-    #expect(!diff.segments.isEmpty)
+    #expect(diff == suppliedDiff)
+  }
+
+  @Test("marked up mode with no cached diff yet falls back to cleaned text, never blocking")
+  func markedUpModeWithNoDiffFallsBackToCleanedText() {
+    let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hi!")]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .markedUp, timesOn: false,
+      diffLookup: Self.noDiff)
+    #expect(result?[0].content == .plain("Hi!"))
   }
 
   @Test("unknown speaker never gets a name, regardless of what speakerNames carries")
@@ -79,7 +91,7 @@ struct TranscriptDocumentPresenterTests {
     let turns = [Self.turn("0-5", "unknown", 0..<5)]
     let result = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: ["unknown": "should never surface"],
-      mode: .cleaned, timesOn: false, engineLanguage: nil)
+      mode: .cleaned, timesOn: false, diffLookup: Self.noDiff)
     #expect(result?[0].speakerName == nil)
   }
 
@@ -88,7 +100,7 @@ struct TranscriptDocumentPresenterTests {
     let turns = [Self.turn("0-5", "A", 0..<5)]
     let result = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: false,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     #expect(result?[0].speakerName == nil)
   }
 
@@ -97,10 +109,10 @@ struct TranscriptDocumentPresenterTests {
     let turns = [Self.turn("0-5", "A", 0..<5, startMs: 65_000)]
     let on = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     let off = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: false,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     #expect(on?[0].timeLabel == "1:05")
     #expect(off?[0].timeLabel == nil)
   }
@@ -110,7 +122,7 @@ struct TranscriptDocumentPresenterTests {
     let turns = [Self.turn("0-5", "A", 0..<5, startMs: nil)]
     let result = TranscriptDocumentPresenter.render(
       turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     #expect(result?[0].timeLabel == nil)
   }
 
@@ -173,7 +185,7 @@ struct TranscriptDocumentPresenterTests {
     let turns = [Self.turn("100-200", "A", 100..<200)]
     let result = TranscriptDocumentPresenter.render(
       turns: turns, rawText: "short", speakerNames: [:], mode: .original, timesOn: false,
-      engineLanguage: nil)
+      diffLookup: Self.noDiff)
     #expect(result?[0].content == .plain(""))
   }
 }

--- a/Tests/EnviousWisprTests/App/TranscriptDocumentPresenterTests.swift
+++ b/Tests/EnviousWisprTests/App/TranscriptDocumentPresenterTests.swift
@@ -1,0 +1,179 @@
+import EnviousWisprCore
+import Foundation
+import Testing
+
+@testable import EnviousWisprAppKit
+
+/// #2811, phase 4 of #2807: what fails when these fail is the wrong text on screen or in an
+/// export — a rename that doesn't show, a mode that exports the wrong text, or a solo memo
+/// that stops looking like today's plain text.
+@Suite("TranscriptDocumentPresenter", .tags(.productOutcome))
+struct TranscriptDocumentPresenterTests {
+
+  private static let rawText = "hello there friend"
+  private static func turn(
+    _ id: String, _ speaker: String, _ range: Range<Int>, startMs: Int? = 0,
+    processedText: String? = nil
+  ) -> Turn {
+    Turn(
+      id: id, speakerId: speaker, startMs: startMs, endMs: startMs.map { $0 + 100 },
+      originalTextRange: range, processedText: processedText)
+  }
+
+  @Test("nil turns renders nil, never an empty list")
+  func nilTurnsRendersNil() {
+    let result = TranscriptDocumentPresenter.render(
+      turns: nil, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
+      engineLanguage: nil)
+    #expect(result == nil)
+  }
+
+  @Test("an empty turns array renders nil too — the same fallback as nil, never an empty list")
+  func emptyTurnsRendersNilToo() {
+    let result = TranscriptDocumentPresenter.render(
+      turns: [], rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
+      engineLanguage: nil)
+    #expect(result == nil)
+  }
+
+  @Test("cleaned mode shows processedText when present, falls back to the original slice otherwise")
+  func cleanedModeShowsProcessedTextOrFallsBack() {
+    let turns = [
+      Self.turn("0-5", "A", 0..<5, processedText: "Hello!"),
+      Self.turn("6-18", "B", 6..<18),
+    ]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: ["A": "Zach"], mode: .cleaned,
+      timesOn: false, engineLanguage: nil)
+    #expect(result?.count == 2)
+    #expect(result?[0].content == .plain("Hello!"))
+    #expect(
+      result?[1].content == .plain("there friend"),
+      "no processedText yet — falls back to the raw slice")
+  }
+
+  @Test("original mode always shows the raw slice, ignoring processedText")
+  func originalModeAlwaysShowsRawSlice() {
+    let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hello!")]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .original, timesOn: false,
+      engineLanguage: nil)
+    #expect(result?[0].content == .plain("hello"))
+  }
+
+  @Test("marked up mode produces a diff, not plain text")
+  func markedUpModeProducesADiff() {
+    let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hi!")]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .markedUp, timesOn: false,
+      engineLanguage: nil)
+    guard case .markedUp(let diff) = result?[0].content else {
+      Issue.record("expected a .markedUp content case")
+      return
+    }
+    #expect(!diff.segments.isEmpty)
+  }
+
+  @Test("unknown speaker never gets a name, regardless of what speakerNames carries")
+  func unknownSpeakerNeverGetsAName() {
+    let turns = [Self.turn("0-5", "unknown", 0..<5)]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: ["unknown": "should never surface"],
+      mode: .cleaned, timesOn: false, engineLanguage: nil)
+    #expect(result?[0].speakerName == nil)
+  }
+
+  @Test("a real speaker with no name yet renders nil, never a fabricated default")
+  func unnamedRealSpeakerRendersNilName() {
+    let turns = [Self.turn("0-5", "A", 0..<5)]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: false,
+      engineLanguage: nil)
+    #expect(result?[0].speakerName == nil)
+  }
+
+  @Test("times on shows a time label; times off shows none, even when the turn has real timing")
+  func timesToggleControlsTheLabel() {
+    let turns = [Self.turn("0-5", "A", 0..<5, startMs: 65_000)]
+    let on = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
+      engineLanguage: nil)
+    let off = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: false,
+      engineLanguage: nil)
+    #expect(on?[0].timeLabel == "1:05")
+    #expect(off?[0].timeLabel == nil)
+  }
+
+  @Test("a turn with no timing at all never gets a time label, even with times on")
+  func untimedTurnNeverGetsALabel() {
+    let turns = [Self.turn("0-5", "A", 0..<5, startMs: nil)]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], mode: .cleaned, timesOn: true,
+      engineLanguage: nil)
+    #expect(result?[0].timeLabel == nil)
+  }
+
+  @Test("exportText is nil under the same condition as render — nil or empty turns")
+  func exportTextNilMatchesRenderNil() {
+    #expect(
+      TranscriptDocumentPresenter.exportText(
+        turns: nil, rawText: Self.rawText, speakerNames: [:], timesOn: false, mode: .cleaned)
+        == nil)
+    #expect(
+      TranscriptDocumentPresenter.exportText(
+        turns: [], rawText: Self.rawText, speakerNames: [:], timesOn: false, mode: .cleaned)
+        == nil)
+  }
+
+  @Test("marked up export hands over the CLEANED text and flags the fallback")
+  func markedUpExportHandsOverCleanedText() {
+    let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hi!")]
+    let result = TranscriptDocumentPresenter.exportText(
+      turns: turns, rawText: Self.rawText, speakerNames: ["A": "Zach"], timesOn: false,
+      mode: .markedUp)
+    #expect(result?.isCleanedFallback == true)
+    #expect(result?.text.contains("Hi!") == true)
+    #expect(result?.text.contains("Zach") == true)
+  }
+
+  @Test("cleaned and original export are never flagged as a fallback")
+  func cleanedAndOriginalExportAreNeverFlagged() {
+    let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hi!")]
+    let cleaned = TranscriptDocumentPresenter.exportText(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], timesOn: false, mode: .cleaned)
+    let original = TranscriptDocumentPresenter.exportText(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], timesOn: false, mode: .original)
+    #expect(cleaned?.isCleanedFallback == false)
+    #expect(original?.isCleanedFallback == false)
+  }
+
+  @Test("an unnamed speaker exports under an explicit label, never a blank line")
+  func unnamedSpeakerExportsUnderAnExplicitLabel() {
+    let turns = [Self.turn("0-5", "A", 0..<5, processedText: "Hi!")]
+    let result = TranscriptDocumentPresenter.exportText(
+      turns: turns, rawText: Self.rawText, speakerNames: [:], timesOn: false, mode: .cleaned)
+    #expect(result?.text.hasPrefix("Unknown speaker") == true)
+  }
+
+  @Test("export button labels relabel only for marked up, and only to the cleaned-export copy")
+  func exportButtonLabelsRelabelOnlyForMarkedUp() {
+    let cleaned = TranscriptDocumentPresenter.exportButtonLabels(mode: .cleaned)
+    let original = TranscriptDocumentPresenter.exportButtonLabels(mode: .original)
+    let markedUp = TranscriptDocumentPresenter.exportButtonLabels(mode: .markedUp)
+    #expect(cleaned.copy == "Copy everything")
+    #expect(original.copy == "Copy everything")
+    #expect(markedUp.copy == "Copy cleaned")
+    #expect(markedUp.save == "Save cleaned as…")
+    #expect(markedUp.share == "Share cleaned…")
+  }
+
+  @Test("a range mismatch against the supplied rawText renders an empty slice rather than crashing")
+  func rangeMismatchRendersEmptySliceRatherThanCrashing() {
+    let turns = [Self.turn("100-200", "A", 100..<200)]
+    let result = TranscriptDocumentPresenter.render(
+      turns: turns, rawText: "short", speakerNames: [:], mode: .original, timesOn: false,
+      engineLanguage: nil)
+    #expect(result?[0].content == .plain(""))
+  }
+}


### PR DESCRIPTION
Phase 4 of the speaker-labels epic. #2807 remains open (phase 5 follows). Closes #2811.

## What the user gets

- **Transcribe a File, Done step:** a two-person recording shows as turns labeled "Speaker 1" / "Speaker 2" with times. Click a name to rename it; every turn with that speaker updates. A Times toggle hides the timestamps. Three views: Cleaned, Marked-up, Original.
- **History:** the same recording's row shows the same turn view with the names you set, plus the speaker names in the row subtitle and in search.
- **Copy / Save / Share** hand over exactly what is on screen. In Marked-up view they hand over the cleaned text and say so on the button ("Copy cleaned", "Save cleaned as…", "Share cleaned…").
- **Speaker detection failed?** A notice says so with "Try again". "Clean it again" now re-cleans every speaker's turns too, so a retry's raw turns and a fresh cleanup both reach the screen.
- A single-voice memo looks exactly as it does today on both screens.
- Menu bar: "Transcribe a File…" now sits with "Start Recording" and "Add Selected Word", above the divider (founder request).

## What changed

- New shared `TurnDocumentView` (both screens) and `TranscriptDocumentPresenter` (render + export, one authority for "what is on screen is what exports").
- `FileImportCoordinator`: speaker retry (task-owned, cancellable), rename, off-main turn diffs with a cache validated by input, turn re-clean on "Clean it again", live-`historyID` staleness guards throughout.
- `TranscriptCoordinator`: rename entry point, speaker-name search, live-row exports.
- Telemetry, shape only: `file_import_turns_rename` (`saved|failed|cancelled`), `file_import_turns_retry` (`recovered|still_failed`), `file_import_turns_displayed` (`wizard|history`). Sibling events under the existing prefix; the plan's §3e was corrected to say so and why (`file_import_turns` fires once per import, so per-attempt facts cannot ride on it).
- Accessibility: speaker names are real buttons with a stable label and the name as value; marked-up turns carry the wizard's spoken change descriptions; turn text is selectable.

## Review trail

Chunked build: 4 chunks (1, 2a, 2b, 3a, 3b, 4), each to CHUNK-CLEAN with the persistent orchestrator. Whole-diff `codex review`: 3 findings, fixed. Second-pass behavioural review: 5 findings, fixed. Confirming round: 1 finding, fixed (Stop reaches a turn re-clean). Cloud review rounds 1 to 3: 2 + 1 + 4 findings, each routed through a local lens pass, all fixed (retry audio released once settled and on row deletion, including Delete All; no "Try again" when the timing data can never bind a speaker; a refused polisher, a new file, Start Over, or a deleted row all stop a post-Done turn re-clean). Every fix that could be bound by a test has one.

## Tests

- Xcode Debug lane: 7,876 tests in 702 suites; the only failures are `RenderedPillFreezeTests`' four dev-machine-gated rows (#2814, fails identically on untouched main on this Mac).
- Xcode Release lane, filtered to `FileImportCoordinatorSpeakerTests`: 43/43 PASS (the whole release test bundle compiles).
- Test-hardening recipe: #2845 (9 rows, validated).

## Live UAT

Driven by the CTO session on the dev app with video (founder delegated, 2026-09-13), record with frames and two recordings at `docs/feature-requests/2811-uat-evidence/README.md` (main checkout, gitignored). 4-minute two-speaker clip: Working shows the bar only; Done shows "Finding speakers", then "Cleaning speaker turns: N of 32" with Stop, then the labeled turns, about 21 s after Start. Marked up per turn; "Copy cleaned" copies labeled cleaned text with no marks. History: speaker chip on the row, speaker-name search narrows 21,209 rows to the two labeled imports, rename in the detail view pre-fills the current name and renames every turn, Escape cancels, blank reverts, and the renamed row is on disk.

One defect found live and fixed in `bc73c494`: the rename popover opened empty (SwiftUI builds popover content before first show, so a `@State` seeded in `init` was ignored); the field is now a binding on the row's draft.

Founder's own UAT on the 48-minute file (before the last two commits) drove the two status-line changes and the redesign now filed as #2851.

## Known limits

- `RenameInteractionTests` for the popover's own rules (blank reverts, Escape, outside-click commit, 60-char cap) are covered by Live UAT, not unit tests: SwiftUI view internals with no view-testing harness in this repo.
- CJK / space-free scripts still reach the failure notice (#2838); the notice wording is true for that case.

Part of #2807.
