### PR TITLE
perf(snippets): scan the take for the sentinel prefix once, not once per fired snippet (#2759 site 2)

### DIFF
--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -117,9 +117,10 @@ public struct SnippetExpander: Sendable {
     var issued: Set<String> = []
     // Decided ONCE per take, not once per fired snippet (#2759 site 2): the input and the saved
     // expansions do not change while this loop runs, and a scan of both per mint made a long
-    // take with several triggers pay O(text x fired).
-    let expansions = vocabulary.snippets.map(\.expansion)
-    let domainCanCollide = Self.domainCanCollide(rawInput: text, expansions: expansions)
+    // take with several triggers pay O(text x fired). Lazy, so a take that fires nothing, the
+    // common case, pays no scan at all, as before.
+    lazy var expansions = vocabulary.snippets.map(\.expansion)
+    lazy var domainCanCollide = Self.domainCanCollide(rawInput: text, expansions: expansions)
     var cursor = 0
 
     while cursor < wordIndices.count {

--- a/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
+++ b/Sources/EnviousWisprPostProcessing/SnippetExpander.swift
@@ -115,6 +115,11 @@ public struct SnippetExpander: Sendable {
     var out = pieces.first?.isWhitespaceRun == true ? pieces[0].text : ""
     var records: [SnippetExpansionRecord] = []
     var issued: Set<String> = []
+    // Decided ONCE per take, not once per fired snippet (#2759 site 2): the input and the saved
+    // expansions do not change while this loop runs, and a scan of both per mint made a long
+    // take with several triggers pay O(text x fired).
+    let expansions = vocabulary.snippets.map(\.expansion)
+    let domainCanCollide = Self.domainCanCollide(rawInput: text, expansions: expansions)
     var cursor = 0
 
     while cursor < wordIndices.count {
@@ -145,7 +150,8 @@ public struct SnippetExpander: Sendable {
       let lastWordIndex = wordIndices[cursor + hit.length]
       let lastToken = pieces[lastWordIndex].text
       let sentinel = mintSentinel(
-        rawInput: text, expansions: vocabulary.snippets.map(\.expansion), alreadyIssued: issued)
+        rawInput: text, expansions: expansions, alreadyIssued: issued,
+        domainCanCollide: domainCanCollide)
       issued.insert(sentinel)
       let trailing = Self.trailingToRestore(
         lastToken: lastToken,
@@ -219,6 +225,17 @@ public struct SnippetExpander: Sendable {
     return (SnippetText.droppingSentenceEndings(from: run), true)
   }
 
+  /// Whether ANY candidate could collide with the input or a saved expansion.
+  ///
+  /// Every candidate this type mints carries `prefix`, so a domain that does not contain the
+  /// prefix cannot contain a candidate: one scan of each domain answers for every mint of the
+  /// take. `mintSentinel` still scans per candidate when this is true, and for a candidate that
+  /// does not carry the prefix (an injected source), so the guarantee does not rest on the
+  /// source.
+  static func domainCanCollide(rawInput: String, expansions: [String]) -> Bool {
+    rawInput.contains(prefix) || expansions.contains(where: { $0.contains(prefix) })
+  }
+
   /// A sentinel that appears in NONE of: the raw input, any saved expansion, or the sentinels
   /// already issued for this run.
   ///
@@ -227,12 +244,20 @@ public struct SnippetExpander: Sendable {
   /// reintroduce one after the finalizer had already checked. Re-minting is bounded — a
   /// collision on 128 random bits is not a case that recurs — but the loop is written to
   /// terminate rather than to trust that.
-  func mintSentinel(rawInput: String, expansions: [String], alreadyIssued: Set<String>) -> String {
+  ///
+  /// `domainCanCollide` is `Self.domainCanCollide` for this input and these expansions, computed
+  /// once by the caller; `false` skips the two domain scans for a prefixed candidate, which is
+  /// exact because such a candidate cannot occur in a domain the prefix does not occur in.
+  func mintSentinel(
+    rawInput: String, expansions: [String], alreadyIssued: Set<String>, domainCanCollide: Bool
+  ) -> String {
     for _ in 0..<8 {
       let candidate = candidateSource()
-      if rawInput.contains(candidate) { continue }
       if alreadyIssued.contains(candidate) { continue }
-      if expansions.contains(where: { $0.contains(candidate) }) { continue }
+      if domainCanCollide || !candidate.hasPrefix(Self.prefix) {
+        if rawInput.contains(candidate) { continue }
+        if expansions.contains(where: { $0.contains(candidate) }) { continue }
+      }
       return candidate
     }
     // Exhausted only when the candidate source is degenerate (a test forcing a collision).
@@ -243,8 +268,10 @@ public struct SnippetExpander: Sendable {
     while true {
       let candidate = "\(Self.prefix)fallback\(suffix)"
       let collides =
-        rawInput.contains(candidate) || alreadyIssued.contains(candidate)
-        || expansions.contains(where: { $0.contains(candidate) })
+        alreadyIssued.contains(candidate)
+        || (domainCanCollide
+          && (rawInput.contains(candidate)
+            || expansions.contains(where: { $0.contains(candidate) })))
       if !collides { return candidate }
       suffix += 1
     }

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -502,6 +502,34 @@ struct SnippetExpanderTests {
     #expect(out.records[0].sentinel != out.records[1].sentinel)
   }
 
+  /// #2759 site 2: the two domain scans run once per take, not once per fired snippet. What
+  /// makes that exact is the prefix every minted candidate carries, so the decision is bound
+  /// here on both sides.
+  @Test("The domains can only collide when they contain the sentinel prefix")
+  func domainCanCollideIsThePrefixTest() {
+    #expect(
+      !SnippetExpander.domainCanCollide(
+        rawInput: "backslash my email", expansions: ["sam@example.com"]))
+    #expect(
+      SnippetExpander.domainCanCollide(
+        rawInput: "code EWSNIPx here", expansions: ["sam@example.com"]))
+    #expect(
+      SnippetExpander.domainCanCollide(rawInput: "backslash my email", expansions: ["see EWSNIP"]))
+    #expect(!SnippetExpander.domainCanCollide(rawInput: "", expansions: []))
+  }
+
+  /// An injected source is not bound to the prefix, so a candidate without it is still scanned
+  /// against the input even when the prefix scan said nothing could collide.
+  @Test("A candidate without the prefix is still checked against the dictated text")
+  func unprefixedCandidateIsStillCheckedAgainstInput() {
+    let expander = fixedExpander(["plain", "EWSNIPok"])
+    let out = expander.expand(
+      "the code is plain and backslash my email",
+      using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.records.first?.sentinel == "EWSNIPok")
+  }
+
   // MARK: - The duplicate rule, stated once on the type
 
   @Test("Two triggers differing only by case and punctuation are the same trigger")

--- a/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
+++ b/Tests/EnviousWisprTests/PostProcessing/SnippetExpanderTests.swift
@@ -502,9 +502,25 @@ struct SnippetExpanderTests {
     #expect(out.records[0].sentinel != out.records[1].sentinel)
   }
 
-  /// #2759 site 2: the two domain scans run once per take, not once per fired snippet. What
-  /// makes that exact is the prefix every minted candidate carries, so the decision is bound
-  /// here on both sides.
+  /// The fallback mint checks the same three domains as the random path. Bound here because
+  /// the fallback is the one route a degenerate source takes, and nothing else drives it with
+  /// a colliding value in the text.
+  @Test("A fallback sentinel already in the dictated text is skipped, and issued ones too")
+  func fallbackSentinelSkipsInputAndIssuedCollisions() {
+    let expander = fixedExpander(["EWSNIPsame"])
+    let out = expander.expand(
+      "EWSNIPsame EWSNIPfallback0 backslash my email or backslash support address",
+      using: vocabulary([
+        ("my email", "sam@example.com"),
+        ("support address", "help@example.com"),
+      ]))
+
+    #expect(out.records.map(\.sentinel) == ["EWSNIPfallback1", "EWSNIPfallback2"])
+  }
+
+  /// #2759 site 2: the PREFIX scan of the two domains runs once per take; the per-candidate
+  /// scans remain only when the prefix is present. What makes the skip exact is the prefix
+  /// every minted candidate carries, so the decision is bound here on both sides.
   @Test("The domains can only collide when they contain the sentinel prefix")
   func domainCanCollideIsThePrefixTest() {
     #expect(
@@ -526,6 +542,19 @@ struct SnippetExpanderTests {
     let out = expander.expand(
       "the code is plain and backslash my email",
       using: vocabulary([("my email", "sam@example.com")]))
+
+    #expect(out.records.first?.sentinel == "EWSNIPok")
+  }
+
+  @Test("A candidate without the prefix is still checked against saved expansions")
+  func unprefixedCandidateIsStillCheckedAgainstExpansions() {
+    let expander = fixedExpander(["plain", "EWSNIPok"])
+    let out = expander.expand(
+      "backslash my email",
+      using: vocabulary([
+        ("my email", "sam@example.com"),
+        ("my note", "in plain words"),
+      ]))
 
     #expect(out.records.first?.sentinel == "EWSNIPok")
   }


### PR DESCRIPTION
## Summary

#2759 site 2. `SnippetExpander.mintSentinel` scanned the whole dictated text and every saved expansion for each candidate it minted, once per fired snippet, on input that does not change while the loop runs. Site 1 shipped in PR #2866; site 3 (`EmojiRestorer`) remains.

Part of #2759.

`Tier: SMALL | Test: required (PostProcessing) | Modules: PostProcessing`
`Lane: Code`

Recipe: #2872

## Measured

`swiftc -O`, best of five, a 54 KB take of dictation words, 40 saved expansions, the two per-mint scans as written on main:

| fired snippets | per-mint scans |
|---|---|
| 1 | 0.7 ms |
| 10 | 7.3 ms |
| 50 | 36.3 ms |
| 200 | 150.0 ms |

After: one prefix scan for the take (the 1-row figure) whatever the count, and none at all when no snippet fires.

## What it does

Every candidate this type mints carries `prefix` (`EWSNIP`), so a domain that does not contain the prefix cannot contain a candidate. `domainCanCollide(rawInput:expansions:)` decides that once per `expand()`, lazily on the first mint so a take with no trigger (the common case) pays nothing, as before. When false, `mintSentinel` skips the two domain scans for a prefixed candidate. The guarantee does not rest on the candidate source: an injected candidate without the prefix is still scanned. `alreadyIssued` is checked as before, and the fallback loop keeps its scans under the same condition. The `expansions` array is also built lazily, where it was rebuilt on every match.

## Tests

Four new cases in `SnippetExpanderTests` (41/41): the domain test is exactly the prefix test (four inputs); an unprefixed candidate is still checked against the text; against a saved expansion; and the fallback mint skips a `fallback0` present in the text and a `fallback1` already issued (that route had no test driving it with a colliding value). Own mutant this session (night): dropping `|| !candidate.hasPrefix(Self.prefix)` turns the named case red with sentinel `plain` accepted; source restored and checked by content. Recipe #2872, 4/4 rows runnable against this branch.

## Review

Local r1 clean. Second pass (diff only, ten questions): adopted the lazy evaluation (the hoist as first written scanned every take with saved snippets, including the ones that fire nothing), the comment wording (the PREFIX scan is once per take; per-candidate scans remain when the prefix is present), and the two missing cases. Rejected: the `EWSNIPa`/`EWSNIPab` overlap (pre-existing, reachable only through an injected source since random candidates are equal length; known limit), and a scan-count assertion (a seam on the guard for testing only; the property is measured above). Confirming local r2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
