### PR TITLE
perf(itn): restore register-preserved spans in one pass, not one scan per span (#2759)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
+++ b/Sources/EnviousWisprPostProcessing/InverseTextNormalizer.swift
@@ -604,10 +604,7 @@ public struct InverseTextNormalizer: Sendable {
     t = applyPunct(t, spokenPunctuation: spokenPunctuation)
 
     // restore register-preserved spans verbatim
-    for (i, p) in protected.enumerated() {
-      t = t.replacingOccurrences(
-        of: "\u{0}\(i)\u{0}", with: p.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
+    t = Self.restoreProtectedSpans(t, protected)
     t = reSub(#"\s+([,.!?;:])"#, t, caseInsensitive: false) { m in m.g(1) }
     t = reSub(#"([(\[“‘])\s+"#, t, caseInsensitive: false) { m in m.g(1) }  // open quote/bracket tight
     t = reSub(#"\s+([)\]”’])"#, t, caseInsensitive: false) { m in m.g(1) }  // space before close tight
@@ -1292,6 +1289,28 @@ public struct InverseTextNormalizer: Sendable {
   /// nearest whitespace. Only strippable punctuation means there genuinely is no neighbour —
   /// that is `(one B two C)`, which must still convert. A letter or digit means something is
   /// glued to this match and the run cannot be read, so refuse.
+  /// Put every register-preserved span back in ONE left-to-right pass (#2759).
+  ///
+  /// The sentinel is `\u{0}<index>\u{0}`, minted by `normalize`'s `protect` closures. The
+  /// previous shape was one `replacingOccurrences` per span, a full scan and copy of the text
+  /// for each idiom the take contains, so a take that repeats "quarter past four" paid
+  /// O(text x spans) inside the same 0.5 s budget #2758 already had to defend. One regex pass
+  /// visits each character once whatever the span count.
+  ///
+  /// Same result as the loop by construction: a span's text comes from the ORIGINAL take,
+  /// where `\w+` and the idiom literals cannot match across a NUL, so no restored span can
+  /// itself contain a sentinel for the loop to have found on a later iteration. An index the
+  /// take carries by accident that names no span (`\u{0}9\u{0}` with two spans) is left as
+  /// it was, which is also what the loop did. `InverseTextNormalizerSpanRestoreTests` pins both.
+  static func restoreProtectedSpans(_ text: String, _ protected: [String]) -> String {
+    guard !protected.isEmpty else { return text }
+    return reSub("\u{0}([0-9]+)\u{0}", text, caseInsensitive: false) { m in
+      guard let digits = m.g(1), let index = Int(digits), protected.indices.contains(index)
+      else { return nil }
+      return protected[index].trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+  }
+
   static let unreadableToken = "\u{0}unreadable"
 
   /// The Unicode White_Space property, written out so the Python oracle carries the SAME literal

--- a/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerSpanRestoreTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/InverseTextNormalizerSpanRestoreTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import EnviousWisprPostProcessing
+
+/// Register-preserved spans are put back in ONE pass, and that pass decides exactly what the
+/// per-span loop it replaced decided (#2759).
+///
+/// Why this exists: `normalize` shields idioms like "quarter past four" behind a
+/// `\u{0}<index>\u{0}` sentinel, and used to restore them with one `replacingOccurrences` per
+/// span, a full scan of the take per idiom. A take that repeats an idiom paid O(text x spans)
+/// inside the same 0.5 s budget #2758 already defends. The single pass is the fix; these rows
+/// pin that it restores every span verbatim and leaves alone the one shape where a loop and a
+/// pass could differ.
+///
+/// Drift guard: a slow restoration still produces the right text, so nothing here is safety
+/// for the user. The product claim (the idioms survive) is `everySpanSurvivesALongTake`.
+@Suite("ITN protected spans are restored in one pass (#2759)", .tags(.driftGuard))
+struct InverseTextNormalizerSpanRestoreTests {
+
+  /// The loop this replaced, kept here as the ORACLE the pass must agree with.
+  private static func loopRestore(_ text: String, _ protected: [String]) -> String {
+    var t = text
+    for (i, p) in protected.enumerated() {
+      t = t.replacingOccurrences(
+        of: "\u{0}\(i)\u{0}", with: p.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return t
+  }
+
+  private static func sentinel(_ i: Int) -> String { "\u{0}\(i)\u{0}" }
+
+  @Test(
+    "the pass agrees with the loop on every shape the sentinel can take",
+    arguments: [
+      // (text with sentinels, protected spans)
+      (" a \u{0}0\u{0} b ", ["quarter past four"]),
+      (" \u{0}0\u{0} \u{0}1\u{0} ", ["quarter past four", " eleventh hour "]),
+      // out of order, and a span used twice
+      (" \u{0}1\u{0} then \u{0}0\u{0} then \u{0}1\u{0} ", ["half past ten", "seventh heaven"]),
+      // an index that names no span stays as it was, in both
+      (" \u{0}9\u{0} and \u{0}0\u{0} ", ["the fourth wall"]),
+      // a bare NUL, a NUL with letters, and a sentinel with no digits are not sentinels
+      (" \u{0} \u{0}x\u{0} \u{0}\u{0} \u{0}0\u{0} ", ["first among equals"]),
+      // ten or more spans: the index has two digits and must not be read as two sentinels
+      (
+        (0..<12).map { " \u{0}\($0)\u{0}" }.joined() + " ",
+        (0..<12).map { "quarter to \($0)" }
+      ),
+      // no spans at all: nothing to restore, text untouched
+      (" nothing here \u{0}0\u{0} ", []),
+      ("", ["quarter past four"]),
+    ] as [(text: String, spans: [String])])
+  func passAgreesWithLoop(text: String, spans: [String]) {
+    #expect(
+      InverseTextNormalizer.restoreProtectedSpans(text, spans) == Self.loopRestore(text, spans),
+      "the single pass must decide exactly what the loop decided")
+  }
+
+  /// The product claim: a long take that repeats an idiom gets every copy back verbatim, and
+  /// no sentinel leaks into the text the user sees.
+  @Test("every span survives a long take, and no sentinel leaks")
+  func everySpanSurvivesALongTake() {
+    let idiom = "quarter past four"
+    let take = (0..<300).map { "at \(idiom) on day \($0 + 1)" }.joined(separator: ", ") + "."
+    let out = InverseTextNormalizer().normalize(take)
+    #expect(!out.contains("\u{0}"), "a sentinel reached the output")
+    #expect(
+      out.components(separatedBy: idiom).count - 1 == 300,
+      "every one of 300 protected idioms must come back spelled")
+  }
+
+  /// The pass is one regex visit over the text, so a span count that grows ten-fold must not
+  /// grow the work ten-fold. Asserted as a RELATION between two runs in the same process,
+  /// never as an absolute number (validation-discipline: a local performance number is a
+  /// measurement of the machine).
+  @Test("restoring ten times the spans costs far less than ten times the time")
+  func costDoesNotTrackSpanCount() {
+    func build(_ n: Int) -> (String, [String]) {
+      let spans = (0..<n).map { "quarter past \($0)" }
+      let text =
+        " " + (0..<n).map { "filler words here \u{0}\($0)\u{0}" }.joined(separator: " ") + " "
+      return (text, spans)
+    }
+    func time(_ n: Int) -> Double {
+      let (text, spans) = build(n)
+      var best = Double.infinity
+      for _ in 0..<5 {
+        let start = DispatchTime.now().uptimeNanoseconds
+        _ = InverseTextNormalizer.restoreProtectedSpans(text, spans)
+        best = min(best, Double(DispatchTime.now().uptimeNanoseconds - start))
+      }
+      return best
+    }
+    _ = time(200)  // warm the regex cache
+    let small = time(200)
+    let large = time(2000)
+    // Linear would be ~10x; the loop was ~100x. Generous bound so contention cannot fail it.
+    #expect(
+      large < small * 40,
+      "2000 spans took \(large / 1e6) ms against \(small / 1e6) ms for 200: not one pass")
+  }
+}


### PR DESCRIPTION
## Summary

`normalize` shields idioms ("quarter past four", "eleventh hour") behind a `\u{0}<index>\u{0}` sentinel and put them back with one `replacingOccurrences` per span: a full scan and copy of the take for every idiom it contains, so a take that repeats an idiom paid O(text x spans) inside the 0.5 s deadline #2758 already had to defend. This is #2759's site 1. Sites 2 and 3 (`SnippetExpander`, `EmojiRestorer`) are diagnosis only on that issue and are untouched; the issue stays open for them.

Part of #2759.

`Tier: SMALL | Test: required (PostProcessing) | Modules: PostProcessing`
`Lane: Code`

## The change

`restoreProtectedSpans` visits the text once with one regex and substitutes each sentinel from the span table. Same result as the loop by construction: a span's text comes from the ORIGINAL take, where `\w+` and the idiom literals cannot match across a NUL, so no restored span can itself contain a sentinel for the loop to have found on a later iteration; an index the take carries by accident that names no span is left as it was, which is also what the loop did.

## Measured

Best of five, `swiftc -O`, both shapes on the same input, this machine (M5 Max; the relation is the claim, not the absolute):

| spans | take | loop | single pass |
|---|---|---|---|
| 200 | 4.7 KB | 3.7 ms | 0.1 ms |
| 2,000 | 49 KB (the #2770 timeout's shape) | 361 ms | 0.6 ms |

## Evidence

- `InverseTextNormalizerSpanRestoreTests` (drift guard), 3/3: the pass agrees with the loop, kept in the test as the oracle, over eight sentinel shapes (an index naming no span, a bare NUL, two-digit indexes, a span used twice, an empty span table, empty text); 300 repeated idioms in one take all come back spelled with no sentinel leaking; ten times the spans cost far less than ten times the time, asserted as a relation between two runs in one process with a 40x bound, never an absolute.
- Neighbouring suites green: parity 8/8, neighbour window 8/8, long take 4/4, dotted email 11/11, country TLD 4/4.
- Local Codex `review --base origin/main`: "No actionable bugs found."
- Parent-red is not available (the cases call the function the change introduced); binding is filed as test-hardening #2865, 4/4 rows validated against this branch.

## Pre-Merge Checklist

- [x] Suites green, local Codex clean, no-slot dev build succeeded for the push gate.
- [x] Self-review grep over `restoreProtectedSpans` and every `replacingOccurrences(` left in the normalizer: the remaining ones are single fixed-string replacements, not per-item loops over the text.
- [ ] CI `build-check` — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
