### PR TITLE
test(asr): the occupancy waiter test is bounded, so a mutant fails instead of parking the lane (#2793)

### DIFF
--- a/Tests/EnviousWisprASRTests/VendorDecodeOccupancyTests.swift
+++ b/Tests/EnviousWisprASRTests/VendorDecodeOccupancyTests.swift
@@ -145,9 +145,22 @@ struct VendorDecodeOccupancyTests {
     #expect(resumed.names.isEmpty, "a cancelled waiter is not a returned decode")
     gate.open()
     _ = await sessionWait.value
-    _ = await waiterA.value
-    _ = await waiterB.value
-    #expect(resumed.names.sorted() == ["a", "b"])
+    // BOUNDED. `awaitIdle` resumes only when the count reaches zero, so a
+    // subject that never counts a decode down parks both waiters forever, and
+    // an unbounded `await waiterA.value` parked the whole lane with them: the
+    // #2793 battery's first row timed out at 30 minutes instead of failing
+    // (2026-09-13). The waiters are observed through `resumed` under a deadline,
+    // so that mutant now FAILS the assertion below in seconds. Both waiters are
+    // cancelled at the end so a parked one cannot outlive the test.
+    let deadline = ContinuousClock.now + .seconds(5)
+    while resumed.names.count < 2, ContinuousClock.now < deadline {
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+    waiterA.cancel()
+    waiterB.cancel()
+    #expect(
+      resumed.names.sorted() == ["a", "b"],
+      "both waiters must resume once the decode returns, got \(resumed.names)")
     #expect(occupancy.isIdle)
   }
 


### PR DESCRIPTION
## Summary

The overnight mutation battery of 2026-09-13 ran the five runnable filed recipes (#2793, #2797, #2802, #2804, #2813) plus one own mutant per suite. One row could not be scored: row 1 of #2793 ("occupancy never counts down") parked the lane for the 30-minute cap instead of failing, because `awaitIdleWaitsForTheVendorCallNotTheWaiter` awaited two waiters that, under that mutant, never resume. This PR is that one test fix; everything else the battery found is recorded on the issues.

Part of #2793.

`Tier: SMALL | Test: this IS the test | Modules: Tests`
`Lane: Code`

## The change

The waiters are observed through the suite's own `resumed` recorder under a five-second deadline, then cancelled so a parked one cannot outlive the test, and the assertion carries what was seen. The test's meaning is unchanged: both waiters must resume once the decode returns.

## Evidence

- Re-run through `scripts/mutation-battery.py --from-issue 2793 --row 1`: baseline 8/8 green, row 1 **CAUGHT** in seconds, baseline 8/8 green after the restore.
- The full battery results, filed on the issues: #2793 8/8 (after this fix), #2802 2/2, #2804 2/2, #2813 5/5, #2797 5/5 with row 1 re-pointed (its anchor literal became `modernPromptMajorVersionFloor` in #2836; filed separately per the frozen-recipe rule). Own mutants: 13/13 CAUGHT across the thirteen suites.

## Pre-Merge Checklist

- [x] Battery row and suite green, restore verified byte-identical by the runner.
- [x] Self-review grep over the suite's `await ...value` sites: the remaining ones await tasks whose operation returns when its gate opens, independent of the count.
- [ ] Dev build — N/A, no `Sources/` touched.
- [ ] CI `build-check` — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
