### PR TITLE
test(simulator): A13 waits for the wedge terminal before it cancels (#2502)

### DIFF
--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioInventory.swift
@@ -174,12 +174,24 @@ enum ScenarioInventory {
       // after a stall window of logical time (PR-3 plan §3.7). STOP waits for
       // the watcher's real clock registration before advanceClock supplies that
       // window; the trailing cancel then hits an already-terminal state (#1868).
+      //
+      // #2502: the cancel WAITS for that terminal. `advanceClock` makes the
+      // watcher's sleeper READY, never RUN, and the per-step ready-work drain is
+      // a quiescence heuristic, so under the hosted runner's scheduling the
+      // cancel landed before the wedge was detected and the scenario reached
+      // `.cancelled` with no user-visible error — a product-shaped failure for a
+      // harness-shaped race. A terminal `expectState` waits on the kernel's own
+      // conclusion signal (the thing being asserted is the thing waited on) and
+      // fails LOUDLY, naming the state it found, if four ticks ever stop being
+      // enough. The tick count is not raised: the next slower runner would need
+      // five, and nothing would say so.
       id: "A13", name: "adapter wedge on finalize",
       steps: [
         .engine(.setBehavior(.wedgeOnFinalize)),
         .trigger(.start), .capture(.deliverBuffer),
         .triggerAwaitingClockRegistration(.stop),
-        .advanceClock(ticks: 4), .trigger(.cancel),
+        .advanceClock(ticks: 4), .expectState(.failed(.asrWedged)),
+        .trigger(.cancel),
       ],
       expected: ExpectedOutcome(
         terminalState: .failed(.asrWedged), pasteCount: 0, pasteOutcome: .none,

--- a/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
+++ b/Tests/EnviousWisprTests/Pipeline/Simulator/ScenarioRunnerTests.swift
@@ -248,4 +248,34 @@ struct ScenarioRunnerTests {
       the logical clock; a plain STOP reopens the CI-only spawn-to-register race.
       """)
   }
+
+  @Test("A13 waits for the wedge terminal before it cancels")
+  func a13WaitsForTheWedgeBeforeCancelling() {
+    // #2502: `advanceClock` resumes the watcher's sleeper but does not run it,
+    // so a cancel applied straight after can win and the scenario ends
+    // `.cancelled`. The terminal `expectState` between them is what makes the
+    // runner wait on the kernel's conclusion signal, and a bare advance-then-
+    // cancel reopens the CI-only resume-to-run race.
+    let a13 = ScenarioInventory.all.first { $0.id == "A13" }
+    let steps = a13?.steps ?? []
+    let advance = steps.firstIndex {
+      if case .advanceClock = $0 { return true } else { return false }
+    }
+    let cancel = steps.firstIndex {
+      if case .trigger(.cancel) = $0 { return true } else { return false }
+    }
+    let waitsForWedge = steps.indices.contains { index in
+      guard case .expectState(.failed(.asrWedged)) = steps[index],
+        let advance, let cancel
+      else { return false }
+      return advance < index && index < cancel
+    }
+    #expect(
+      waitsForWedge,
+      """
+      A13 must assert the wedge terminal between advancing the clock and \
+      cancelling; advance-then-cancel lets the cancel land before the wedge \
+      watcher has run.
+      """)
+  }
 }


### PR DESCRIPTION
## Summary

Scenario A13 ("adapter wedge on finalize") failed once on CI with `expected failed(asrWedged), got cancelled` and no user-visible error. The script was `advanceClock(ticks: 4)` then `trigger(.cancel)`: advancing the clock makes the wedge watcher's sleeper READY, never RUN, and the per-step ready-work drain is a quiescence heuristic, so under the hosted runner's scheduling the cancel could land before the wedge was detected. Four ticks was a count chosen against local timing with nothing that failed loudly when it stopped being enough.

Closes #2502.

`Tier: SMALL | Test: this IS the test | Modules: Tests`
`Lane: Code`

## The change

The cancel now waits on the condition the scenario actually needs. A terminal `.expectState(.failed(.asrWedged))` sits between the advance and the cancel. The runner's terminal branch waits on the kernel's own conclusion signal (`drainUntilConcluded`), the same mechanism #1857 and #1868 introduced for this harness, and if four ticks ever stop being enough it fails naming the state it found instead of reaching a wrong terminal.

- The tick count is NOT raised; that would only move the race to the next slower runner.
- A13 carries no `.concurrencySensitive` tag (checked against `ScenarioInventory.swift`; the issue's triage comment said otherwise), so the `zeroTick` sweep class, which would strand a mid-scenario terminal wait until teardown, does not apply to it.
- `ScenarioRunnerTests` gains a structural case requiring the wedge expectation between the advance and the cancel, beside the existing one that binds STOP to registration.

## Evidence

- `EnviousWisprTests/ScenarioRunnerTests` 10/10, including the new structural case.
- `EnviousWisprTests/RecordingSessionKernelScenarioTests` 2/2: every inventory scenario against the kernel, and the 64-schedule interleaving sweep.
- Classification: HYPOTHETICAL under local timing (0 recurrences in 77 CI observations, measured on the issue), REPRODUCIBLE in shape: the resume-to-run window is the one the harness's own `FakeClock` comments name.

## Pre-Merge Checklist

- [x] Suite green locally in the Debug lane (filtered runs above).
- [x] Self-review grep over `A13` / `adapter wedge on finalize` across the simulator directory: inventory, runner test, and the `FakeClock` / `RecordingSessionDriving` comments that describe the registration mechanism, all still accurate.
- [ ] Dev build — N/A, no `Sources/` touched.
- [ ] CI `build-check` — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
