### PR TITLE
feat(website): GitHub link with live star count in the shared header; shorter Download button (#2849)

### DIFF
--- a/website/src/components/SiteFooter.astro
+++ b/website/src/components/SiteFooter.astro
@@ -3,7 +3,7 @@
 // tagline, three catalog links plus GitHub, then the legal line. The mock's
 // footer has no download link. The homepage passes motionControl so its
 // existing "Pause motion" control keeps rendering there.
-import { footerLinks } from '../data/site-navigation.js';
+import { footerLinks, githubUrl } from '../data/site-navigation.js';
 
 interface Props {
   motionControl?: boolean;
@@ -20,7 +20,7 @@ const year = new Date().getFullYear();
     </div>
     <nav class="chrome-footer-links" aria-label="Footer">
       {footerLinks.map(([label, href]) => <a href={href}>{label}</a>)}
-      <a href="https://github.com/saurabhav88/EnviousWispr" target="_blank" rel="noopener">GitHub ↗</a>
+      <a href={githubUrl} target="_blank" rel="noopener">GitHub ↗</a>
     </nav>
     <span class="chrome-footer-legal"
       >© {year} Envious Labs · GPLv3 app <a href="/privacy-policy/">Privacy</a>

--- a/website/src/components/SiteHeader.astro
+++ b/website/src/components/SiteHeader.astro
@@ -7,9 +7,13 @@
 // data-nav-ready on the header. A failed script leaves working links.
 // SiteHead.astro stamps html[data-nav-js] before first paint so the visible
 // lists never flash on a browser that is about to collapse them.
+//
+// The GitHub link (#2849) renders its plain label; github-stars.js swaps in
+// the live star count once it has a valid number, never before.
 import Logo from './home/Logo.astro';
 import SiteIcon from './SiteIcon.astro';
-import { menuProducts, menuFoot, headerLinks, resources, downloadUrl } from '../data/site-navigation.js';
+import StarCount from './StarCount.astro';
+import { menuProducts, menuFoot, headerLinks, resources, downloadUrl, githubUrl } from '../data/site-navigation.js';
 
 interface Props {
   activePage?: string;
@@ -95,8 +99,19 @@ const { activePage = 'home', themed = false } = Astro.props;
           }
         </div>
       </div>
+      <a class="nav-link nav-github" href={githubUrl} target="_blank" rel="noopener" aria-label="EnviousWispr on GitHub">
+        <StarCount />
+      </a>
     </nav>
     <div class="chrome-actions">
+      <a class="chrome-github chrome-pill" href={githubUrl} target="_blank" rel="noopener" aria-label="EnviousWispr on GitHub">
+        <svg class="github-mark" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"
+          ><path
+            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+          /></svg
+        >
+        <StarCount />
+      </a>
       {
         themed && (
           <button class="chrome-theme-toggle chrome-icon-button" aria-label="Switch theme" data-theme-toggle data-enhancement-control hidden>
@@ -104,12 +119,12 @@ const { activePage = 'home', themed = false } = Astro.props;
           </button>
         )
       }
-      <a class="chrome-button chrome-download" href={downloadUrl} data-download-source="nav"
+      <a class="chrome-button chrome-download" href={downloadUrl} data-download-source="nav" aria-label="Download for Mac"
         ><svg class="download-apple" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"
           ><path
             d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.23 3.39 7.54 8.94 7.26c1.35.07 2.29.76 3.08.82 1.18-.24 2.31-.94 3.57-.85 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.43 4.13l.01-.01ZM12.03 7.2c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25Z"
           /></svg
-        >Download for Mac</a
+        >Download</a
       >
     </div>
   </div>
@@ -117,4 +132,5 @@ const { activePage = 'home', themed = false } = Astro.props;
 
 <script>
   import '../scripts/site-nav.js';
+  import '../scripts/github-stars.js';
 </script>

--- a/website/src/components/StarCount.astro
+++ b/website/src/components/StarCount.astro
@@ -1,0 +1,15 @@
+---
+// The GitHub star count host (#2849). Server-rendered as the word "GitHub";
+// github-stars.js fills [data-stars-count] and stamps data-stars-ready, and
+// the stylesheet then shows the star and number. No script, no number.
+---
+
+<span class="chrome-stars" data-stars>
+  <span class="chrome-stars-label">GitHub</span>
+  <span class="chrome-stars-count">
+    <svg class="chrome-star" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"
+      ><path d="m12 2 3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01z"
+      /></svg
+    ><span data-stars-count></span>
+  </span>
+</span>

--- a/website/src/data/site-navigation.js
+++ b/website/src/data/site-navigation.js
@@ -8,8 +8,8 @@
 // times for these URLs (a fresh checkout or the daily rebuild would otherwise
 // publish a false freshness signal).
 
-export const downloadUrl =
-  'https://github.com/saurabhav88/EnviousWispr/releases/latest/download/EnviousWispr.dmg';
+export const githubUrl = 'https://github.com/saurabhav88/EnviousWispr';
+export const downloadUrl = `${githubUrl}/releases/latest/download/EnviousWispr.dmg`;
 
 export const catalog = [
   {

--- a/website/src/scripts/github-stars.js
+++ b/website/src/scripts/github-stars.js
@@ -1,0 +1,73 @@
+// GitHub star count in the shared header (#2849). Ported from the homepage
+// shell the old chrome carried; #2816 retired it with that header.
+//
+// An unavailable count must not compromise navigation or invent social
+// proof: every [data-stars] host is server-rendered with its plain "GitHub"
+// label and only swaps to the star count once a valid number is in hand. The
+// count is cached for an hour so a return visit paints it before the network
+// answers; the API call carries a hard timeout so a slow GitHub costs nothing.
+const REPO_API = 'https://api.github.com/repos/saurabhav88/EnviousWispr';
+const CACHE_KEY = 'ew-github-stars';
+const MAX_AGE_MS = 3600000;
+const TIMEOUT_MS = 7000;
+
+const valid = (value) =>
+  Boolean(value) && Number.isInteger(value.count) && value.count >= 0 && Number.isFinite(value.at);
+
+function display(value) {
+  const text = new Intl.NumberFormat('en').format(value.count);
+  const checked = new Date(value.at).toLocaleString();
+  for (const host of document.querySelectorAll('[data-stars]')) {
+    const count = host.querySelector('[data-stars-count]');
+    if (!count) continue;
+    count.textContent = text;
+    host.dataset.starsReady = 'true';
+    const link = host.closest('a');
+    if (link) {
+      link.title = `${text} GitHub stars, checked ${checked}`;
+      link.setAttribute('aria-label', `EnviousWispr on GitHub, ${text} stars`);
+    }
+  }
+}
+
+function readCache() {
+  try {
+    return JSON.parse(localStorage.getItem(CACHE_KEY));
+  } catch {
+    return null; /* Optional cache. */
+  }
+}
+
+function writeCache(value) {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(value));
+  } catch {
+    /* Optional cache. */
+  }
+}
+
+function install() {
+  if (!document.querySelector('[data-stars]')) return;
+  const cache = readCache();
+  if (valid(cache)) display(cache);
+  if (valid(cache) && Date.now() - cache.at <= MAX_AGE_MS) return;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  fetch(REPO_API, { signal: controller.signal, headers: { Accept: 'application/vnd.github+json' } })
+    .then((response) => {
+      if (!response.ok) throw new Error('Count unavailable');
+      return response.json();
+    })
+    .then((data) => {
+      const value = { count: data.stargazers_count, at: Date.now() };
+      if (!valid(value)) return;
+      display(value);
+      writeCache(value);
+    })
+    .catch(() => {
+      /* The plain GitHub label stays. */
+    })
+    .finally(() => clearTimeout(timeout));
+}
+
+install();

--- a/website/src/styles/site-header.css
+++ b/website/src/styles/site-header.css
@@ -315,6 +315,66 @@ html[data-theme='dark'] .site-chrome {
   color: var(--nav-body);
   font-size: 21px;
 }
+
+/* GitHub link with the live star count (#2849). The pill sits beside the
+ * theme toggle from 600px up; below that the phone menu carries the same link
+ * as a plain row. Both hosts start as the word "GitHub" and switch to the
+ * star and number only once github-stars.js stamps data-stars-ready. */
+.site-chrome .chrome-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--nav-line);
+  border-radius: 999px;
+  color: var(--nav-ink);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  transition: border-color 0.18s, color 0.18s;
+}
+.site-chrome .chrome-pill:hover {
+  border-color: var(--nav-accent);
+  color: var(--nav-accent);
+}
+.site-chrome .github-mark {
+  display: block;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+.site-chrome .chrome-stars {
+  display: inline-flex;
+  align-items: center;
+}
+.site-chrome .chrome-stars-count {
+  display: none;
+  align-items: center;
+  gap: 4px;
+}
+.site-chrome .chrome-star {
+  display: block;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: #e8a53a;
+}
+.site-chrome [data-stars-ready] .chrome-stars-label {
+  display: none;
+}
+.site-chrome [data-stars-ready] .chrome-stars-count {
+  display: inline-flex;
+}
+/* The phone-menu row keeps the word and adds the count after it. */
+.chrome-header .nav-github [data-stars-ready] .chrome-stars-label {
+  display: inline;
+  margin-right: 8px;
+}
+.chrome-header .nav-github {
+  display: none;
+}
 .chrome-header .chrome-mobile-trigger {
   display: none;
 }
@@ -504,6 +564,10 @@ html[data-nav-js] .chrome-header:not([data-nav-ready]) [data-nav-panel] {
     padding: 10px 13px;
     font-size: 13px;
   }
+  .chrome-header .chrome-actions .chrome-pill {
+    padding: 0 12px;
+    font-size: 13px;
+  }
 }
 @media (max-width: 999px) {
   .chrome-header .chrome-inner {
@@ -617,6 +681,12 @@ html[data-nav-js] .chrome-header:not([data-nav-ready]) [data-nav-panel] {
     width: 18px;
     height: 18px;
   }
+  .chrome-header .chrome-actions .chrome-pill {
+    display: none;
+  }
+  .chrome-header .nav-github {
+    display: flex;
+  }
   html[data-nav-js] .chrome-header .main-nav {
     top: 78px;
     gap: 3px;
@@ -668,6 +738,7 @@ html[data-nav-js] .chrome-header:not([data-nav-ready]) [data-nav-panel] {
     transform: none;
   }
   .site-chrome .chrome-button,
+  .site-chrome .chrome-pill,
   .chrome-header .menu-product {
     transition: none;
   }

--- a/website/src/styles/site-header.css
+++ b/website/src/styles/site-header.css
@@ -529,9 +529,13 @@ html[data-nav-js] .chrome-header:not([data-nav-ready]) [data-nav-panel] {
     font-size: 26px;
   }
 }
-@media (min-width: 1000px) and (max-width: 1190px) {
+/* The compact desktop band. The pill and the button need 1123px of header
+ * in the 1240px-up layout, so that layout starts there; here the brand, nav
+ * gaps and actions tighten so everything fits from 1000px with room to spare
+ * (#2849: measured 921px needed inside a 934px header at 1000px). */
+@media (min-width: 1000px) and (max-width: 1239px) {
   html[data-nav-js] .chrome-header .main-nav {
-    gap: 22px;
+    gap: 18px;
   }
   html[data-nav-js] .chrome-header .nav-trigger,
   html[data-nav-js] .chrome-header .nav-link {
@@ -539,12 +543,15 @@ html[data-nav-js] .chrome-header:not([data-nav-ready]) [data-nav-panel] {
   }
 }
 @media (max-width: 1190px) {
+  /* The page content's .wrap narrows here too; the chrome stays aligned. */
   .chrome-header,
   .chrome-footer {
     width: calc(100% - 64px);
   }
+}
+@media (max-width: 1239px) {
   .chrome-header .chrome-inner {
-    gap: 17px;
+    gap: 14px;
     padding: 0 18px;
   }
   .site-chrome .chrome-brand {
@@ -558,14 +565,14 @@ html[data-nav-js] .chrome-header:not([data-nav-ready]) [data-nav-panel] {
     gap: 16px;
   }
   .chrome-header .chrome-actions {
-    gap: 8px;
+    gap: 7px;
   }
   .chrome-header .chrome-actions .chrome-button {
     padding: 10px 13px;
     font-size: 13px;
   }
   .chrome-header .chrome-actions .chrome-pill {
-    padding: 0 12px;
+    padding: 0 11px;
     font-size: 13px;
   }
 }


### PR DESCRIPTION
Closes #2849

## What changed

The shared header gets its GitHub link back, now with the repository's live star count, as a pill beside the theme toggle. The Download button reads "Download" with the Apple mark carrying the platform; its accessible name stays "Download for Mac". Shortening the button is what makes room for the pill on the 1000 to 1190 px band.

- `website/src/scripts/github-stars.js`: the fetch the old homepage shell carried, ported. One-hour cache in `localStorage`, 7 s abort, validated integer before anything renders. Every `[data-stars]` host is server-rendered as the word "GitHub" and only switches to the star and number once a valid count is in hand, so an unavailable API never invents social proof. CSP already allows `https://api.github.com` in `connect-src`.
- `website/src/components/StarCount.astro`: the host markup, shared by the desktop pill and the phone-menu row (the row keeps the word and adds the count).
- `website/src/data/site-navigation.js`: `githubUrl` is now the one owner of the repository URL; `downloadUrl` derives from it and the footer imports it.
- `website/src/styles/site-header.css`: pill in both themes, tighter on the tablet band, hidden under 600 px where the phone menu row takes over, reduced-motion drops its transition.

Not touched: the legacy `.github` / `.nav-actions` rules in `styles/home/foundation.css` from the pre-#2816 header. No markup carries those classes any more, so they match nothing; a separate cleanup can retire that block.

## Verified

- `npm run build`: 145 pages. `npm run check:help`: routes 71/71, search 47 passed, features catalog 9 built 9, 330 links checked.
- Headless screenshots at 1440 light and dark, 1190, 1000, 768, 390 and the 390 open menu, plus `/compare/`: count 139 rendered on every page, no console errors, no horizontal overflow.

Lane: Content | Tier: SMALL | council-skip: zero-blast-radius (user-facing copy and one header link)
