### PR TITLE
feat(services): the terminal breaker reports every trip as terminal_breaker.tripped (#2777)

### DIFF
--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2417,10 +2417,18 @@ public final class TelemetryService {
   /// trips — one production user carried 1,647 `terminal_breaker_open` rows over
   /// 25 days with no `terminal_deadline` at all, and nothing in the data could say
   /// whether the breaker tripped once or on every launch. One row per trip closes
-  /// that: `step` is which labelled read spent the budget (`scan`, `focused`,
-  /// `screen`), `phase` is `recheck` when it happened at the commit boundary and
-  /// absent during the initial resolution, and `already_open` is true when the
-  /// same terminal tripped again. Names and shapes only, never screen text.
+  /// that: `step` is which labelled read spent the budget, `phase` is `recheck`
+  /// when it happened at the commit boundary and absent during the initial
+  /// resolution, and `already_open` is true when the same terminal tripped again.
+  ///
+  /// `step` is the closed set of `TerminalResolutionBudget.step` labels, and
+  /// every site that charges the budget is one of these (cloud review of the
+  /// #2777 PR asked for the whole set, not the three the resolver alone uses):
+  /// `scan` (the process sweep), `focused`, `role`, `count`, `range`,
+  /// `range_read`, `browser_address_bar` (the caret reads in
+  /// `PasteService.caretDerivedContext`) and `screen` (the terminal screen
+  /// read). Adding a label is adding a value here. Names and shapes only, never
+  /// screen text.
   package func terminalBreakerTripped(_ trip: TerminalBreakerTrip) {
     var props: [String: Any] = ["already_open": trip.wasAlreadyOpen]
     if let step = trip.exhaustedStep { props["step"] = step }

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -2409,6 +2409,35 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("paste.copies_observed", properties: props)
   }
 
+  /// #2777. The terminal circuit breaker TRIPPED, reported from the trip site.
+  ///
+  /// Until this event a trip was only inferable from `dictation.completed`'s
+  /// `caret_context`: `terminal_deadline` on the take that tripped, then
+  /// `terminal_breaker_open` on every take after it. That inference cannot count
+  /// trips — one production user carried 1,647 `terminal_breaker_open` rows over
+  /// 25 days with no `terminal_deadline` at all, and nothing in the data could say
+  /// whether the breaker tripped once or on every launch. One row per trip closes
+  /// that: `step` is which labelled read spent the budget (`scan`, `focused`,
+  /// `screen`), `phase` is `recheck` when it happened at the commit boundary and
+  /// absent during the initial resolution, and `already_open` is true when the
+  /// same terminal tripped again. Names and shapes only, never screen text.
+  package func terminalBreakerTripped(_ trip: TerminalBreakerTrip) {
+    var props: [String: Any] = ["already_open": trip.wasAlreadyOpen]
+    if let step = trip.exhaustedStep { props["step"] = step }
+    if let phase = trip.phase { props["phase"] = phase }
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "terminal_breaker.tripped",
+          stringProps: props.compactMapValues { $0 as? String },
+          intProps: [:],
+          doubleProps: [:],
+          boolProps: props.compactMapValues { $0 as? Bool }
+        ))
+    #endif
+    PostHogSDK.shared.capture("terminal_breaker.tripped", properties: props)
+  }
+
   public func pasteCompleted(
     tier: String, targetApp: String?, result: String, latencyMs: Int,
     insertion: PasteInsertionTelemetry = .init(),

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -266,9 +266,12 @@ package final class TerminalResolutionBudget: Sendable {
 // MARK: - Circuit breaker
 
 /// One breaker trip, as reported from the trip site (#2777). Metadata only —
-/// a step label from the closed set the budget records (`scan`, `focused`,
-/// `screen`), a phase marker, and a flag — never screen text, a path, or the
-/// derived line, the same boundary `TerminalContextRefusal` keeps.
+/// a step label from the closed set the budget records (every
+/// `TerminalResolutionBudget.step` label: the resolver's `scan` and `screen`,
+/// and `PasteService.caretDerivedContext`'s `focused`, `role`, `count`,
+/// `range`, `range_read`, `browser_address_bar`), a phase marker, and a flag —
+/// never screen text, a path, or the derived line, the same boundary
+/// `TerminalContextRefusal` keeps.
 package struct TerminalBreakerTrip: Equatable, Sendable {
   /// The labelled step that exhausted the budget, or nil when none recorded itself.
   package let exhaustedStep: String?

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -290,11 +290,22 @@ package struct TerminalBreakerTrip: Equatable, Sendable {
 /// nothing ever cleared it, so once macOS recycled that PID an unrelated
 /// terminal would be refused forever with no way back. Identity, not a number.
 package final class TerminalCircuitBreaker: Sendable {
-  /// The production breaker reports every trip to telemetry (#2777). The hop to
-  /// the main actor is what `TelemetryService` requires; the trip itself has
-  /// already latched under the lock by the time the observer runs.
+  /// The production breaker reports every trip to telemetry (#2777). The trip
+  /// itself has already latched under the lock by the time the observer runs.
+  ///
+  /// `TelemetryService` is main-actor bound and every production trip already
+  /// happens there (the paste path reads the caret from `@MainActor` code), so
+  /// the event is emitted SYNCHRONOUSLY when the trip is on the main thread and
+  /// only hops when it is not. A synchronous emit is what lets a test observe
+  /// the `.shared` wiring with no suspension point — the process-wide test hook
+  /// is shared by every telemetry suite, and an `await` between installing it
+  /// and reading it is a window another suite can clobber (local review r1).
   package static let shared = TerminalCircuitBreaker(onTrip: { trip in
-    Task { @MainActor in TelemetryService.shared.terminalBreakerTripped(trip) }
+    if Thread.isMainThread {
+      MainActor.assumeIsolated { TelemetryService.shared.terminalBreakerTripped(trip) }
+    } else {
+      Task { @MainActor in TelemetryService.shared.terminalBreakerTripped(trip) }
+    }
   })
 
   /// A process, not merely a PID.

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -215,24 +215,34 @@ package final class TerminalResolutionBudget: Sendable {
     trace.withLock { $0.append((label, 0, true)) }
   }
 
-  /// The step that spent the budget last, and the phase marker in force when it
-  /// ran — what a breaker trip NAMES (#2777).
+  /// The step whose cost first reached the cap, and the phase marker in force
+  /// when it ran — what a breaker trip NAMES (#2777).
   ///
   /// The trace already records both; this reads them back so the trip event can
   /// carry "which labelled step exhausted the budget" without a second bookkeeping
-  /// path that could disagree with the log line. Nil label when no step recorded
-  /// itself (a budget exhausted before any read); nil phase during the initial
-  /// resolution, before the first `mark`.
+  /// path that could disagree with the log line.
+  ///
+  /// The FIRST step to reach the cap, never the last one recorded: the caret path
+  /// runs several reads against this budget and its caller tests exhaustion once,
+  /// afterwards, so reads keep being recorded after the one that crossed the line
+  /// and the last label would blame an innocent later read (local review r2).
+  /// When no traced step reaches the cap on its own — a cost charged with a nil
+  /// label is spent but not traced — the last recorded step is the best answer
+  /// available. Nil label when no step recorded itself; nil phase during the
+  /// initial resolution, before the first `mark`.
   package var exhaustingStep: (label: String?, phase: String?) {
     let samples = trace.withLock { $0 }
     var phase: String?
     var last: (label: String?, phase: String?) = (nil, nil)
+    var cumulative = 0.0
     for sample in samples {
       if sample.isMark {
         phase = sample.label
-      } else {
-        last = (sample.label, phase)
+        continue
       }
+      cumulative += sample.seconds
+      last = (sample.label, phase)
+      if cumulative >= total { return last }
     }
     return last
   }

--- a/Sources/EnviousWisprServices/TerminalContextResolver.swift
+++ b/Sources/EnviousWisprServices/TerminalContextResolver.swift
@@ -215,6 +215,28 @@ package final class TerminalResolutionBudget: Sendable {
     trace.withLock { $0.append((label, 0, true)) }
   }
 
+  /// The step that spent the budget last, and the phase marker in force when it
+  /// ran — what a breaker trip NAMES (#2777).
+  ///
+  /// The trace already records both; this reads them back so the trip event can
+  /// carry "which labelled step exhausted the budget" without a second bookkeeping
+  /// path that could disagree with the log line. Nil label when no step recorded
+  /// itself (a budget exhausted before any read); nil phase during the initial
+  /// resolution, before the first `mark`.
+  package var exhaustingStep: (label: String?, phase: String?) {
+    let samples = trace.withLock { $0 }
+    var phase: String?
+    var last: (label: String?, phase: String?) = (nil, nil)
+    for sample in samples {
+      if sample.isMark {
+        phase = sample.label
+      } else {
+        last = (sample.label, phase)
+      }
+    }
+    return last
+  }
+
   /// The per-step costs, for one log line. Empty when no step ran.
   ///
   /// Reads as `focused=0.4ms screen=0.2ms |recheck| focused=97.1ms total=97.7ms`,
@@ -233,6 +255,27 @@ package final class TerminalResolutionBudget: Sendable {
 
 // MARK: - Circuit breaker
 
+/// One breaker trip, as reported from the trip site (#2777). Metadata only —
+/// a step label from the closed set the budget records (`scan`, `focused`,
+/// `screen`), a phase marker, and a flag — never screen text, a path, or the
+/// derived line, the same boundary `TerminalContextRefusal` keeps.
+package struct TerminalBreakerTrip: Equatable, Sendable {
+  /// The labelled step that exhausted the budget, or nil when none recorded itself.
+  package let exhaustedStep: String?
+  /// The phase marker in force when that step ran (`recheck`), or nil during
+  /// the initial resolution.
+  package let phase: String?
+  /// True when this terminal was ALREADY latched — the same process tripping
+  /// again, which the resolver's entry check makes rare and this makes countable.
+  package let wasAlreadyOpen: Bool
+
+  package init(exhaustedStep: String?, phase: String?, wasAlreadyOpen: Bool) {
+    self.exhaustedStep = exhaustedStep
+    self.phase = phase
+    self.wasAlreadyOpen = wasAlreadyOpen
+  }
+}
+
 /// Latches a wedged terminal off for the rest of the process's life.
 ///
 /// Without this, repeated dictations against one wedged terminal each start
@@ -247,7 +290,12 @@ package final class TerminalResolutionBudget: Sendable {
 /// nothing ever cleared it, so once macOS recycled that PID an unrelated
 /// terminal would be refused forever with no way back. Identity, not a number.
 package final class TerminalCircuitBreaker: Sendable {
-  package static let shared = TerminalCircuitBreaker()
+  /// The production breaker reports every trip to telemetry (#2777). The hop to
+  /// the main actor is what `TelemetryService` requires; the trip itself has
+  /// already latched under the lock by the time the observer runs.
+  package static let shared = TerminalCircuitBreaker(onTrip: { trip in
+    Task { @MainActor in TelemetryService.shared.terminalBreakerTripped(trip) }
+  })
 
   /// A process, not merely a PID.
   struct Key: Hashable {
@@ -259,7 +307,13 @@ package final class TerminalCircuitBreaker: Sendable {
 
   private let open = OSAllocatedUnfairLock(initialState: Set<Key>())
 
-  package init() {}
+  /// Told about every trip, from the trip site itself. Nil for a test breaker
+  /// that only wants the latch.
+  private let onTrip: (@Sendable (TerminalBreakerTrip) -> Void)?
+
+  package init(onTrip: (@Sendable (TerminalBreakerTrip) -> Void)? = nil) {
+    self.onTrip = onTrip
+  }
 
   private func key(_ pid: pid_t) -> Key {
     Key(pid: pid, startedAt: TerminalProcessScanner.startTime(of: pid))
@@ -270,9 +324,25 @@ package final class TerminalCircuitBreaker: Sendable {
     return open.withLock { $0.contains(key) }
   }
 
-  package func trip(for pid: pid_t) {
+  /// Latch this terminal off and REPORT it.
+  ///
+  /// Before #2777 a trip was recorded only indirectly: the take that tripped
+  /// reported `caret_context = terminal_deadline` and every later take reported
+  /// `terminal_breaker_open`. One production user showed 1,647 of the latter over
+  /// 25 days and none of the former, and the data could not say whether the
+  /// breaker had tripped once and outlived its cause or re-tripped on every
+  /// launch without recording it. A trip is now a fact of its own, emitted HERE,
+  /// so "tripped once" and "tripped forty times" are different counts.
+  /// - Parameter exhaustedStep: the labelled step that spent the budget, and the
+  ///   phase it ran in, read off `TerminalResolutionBudget.exhaustingStep`. Both
+  ///   nil for a trip with no budget behind it, which only a test does.
+  package func trip(for pid: pid_t, exhaustedStep: (label: String?, phase: String?) = (nil, nil)) {
     let key = key(pid)
-    open.withLock { _ = $0.insert(key) }
+    let inserted = open.withLock { $0.insert(key).inserted }
+    onTrip?(
+      TerminalBreakerTrip(
+        exhaustedStep: exhaustedStep.label, phase: exhaustedStep.phase,
+        wasAlreadyOpen: !inserted))
   }
 
   package func resetAll() {
@@ -340,7 +410,8 @@ package enum TerminalContextResolver {
   ) -> Bool {
     budget.charge(elapsed, label: label)
     guard budget.isExhausted else { return false }
-    breaker.trip(for: pid)
+    // The trace names the step, so the trip event can too (#2777).
+    breaker.trip(for: pid, exhaustedStep: budget.exhaustingStep)
     return true
   }
 

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -587,11 +587,16 @@ struct TerminalContextResolverTests {
   #if DEBUG
     @Test("The production breaker reaches telemetry as terminal_breaker.tripped")
     @MainActor
-    func sharedBreakerEmitsTheEvent() async throws {
+    func sharedBreakerEmitsTheEvent() throws {
       // The observer on `.shared` is the only wiring between the trip site and
       // PostHog. A test breaker with its own observer cannot prove it exists, and
       // the founder's question — how many times did THIS user's breaker trip —
       // is answered by this event or by nothing.
+      //
+      // NO suspension point between installing the process-wide hook and reading
+      // it: every telemetry suite shares that hook, and a suite that parks on an
+      // `await` here is a suite another one can clobber mid-test (local review
+      // r1). A main-thread trip emits synchronously, so nothing needs waiting for.
       let waiter = TelemetryEventWaiter()
       TelemetryService.shared.testEventHook = { @Sendable event in
         MainActor.assumeIsolated { waiter.record(event) }
@@ -605,7 +610,7 @@ struct TerminalContextResolverTests {
       TerminalCircuitBreaker.shared.trip(
         for: pid_t(Int32.max), exhaustedStep: ("screen", "recheck"))
 
-      let event = try await waiter.waitForEvent(named: "terminal_breaker.tripped")
+      let event = try #require(waiter.events.first { $0.name == "terminal_breaker.tripped" })
       #expect(event.stringProps["step"] == "screen")
       #expect(event.stringProps["phase"] == "recheck")
       #expect(event.boolProps["already_open"] == false)

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -501,6 +501,117 @@ struct TerminalContextResolverTests {
     #expect(!breaker.isOpen(for: 900))
   }
 
+  // MARK: - The trip is reported (#2777)
+
+  /// Collects what the breaker reports. The observer is `@Sendable`, so a plain
+  /// captured array will not compile.
+  private final class TripLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var trips: [TerminalBreakerTrip] = []
+    func record(_ trip: TerminalBreakerTrip) {
+      lock.lock()
+      defer { lock.unlock() }
+      trips.append(trip)
+    }
+    var all: [TerminalBreakerTrip] {
+      lock.lock()
+      defer { lock.unlock() }
+      return trips
+    }
+  }
+
+  @Test("An overrun REPORTS the trip, naming the step that spent the budget")
+  func overrunReportsTheTripWithItsStep() {
+    // Before #2777 a trip was only inferable from the refusal reason of the take
+    // that caused it, and one production user carried 1,647 `terminal_breaker_open`
+    // takes with no `terminal_deadline` at all. The trip is now a fact of its own,
+    // reported from the trip site, so it can be counted.
+    let clock = TestClock()
+    clock.perCallCost = 0.400  // the process scan is the first thing timed, and it wedges
+    let log = TripLog()
+    let breaker = TerminalCircuitBreaker(onTrip: { log.record($0) })
+    let budget = TerminalResolutionBudget(total: 0.100)
+
+    let result = resolve(dependencies(clock: clock), budget: budget, breaker: breaker, pid: 900)
+    #expect(result == .refused(.deadline))
+    #expect(
+      log.all == [TerminalBreakerTrip(exhaustedStep: "scan", phase: nil, wasAlreadyOpen: false)],
+      "exactly one trip, naming the scan that ate the budget, got \(log.all)")
+  }
+
+  @Test("A healthy resolution reports no trip")
+  func healthyResolutionReportsNoTrip() {
+    // The two-way control for the event: an observer that fired on every
+    // resolution would inflate the count the event exists to make honest.
+    let log = TripLog()
+    let breaker = TerminalCircuitBreaker(onTrip: { log.record($0) })
+    #expect(resolve(dependencies(), breaker: breaker, pid: 900).evidence != nil)
+    #expect(log.all.isEmpty)
+  }
+
+  @Test("The same terminal tripping again is reported as already open")
+  func repeatTripReportsAlreadyOpen() {
+    // "Tripped once" and "tripped forty times" were the same data; this flag is
+    // what tells them apart on the same process.
+    let log = TripLog()
+    let breaker = TerminalCircuitBreaker(onTrip: { log.record($0) })
+    breaker.trip(for: 900)
+    breaker.trip(for: 900)
+    breaker.trip(for: 901)
+    #expect(log.all.map(\.wasAlreadyOpen) == [false, true, false])
+  }
+
+  @Test("The exhausting step is the LAST recorded step, in the phase it ran")
+  func exhaustingStepReadsTheTrace() {
+    // The commit-boundary re-check re-runs the same reads under the same labels
+    // after a `recheck` marker, so a trip there must say so or two different
+    // wedges (`focused` at capture, `focused` at commit) collapse into one.
+    let budget = TerminalResolutionBudget(total: 0.100)
+    #expect(budget.exhaustingStep.label == nil, "nothing ran yet")
+    #expect(budget.exhaustingStep.phase == nil)
+
+    budget.charge(0.010, label: "scan")
+    #expect(budget.exhaustingStep.label == "scan")
+    #expect(budget.exhaustingStep.phase == nil, "the initial resolution has no marker")
+
+    budget.mark("recheck")
+    #expect(
+      budget.exhaustingStep.label == "scan" && budget.exhaustingStep.phase == nil,
+      "a marker with no step after it changes nothing: the last STEP still ran before it")
+
+    budget.charge(0.090, label: "focused")
+    #expect(budget.exhaustingStep.label == "focused")
+    #expect(budget.exhaustingStep.phase == "recheck")
+  }
+
+  #if DEBUG
+    @Test("The production breaker reaches telemetry as terminal_breaker.tripped")
+    @MainActor
+    func sharedBreakerEmitsTheEvent() async throws {
+      // The observer on `.shared` is the only wiring between the trip site and
+      // PostHog. A test breaker with its own observer cannot prove it exists, and
+      // the founder's question — how many times did THIS user's breaker trip —
+      // is answered by this event or by nothing.
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer {
+        TelemetryService.shared.testEventHook = nil
+        TerminalCircuitBreaker.shared.resetAll()
+      }
+
+      // A pid no live process holds, so the latch cannot touch a real terminal.
+      TerminalCircuitBreaker.shared.trip(
+        for: pid_t(Int32.max), exhaustedStep: ("screen", "recheck"))
+
+      let event = try await waiter.waitForEvent(named: "terminal_breaker.tripped")
+      #expect(event.stringProps["step"] == "screen")
+      #expect(event.stringProps["phase"] == "recheck")
+      #expect(event.boolProps["already_open"] == false)
+    }
+  #endif
+
   // MARK: - Revalidation
 
   @Test("Unchanged evidence revalidates")

--- a/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
+++ b/Tests/EnviousWisprTests/Services/TerminalContextResolverTests.swift
@@ -584,6 +584,25 @@ struct TerminalContextResolverTests {
     #expect(budget.exhaustingStep.phase == "recheck")
   }
 
+  @Test("The exhausting step is the FIRST to reach the cap, not the last read recorded")
+  func exhaustingStepIsTheFirstToCrossTheCap() {
+    // The caret path records several reads against one budget and its caller
+    // tests exhaustion once, afterwards. Reads recorded after the one that
+    // crossed the line must not take the blame (local review r2).
+    let budget = TerminalResolutionBudget(total: 0.100)
+    budget.charge(0.080, label: "focused")
+    budget.charge(0.050, label: "screen")  // cumulative 0.130: this is the one
+    budget.charge(0.010, label: "browser_address_bar")  // recorded after exhaustion
+    #expect(budget.exhaustingStep.label == "screen")
+
+    // A single read that blows the whole cap by itself is named even when
+    // healthy reads follow it.
+    let wedged = TerminalResolutionBudget(total: 0.100)
+    wedged.charge(0.400, label: "scan")
+    wedged.charge(0.001, label: "focused")
+    #expect(wedged.exhaustingStep.label == "scan")
+  }
+
   #if DEBUG
     @Test("The production breaker reaches telemetry as terminal_breaker.tripped")
     @MainActor


### PR DESCRIPTION
## Summary

A trip of the terminal circuit breaker was recorded only indirectly: the take that tripped it reported `caret_context = terminal_deadline`, and every take after it reported `terminal_breaker_open`. That inference cannot COUNT trips. One production user carried 1,647 `terminal_breaker_open` rows over 25 days and no `terminal_deadline` at all, and the data could not say whether the breaker tripped once and outlived its cause or re-tripped on every launch without recording it, which is the measurement #1941's ship criterion needs.

Closes #2777.

`Tier: SMALL | Test: required (Services) | Modules: Services`
`Lane: Code`

## What ships

**One event per trip, emitted from the trip site.** `TerminalCircuitBreaker.trip(for:exhaustedStep:)` takes an observer; the production `.shared` breaker hands each trip to `TelemetryService.terminalBreakerTripped`, which captures `terminal_breaker.tripped`:

| property | meaning |
|---|---|
| `step` | the labelled read that spent the budget: `scan`, `focused`, `screen` (absent when no step recorded itself) |
| `phase` | `recheck` when it happened at the commit boundary; absent during the initial resolution |
| `already_open` | the same terminal tripping again |

`TerminalResolutionBudget.exhaustingStep` reads the step and phase off the trace the log line already carries, so the event and the log cannot disagree. It names the FIRST step whose cumulative cost reached the cap, not the last read recorded: the caret path runs several reads and tests exhaustion once afterwards, so reads keep being recorded after the one that crossed the line (local review r2). Names and shapes only, never screen text (`sentry-operations.md` RULE: telemetry-privacy-boundary).

**Emission is synchronous on the main thread.** Every production trip already happens there (the paste path reads the caret from `@MainActor` code), so the observer emits through `MainActor.assumeIsolated` and only hops when a trip arrives off the main thread. That is what lets the wiring test observe `.shared` with no suspension point, since the process-wide test hook is shared by every telemetry suite (local review r1).

## The process-start half of the issue

Settled in `.claude/knowledge/analytics-operations.md` FACT: process-start-marker (gitignored, edited in the main checkout): **a process start is `Application Opened` WHERE `from_background = false`.** That is the posthog-ios SDK's own synchronous launch marker; on macOS the same event ALSO fires on every return to the foreground with `from_background = true`, so an unfiltered count is foreground switches, and the #2777 user's 40 rows were not 40 relaunches until filtered. `app.launched` is ours but is emitted from a detached task after an Apple Intelligence eligibility read and can be missed on an immediate quit. The new event has its own row in FACT: app-posthog-events.

## Evidence

- `EnviousWisprTests/TerminalContextResolverTests` **36/36** in the Debug lane: an overrun reports exactly one trip naming `scan`; a healthy resolution reports none (the two-way control); a repeat trip reports `already_open`; the exhausting step is the first to reach the cap and keeps its phase; a read recorded after exhaustion is not blamed; the `.shared` observer reaches `terminal_breaker.tripped` through `testEventHook`.
- Local Codex `review --base origin/main`: r1 one P2 (shared hook across an `await`, fixed by the synchronous emit), r2 one P2 (last-read attribution, fixed by first-to-cross), r3 clean: "No actionable bugs found in the changes."
- Test-hardening recipe filed as #2853, 5/5 rows validated against this branch.
- Not yet observed in production: the event is new. First-release floor applies; `app_version` slicing before aggregating.

## Pre-Merge Checklist

- [x] Suite green locally, three local Codex rounds ending clean.
- [x] No-slot dev build (`EnviousWispr-Dev` into the worktree's `.derivedData/Dev`) succeeded for the push gate.
- [x] Self-review grep over `trip(for:`, `exhaustingStep`, `terminalBreakerTripped`, `terminal_breaker` across `Sources/ Tests/ scripts/ workers/`: the only production trip site is `overspent`; `revalidate` has no production caller; `scripts/telemetry-join.py`'s take-keyed event list is untouched because this event carries no `take_id`.
- [ ] CI `build-check` — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
