### PR TITLE
test(app): the file-import suites wait on a deadline, not a yield count (#2854)

### DIFF
--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorSpeakerTests.swift
@@ -91,14 +91,10 @@ struct FileImportCoordinatorSpeakerTests {
 
   private static let anyURL = URL(fileURLWithPath: "/tmp/recording.m4a")
 
-  private func settleUntil(
-    limit: Int = 500, _ condition: @MainActor () async -> Bool
-  ) async -> Bool {
-    for _ in 0..<limit {
-      if await condition() { return true }
-      await Task.yield()
-    }
-    return await condition()
+  /// #2854: a deadline-bounded wait on the condition, never a yield count.
+  /// Owner: `FileImportSettle.swift`.
+  private func settleUntil(_ condition: @MainActor () async -> Bool) async -> Bool {
+    await settleUntilObserved(condition)
   }
 
   private func makeCoordinator(

--- a/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportCoordinatorTests.swift
@@ -829,18 +829,14 @@ struct FileImportCoordinatorTests {
     #expect(!coordinator.rawTranscript.isEmpty, "Change lost the words a re-run needs")
   }
 
-  /// Yields until the condition holds, or gives up. `Task.yield()` rather than a sleep: everything
-  /// here is main-actor work with no real waiting in it, so a clock would only make the suite slower
-  /// and flakier.
+  /// #2854: a deadline-bounded wait on the condition, never a yield count. The
+  /// earlier note here said everything was main-actor work with no real waiting
+  /// in it; the coordinator's decode, speaker analysis and turn assembly are
+  /// detached tasks, and on the hosted runner a yield count ran out before they
+  /// finished. Owner: `FileImportSettle.swift`.
   @discardableResult
-  private func settleUntil(
-    limit: Int = 500, _ condition: @MainActor () async -> Bool
-  ) async -> Bool {
-    for _ in 0..<limit {
-      if await condition() { return true }
-      await Task.yield()
-    }
-    return await condition()
+  private func settleUntil(_ condition: @MainActor () async -> Bool) async -> Bool {
+    await settleUntilObserved(condition)
   }
 
   private static let anyURL = URL(fileURLWithPath: "/tmp/recording.m4a")

--- a/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
+++ b/Tests/EnviousWisprTests/App/FileImportHistoryTests.swift
@@ -95,16 +95,13 @@ struct FileImportHistoryTests {
       })
   }
 
-  /// Yields until the condition holds. No clock: the run is a real `Task` and its terminal is
-  /// a STATE, so cooperative yielding is what advances it. Same shape and same limit as
-  /// `FileImportCoordinatorTests.settleUntil`.
+  /// #2854: a deadline-bounded wait on the condition, never a yield count. The
+  /// earlier note here said cooperative yielding was what advanced the run; the
+  /// coordinator's work is detached, so it is not.
+  /// Owner: `FileImportSettle.swift`.
   @discardableResult
-  private func settleUntil(limit: Int = 500, _ condition: @MainActor () -> Bool) async -> Bool {
-    for _ in 0..<limit {
-      if condition() { return true }
-      await Task.yield()
-    }
-    return condition()
+  private func settleUntil(_ condition: @MainActor @escaping () -> Bool) async -> Bool {
+    await settleUntilObserved { condition() }
   }
 
   private func run(_ c: FileImportCoordinator) async {

--- a/Tests/EnviousWisprTests/App/FileImportSettle.swift
+++ b/Tests/EnviousWisprTests/App/FileImportSettle.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// #2854: the one bounded wait the three file-import suites share.
+///
+/// The coordinator runs its decode, speaker analysis and turn assembly in
+/// DETACHED tasks, so the moment a condition becomes true is set by CPU time on
+/// whatever machine runs the suite, not by how many times the main actor
+/// yields. The yield-count settle those suites carried (`for _ in 0..<500`)
+/// passed on a dev machine with spare cores and, on the hosted runner, ran out
+/// of yields before a detached decode finished: a different case failed on each
+/// of five CI runs in one night, with the coordinator still mid-flight.
+///
+/// This waits on the CONDITION under a wall-clock deadline instead. The deadline
+/// is a fail-fast bound, never something the suites assert on, and on expiry
+/// the caller's own `#expect` names the state it found. The short sleep between
+/// probes is a settle tick so a hot yield loop cannot starve the very actor hop
+/// it is waiting for (`test-timing.md`); it is not the mechanism. Not a count:
+/// there is no parameter here that a slower runner can prove too small.
+@MainActor
+func settleUntilObserved(
+  deadline: Duration = .seconds(10),
+  _ condition: @MainActor () async -> Bool
+) async -> Bool {
+  let clock = ContinuousClock()
+  let end = clock.now + deadline
+  while clock.now < end {
+    if await condition() { return true }
+    await Task.yield()
+    // settle: give detached work and the coordinator's own continuations a turn
+    try? await Task.sleep(for: .milliseconds(2))
+  }
+  return await condition()
+}


### PR DESCRIPTION
## Summary

`FileImportCoordinatorSpeakerTests` failed on the hosted runner in a DIFFERENT case on each of five CI runs in one night (PRs #2852, #2855 and the #2811 branch), and passed locally every time. Every failing assertion was downstream of `settleUntil` returning false. The coordinator runs its decode, speaker analysis and turn assembly in DETACHED tasks, so the moment a condition becomes true is set by CPU time on the runner, and a count of 500 main-actor yields ran out before the detached work finished. The two sibling suites carried the same helper with the same limit.

Closes #2854.

`Tier: SMALL | Test: this IS the test | Modules: Tests`
`Lane: Code`

## The change

One shared helper, `settleUntilObserved` in `Tests/EnviousWisprTests/App/FileImportSettle.swift`, waits on the condition under a wall-clock deadline (10 s, a fail-fast bound the suites never assert on) with a 2 ms settle tick between probes, so a hot yield loop cannot starve the actor hop it is waiting for (`test-timing.md`). On expiry the caller's own `#expect` names the state it found. There is no count left for a slower runner to prove too small, which is the shape #2502's triage asked for and PR #2855 applied to A13.

- The three private `settleUntil` helpers (`FileImportCoordinatorSpeakerTests`, `FileImportCoordinatorTests`, `FileImportHistoryTests`) delegate to it; their 130 call sites are untouched.
- Two doc comments that said the work was all main-actor and needed no clock were wrong about the coordinator and are corrected in place.
- The limit is not raised: the next slower runner would need more, and nothing would say so.

## Evidence

- The three suites are green, 20 / 27 / 19, at 0.13 to 0.22 s, so no case is passing ON the deadline (`test-timing.md`'s "a suite whose runtime lands near a deadline value is an instrument fault").
- Under 12 to 16 `yes` loops (1-minute load 22) the fixed speaker suite passes.
- **Control, stated plainly: the ORIGINAL helper also passes three runs under that load on this 16-core machine.** The CI failure is not reproducible here, which the issue's own body predicted. The fix rests on the failure mechanism the five runs show (a condition true only after detached work finished, with the coordinator mid-flight in every failing assertion), not on a local red.
- Classification: REPRODUCIBLE on CI (five runs, five cases), HYPOTHETICAL locally.

## Pre-Merge Checklist

- [x] Three suites green in the Debug lane; speaker suite green under load.
- [x] Self-review grep: `limit: Int = 500` has zero hits under `Tests/EnviousWisprTests/App/`; every `settleUntil` in the three files resolves to the shared helper.
- [ ] Dev build — N/A, no `Sources/` touched.
- [ ] CI `build-check` — pending. This PR is itself an observation of the suite on the hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
