### PR TITLE
feat(llm): every polish retry reports its outcome as llm.retry_completed (#2641)

### DIFF
--- a/Sources/EnviousWisprCore/LLMTelemetrySink.swift
+++ b/Sources/EnviousWisprCore/LLMTelemetrySink.swift
@@ -44,19 +44,36 @@ public struct LLMTelemetrySink: Sendable {
   /// intentions. Metadata only: provider and model, never key material.
   public let prewarmStarted: @Sendable (_ provider: String, _ model: String) -> Void
 
-  /// `prewarmStarted` is deliberately NOT defaulted. Only three sites construct
-  /// this type, so requiring it costs almost nothing and makes the compiler,
-  /// rather than a reviewer, catch a `.live` factory that forgets to wire the
-  /// event — the failure mode where the counter silently never fires and the
-  /// change looks unmeasurable rather than broken.
+  /// #2641: a transient-failure RETRY finished → `llm.retry_completed`.
+  ///
+  /// `llm.polish_failed` records only FINAL failures, so a retry that recovered
+  /// left no row anywhere and nobody could say whether the 200 ms / 400 ms
+  /// backoff (#2093) ever rescues a rate-limited or 5xx call. One row per retry
+  /// ATTEMPT, emitted after that attempt returns: the provider, the classified
+  /// reason of the failure that triggered it, the attempt index (1-based: the
+  /// first retry is 1), the delay slept before it, and whether it SUCCEEDED.
+  /// The last field is the whole point; attempts alone say the mechanism ran,
+  /// not that it works. Metadata only, never content or key material.
+  public let retryCompleted:
+    @Sendable (
+      _ provider: String, _ reason: String, _ attempt: Int, _ delayMs: Int, _ succeeded: Bool
+    ) -> Void
+
+  /// `prewarmStarted` and `retryCompleted` are deliberately NOT defaulted. Only
+  /// a handful of sites construct this type, so requiring them costs almost
+  /// nothing and makes the compiler, rather than a reviewer, catch a `.live`
+  /// factory that forgets to wire an event — the failure mode where the counter
+  /// silently never fires and the change looks unmeasurable rather than broken.
   public init(
     limbFailure: @escaping @Sendable (String, String, String, String, Int?) -> Void,
     legacyKeyCleanupFailed: @escaping @Sendable (any Error, String) -> Void,
-    prewarmStarted: @escaping @Sendable (String, String) -> Void
+    prewarmStarted: @escaping @Sendable (String, String) -> Void,
+    retryCompleted: @escaping @Sendable (String, String, Int, Int, Bool) -> Void
   ) {
     self.limbFailure = limbFailure
     self.legacyKeyCleanupFailed = legacyKeyCleanupFailed
     self.prewarmStarted = prewarmStarted
+    self.retryCompleted = retryCompleted
   }
 
   /// No-op sink — the default at every construction site except the App composition
@@ -64,5 +81,6 @@ public struct LLMTelemetrySink: Sendable {
   public static let noop = LLMTelemetrySink(
     limbFailure: { _, _, _, _, _ in },
     legacyKeyCleanupFailed: { _, _ in },
-    prewarmStarted: { _, _ in })
+    prewarmStarted: { _, _ in },
+    retryCompleted: { _, _, _, _, _ in })
 }

--- a/Sources/EnviousWisprLLM/ClaudeConnector.swift
+++ b/Sources/EnviousWisprLLM/ClaudeConnector.swift
@@ -381,9 +381,12 @@ public struct ClaudeConnector: TranscriptPolisher {
     operation: () async throws -> LLMResult
   ) async throws -> LLMResult {
     var lastError: Error?
+    // #2641: what this attempt waited, so its outcome row can say so.
+    var sleptBeforeAttempt: UInt64 = 0
     for attempt in 0...maxRetries {
       if attempt > 0 {
         let delay = delays[min(attempt - 1, delays.count - 1)]
+        sleptBeforeAttempt = delay
         Task {
           await AppLogger.shared.log(
             "Claude retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
@@ -393,8 +396,20 @@ public struct ClaudeConnector: TranscriptPolisher {
         try await Task.sleep(nanoseconds: delay)
       }
       do {
-        return try await operation()
+        let result = try await operation()
+        // #2641: a retry that RECOVERED is the row nothing else records.
+        if attempt > 0 {
+          LLMRetryPolicy.reportRetry(
+            keychainManager.telemetrySink, provider: .claude, retrying: lastError,
+            attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: true)
+        }
+        return result
       } catch {
+        if attempt > 0 {
+          LLMRetryPolicy.reportRetry(
+            keychainManager.telemetrySink, provider: .claude, retrying: lastError,
+            attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: false)
+        }
         lastError = error
         if !LLMRetryPolicy.isRetryable(error) { throw error }
       }

--- a/Sources/EnviousWisprLLM/GeminiConnector.swift
+++ b/Sources/EnviousWisprLLM/GeminiConnector.swift
@@ -502,9 +502,12 @@ public struct GeminiConnector: TranscriptPolisher {
     operation: () async throws -> LLMResult
   ) async throws -> LLMResult {
     var lastError: Error?
+    // #2641: what this attempt waited, so its outcome row can say so.
+    var sleptBeforeAttempt: UInt64 = 0
     for attempt in 0...maxRetries {
       if attempt > 0 {
         let delay = delays[min(attempt - 1, delays.count - 1)]
+        sleptBeforeAttempt = delay
         Task {
           await AppLogger.shared.log(
             "Gemini retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
@@ -514,8 +517,20 @@ public struct GeminiConnector: TranscriptPolisher {
         try await Task.sleep(nanoseconds: delay)
       }
       do {
-        return try await operation()
+        let result = try await operation()
+        // #2641: a retry that RECOVERED is the row nothing else records.
+        if attempt > 0 {
+          LLMRetryPolicy.reportRetry(
+            keychainManager.telemetrySink, provider: .gemini, retrying: lastError,
+            attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: true)
+        }
+        return result
       } catch {
+        if attempt > 0 {
+          LLMRetryPolicy.reportRetry(
+            keychainManager.telemetrySink, provider: .gemini, retrying: lastError,
+            attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: false)
+        }
         lastError = error
         if !LLMRetryPolicy.isRetryable(error) { throw error }
       }

--- a/Sources/EnviousWisprLLM/KeychainManager.swift
+++ b/Sources/EnviousWisprLLM/KeychainManager.swift
@@ -28,7 +28,9 @@ public struct KeychainManager: Sendable {
   /// reads it off the `keychainManager` it already receives). `internal` — module-visible
   /// to `LLMNetworkSession`, injected via the public `init` param. Defaults to `.noop`,
   /// so the ~43 test sites + the connector default-args stay silent.
-  let telemetrySink: LLMTelemetrySink
+  /// `public` so the polish step's connector factory can hand the same sink to
+  /// a connector that carries no keychain (Ollama, #2641).
+  public let telemetrySink: LLMTelemetrySink
 
   public init(telemetrySink: LLMTelemetrySink = .noop) {
     let legacyStore = FileLegacyKeyStore()

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -1,3 +1,4 @@
+import EnviousWisprCore
 import Foundation
 
 /// Shared retry infrastructure for LLM connectors.
@@ -26,6 +27,40 @@ enum LLMRetryPolicy {
   /// an accident.
   static let defaultDelays: [UInt64] = [200_000_000, 400_000_000]
   static let defaultMaxRetries = 2
+
+  /// #2641: the closed-vocabulary name of the failure a retry is answering, for
+  /// `llm.retry_completed`. A classified error names its `PolishFailureReason`;
+  /// a transport error names its `URLError` code; the legacy string-carrying
+  /// `requestFailed` is one bucket, because its message is free text and free
+  /// text is not a telemetry value.
+  static func telemetryReason(for error: Error) -> String {
+    if let llmError = error as? LLMError {
+      switch llmError {
+      case .classified(let reason): return reason.rawValue
+      case .requestFailed: return "request_failed"
+      default: return "llm_error"
+      }
+    }
+    if let urlError = error as? URLError {
+      return "url_error_\(urlError.code.rawValue)"
+    }
+    return "unknown"
+  }
+
+  /// #2641: report one retry attempt's outcome through the module's telemetry
+  /// seam. Called by every connector's retry loop AFTER the retried attempt
+  /// returns, never for attempt 0 (a first attempt is not a retry).
+  static func reportRetry(
+    _ sink: LLMTelemetrySink, provider: LLMProvider, retrying error: Error?,
+    attempt: Int, delayNanoseconds: UInt64, succeeded: Bool
+  ) {
+    sink.retryCompleted(
+      provider.rawValue,
+      error.map(telemetryReason(for:)) ?? "unknown",
+      attempt,
+      Int(delayNanoseconds / 1_000_000),
+      succeeded)
+  }
 
   /// Determine if an error is transient and worth retrying.
   static func isRetryable(_ error: Error) -> Bool {

--- a/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
+++ b/Sources/EnviousWisprLLM/LLMRetryPolicy.swift
@@ -54,12 +54,37 @@ enum LLMRetryPolicy {
     _ sink: LLMTelemetrySink, provider: LLMProvider, retrying error: Error?,
     attempt: Int, delayNanoseconds: UInt64, succeeded: Bool
   ) {
-    sink.retryCompleted(
-      provider.rawValue,
-      error.map(telemetryReason(for:)) ?? "unknown",
-      attempt,
-      Int(delayNanoseconds / 1_000_000),
-      succeeded)
+    RetryReceipt(
+      provider: provider, retrying: error, attempt: attempt, delayNanoseconds: delayNanoseconds
+    ).report(sink, succeeded: succeeded)
+  }
+
+  /// #2641: a retry whose HTTP exchange came back, awaiting the caller's verdict.
+  ///
+  /// Three connectors validate the response INSIDE the retried operation, so
+  /// "the operation returned" is "the polish succeeded". Ollama's loop returns
+  /// raw bytes and its two callers parse them differently (chat shape versus
+  /// the S1-mini generate shape, which accepts an empty answer), so a 200 with
+  /// a body the caller then rejects must not count as a recovered retry (local
+  /// review r1). The loop hands back this receipt instead of reporting, and
+  /// the caller reports once it knows.
+  struct RetryReceipt {
+    let provider: LLMProvider
+    let reason: String
+    let attempt: Int
+    let delayNanoseconds: UInt64
+
+    init(provider: LLMProvider, retrying error: Error?, attempt: Int, delayNanoseconds: UInt64) {
+      self.provider = provider
+      self.reason = error.map(LLMRetryPolicy.telemetryReason(for:)) ?? "unknown"
+      self.attempt = attempt
+      self.delayNanoseconds = delayNanoseconds
+    }
+
+    func report(_ sink: LLMTelemetrySink, succeeded: Bool) {
+      sink.retryCompleted(
+        provider.rawValue, reason, attempt, Int(delayNanoseconds / 1_000_000), succeeded)
+    }
   }
 
   /// Determine if an error is transient and worth retrying.

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -204,7 +204,12 @@ public struct OllamaConnector: TranscriptPolisher {
     // the idle ceiling for every request on the shared session, and a
     // per-request value would SHADOW it (measured; see that file).
 
-    let (data, _) = try await performWithRetry(request: request, config: config)
+    let (data, _, retryReceipt) = try await performWithRetry(request: request, config: config)
+    // #2641: the retry's verdict is the CALLER's, after validation. `accepted`
+    // flips only on the path that returns a result, so every throw below
+    // reports the retry as failed.
+    var accepted = false
+    defer { retryReceipt?.report(telemetrySink, succeeded: accepted) }
 
     let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
     guard let message = json?["message"] as? [String: Any],
@@ -226,6 +231,7 @@ public struct OllamaConnector: TranscriptPolisher {
       }
     }
 
+    accepted = true
     return LLMResult(
       polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
         .strippingLLMPreamble()
@@ -291,7 +297,11 @@ public struct OllamaConnector: TranscriptPolisher {
     // the idle ceiling for every request on the shared session, and a
     // per-request value would SHADOW it (measured; see that file).
 
-    let (data, _) = try await performWithRetry(request: request, config: config)
+    let (data, _, retryReceipt) = try await performWithRetry(request: request, config: config)
+    // #2641: the retry's verdict is the CALLER's, after validation (see the
+    // chat path above). Both accepting returns flip `accepted`.
+    var accepted = false
+    defer { retryReceipt?.report(telemetrySink, succeeded: accepted) }
 
     let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
     // `/api/generate` returns the text at the TOP LEVEL as `response`;
@@ -308,6 +318,7 @@ public struct OllamaConnector: TranscriptPolisher {
       if content.isEmpty {
         // A correct empty result: the empty-output floor keeps the user's
         // deterministic text, and no failure is recorded for a model doing its job.
+        accepted = true
         return LLMResult(polishedText: "")
       }
     } else {
@@ -347,6 +358,7 @@ public struct OllamaConnector: TranscriptPolisher {
     // Keyed off the same first-party authority the planner routes on, not a string sniff of
     // the outgoing prompt, which a user's own dictation could satisfy.
     let sentTranscriptTags = OllamaSetupService.isFirstPartyModel(config.model)
+    accepted = true
     return LLMResult(
       polishedText: content.trimmingCharacters(in: .whitespacesAndNewlines)
         .strippingLLMPreamble(stripTranscriptTags: sentTranscriptTags)
@@ -691,7 +703,7 @@ public struct OllamaConnector: TranscriptPolisher {
     config: LLMProviderConfig,
     maxRetries: Int = LLMRetryPolicy.defaultMaxRetries,
     delays: [UInt64] = LLMRetryPolicy.defaultDelays
-  ) async throws -> (Data, HTTPURLResponse) {
+  ) async throws -> (Data, HTTPURLResponse, LLMRetryPolicy.RetryReceipt?) {
     var lastError: Error?
     // #2641: what this attempt waited, so its outcome row can say so.
     var sleptBeforeAttempt: UInt64 = 0
@@ -727,13 +739,16 @@ public struct OllamaConnector: TranscriptPolisher {
 
         switch httpResponse.statusCode {
         case 200:
-          // #2641: a retry that RECOVERED is the row nothing else records.
-          if attempt > 0 {
-            LLMRetryPolicy.reportRetry(
-              telemetrySink, provider: .ollama, retrying: lastError,
-              attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: true)
-          }
-          return (data, httpResponse)
+          // #2641: a retried 200 is NOT yet a recovered retry — the caller still
+          // has to parse the body, and a 200 it rejects must count as failed.
+          // Hand back a receipt; the caller reports once it knows.
+          let receipt =
+            attempt > 0
+            ? LLMRetryPolicy.RetryReceipt(
+              provider: .ollama, retrying: lastError, attempt: attempt,
+              delayNanoseconds: sleptBeforeAttempt)
+            : nil
+          return (data, httpResponse, receipt)
         default:
           // #945: read the body INSIDE the error arm for classification (404 ->
           // model not pulled, 5xx -> server error). `data` is in hand from above.

--- a/Sources/EnviousWisprLLM/OllamaConnector.swift
+++ b/Sources/EnviousWisprLLM/OllamaConnector.swift
@@ -136,14 +136,21 @@ public struct OllamaConnector: TranscriptPolisher {
   /// non-routable host, which a deleted guard still satisfied via fast ECONNREFUSED).
   private let networkExecutor: @Sendable (URLRequest) async throws -> (Data, URLResponse)
 
+  /// #2641: Ollama carries no keychain, so the module's telemetry seam is
+  /// handed in directly. `.noop` everywhere except the polish step's connector
+  /// factory, which passes the keychain's live sink.
+  private let telemetrySink: LLMTelemetrySink
+
   public init(
     baseURL: String = "http://localhost:11434",
     networkExecutor: @Sendable @escaping (URLRequest) async throws -> (Data, URLResponse) = {
       try await LLMNetworkSession.shared.session.data(for: $0)
-    }
+    },
+    telemetrySink: LLMTelemetrySink = .noop
   ) {
     self.baseURL = baseURL
     self.networkExecutor = networkExecutor
+    self.telemetrySink = telemetrySink
   }
 
   /// NOT REACHED IN PRODUCTION, and kept only because `TranscriptPolisher` requires it
@@ -686,9 +693,12 @@ public struct OllamaConnector: TranscriptPolisher {
     delays: [UInt64] = LLMRetryPolicy.defaultDelays
   ) async throws -> (Data, HTTPURLResponse) {
     var lastError: Error?
+    // #2641: what this attempt waited, so its outcome row can say so.
+    var sleptBeforeAttempt: UInt64 = 0
     for attempt in 0...maxRetries {
       if attempt > 0 {
         let delay = delays[min(attempt - 1, delays.count - 1)]
+        sleptBeforeAttempt = delay
         Task {
           await AppLogger.shared.log(
             "Ollama retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
@@ -717,6 +727,12 @@ public struct OllamaConnector: TranscriptPolisher {
 
         switch httpResponse.statusCode {
         case 200:
+          // #2641: a retry that RECOVERED is the row nothing else records.
+          if attempt > 0 {
+            LLMRetryPolicy.reportRetry(
+              telemetrySink, provider: .ollama, retrying: lastError,
+              attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: true)
+          }
           return (data, httpResponse)
         default:
           // #945: read the body INSIDE the error arm for classification (404 ->
@@ -742,6 +758,11 @@ public struct OllamaConnector: TranscriptPolisher {
             Self.classify(statusCode: httpResponse.statusCode, bodyString: bodyString))
         }
       } catch {
+        if attempt > 0 {
+          LLMRetryPolicy.reportRetry(
+            telemetrySink, provider: .ollama, retrying: lastError,
+            attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: false)
+        }
         lastError = error
         if !LLMRetryPolicy.isRetryable(error) { throw error }
       }

--- a/Sources/EnviousWisprLLM/OpenAIConnector.swift
+++ b/Sources/EnviousWisprLLM/OpenAIConnector.swift
@@ -164,9 +164,12 @@ public struct OpenAIConnector: TranscriptPolisher {
     // request still emits its own metrics line via executeOnce.
     let callNumber = LLMNetworkSession.shared.nextCallNumber()
     var lastError: Error?
+    // #2641: what this attempt waited, so its outcome row can say so.
+    var sleptBeforeAttempt: UInt64 = 0
     for attempt in 0...maxRetries {
       if attempt > 0 {
         let delay = delays[min(attempt - 1, delays.count - 1)]
+        sleptBeforeAttempt = delay
         Task {
           await AppLogger.shared.log(
             "OpenAI retry \(attempt)/\(maxRetries) after \(delay / 1_000_000)ms (model=\(config.model))",
@@ -192,6 +195,12 @@ public struct OpenAIConnector: TranscriptPolisher {
             request: request, config: config, callNumber: callNumber)
           {
           case .success(let result):
+            // #2641: a retry that RECOVERED is the row nothing else records.
+            if attempt > 0 {
+              LLMRetryPolicy.reportRetry(
+                keychainManager.telemetrySink, provider: .openAI, retrying: lastError,
+                attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: true)
+            }
             return result
 
           case .httpFailure(let statusCode, let bodyString):
@@ -237,6 +246,11 @@ public struct OpenAIConnector: TranscriptPolisher {
           }
         }
       } catch {
+        if attempt > 0 {
+          LLMRetryPolicy.reportRetry(
+            keychainManager.telemetrySink, provider: .openAI, retrying: lastError,
+            attempt: attempt, delayNanoseconds: sleptBeforeAttempt, succeeded: false)
+        }
         lastError = error
         if !LLMRetryPolicy.isRetryable(error) { throw error }
       }

--- a/Sources/EnviousWisprPipeline/LLMPolishStep.swift
+++ b/Sources/EnviousWisprPipeline/LLMPolishStep.swift
@@ -58,7 +58,8 @@ public final class LLMPolishStep: TextProcessingStep, PolishVocabularyConsumer {
     case .openAI: OpenAIConnector(keychainManager: keychain)
     case .gemini: GeminiConnector(keychainManager: keychain)
     case .claude: ClaudeConnector(keychainManager: keychain)
-    case .ollama: OllamaConnector()
+    // #2641: Ollama has no keychain; the retry telemetry seam rides in explicitly.
+    case .ollama: OllamaConnector(telemetrySink: keychain.telemetrySink)
     // #832/#913 PR8: the on-device output-safety classifier runs ONLY on Apple
     // Intelligence output (the path where AFM can compose artifacts). Injected
     // via init — fail-open when nil (not yet prewarmed / load failed).

--- a/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
+++ b/Sources/EnviousWisprServices/LLMTelemetrySink+Live.swift
@@ -41,6 +41,17 @@ extension LLMTelemetrySink {
     TelemetryService.shared.prewarmStarted(provider: provider, model: model)
   }
 
+  package typealias RetryCompletedReporter = @MainActor (
+    _ provider: String, _ reason: String, _ attempt: Int, _ delayMs: Int, _ succeeded: Bool
+  ) -> Void
+
+  package static let defaultRetryCompletedReporter: RetryCompletedReporter = {
+    provider, reason, attempt, delayMs, succeeded in
+    TelemetryService.shared.llmRetryCompleted(
+      provider: provider, reason: reason, attempt: attempt, delayMs: delayMs,
+      succeeded: succeeded)
+  }
+
   package static let defaultHandledErrorReporter: HandledErrorReporter = {
     error, category, stage, extra, fingerprintDetail in
     SentryBreadcrumb.captureError(
@@ -58,7 +69,8 @@ extension LLMTelemetrySink {
   package static func makeLive(
     limbFailureReporter: @escaping LimbFailureReporter = defaultLimbFailureReporter,
     handledErrorReporter: @escaping HandledErrorReporter = defaultHandledErrorReporter,
-    prewarmStartedReporter: @escaping PrewarmStartedReporter = defaultPrewarmStartedReporter
+    prewarmStartedReporter: @escaping PrewarmStartedReporter = defaultPrewarmStartedReporter,
+    retryCompletedReporter: @escaping RetryCompletedReporter = defaultRetryCompletedReporter
   ) -> LLMTelemetrySink {
     LLMTelemetrySink(
       limbFailure: { limb, operation, result, errorCategory, durationMs in
@@ -88,6 +100,13 @@ extension LLMTelemetrySink {
         DispatchQueue.main.async {
           MainActor.assumeIsolated {
             prewarmStartedReporter(provider, model)
+          }
+        }
+      },
+      retryCompleted: { provider, reason, attempt, delayMs, succeeded in
+        DispatchQueue.main.async {
+          MainActor.assumeIsolated {
+            retryCompletedReporter(provider, reason, attempt, delayMs, succeeded)
           }
         }
       })

--- a/Sources/EnviousWisprServices/TelemetryService.swift
+++ b/Sources/EnviousWisprServices/TelemetryService.swift
@@ -1042,6 +1042,38 @@ public final class TelemetryService {
     PostHogSDK.shared.capture("llm.prewarm_started", properties: props)
   }
 
+  /// #2641: one transient-failure retry of a polish call finished.
+  ///
+  /// `llm.polish_failed` records FINAL failures only, so until this event a
+  /// retry that recovered left no row anywhere: 41 `rate_limited` rows in 60
+  /// days said the retries had failed, and nothing could say how many had
+  /// worked. One row per retry ATTEMPT: `provider`, `reason` (the classified
+  /// reason of the failure that triggered it, `PolishFailureReason` raw values
+  /// plus `url_error_<code>` for transport failures), `attempt` (1-based),
+  /// `delay_ms` (what was slept before it), `succeeded`. Recovery rate =
+  /// `succeeded = true` over all rows, per `provider` and `reason`. Metadata
+  /// only, never content or key material.
+  public func llmRetryCompleted(
+    provider: String, reason: String, attempt: Int, delayMs: Int, succeeded: Bool
+  ) {
+    let props: [String: Any] = [
+      "provider": provider,
+      "reason": reason,
+      "attempt": attempt,
+      "delay_ms": delayMs,
+      "succeeded": succeeded,
+    ]
+    #if DEBUG
+      testEventHook?(
+        CapturedTelemetryEvent(
+          name: "llm.retry_completed",
+          stringProps: ["provider": provider, "reason": reason],
+          intProps: ["attempt": attempt, "delay_ms": delayMs],
+          boolProps: ["succeeded": succeeded]))
+    #endif
+    PostHogSDK.shared.capture("llm.retry_completed", properties: props)
+  }
+
   /// #1408: the microphone died (or the duration cap fired) while a recording was
   /// in flight. Fires on EVERY such interruption that reaches a recording exit —
   /// salvaged or not — so `dictation.completed`'s salvage count has a denominator.

--- a/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
+++ b/Tests/EnviousWisprTests/LLM/KeychainManagerTests.swift
@@ -15,7 +15,8 @@ private final class CleanupSinkSpy: @unchecked Sendable {
       limbFailure: { _, _, _, _, _ in },
       legacyKeyCleanupFailed: { _, account in self.lock.withLock { self._accounts.append(account) }
       },
-      prewarmStarted: { _, _ in })
+      prewarmStarted: { _, _ in },
+      retryCompleted: { _, _, _, _, _ in })
   }
 }
 

--- a/Tests/EnviousWisprTests/LLM/LLMRetryTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMRetryTelemetryTests.swift
@@ -169,6 +169,80 @@ struct LLMRetryTelemetryTests {
     #expect(spy.reported.isEmpty)
   }
 
+  @Test("Ollama's loop reports through the sink handed to its initializer (no keychain)")
+  func ollamaReportsThroughItsOwnSink() async throws {
+    // Ollama carries no keychain, so the seam rides in at init; the polish
+    // step's factory passes the keychain's live sink. A 500 then a 200.
+    let spy = RetrySpy()
+    let responses = OSAllocatedUnfairLock(initialState: [
+      (Data(#"{"error": "overloaded"}"#.utf8), 500),
+      (Data(#"{"message": {"content": "Polished."}}"#.utf8), 200),
+    ])
+    let connector = OllamaConnector(
+      networkExecutor: { request in
+        await Task.yield()
+        let (body, code) = responses.withLock { $0.removeFirst() }
+        return (
+          body,
+          HTTPURLResponse(
+            url: request.url!, statusCode: code, httpVersion: nil, headerFields: nil)!
+        )
+      },
+      telemetrySink: spy.makeSink())
+    let config = LLMProviderConfig(
+      model: "gemma4:latest", apiKeyKeychainId: nil, outputTokens: .capped(128),
+      temperature: 0.3, thinking: nil)
+
+    let result = try await connector.polish(
+      text: "hello", instructions: PolishInstructions(systemPrompt: "sys"), config: config,
+      onToken: nil)
+
+    #expect(result.polishedText == "Polished.")
+    #expect(
+      spy.reported == [
+        Reported(
+          provider: "ollama", reason: PolishFailureReason.providerServerError.rawValue,
+          attempt: 1, delayMs: 200, succeeded: true)
+      ], "\(spy.reported)")
+  }
+
+  @Test("an Ollama retry that returns a 200 the caller rejects is reported as FAILED")
+  func ollamaRejectedRetryBodyIsFailed() async {
+    // Local review r1: Ollama's loop returns raw bytes and the caller parses
+    // them, so a 200 with an empty answer must not count as a recovered retry.
+    let spy = RetrySpy()
+    let responses = OSAllocatedUnfairLock(initialState: [
+      (Data(#"{"error": "overloaded"}"#.utf8), 500),
+      (Data(#"{"message": {"content": ""}}"#.utf8), 200),
+    ])
+    let connector = OllamaConnector(
+      networkExecutor: { request in
+        await Task.yield()
+        let (body, code) = responses.withLock { $0.removeFirst() }
+        return (
+          body,
+          HTTPURLResponse(
+            url: request.url!, statusCode: code, httpVersion: nil, headerFields: nil)!
+        )
+      },
+      telemetrySink: spy.makeSink())
+    let config = LLMProviderConfig(
+      model: "gemma4:latest", apiKeyKeychainId: nil, outputTokens: .capped(128),
+      temperature: 0.3, thinking: nil)
+
+    await #expect(throws: LLMError.self) {
+      _ = try await connector.polish(
+        text: "hello", instructions: PolishInstructions(systemPrompt: "sys"), config: config,
+        onToken: nil)
+    }
+    #expect(
+      spy.reported == [
+        Reported(
+          provider: "ollama", reason: PolishFailureReason.providerServerError.rawValue,
+          attempt: 1, delayMs: 200, succeeded: false)
+      ], "the retried exchange came back, the polish still failed: \(spy.reported)")
+  }
+
   @Test("the reason vocabulary is closed: classified reasons, URL error codes, one legacy bucket")
   func telemetryReasonVocabulary() {
     #expect(

--- a/Tests/EnviousWisprTests/LLM/LLMRetryTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/LLMRetryTelemetryTests.swift
@@ -1,0 +1,266 @@
+import EnviousWisprCore
+import EnviousWisprServices
+import Foundation
+import Testing
+import os
+
+@testable import EnviousWisprLLM
+
+/// #2641: every transient-failure retry reports its OUTCOME.
+///
+/// **When this fails, a dashboard lies, not the user's text:** `llm.polish_failed`
+/// records only final failures, so a retry that recovered left no row anywhere
+/// and nobody could say whether the 200 ms / 400 ms backoff rescues a
+/// rate-limited or 5xx call. Without this event the next tuning of the backoff
+/// is a guess again. Observability contract, not product coverage.
+@Suite(.tags(.observabilityContract))
+struct LLMRetryTelemetryTests {
+
+  /// One reported retry attempt, as the sink saw it.
+  private struct Reported: Equatable {
+    let provider: String
+    let reason: String
+    let attempt: Int
+    let delayMs: Int
+    let succeeded: Bool
+  }
+
+  private final class RetrySpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [Reported] = []
+    var reported: [Reported] { lock.withLock { stored } }
+    func makeSink() -> LLMTelemetrySink {
+      LLMTelemetrySink(
+        limbFailure: { _, _, _, _, _ in },
+        legacyKeyCleanupFailed: { _, _ in },
+        prewarmStarted: { _, _ in },
+        retryCompleted: { provider, reason, attempt, delayMs, succeeded in
+          self.lock.withLock {
+            self.stored.append(
+              Reported(
+                provider: provider, reason: reason, attempt: attempt, delayMs: delayMs,
+                succeeded: succeeded))
+          }
+        })
+    }
+  }
+
+  private struct PopulatedKeyStore: LegacyKeyFileStorage {
+    func store(key: String, value: String) throws {}
+    func retrieve(key: String) throws -> String { "sk-test-not-a-real-key" }
+    func delete(key: String) throws {}
+  }
+
+  /// Scripted executor: pops one response per physical request. The yield
+  /// before returning satisfies swift-patterns RULE:
+  /// fake-executor-must-yield-before-throw.
+  private final class ScriptedTransport: Sendable {
+    private let state: OSAllocatedUnfairLock<[(Data, HTTPURLResponse)]>
+    init(script: [(Data, HTTPURLResponse)]) {
+      state = OSAllocatedUnfairLock(initialState: script)
+    }
+    func executor() -> OpenAIConnector.RequestExecutor {
+      { _, _ in
+        await Task.yield()
+        return try self.state.withLock { script in
+          guard !script.isEmpty else { throw URLError(.badServerResponse) }
+          return script.removeFirst()
+        }
+      }
+    }
+  }
+
+  private static let endpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
+  private static func response(_ code: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: endpoint, statusCode: code, httpVersion: nil, headerFields: nil)!
+  }
+  private static let successBody = Data(
+    #"{"choices": [{"message": {"content": "Polished."}, "finish_reason": "stop"}]}"#.utf8)
+  private static let serverErrorBody = Data(#"{"error": {"message": "overloaded"}}"#.utf8)
+
+  private func connector(_ transport: ScriptedTransport, spy: RetrySpy) -> OpenAIConnector {
+    OpenAIConnector(
+      keychainManager: KeychainManager(
+        backend: .legacyFiles, legacyStore: PopulatedKeyStore(), telemetrySink: spy.makeSink()),
+      requestExecutor: transport.executor())
+  }
+
+  private func config(model: String) -> LLMProviderConfig {
+    LLMProviderConfig(
+      model: model, apiKeyKeychainId: "openai-api-key", outputTokens: .capped(512),
+      temperature: 0, thinking: nil)
+  }
+
+  @Test("a 5xx followed by a 200 reports one retry that SUCCEEDED, with its reason and delay")
+  func recoveredRetryIsReported() async throws {
+    let spy = RetrySpy()
+    let transport = ScriptedTransport(script: [
+      (Self.serverErrorBody, Self.response(503)),
+      (Self.successBody, Self.response(200)),
+    ])
+
+    let result = try await connector(transport, spy: spy).polish(
+      text: "hello", instructions: .default, config: config(model: "gpt-4o-retry-a"),
+      onToken: nil)
+
+    #expect(result.polishedText == "Polished.")
+    #expect(
+      spy.reported == [
+        Reported(
+          provider: "openAI", reason: PolishFailureReason.providerServerError.rawValue,
+          attempt: 1, delayMs: 200, succeeded: true)
+      ],
+      "exactly one retry row, for the attempt that recovered: \(spy.reported)")
+  }
+
+  @Test("every retry that fails is reported, with the delay each one waited")
+  func exhaustedRetriesAreEachReported() async {
+    let spy = RetrySpy()
+    let transport = ScriptedTransport(script: [
+      (Self.serverErrorBody, Self.response(503)),
+      (Self.serverErrorBody, Self.response(503)),
+      (Self.serverErrorBody, Self.response(503)),
+    ])
+
+    do {
+      _ = try await connector(transport, spy: spy).polish(
+        text: "hello", instructions: .default, config: config(model: "gpt-4o-retry-b"),
+        onToken: nil)
+      Issue.record("three 5xx responses must exhaust the retries")
+    } catch let LLMError.classified(reason) {
+      #expect(reason == .providerServerError)
+    } catch {
+      Issue.record("unexpected error: \(error)")
+    }
+    let reason = PolishFailureReason.providerServerError.rawValue
+    #expect(
+      spy.reported == [
+        Reported(provider: "openAI", reason: reason, attempt: 1, delayMs: 200, succeeded: false),
+        Reported(provider: "openAI", reason: reason, attempt: 2, delayMs: 400, succeeded: false),
+      ],
+      "two retries, both failed, 200 ms then 400 ms: \(spy.reported)")
+  }
+
+  @Test("a first attempt that fails for a non-retryable reason reports nothing")
+  func nonRetryableFailureReportsNoRetry() async {
+    // The two-way control: a first attempt is not a retry, and a fail-fast
+    // reason never reaches the retry loop's second pass.
+    let spy = RetrySpy()
+    let transport = ScriptedTransport(script: [
+      (Data(#"{"error": {"message": "Incorrect API key"}}"#.utf8), Self.response(401))
+    ])
+
+    _ = try? await connector(transport, spy: spy).polish(
+      text: "hello", instructions: .default, config: config(model: "gpt-4o-retry-c"),
+      onToken: nil)
+
+    #expect(spy.reported.isEmpty, "no retry ran, so no retry row: \(spy.reported)")
+  }
+
+  @Test("a first attempt that succeeds reports nothing")
+  func firstAttemptSuccessReportsNoRetry() async throws {
+    let spy = RetrySpy()
+    let transport = ScriptedTransport(script: [(Self.successBody, Self.response(200))])
+
+    _ = try await connector(transport, spy: spy).polish(
+      text: "hello", instructions: .default, config: config(model: "gpt-4o-retry-d"),
+      onToken: nil)
+
+    #expect(spy.reported.isEmpty)
+  }
+
+  @Test("the reason vocabulary is closed: classified reasons, URL error codes, one legacy bucket")
+  func telemetryReasonVocabulary() {
+    #expect(
+      LLMRetryPolicy.telemetryReason(for: LLMError.classified(.rateLimited))
+        == PolishFailureReason.rateLimited.rawValue)
+    #expect(
+      LLMRetryPolicy.telemetryReason(for: URLError(.timedOut))
+        == "url_error_\(URLError.Code.timedOut.rawValue)")
+    #expect(
+      LLMRetryPolicy.telemetryReason(for: LLMError.requestFailed("server error 502: free text"))
+        == "request_failed",
+      "the legacy message is free text, and free text is not a telemetry value")
+    struct Opaque: Error {}
+    #expect(LLMRetryPolicy.telemetryReason(for: Opaque()) == "unknown")
+  }
+
+  @Test("the live factory routes retryCompleted to its reporter with every field")
+  func liveFactoryRoutesToTheReporter() async throws {
+    // The live mapping is the only wiring between the connectors and PostHog; a
+    // spy sink cannot prove it exists. The reporter is injected so the test has
+    // no dependency on the process-wide test hook.
+    let box = ReportedBox()
+    let sink = LLMTelemetrySink.makeLive(retryCompletedReporter: {
+      provider, reason, attempt, delayMs, succeeded in
+      box.record(
+        Reported(
+          provider: provider, reason: reason, attempt: attempt, delayMs: delayMs,
+          succeeded: succeeded))
+    })
+
+    sink.retryCompleted("claude", "rate_limited", 2, 400, true)
+
+    let reported = try await box.awaitFirst()
+    #expect(
+      reported
+        == Reported(
+          provider: "claude", reason: "rate_limited", attempt: 2, delayMs: 400, succeeded: true))
+  }
+
+  #if DEBUG
+    @Test("the default reporter emits llm.retry_completed with every field")
+    @MainActor
+    func defaultReporterEmitsTheEvent() throws {
+      // Synchronous: install the hook, emit, read, uninstall, with no suspension
+      // point for another suite to clobber the process-wide hook in.
+      let waiter = TelemetryEventWaiter()
+      TelemetryService.shared.testEventHook = { @Sendable event in
+        MainActor.assumeIsolated { waiter.record(event) }
+      }
+      defer { TelemetryService.shared.testEventHook = nil }
+
+      LLMTelemetrySink.defaultRetryCompletedReporter(
+        "gemini", "provider_server_error", 1, 200, false)
+
+      let event = try #require(waiter.events.first { $0.name == "llm.retry_completed" })
+      #expect(event.stringProps["provider"] == "gemini")
+      #expect(event.stringProps["reason"] == "provider_server_error")
+      #expect(event.intProps["attempt"] == 1)
+      #expect(event.intProps["delay_ms"] == 200)
+      #expect(event.boolProps["succeeded"] == false)
+    }
+  #endif
+
+  /// Resolves once the live factory's main-queue hop has delivered a row, or
+  /// fails fast after a deadline (swift-patterns.md
+  /// `tests-no-unconditional-continuation-await`).
+  @MainActor
+  private final class ReportedBox {
+    private var rows: [Reported] = []
+    private var waiter: CheckedContinuation<Reported, Error>?
+    struct Timeout: Error {}
+
+    func record(_ row: Reported) {
+      rows.append(row)
+      if let waiter {
+        self.waiter = nil
+        waiter.resume(returning: row)
+      }
+    }
+
+    func awaitFirst(timeout: Duration = .seconds(5)) async throws -> Reported {
+      if let first = rows.first { return first }
+      return try await withCheckedThrowingContinuation { continuation in
+        waiter = continuation
+        Task { @MainActor in
+          try? await Task.sleep(for: timeout)  // deadline-fallback: bounds the signal wait
+          if let waiter = self.waiter {
+            self.waiter = nil
+            waiter.resume(throwing: Timeout())
+          }
+        }
+      }
+    }
+  }
+}

--- a/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
+++ b/Tests/EnviousWisprTests/LLM/Phase8LimbTelemetryTests.swift
@@ -23,7 +23,8 @@ import Testing
         // #2093: this spy does not assert pre-warm counting; that lives in
         // LLMWarmupGateTests. Required rather than defaulted at the type so a
         // production factory cannot silently forget to wire it.
-        prewarmStarted: { _, _ in })
+        prewarmStarted: { _, _ in },
+        retryCompleted: { _, _, _, _, _ in })
     }
   }
 


### PR DESCRIPTION
## Summary

`llm.polish_failed` records only FINAL failures, so a retry that recovered left no row anywhere. Nobody could say whether the 200 ms / 400 ms backoff (#2093) ever rescues a rate-limited or 5xx call: 41 `rate_limited` rows in 60 days said some retries had failed, and nothing could say how many had worked. That is #2641's item 1; item 2 (the unreachable `.rateLimited` arm) had already shipped.

Closes #2641.

`Tier: SMALL | Test: required (LLM, Services) | Modules: Core, LLM, Services, Pipeline`
`Lane: Code`

## What ships

**One row per retry ATTEMPT, `llm.retry_completed`**, emitted after that attempt returns, from all four connectors' retry loops through the module's existing telemetry seam:

| property | meaning |
|---|---|
| `provider` | `openAI` / `claude` / `gemini` / `ollama` |
| `reason` | the classified reason of the failure that TRIGGERED the retry: `PolishFailureReason` raw values (`provider_server_error`, `rate_limited`), `url_error_<code>` for transport failures, `request_failed` for the legacy free-text error |
| `attempt` | 1-based; the first retry is 1 |
| `delay_ms` | what was slept before it (200 then 400 under `LLMRetryPolicy.defaultDelays`) |
| `succeeded` | the point of the event: whether the retried polish produced a usable result |

A first attempt is never a row, and fail-fast reasons never retry, so Gemini `rate_or_quota` produces no rows by design. Recovery rate = `succeeded = true` ÷ all rows, per `provider` × `reason`.

**How:** `LLMTelemetrySink` gains `retryCompleted` (required in the init, like `prewarmStarted`, so a live factory cannot forget it); the live factory maps it to `TelemetryService.llmRetryCompleted`. `LLMRetryPolicy.reportRetry` and `RetryReceipt` own the call and `telemetryReason(for:)` owns the closed vocabulary, so the four loops cannot drift. Ollama carries no keychain, so its connector takes the sink at init and the polish step's factory hands it the keychain's live one; `KeychainManager.telemetrySink` is now `public` for that one caller.

**Ollama's verdict waits for validation (local review r1).** Ollama's loop returns raw bytes and its two callers parse them, so a retried 200 with an empty answer must not count as recovered. The loop hands back a `RetryReceipt`; each caller reports it in a `defer` keyed on an `accepted` flag that flips only on the paths that return a result. The other three connectors validate inside the retried operation already.

**Not done here, deliberately:** preserving provider `Retry-After` timing and retrying only when it fits the remaining budget. The issue orders that AFTER recovered-retry data exists; this is the instrument that produces it.

## Evidence

- `LLMRetryTelemetryTests` (observability contract), **9/9** against scripted transports: a 503 then 200 reports one row (`provider_server_error`, attempt 1, 200 ms, succeeded); three 503s report two failed rows at 200 then 400 ms; a fail-fast 401 and a first-attempt success report nothing (the two-way controls); Ollama reports through its own sink; an Ollama retried 200 the caller rejects reports FAILED; the reason vocabulary; the live factory routes to its reporter; the default reporter emits the event synchronously through the test hook.
- Neighbouring suites green: `Phase8LimbTelemetryTests` 7, `KeychainManagerTests` 21, `LLMTelemetrySinkLiveTests` 2, `OpenAIParamStripTests` 19, `LLMRetryPolicyTests` 14, `OllamaReadinessGateTests` 23, `TestInventoryFreezeTests` 23 (the new suite is tagged).
- Local Codex `review --base origin/main`: r1 one P2 (the Ollama verdict, fixed as above), r2 clean.
- Parent-red is not available: the tests depend on the seam this change introduces. Binding is filed as a test-hardening recipe (linked below) for the night battery.
- `analytics-operations.md` FACT: app-posthog-events carries the new row (gitignored, edited in the main checkout).

## Pre-Merge Checklist

- [x] Suites green, two local Codex rounds ending clean.
- [x] No-slot dev build (`EnviousWispr-Dev` into the worktree's `.derivedData/Dev`) succeeded for the push gate.
- [x] Self-review grep over `retryCompleted`, `reportRetry`, `telemetryReason`, `LLMTelemetrySink(` across `Sources/ Tests/ scripts/eval/`: four construction sites, all updated; the eval packages construct neither the sink nor `OllamaConnector`.
- [ ] CI `build-check` — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
