### PR TITLE
fix(validation): --fix counts tests, not spellings, and refuses to invent a label (#2760, #2761)

### DIFF
--- a/scripts/mutation-battery-test.py
+++ b/scripts/mutation-battery-test.py
@@ -2733,6 +2733,43 @@ check_fix("a malformed row is refused without stopping the rows behind it",
                        "row 2: repairable — anchor re-cut at -2 spaces"],
           expect_runnable="1/1 rows runnable")
 
+# #2760. One test carries up to three spellings, so a prefix of two of them is a prefix of
+# ONE test and the repair is decidable; counting alias KEYS refused it while the refusal
+# message advertised the very completion. Two-way against a prefix of two different tests,
+# which stays refused — and the refusal now says so instead of suggesting the shortest.
+_pipeline_state_row = {
+    "label": "the active states answer inactive",
+    "file": "Sources/EnviousWisprCore/AppSettings.swift",
+    "anchor": "    case .loadingModel, .recording, .transcribing, .polishing:\n      return true",
+    "replacement": "    case .loadingModel, .recording, .transcribing, .polishing:\n      return false",
+    "suite": "EnviousWisprTests/PipelineStateTests",
+}
+check_fix("--fix completes a prefix shared by two spellings of the SAME test",
+          dict(_pipeline_state_row, expect_fail="compl"),
+          expect_text="repairable — must_fire: 'compl' -> 'completeIsNotActive()'",
+          expect_runnable="1/1 rows runnable")
+check_fix("--fix refuses a prefix shared by two DIFFERENT tests, and names them",
+          dict(_pipeline_state_row, expect_fail="error"),
+          expect_text=["PREFIX of 2 different tests",
+                       "'PipelineStateTests/errorEquality()', "
+                       "'PipelineStateTests/errorIsNotActive()'",
+                       "NOT mechanically repairable"],
+          expect_no_block=True)
+
+# #2761. The caller generates a provenance label AFTER the repair and BEFORE the whole-row
+# recheck, so an invalid label was replaced before anything could refuse it: a row with
+# drift and no label printed as repairable, with the authored description gone. The label
+# is neither class `--fix` repairs, so it is refused first. The drifted row WITH a label is
+# the control, already asserted repairable above.
+check_fix("--fix refuses a drifted row whose label is missing, rather than inventing one",
+          {k: v for k, v in _drifted.items() if k != "label"},
+          expect_text="NOT mechanically repairable — the row's label is missing",
+          expect_no_block=True)
+check_fix("--fix refuses a drifted row whose label is not a string",
+          dict(_drifted, label=42),
+          expect_text="NOT mechanically repairable — the row's label is missing",
+          expect_no_block=True)
+
 # #2672 review: `self_test_problems` accepted ANY `"--self-test"` constant that was not a bare
 # docstring statement, so a module constant, a help message or an unreachable branch made a
 # module "parse" a flag it never inspects, and the validator printed a command whose exit

--- a/scripts/validate-mutation-recipe.py
+++ b/scripts/validate-mutation-recipe.py
@@ -387,11 +387,20 @@ def prefix_successor(name, known_names):
     """
     if not name or name in known_names:
         return None
-    near = [
-        candidate for candidate in known_names
-        if candidate and candidate != name and candidate.startswith(name)
-    ]
-    return near[0] if len(near) == 1 else None
+    near = sorted(
+        (candidate for candidate in known_names
+         if candidate and candidate != name and candidate.startswith(name)),
+        key=len,
+    )
+    # Count TESTS, never alias keys. One test carries up to three spellings — its display
+    # name, `function()` and `Suite/function()` — and a prefix of two of them is still a
+    # prefix of ONE test (`compl` → `complete is not active` AND `completeIsNotActive()`).
+    # Counting keys refused that repair while `missing_test_problem` advertised it (#2760).
+    identities = set().union(*(known_names[candidate] for candidate in near)) if near else set()
+    if len(identities) != 1:
+        return None
+    # The same candidate the refusal suggested, so the sentence and the value agree.
+    return near[0]
 
 
 def repaired_row(row, index, default_suite, root, battery, names_by_suite):
@@ -414,6 +423,17 @@ def repaired_row(row, index, default_suite, root, battery, names_by_suite):
     """
     if not isinstance(row, dict):
         return None, "the row is not an object"
