### PR TITLE
ci(pr-check): a PR adding over 100 test lines must name a recipe that validates against it (#2868)

### DIFF
--- a/.github/CI-GOVERNANCE.md
+++ b/.github/CI-GOVERNANCE.md
@@ -30,9 +30,12 @@ Actions updates are grouped into a single PR per week to reduce noise.
 requires exactly one status check:
 
 - `build-check` — the required aggregate gate (from `pr-check.yml`). It depends on
-  two parallel macOS lanes and is green only when both pass:
+  three macOS lanes and three Ubuntu lanes and is green only when all six pass:
   - `build-debug` — debug build, XPC error hygiene, debug-config logic tests
   - `build-release` — release build, FoundationModels compile probe
+  - plus `eval-packages`, `worker-tests`, `website-check`, and `recipe-check` (#2868: a PR adding
+    more than 100 lines under `Tests/` must carry one `Recipe:` line the job can accept; see
+    `scripts/ci/check-test-recipe.py`)
 - Restrict deletions and block force pushes enabled
 
 `ci-drift-check.yml` is NOT a required PR check — it runs weekly (Monday noon UTC)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,15 @@
 
 -
 
+## Recipe
+<!-- Required when this PR adds more than 100 lines under Tests/ (the recipe-check job fails otherwise).
+     Exactly ONE line, one of:
+       Recipe: #<N>                     a test-hardening issue whose recipe validates against this PR
+       Recipe: parent-red <TestName>    the new test ran RED on the parent commit for the bug's reason
+       Recipe: resource-control <Test>  a two-way control on a non-Swift resource, in this PR
+     Under the floor, delete this section. -->
+Recipe:
+
 ## Pre-Merge Checklist
 
 ### Build Verification

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -537,6 +537,41 @@ jobs:
         run: npm run check:help
 
 
+  # A PR adding more than a floor of test lines must name how those tests are
+  # bound (#2868): a `Recipe: #N` whose recipe VALIDATES against this PR's head,
+  # or one of the two substitutes testing-philosophy.md's ship condition names.
+  # Measured 2026-09-13: 8 of 18 such PRs since 2026-09-10 carried none. Runs
+  # on every PR (the count decides whether anything more is asked) and needs no
+  # Xcode. The body is read live with gh rather than from the event payload, so
+  # a body edited after the push is what the check sees on a re-run; an edit
+  # alone does not re-trigger (pull_request `edited` would cancel the macOS
+  # lanes for a typo fix), the failure message says to re-run the job or push.
+  recipe-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # The count is a three-dot diff against the PR base; a shallow clone
+          # cannot resolve it. Same reason as the build lanes.
+          fetch-depth: 0
+
+      - name: Test ship condition (recipe named and runnable against this PR)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check-test-recipe.py --self-test
+          python3 scripts/ci/check-test-recipe.py --base "$BASE_SHA" --head "$HEAD_SHA" --pr "$PR_NUMBER" --checkout "$PWD"
+
   # Required aggregate gate. This is the ONLY required status check on main
   # (ruleset main-protection, context "build-check"); keeping the job id
   # "build-check" preserves that context so no ruleset change is needed (#906).
@@ -544,7 +579,7 @@ jobs:
   # fail closed), but is skipped when the whole run is cancelled (a superseded
   # push) so the obsolete SHA shows "cancelled", not a false "Failure".
   build-check:
-    needs: [build-debug, build-release, eval-packages, worker-tests, website-check]
+    needs: [build-debug, build-release, eval-packages, worker-tests, website-check, recipe-check]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -557,6 +592,7 @@ jobs:
           set -euo pipefail
           scripts/ci/classify-changes.sh --self-test
           scripts/ci/check-pr-check-fetch-depth.sh
+          python3 scripts/ci/check-test-recipe.py --self-test
           # #2580. `actions/cache` hashes the PATH LIST into a cache version, and
           # a restore matches on version BEFORE key — so two lists that differ in
           # any way describe caches that can never see each other, with nothing
@@ -690,8 +726,9 @@ jobs:
              || [ "${{ needs.build-release.result }}" != "success" ] \
              || [ "${{ needs.eval-packages.result }}" != "success" ] \
              || [ "${{ needs.worker-tests.result }}" != "success" ] \
-             || [ "${{ needs.website-check.result }}" != "success" ]; then
-            echo "::error::lane failed — build-debug=${{ needs.build-debug.result }} build-release=${{ needs.build-release.result }} eval-packages=${{ needs.eval-packages.result }} worker-tests=${{ needs.worker-tests.result }} website-check=${{ needs.website-check.result }}"
+             || [ "${{ needs.website-check.result }}" != "success" ] \
+             || [ "${{ needs.recipe-check.result }}" != "success" ]; then
+            echo "::error::lane failed — build-debug=${{ needs.build-debug.result }} build-release=${{ needs.build-release.result }} eval-packages=${{ needs.eval-packages.result }} worker-tests=${{ needs.worker-tests.result }} website-check=${{ needs.website-check.result }} recipe-check=${{ needs.recipe-check.result }}"
             exit 1
           fi
           echo "==> Both build lanes, the eval-package compile, and the worker unit suites passed."

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -538,7 +538,8 @@ jobs:
 
 
   # A PR adding more than a floor of test lines must name how those tests are
-  # bound (#2868): a `Recipe: #N` whose recipe VALIDATES against this PR's head,
+  # bound (#2868): a `Recipe: #N` whose recipe VALIDATES against the checkout,
+  # which on pull_request is this PR merged with its base (the tree that lands),
   # or one of the two substitutes testing-philosophy.md's ship condition names.
   # Measured 2026-09-13: 8 of 18 such PRs since 2026-09-10 carried none. Runs
   # on every PR (the count decides whether anything more is asked) and needs no
@@ -561,7 +562,7 @@ jobs:
           # cannot resolve it. Same reason as the build lanes.
           fetch-depth: 0
 
-      - name: Test ship condition (recipe named and runnable against this PR)
+      - name: Test ship condition (recipe named and runnable in the tree that lands)
         env:
           GH_TOKEN: ${{ github.token }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/scripts/ci/check-pr-check-fetch-depth.sh
+++ b/scripts/ci/check-pr-check-fetch-depth.sh
@@ -25,8 +25,8 @@ set -euo pipefail
 # Raised 2 -> 3 when website-check landed (#1944), 3 -> 5 when recipe-check
 # landed (#2868; eval-packages had a depth-0 checkout the count never covered).
 # recipe-check reads pull_request.base.sha for its three-dot count of added
-# test lines, so a shallow clone there passes every PR on an empty diff. The
-# count is not decoration:
+# test lines; a shallow clone there cannot resolve the base and the job exits 3
+# on every PR until someone notices. The count is not decoration:
 # at >=2, dropping fetch-depth from website-check would leave the two build
 # lanes and keep the lint GREEN, while the help-centre conversion gate silently
 # lost the base commit it reads its source JSON from. A guard that stops arming
@@ -86,13 +86,14 @@ self_test() {
   # Good: five lane checkouts at fetch-depth: 0 (aggregator has no key).
   _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n')" 0 "five depth-0 lanes -> pass"
   _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n')" 1 "only four lanes -> fail (a lane dropped its checkout)"
-  # Bad: a lane re-shallowed to 2.
-  _expect "$(printf '        with:\n          fetch-depth: 0\n        with:\n          fetch-depth: 2\n')" 1 "a re-shallowed lane (2) -> fail"
+  # Bad: five keys (the count passes) and exactly one re-shallowed to 2, so
+  # only the per-key check can fail this.
+  _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 2\n')" 1 "five lanes, one re-shallowed (2) -> fail"
   # Bad: only one depth-0 declaration (a lane lost its key).
   _expect "$(printf '        with:\n          fetch-depth: 0\n')" 1 "fewer than five lanes -> fail"
   # False-positive guard: a comment mentioning fetch-depth: 0 does not count;
   # the real key is 2 -> must fail.
-  _expect "$(printf '          # keep fetch-depth: 0 here per #825\n          fetch-depth: 2\n          fetch-depth: 0\n')" 1 "comment fetch-depth: 0 does not mask a real 2 -> fail"
+  _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n          # keep fetch-depth: 0 here per #825\n          fetch-depth: 2\n')" 1 "comment fetch-depth: 0 does not mask a real 2 -> fail"
 
   if [ "$SELFTEST_FAILS" -eq 0 ]; then
     echo "== check-pr-check-fetch-depth self-test PASS =="

--- a/scripts/ci/check-pr-check-fetch-depth.sh
+++ b/scripts/ci/check-pr-check-fetch-depth.sh
@@ -20,9 +20,13 @@
 #   check-pr-check-fetch-depth.sh --self-test
 set -euo pipefail
 
-# lint <file>: 0 if every fetch-depth key is 0 and >=3 are present; else 1.
+# lint <file>: 0 if every fetch-depth key is 0 and >=5 are present; else 1.
 #
-# Raised 2 -> 3 when website-check landed (#1944). The count is not decoration:
+# Raised 2 -> 3 when website-check landed (#1944), 3 -> 5 when recipe-check
+# landed (#2868; eval-packages had a depth-0 checkout the count never covered).
+# recipe-check reads pull_request.base.sha for its three-dot count of added
+# test lines, so a shallow clone there passes every PR on an empty diff. The
+# count is not decoration:
 # at >=2, dropping fetch-depth from website-check would leave the two build
 # lanes and keep the lint GREEN, while the help-centre conversion gate silently
 # lost the base commit it reads its source JSON from. A guard that stops arming
@@ -38,8 +42,8 @@ lint() {
   local depth_lines count bad=0
   depth_lines="$(grep -nE '^[[:space:]]*fetch-depth:[[:space:]]*[0-9]+' "$file" || true)"
   count="$(printf '%s' "$depth_lines" | grep -c . || true)"
-  if [ "$count" -lt 3 ]; then
-    echo "::error title=fetch-depth-lint::expected >=3 'fetch-depth: 0' PR-lane checkouts in $file, found $count. #825 requires the build lanes keep full history; #1944 added website-check, which reads pull_request.base.sha."
+  if [ "$count" -lt 5 ]; then
+    echo "::error title=fetch-depth-lint::expected >=5 'fetch-depth: 0' PR-lane checkouts in $file, found $count. #825 requires the build lanes keep full history; #1944 added website-check and #2868 added recipe-check, both of which read pull_request.base.sha."
     return 1
   fi
   local ln val
@@ -79,13 +83,13 @@ _expect() {
 }
 
 self_test() {
-  # Good: two lane checkouts at fetch-depth: 0 (aggregator has no key).
-  _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n')" 0 "three depth-0 lanes -> pass"
-  _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n')" 1 "only two lanes -> fail (website-check dropped its checkout)"
+  # Good: five lane checkouts at fetch-depth: 0 (aggregator has no key).
+  _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n')" 0 "five depth-0 lanes -> pass"
+  _expect "$(printf '      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n      - uses: actions/checkout\n        with:\n          fetch-depth: 0\n')" 1 "only four lanes -> fail (a lane dropped its checkout)"
   # Bad: a lane re-shallowed to 2.
   _expect "$(printf '        with:\n          fetch-depth: 0\n        with:\n          fetch-depth: 2\n')" 1 "a re-shallowed lane (2) -> fail"
   # Bad: only one depth-0 declaration (a lane lost its key).
-  _expect "$(printf '        with:\n          fetch-depth: 0\n')" 1 "fewer than three lanes -> fail"
+  _expect "$(printf '        with:\n          fetch-depth: 0\n')" 1 "fewer than five lanes -> fail"
   # False-positive guard: a comment mentioning fetch-depth: 0 does not count;
   # the real key is 2 -> must fail.
   _expect "$(printf '          # keep fetch-depth: 0 here per #825\n          fetch-depth: 2\n          fetch-depth: 0\n')" 1 "comment fetch-depth: 0 does not mask a real 2 -> fail"

--- a/scripts/ci/check-test-recipe.py
+++ b/scripts/ci/check-test-recipe.py
@@ -13,7 +13,9 @@ Usage (the `recipe-check` job in pr-check.yml):
 The PR body carries exactly one line starting with `Recipe:`, in one of three shapes:
 
     Recipe: #<N>                      an issue labelled test-hardening whose recipe VALIDATES
-                                      against the PR head (scripts/validate-mutation-recipe.py)
+                                      against the checkout, which on a pull_request event is the
+                                      PR merged with its base: the tree that lands
+                                      (scripts/validate-mutation-recipe.py)
     Recipe: parent-red <TestName>     the bug-fix route: the named test ran RED on the parent
                                       commit for the bug's reason (declared; no Xcode here)
     Recipe: resource-control <Test>   the non-Swift-subject route (#2693, #2749): a two-way
@@ -24,6 +26,7 @@ reason printed; 3 the check could not run (a gh or git failure), which is not a 
 """
 
 import argparse
+import os
 import pathlib
 import re
 import subprocess
@@ -35,7 +38,9 @@ import tempfile
 # rule's daytime route for a small bug-fix test is the parent-red proof the reviewer reads.
 FLOOR = 100
 LABEL = "test-hardening"
-RECIPE_LINE = re.compile(r"^\s*Recipe:\s*(.*?)\s*$", re.MULTILINE)
+# One physical line: `[ \t]` and never `\s`, which would swallow the newline after a bare
+# `Recipe:` and read the NEXT line as its value.
+RECIPE_LINE = re.compile(r"^[ \t]*Recipe:[ \t]*(.*?)[ \t]*$")
 # The PR template explains the shapes inside an HTML comment that itself contains `Recipe:` lines;
 # a body that keeps the comment must not count them.
 HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
@@ -63,10 +68,12 @@ def added_test_lines(checkout, base, head):
     """Lines ADDED under Tests/ between base and head, three-dot (what the PR introduces).
 
     `--numstat` prints `-` for a binary file; that counts as zero, since no recipe can bind a
-    binary. A diff that cannot resolve is a refusal to answer, never a zero: a zero would pass the
-    PR on the count with nothing measured.
+    binary. `-M` pins rename detection ON whatever `diff.renames` says on the machine, so a moved
+    test file adds nothing and the count does not depend on configuration. A diff that cannot
+    resolve is a refusal to answer, never a zero: a zero would pass the PR on the count with
+    nothing measured.
     """
-    rc, out = run(["git", "diff", "--numstat", f"{base}...{head}", "--", "Tests/"], cwd=checkout)
+    rc, out = run(["git", "diff", "--numstat", "-M", f"{base}...{head}", "--", "Tests/"], cwd=checkout)
     if rc != 0:
         raise Infrastructure(f"git diff --numstat {base}...{head} failed (rc={rc}): {out.strip()[:300]}")
     total = 0
@@ -93,7 +100,7 @@ def issue_labels(number, checkout):
     )
     if rc != 0:
         raise Infrastructure(f"could not read issue #{number}: {out.strip()[:300]}")
-    return out.split()
+    return [name for name in out.splitlines() if name]
 
 
 def validate_recipe(number, checkout):
@@ -109,7 +116,12 @@ def validate_recipe(number, checkout):
 
 
 def recipe_lines(body):
-    return [m.group(1) for m in RECIPE_LINE.finditer(HTML_COMMENT.sub("", body))]
+    found = []
+    for line in HTML_COMMENT.sub("", body).splitlines():
+        m = RECIPE_LINE.match(line)
+        if m:
+            found.append(m.group(1))
+    return found
 
 
 def check(checkout, base, head, pr, *, body=None, labels=issue_labels, validate=validate_recipe):
@@ -135,11 +147,11 @@ def check(checkout, base, head, pr, *, body=None, labels=issue_labels, validate=
             return 1, f"FAIL: `Recipe: #{number}` names an issue without the `{LABEL}` label.\n{need}"
         rc, out = validate(number, checkout)
         if rc != 0:
-            return 1, (f"FAIL: `Recipe: #{number}` does not validate against this PR's head "
+            return 1, (f"FAIL: `Recipe: #{number}` does not validate against this PR merged with its base "
                        f"(validate-mutation-recipe.py exit {rc}):\n{out.rstrip()}\n"
                        f"Every row must be runnable in the tree that is about to merge; a row that "
                        f"anchors on code this PR does not carry is dead on the night it is run.")
-        return 0, f"ok: {added} lines added under Tests/; `Recipe: #{number}` validates against this PR:\n{out.rstrip()}"
+        return 0, f"ok: {added} lines added under Tests/; `Recipe: #{number}` validates against this PR merged with its base:\n{out.rstrip()}"
 
     declared = DECLARED_SHAPE.match(value)
     if declared:
@@ -155,25 +167,38 @@ def check(checkout, base, head, pr, *, body=None, labels=issue_labels, validate=
 # against real issues on GitHub (#2868's kill criterion), never stubbed here beyond the seams.
 # ---------------------------------------------------------------------------
 
+# Fixtures ignore the machine's git configuration (signing, hooks, rename settings) so the
+# self-test measures the script and not the workstation.
+_GIT_ENV = {**{k: v for k, v in os.environ.items() if not k.startswith("GIT_")},
+            "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+
 def _git(repo, *args):
-    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", *args],
+                   cwd=repo, check=True, capture_output=True, text=True, env=_GIT_ENV)
 
 
-def _repo_with_test_lines(lines, path="Tests/Probe/Probe.swift"):
-    repo = pathlib.Path(tempfile.mkdtemp(prefix="recipe-check-"))
+def _repo_with_test_lines(scratch, lines, path="Tests/Probe/Probe.swift"):
+    repo = pathlib.Path(tempfile.mkdtemp(prefix="recipe-check-", dir=scratch))
     _git(repo, "init", "-q", "-b", "main")
-    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "base")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "base")
     base = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
     target = repo / path
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("".join(f"// line {i}\n" for i in range(lines)))
     _git(repo, "add", "-A")
-    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "tests")
+    _git(repo, "commit", "-q", "-m", "tests")
     head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
     return repo, base, head
 
 
 def self_test():
+    with tempfile.TemporaryDirectory(prefix="recipe-check-selftest-") as scratch:
+        return _self_test(pathlib.Path(scratch))
+
+
+def _self_test(scratch):
     fails = 0
 
     def expect(label, got, want):
@@ -193,11 +218,11 @@ def self_test():
             return rc, text
         return fake
 
-    repo, base, head = _repo_with_test_lines(FLOOR)
+    repo, base, head = _repo_with_test_lines(scratch, FLOOR)
     code, _ = check(repo, base, head, 1, body="", labels=labelled, validate=validator(1, "x"))
     expect("at the floor: no Recipe line needed", code, 0)
 
-    repo, base, head = _repo_with_test_lines(FLOOR + 1)
+    repo, base, head = _repo_with_test_lines(scratch, FLOOR + 1)
     code, msg = check(repo, base, head, 1, body="## Summary\nno line here\n", labels=labelled, validate=validator(0, ""))
     expect("over the floor, no Recipe line: fails", (code, "0 `Recipe:` lines" in msg), (1, True))
 
@@ -229,6 +254,12 @@ def self_test():
     code, msg = check(repo, base, head, 1, body="Recipe: none, trust me\n", labels=labelled, validate=validator(1, "x"))
     expect("unrecognised shape: fails", code, 1)
 
+    code, msg = check(repo, base, head, 1, body="Recipe:\nparent-red FooTests/barFails\n", labels=labelled, validate=validator(1, "x"))
+    expect("bare Recipe: with the value on the next line: fails (value is that line, not the next)", (code, "`Recipe: ` is not" in msg), (1, True))
+
+    code, msg = check(repo, base, head, 1, body="Recipe: #9\n", labels=lambda n, c: ["not test-hardening"], validate=validator(0, ""))
+    expect("a label merely containing the word: fails", code, 1)
+
     template = pathlib.Path(__file__).resolve().parent.parent.parent / ".github" / "pull_request_template.md"
     kept = template.read_text().replace("Recipe:\n", "Recipe: #7\n")
     expect("the template names the shapes inside its comment", kept.count("Recipe:") > 2, True)
@@ -238,9 +269,17 @@ def self_test():
     expect("template left unfilled: fails", code, 1)
 
     # Binary and non-Tests additions do not count toward the floor.
-    repo, base, head = _repo_with_test_lines(FLOOR + 50, path="Sources/Probe.swift")
+    repo, base, head = _repo_with_test_lines(scratch, FLOOR + 50, path="Sources/Probe.swift")
     code, _ = check(repo, base, head, 1, body="", labels=labelled, validate=validator(1, "x"))
     expect("lines outside Tests/ do not count", code, 0)
+
+    # A moved test file adds nothing, whatever diff.renames says on this machine.
+    repo, base, head = _repo_with_test_lines(scratch, FLOOR + 50)
+    _git(repo, "mv", "Tests/Probe/Probe.swift", "Tests/Probe/Moved.swift")
+    _git(repo, "commit", "-q", "-m", "move")
+    moved = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+    code, msg = check(repo, head, moved, 1, body="", labels=labelled, validate=validator(1, "x"))
+    expect("a renamed test file counts zero added lines", (code, "0 lines added" in msg), (0, True))
 
     # A diff that cannot resolve is not a zero.
     try:

--- a/scripts/ci/check-test-recipe.py
+++ b/scripts/ci/check-test-recipe.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""A PR that adds more than a floor of test lines must name how those tests are bound (#2868).
+
+testing-philosophy.md RULE: write-the-test-by-day-run-the-battery-by-night states the ship
+condition: a test ships with a `test-hardening` issue carrying its recipe, or with one of the two
+substitutes the same rule names. Measured 2026-09-13: 8 of the 18 PRs merged since 2026-09-10 with
+more than 100 added lines under `Tests/` carried none of the three. Nothing checked.
+
+Usage (the `recipe-check` job in pr-check.yml):
+    check-test-recipe.py --base <sha> --head <sha> --pr <number> [--checkout <dir>]
+    check-test-recipe.py --self-test
+
+The PR body carries exactly one line starting with `Recipe:`, in one of three shapes:
+
+    Recipe: #<N>                      an issue labelled test-hardening whose recipe VALIDATES
+                                      against the PR head (scripts/validate-mutation-recipe.py)
+    Recipe: parent-red <TestName>     the bug-fix route: the named test ran RED on the parent
+                                      commit for the bug's reason (declared; no Xcode here)
+    Recipe: resource-control <Test>   the non-Swift-subject route (#2693, #2749): a two-way
+                                      control on the resource, in the PR (declared)
+
+Exit codes: 0 the PR satisfies the condition (or is under the floor); 1 it does not, with the
+reason printed; 3 the check could not run (a gh or git failure), which is not a verdict.
+"""
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+# The floor is the measurement in #2868: every PR in its table added more than this. Below it a
+# bounded wait, a renamed helper or a settle fix (#2857, #2860) ships without ceremony, and the
+# rule's daytime route for a small bug-fix test is the parent-red proof the reviewer reads.
+FLOOR = 100
+LABEL = "test-hardening"
+RECIPE_LINE = re.compile(r"^\s*Recipe:\s*(.*?)\s*$", re.MULTILINE)
+# The PR template explains the shapes inside an HTML comment that itself contains `Recipe:` lines;
+# a body that keeps the comment must not count them.
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+ISSUE_SHAPE = re.compile(r"^#(\d+)$")
+DECLARED_SHAPE = re.compile(r"^(parent-red|resource-control)\s+(\S.*)$")
+SHAPES = (
+    "Recipe: #<N>  (an issue labelled test-hardening whose recipe validates against this PR)",
+    "Recipe: parent-red <TestName>  (the new test ran RED on the parent commit for the bug's reason)",
+    "Recipe: resource-control <TestName>  (a two-way control on a non-Swift resource, in this PR)",
+)
+
+VALIDATOR = pathlib.Path(__file__).resolve().parent.parent / "validate-mutation-recipe.py"
+
+
+class Infrastructure(Exception):
+    """The check could not ask its question; the answer is unknown, not 'no'."""
+
+
+def run(argv, cwd):
+    proc = subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def added_test_lines(checkout, base, head):
+    """Lines ADDED under Tests/ between base and head, three-dot (what the PR introduces).
+
+    `--numstat` prints `-` for a binary file; that counts as zero, since no recipe can bind a
+    binary. A diff that cannot resolve is a refusal to answer, never a zero: a zero would pass the
+    PR on the count with nothing measured.
+    """
+    rc, out = run(["git", "diff", "--numstat", f"{base}...{head}", "--", "Tests/"], cwd=checkout)
+    if rc != 0:
+        raise Infrastructure(f"git diff --numstat {base}...{head} failed (rc={rc}): {out.strip()[:300]}")
+    total = 0
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        if parts[0].isdigit():
+            total += int(parts[0])
+    return total
+
+
+def pr_body(number, checkout):
+    rc, out = run(["gh", "pr", "view", str(number), "--json", "body", "--jq", ".body"], cwd=checkout)
+    if rc != 0:
+        raise Infrastructure(f"could not read PR #{number}: {out.strip()[:300]}")
+    return out
+
+
+def issue_labels(number, checkout):
+    rc, out = run(
+        ["gh", "issue", "view", str(number), "--json", "labels", "--jq", ".labels[].name"],
+        cwd=checkout,
+    )
+    if rc != 0:
+        raise Infrastructure(f"could not read issue #{number}: {out.strip()[:300]}")
+    return out.split()
+
+
+def validate_recipe(number, checkout):
+    """The validator's exit code is the verdict; its output is the reason, quoted whole."""
+    rc, out = run([sys.executable, str(VALIDATOR), "--issue", str(number), "--checkout", str(checkout)],
+                  cwd=checkout)
+    # The validator's own read failure is exit 2 like a malformed recipe (mutation-battery.py
+    # `could not read issue`); that one is nobody's recipe to fix. Same classification as
+    # test-hardening-recipe.yml.
+    if rc != 0 and "could not read issue" in out:
+        raise Infrastructure(out.strip())
+    return rc, out
+
+
+def recipe_lines(body):
+    return [m.group(1) for m in RECIPE_LINE.finditer(HTML_COMMENT.sub("", body))]
+
+
+def check(checkout, base, head, pr, *, body=None, labels=issue_labels, validate=validate_recipe):
+    """Returns (exit code, message). Keyword seams exist for --self-test only; the job passes none."""
+    added = added_test_lines(checkout, base, head)
+    if added <= FLOOR:
+        return 0, f"ok: {added} lines added under Tests/, at or under the {FLOOR}-line floor; no Recipe line required"
+
+    if body is None:
+        body = pr_body(pr, checkout)
+    lines = recipe_lines(body)
+    need = (f"{added} lines added under Tests/ is over the {FLOOR}-line floor, so the PR body must carry "
+            f"exactly one `Recipe:` line in one of these shapes:\n  " + "\n  ".join(SHAPES))
+    if len(lines) != 1:
+        found = "none" if not lines else "\n  ".join(f"Recipe: {l}" for l in lines)
+        return 1, f"FAIL: {len(lines)} `Recipe:` lines in the PR body (found: {found}).\n{need}"
+
+    value = lines[0]
+    issue = ISSUE_SHAPE.match(value)
+    if issue:
+        number = int(issue.group(1))
+        if LABEL not in labels(number, checkout):
+            return 1, f"FAIL: `Recipe: #{number}` names an issue without the `{LABEL}` label.\n{need}"
+        rc, out = validate(number, checkout)
+        if rc != 0:
+            return 1, (f"FAIL: `Recipe: #{number}` does not validate against this PR's head "
+                       f"(validate-mutation-recipe.py exit {rc}):\n{out.rstrip()}\n"
+                       f"Every row must be runnable in the tree that is about to merge; a row that "
+                       f"anchors on code this PR does not carry is dead on the night it is run.")
+        return 0, f"ok: {added} lines added under Tests/; `Recipe: #{number}` validates against this PR:\n{out.rstrip()}"
+
+    declared = DECLARED_SHAPE.match(value)
+    if declared:
+        route, subject = declared.groups()
+        return 0, (f"ok: {added} lines added under Tests/; declared route `{route}` for `{subject}`. "
+                   f"This runner has no Xcode, so the declaration is what the review gate reads.")
+
+    return 1, f"FAIL: `Recipe: {value}` is not one of the accepted shapes.\n{need}"
+
+
+# ---------------------------------------------------------------------------
+# Self-test: a real git repo for the count, real bodies for the parse. The issue half is proven
+# against real issues on GitHub (#2868's kill criterion), never stubbed here beyond the seams.
+# ---------------------------------------------------------------------------
+
+def _git(repo, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _repo_with_test_lines(lines, path="Tests/Probe/Probe.swift"):
+    repo = pathlib.Path(tempfile.mkdtemp(prefix="recipe-check-"))
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "base")
+    base = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("".join(f"// line {i}\n" for i in range(lines)))
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "tests")
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+    return repo, base, head
+
+
+def self_test():
+    fails = 0
+
+    def expect(label, got, want):
+        nonlocal fails
+        if got == want:
+            print(f"ok   [{label}]")
+        else:
+            fails += 1
+            print(f"FAIL [{label}] expected {want!r}, got {got!r}")
+
+    labelled = lambda n, c: [LABEL] if n == 7 else ["task"]
+    calls = []
+
+    def validator(rc, text):
+        def fake(n, c):
+            calls.append(n)
+            return rc, text
+        return fake
+
+    repo, base, head = _repo_with_test_lines(FLOOR)
+    code, _ = check(repo, base, head, 1, body="", labels=labelled, validate=validator(1, "x"))
+    expect("at the floor: no Recipe line needed", code, 0)
+
+    repo, base, head = _repo_with_test_lines(FLOOR + 1)
+    code, msg = check(repo, base, head, 1, body="## Summary\nno line here\n", labels=labelled, validate=validator(0, ""))
+    expect("over the floor, no Recipe line: fails", (code, "0 `Recipe:` lines" in msg), (1, True))
+
+    code, msg = check(repo, base, head, 1, body="Recipe: #7\nRecipe: parent-red X\n", labels=labelled, validate=validator(0, ""))
+    expect("two Recipe lines: fails", (code, "2 `Recipe:` lines" in msg), (1, True))
+
+    code, msg = check(repo, base, head, 1, body="Recipe:\n", labels=labelled, validate=validator(0, ""))
+    expect("template line left empty: fails naming the shapes", (code, SHAPES[0] in msg), (1, True))
+
+    code, msg = check(repo, base, head, 1, body="Recipe: #8\n", labels=labelled, validate=validator(0, ""))
+    expect("issue without the label: fails before validating", (code, calls), (1, []))
+
+    code, msg = check(repo, base, head, 1, body="Recipe: #7\n", labels=labelled, validate=validator(2, "REFUSED — no block"))
+    expect("labelled issue, validator refuses: fails quoting it", (code, "REFUSED — no block" in msg, calls), (1, True, [7]))
+
+    calls.clear()
+    code, msg = check(repo, base, head, 1, body="Recipe: #7\n", labels=labelled, validate=validator(0, "#7: 4/4 rows runnable"))
+    expect("labelled issue, validator passes: ok", (code, "4/4 rows runnable" in msg), (0, True))
+
+    code, msg = check(repo, base, head, 1, body="  Recipe: parent-red FooTests/barFails\n", labels=labelled, validate=validator(1, "x"))
+    expect("parent-red declaration: ok", (code, "parent-red" in msg), (0, True))
+
+    code, msg = check(repo, base, head, 1, body="Recipe: resource-control ManifestTests\n", labels=labelled, validate=validator(1, "x"))
+    expect("resource-control declaration: ok", code, 0)
+
+    code, msg = check(repo, base, head, 1, body="Recipe: parent-red\n", labels=labelled, validate=validator(1, "x"))
+    expect("parent-red with no test named: fails", code, 1)
+
+    code, msg = check(repo, base, head, 1, body="Recipe: none, trust me\n", labels=labelled, validate=validator(1, "x"))
+    expect("unrecognised shape: fails", code, 1)
+
+    template = pathlib.Path(__file__).resolve().parent.parent.parent / ".github" / "pull_request_template.md"
+    kept = template.read_text().replace("Recipe:\n", "Recipe: #7\n")
+    expect("the template names the shapes inside its comment", kept.count("Recipe:") > 2, True)
+    code, msg = check(repo, base, head, 1, body=kept, labels=labelled, validate=validator(0, "#7: 1/1 rows runnable"))
+    expect("template comment kept beside one real line: ok", code, 0)
+    code, msg = check(repo, base, head, 1, body=template.read_text(), labels=labelled, validate=validator(0, ""))
+    expect("template left unfilled: fails", code, 1)
+
+    # Binary and non-Tests additions do not count toward the floor.
+    repo, base, head = _repo_with_test_lines(FLOOR + 50, path="Sources/Probe.swift")
+    code, _ = check(repo, base, head, 1, body="", labels=labelled, validate=validator(1, "x"))
+    expect("lines outside Tests/ do not count", code, 0)
+
+    # A diff that cannot resolve is not a zero.
+    try:
+        check(repo, "0" * 40, head, 1, body="", labels=labelled, validate=validator(1, "x"))
+        expect("unresolvable base raises", "returned", "raised")
+    except Infrastructure:
+        expect("unresolvable base raises", "raised", "raised")
+
+    print(f"self-test: {fails} failure(s)")
+    return 1 if fails else 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--pr", type=int)
+    parser.add_argument("--checkout", type=pathlib.Path, default=pathlib.Path.cwd())
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return self_test()
+    if not (args.base and args.head and args.pr):
+        parser.error("--base, --head and --pr are required (or --self-test)")
+    try:
+        code, message = check(args.checkout, args.base, args.head, args.pr)
+    except Infrastructure as error:
+        print(f"::error title=recipe-check::could not run: {error}\nNot a verdict on the PR; re-run the job.")
+        return 3
+    print(message)
+    if code != 0:
+        print("::error title=recipe-check::the PR body does not satisfy the test ship condition; "
+              "edit the body, then re-run this job (gh run rerun <run id> --failed) or push.")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`testing-philosophy.md`'s ship condition says a test ships with a `test-hardening` issue carrying its recipe. Nothing checked. Measured 2026-09-13 (table on #2868): 8 of the 18 PRs merged since 2026-09-10 with more than 100 added lines under `Tests/` carried no recipe anywhere, 7,646 lines between them, the two largest included. #2703's three candidates all act on an issue that exists; this is the guard for the issue that was never filed.

Closes #2868.

`Tier: SMALL | Test: n/a (workflow + 19-case self-test + on-GitHub kill criterion) | Modules: .github, scripts/ci`
`Lane: CI/workflow`

## What it does

New `recipe-check` job in `pr-check.yml` (Ubuntu, no Xcode), folded into `build-check`'s `needs:` AND its fail-closed `Require every lane` clause. `scripts/ci/check-test-recipe.py`:

1. Counts lines ADDED under `Tests/` between the PR base and head (`git diff --numstat -M base...head`, three-dot, rename detection pinned on so a moved file adds nothing). **At or under 100, the job passes and says so.** A bounded wait, a renamed helper or a settle fix (#2857, #2860 this week) asks nothing.
2. Over 100, the PR body must carry exactly one `Recipe:` line (physical line; HTML comments stripped first so the template's explanation does not count), in one of the three shapes the rule itself names:
   - `Recipe: #N`: N carries the `test-hardening` label AND `scripts/validate-mutation-recipe.py --issue N --checkout "$PWD"` exits 0. On `pull_request` the checkout is the PR merged with its base, the tree that lands, so a recipe whose anchors are not in that tree fails here rather than on the night it is run.
   - `Recipe: parent-red <TestName>`: the bug-fix route (the new test ran RED on the parent commit for the bug's reason). Declared; the runner cannot execute it. It is in the PR body where the cloud reviewer reads it.
   - `Recipe: resource-control <TestName>`: the non-Swift-subject route (#2693, #2749). Declared the same way.
3. A `gh` or `git` failure is exit 3 with "not a verdict", never a pass and never "fix your body".

The PR template gains the `Recipe:` section. The fetch-depth lint floor goes 3 to 5 (this job reads `base.sha`; `eval-packages` had a depth-0 checkout the count never covered), and its two per-key self-test cases now carry five keys with exactly one wrong so they fail on the check they name. CI-GOVERNANCE lists the six lanes.

## Kill criterion, observed on GitHub (probe PR #2869, draft, never merged, closed after)

Mutating the repository, not the checker: a branch with 101 stub lines under `Tests/`.

| state | PR body | expected | observed |
|---|---|---|---|
| A | no line | FAIL naming the three shapes | `FAIL: 0 Recipe: lines in the PR body (found: none). 101 lines added under Tests/ is over the 100-line floor...` (run 34751586603) |
| B | `Recipe: #2703` (labelled, no block) | FAIL quoting the refusal | `FAIL: Recipe: #2703 does not validate against this PR merged with its base (validate-mutation-recipe.py exit 2): REFUSED, issue #2703 carries neither a json nor a mutation-recipe block...` (job 103709123894) |
| C | `Recipe: #2865` (4/4 on main) | pass | `ok: 101 lines added under Tests/; Recipe: #2865 validates against this PR merged with its base: row 1..4 runnable, #2865: 4/4 rows runnable` (job 103709234055) |
| D | `Recipe: parent-red X` | pass | `ok: 101 lines added under Tests/; declared route parent-red for InverseTextNormalizerSpanRestoreTests. This runner has no Xcode, so the declaration is what the review gate reads.` (job 103709396969) |

Locally, the same four plus `Recipe: #2868` (unlabelled) against the real #2866 diff (103 lines) gave the same verdicts, with the validator's own output quoted.

## Review

Local Codex r1 clean. Second pass (`second-pass-review.md`, diff only): ten findings, seven adopted (the `\s*` newline swallow so a bare `Recipe:` read the next line as its value; whole-name label compare; `-M`; isolated fixture git config and cleanup; two lint self-test controls that failed on the count rather than the check; two wording claims wider than the code). Two rejected with the reason in the r2 commit: mapping every validator exit 2 to infrastructure (only the issue read is remote), and re-running on PR body edits (`pull_request: edited` here would cancel the macOS lanes on a typo fix; a separate workflow needs a second required check in the ruleset, CI-GOVERNANCE says exactly one, and that is the founder's call). Confirming local r2 clean.

**Known limit, stated in the job comment:** a body edited after the run is seen only on a re-run or a push; the failure message says so. The night battery re-validates every recipe before running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
