### PR TITLE
fix(eval): apple_runner --preclean honours production's ITN language gate; --preclean-only writes a reusable corpus (#2843, #2844)

### DIFF
--- a/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
+++ b/Sources/EnviousWisprPipeline/InverseTextNormalizationStep.swift
@@ -188,6 +188,19 @@ final class InverseTextNormalizationStep: TextProcessingStep {
   ///   (Parakeet-class, legacy English); defensively skip for LID backends
   ///   (WhisperKit), where nil means "couldn't identify" (`lid_backend_nil`).
   private func skipReason(language: String?, englishVetoed: Bool) -> String? {
+    InverseTextNormalizationGate.skipReason(
+      language: language, englishVetoed: englishVetoed, backendSupportsLID: backendSupportsLID)
+  }
+}
+
+/// The step's language gate as a pure function, public so a harness that claims to feed the
+/// model what production feeds it (`scripts/eval/apple_runner --preclean`, #2844) asks THIS
+/// predicate rather than carrying a copy that drifts. The step above is the only production
+/// caller; the buckets and their order are documented on `skipReason` there.
+public enum InverseTextNormalizationGate {
+  public static func skipReason(language: String?, englishVetoed: Bool, backendSupportsLID: Bool)
+    -> String?
+  {
     if englishVetoed { return "language_vetoed" }
     let lang = language?.lowercased()
     if let lang, !lang.isEmpty {

--- a/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
+++ b/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
@@ -134,42 +134,45 @@ func fail(_ msg: String) -> Never {
 struct RunnerMain {
   static func main() async {
     let args = parseArgs()
-    let cases = loadCorpus(path: args.corpusPath)
 
     if args.precleanOnly {
-      // Re-read the corpus as raw objects: the output is meant to be fed back in as a corpus
-      // (#2843), so every field the gate reads (expected_output, must_contain, tiers...) must
-      // survive, and the CLEANED text must sit in `asr_input`, the one field every consumer
-      // reads. The original moves to `original_input`.
+      // The corpus is read as raw objects, once: the output is meant to be fed back in as a
+      // corpus (#2843), so every field the gate reads (expected_output, must_contain, tiers...)
+      // must survive, and the CLEANED text must sit in `asr_input`, the one field every consumer
+      // reads. The original moves to `original_input`; a record that already carries one (a
+      // second pass over this mode's own output) keeps it, so the first transcript stays
+      // recoverable. `changed` is about THIS pass.
       let rawCases = loadCorpusObjects(path: args.corpusPath)
-      let sink: FileHandle
-      if let outPath = args.outPath {
-        try? FileManager.default.removeItem(atPath: outPath)
-        FileManager.default.createFile(atPath: outPath, contents: nil)
-        guard let handle = FileHandle(forWritingAtPath: outPath) else {
-          fail("could not open --out for writing: \(outPath)")
-        }
-        sink = handle
-      } else {
-        sink = FileHandle.standardOutput
-      }
       let normalizer = InverseTextNormalizer()
+      var out = Data()
       for var object in rawCases {
         let original = object["asr_input"] as! String
         let cleaned = preclean(original, language: args.detectedLanguage, normalizer: normalizer)
         object["asr_input"] = cleaned
-        object["original_input"] = original
+        object["original_input"] = object["original_input"] ?? original
         object["changed"] = cleaned != original
         guard
           let data = try? JSONSerialization.data(
             withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
         else { fail("could not encode the preclean record for \(object["id"] ?? "?")") }
-        sink.write(data)
-        sink.write(Data("\n".utf8))
+        out.append(data)
+        out.append(Data("\n".utf8))
       }
-      if args.outPath != nil { try? sink.close() }
+      if let outPath = args.outPath {
+        // Whole file at once, so an interrupted run never leaves a valid-looking corpus that is
+        // missing its tail; the gate accepts any non-empty subset.
+        do {
+          try out.write(to: URL(fileURLWithPath: outPath), options: .atomic)
+        } catch {
+          fail("could not write --out \(outPath): \(error)")
+        }
+      } else {
+        FileHandle.standardOutput.write(out)
+      }
       exit(0)
     }
+
+    let cases = loadCorpus(path: args.corpusPath)
 
     // Enable file logging so [AIPolish] trace lines from AppleIntelligenceConnector
     // land in ~/Library/Logs/EnviousWispr/app.log. Required for bench-mode A/B

--- a/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
+++ b/scripts/eval/apple_runner/Sources/AppleIntelligenceRunner/main.swift
@@ -137,6 +137,11 @@ struct RunnerMain {
     let cases = loadCorpus(path: args.corpusPath)
 
     if args.precleanOnly {
+      // Re-read the corpus as raw objects: the output is meant to be fed back in as a corpus
+      // (#2843), so every field the gate reads (expected_output, must_contain, tiers...) must
+      // survive, and the CLEANED text must sit in `asr_input`, the one field every consumer
+      // reads. The original moves to `original_input`.
+      let rawCases = loadCorpusObjects(path: args.corpusPath)
       let sink: FileHandle
       if let outPath = args.outPath {
         try? FileManager.default.removeItem(atPath: outPath)
@@ -149,25 +154,18 @@ struct RunnerMain {
         sink = FileHandle.standardOutput
       }
       let normalizer = InverseTextNormalizer()
-      let encoder = JSONEncoder()
-      encoder.outputFormatting = [.sortedKeys]
-      struct PrecleanRecord: Encodable {
-        let id: String
-        let asr_input: String
-        let deterministic_output: String
-        let changed: Bool
-      }
-      for caseItem in cases {
-        let noFillers = FillerRemovalStep.removingFillers(
-          from: caseItem.asr_input, language: args.detectedLanguage, englishVetoed: false)
-        let cleaned = normalizer.normalize(noFillers)
-        let record = PrecleanRecord(
-          id: caseItem.id, asr_input: caseItem.asr_input, deterministic_output: cleaned,
-          changed: cleaned != caseItem.asr_input)
-        if let data = try? encoder.encode(record) {
-          sink.write(data)
-          sink.write(Data("\n".utf8))
-        }
+      for var object in rawCases {
+        let original = object["asr_input"] as! String
+        let cleaned = preclean(original, language: args.detectedLanguage, normalizer: normalizer)
+        object["asr_input"] = cleaned
+        object["original_input"] = original
+        object["changed"] = cleaned != original
+        guard
+          let data = try? JSONSerialization.data(
+            withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+        else { fail("could not encode the preclean record for \(object["id"] ?? "?")") }
+        sink.write(data)
+        sink.write(Data("\n".utf8))
       }
       if args.outPath != nil { try? sink.close() }
       exit(0)
@@ -250,9 +248,8 @@ struct RunnerMain {
       let caseStart = Date()
       let inputText: String
       if args.preclean {
-        let noFillers = FillerRemovalStep.removingFillers(
-          from: caseItem.asr_input, language: args.detectedLanguage, englishVetoed: false)
-        inputText = normalizer.normalize(noFillers)
+        inputText = preclean(
+          caseItem.asr_input, language: args.detectedLanguage, normalizer: normalizer)
       } else {
         inputText = caseItem.asr_input
       }
@@ -344,6 +341,50 @@ func loadCorpus(path: String) -> [CorpusCase] {
   }
   if cases.isEmpty { fail("corpus has zero cases") }
   return cases
+}
+
+/// The corpus lines as raw JSON objects, for `--preclean-only`, which rewrites one field and
+/// must carry every other one through unchanged. Same file, same validation as `loadCorpus`
+/// (each line is an object with a string `id` and a string `asr_input`), so the two loaders
+/// cannot accept different corpora.
+func loadCorpusObjects(path: String) -> [[String: Any]] {
+  let url = URL(fileURLWithPath: path)
+  guard let data = try? Data(contentsOf: url),
+    let text = String(data: data, encoding: .utf8)
+  else {
+    fail("could not read corpus at \(path)")
+  }
+  var objects: [[String: Any]] = []
+  for (lineNumber, rawLine) in text.split(separator: "\n", omittingEmptySubsequences: false)
+    .enumerated()
+  {
+    let line = rawLine.trimmingCharacters(in: .whitespaces)
+    if line.isEmpty { continue }
+    guard let lineData = line.data(using: .utf8),
+      let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+      object["id"] is String, object["asr_input"] is String
+    else {
+      fail("corpus line \(lineNumber + 1) is not a valid CorpusCase JSON object")
+    }
+    objects.append(object)
+  }
+  if objects.isEmpty { fail("corpus has zero cases") }
+  return objects
+}
+
+/// The production pre-polish chain on one input: filler removal, then inverse text
+/// normalization under production's OWN language gate (#2844). Production skips ITN
+/// entirely for a non-English language (`InverseTextNormalizationStep`), so a bench that ran
+/// the English-oriented normalizer on German input was measuring a chain production never
+/// runs. `englishVetoed: false` and `backendSupportsLID: false`: the bench has no resolver
+/// veto and models the Parakeet-class backend, where an explicit language decides alone.
+@MainActor
+func preclean(_ text: String, language: String, normalizer: InverseTextNormalizer) -> String {
+  let noFillers = FillerRemovalStep.removingFillers(
+    from: text, language: language, englishVetoed: false)
+  let itnSkip = InverseTextNormalizationGate.skipReason(
+    language: language, englishVetoed: false, backendSupportsLID: false)
+  return itnSkip == nil ? normalizer.normalize(noFillers) : noFillers
 }
 
 func write(record: OutRecord, to sink: FileHandle, encoder: JSONEncoder) {


### PR DESCRIPTION
## Summary

Two Codex findings from PR #2831, both in `apple_runner`'s deterministic pre-polish chain.

Closes #2843. Closes #2844.

`Tier: SMALL | Test: n/a (eval harness; real-tool runs below) | Modules: Pipeline (one public predicate), scripts/eval`
`Lane: Eval-harness`

## #2844: the bench applied English ITN to non-English input

Both `--preclean` and `--preclean-only` ran `InverseTextNormalizer` whatever `--detected-language` said. Production's `InverseTextNormalizationStep` skips ITN for a non-English language. Measured with the built runner on `wir treffen uns um zehn uhr, ähm, am ersten märz`: under `--detected-language en` the line lost its `um` (the English filler rule deleting a German preposition); under `de` it now comes back unchanged.

The gate is production's own, not a copy: the step's private `skipReason` delegates to a new public `InverseTextNormalizationGate.skipReason(language:englishVetoed:backendSupportsLID:)` in the same file (buckets and order unchanged; `InverseTextNormalizationStepTests` 12/12), and the runner calls that with no veto and a non-LID backend through one shared `preclean(_:language:normalizer:)` used by both modes.

## #2843: `--preclean-only` wrote a corpus nobody could reuse

It put the ORIGINAL text in `asr_input` and the cleaned text in `deterministic_output`, which nothing reads (`git grep`: zero hits outside the runner). The mode now reads the corpus once as raw JSON objects, puts the cleaned text in `asr_input`, moves the original to `original_input` (kept if already present, so a second pass does not erase the first transcript), sets `changed` for the current pass, carries every other field through, and writes the file atomically so an interrupted run cannot leave a valid-looking corpus missing its tail.

Measured on `scripts/eval/corpus/ci_corpus.jsonl`: 161 in, 161 out, every source key present, 33 rows changed, `original_input` equal to the source on all 161; a second pass over that output keeps `original_input` on all 161.

## Found on the way, filed separately

The second pass changed exactly one row again: `two four oh seven dot one two three` converts to `2407 dot one two three` in one pass and to `2407.123` in two, and the `point` variant pastes `24070.123`. That is an ITN bug, not this tool's, filed as #2874 with nine probe rows.

## Review

Local r1 clean. Second pass (diff only): adopted the single read, the atomic write, and the provenance rule above. Rejected with reasons in the r2 commit: resolver veto, filler enablement, spoken punctuation and the 500 ms ITN deadline are production inputs the bench does not model (pre-existing, known limits of `--preclean`); the `5  mm` filler-guard whitespace gap is a product defect already open as #2728; the package has no test target, so both modes were run on the real corpus instead. Confirming r2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