+    # The label is the author's description of what the row MEANS, and the runner refuses a
+    # row without one. The caller prefixes a provenance note onto it AFTER this repair, so an
+    # invalid label checked only by the whole-row recheck would already have been replaced
+    # by a generated one — a row with drift AND no label printed as repairable, and the
+    # authored description was silently discarded (#2761). Neither class this repairs is
+    # the label, so an invalid one is refused here, before anything is generated.
+    label_value = row.get("label")
+    if not isinstance(label_value, str) or not label_value:
+        return None, (
+            "the row's label is missing or not a non-empty string, and a description of "
+            "what the row means is the author's to write, not a repair's to invent")
 
     fixed = dict(row)
     notes = []
@@ -531,6 +551,14 @@ def missing_test_problem(name, known_names):
         key=len,
     )
     if near:
+        # A prefix of several spellings of ONE test has one answer; a prefix of several
+        # TESTS has none, and suggesting the shortest would be a guess dressed as a hint.
+        identities = set().union(*(known_names[candidate] for candidate in near))
+        if len(identities) > 1:
+            return (
+                f"expectation name is a PREFIX of {len(identities)} different tests, "
+                f"not a full test name: {name!r}; name one of "
+                f"{', '.join(repr(spelling) for spelling in sorted(identities))} in full")
         return (
             f"expectation name is a PREFIX, not a full test name; "
             f"did you mean {near[0]!r}")


### PR DESCRIPTION
## Summary

Two Codex findings on #2738, both in the recipe validator's `--fix` path, both the expensive direction: a repair the tool advertises and then refuses (#2760), and a repair the tool prints that silently discards what the author wrote (#2761).

Closes #2760. Closes #2761.

`Tier: SMALL | Test: required | Modules: scripts`
`Lane: Docs/dev-tooling`

## #2760 — count tests, not spellings

`prefix_successor` counted alias KEYS. One test carries up to three spellings (display name, `function()`, `Suite/function()`), so a prefix of two of them is a prefix of ONE test: `compl` against `complete is not active` and `completeIsNotActive()` both resolve to `PipelineStateTests/completeIsNotActive()`. `missing_test_problem` said "did you mean …" while `--fix` said "no mechanical class applies".

Candidates are now grouped by the canonical identities the oracle already carries. One identity repairs, and the repaired value is the same shortest candidate the refusal names, so the sentence and the value agree. A prefix of several DIFFERENT tests is still refused, and the refusal now says so and lists them instead of suggesting the shortest as if it were an answer.

## #2761 — refuse an invalid label instead of inventing one

`validate()` generated the provenance label AFTER `repaired_row` and BEFORE the whole-row recheck, so a missing or non-string label was replaced by a valid generated one before anything could refuse it. A row with indentation drift and no label printed as repairable, with the authored description gone. `repaired_row` now refuses an invalid label first, mirroring the runner's own `load_recipes` check (a non-empty string), since the label is neither of the two classes `--fix` repairs.

## Evidence

- `python3 scripts/mutation-battery-test.py` — **236/236**, four new paired `--fix` cases.
- All four new cases RED against the parent validator (`origin/main:scripts/validate-mutation-recipe.py`) for the finding's reason: the #2760 case printed no corrected block; the different-tests control lacked the new refusal; both #2761 cases printed a corrected block when nothing was repairable.
- Precedent round trips unchanged: #2626 9/9 repairable, #2352 4/4 repairable.
- Classification: both REPRODUCIBLE. #2760's input is a real suite in the repo; #2761's is any drifted row filed without a label.

## Pre-Merge Checklist

- [x] Tooling self-test green, parent-red on the new cases.
- [x] Self-review grep over `prefix_successor`, `missing_test_problem`, `repaired_row`, "did you mean" across `scripts/ docs/ Tests/`. The runner's own baseline-time `did you mean` hint (`mutation-battery.py`) is a substring hint over run output, a different mechanism, left as is.
- [ ] Dev build — N/A, no Swift touched.
- [ ] CI `build-check` — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
