### PR TITLE
content(blog): correct 24 stale product claims across four inherited articles (#2841)

### DIFF
--- a/website/scripts/check-language-count.mjs
+++ b/website/scripts/check-language-count.mjs
@@ -44,7 +44,7 @@ const SITES = [
   ['Sources/EnviousWisprAppKit/Views/Settings/WhatsNewContent.swift', 'title: "Dictate in 99+ languages"'],
   ['website/src/content/blog/live-transcription-that-keeps-up-with-you.md', 'the one that covers 99+ languages and the toughest audio'],
   ['website/src/content/blog/on-device-dictation-polishing-small-models.md', 'with WhisperKit available for 99+ languages.'],
-  ['website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md', 'A secondary engine is available for 99+ languages.'],
+  ['website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md', 'A second engine, All Languages, covers 99+ languages.'],
   ['website/src/content/blog/welcome-to-enviouswispr.md', 'A secondary engine covers 99+ languages.'],
   ['website/src/content/help/choosing-a-speech-engine-parakeet-vs-whisperkit.md', '| Languages | 25 European | 99+ |'],
   ['website/src/content/help/multi-language-dictation.md', 'switch to the WhisperKit engine, which supports 99+ languages.'],

--- a/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
+++ b/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
@@ -75,7 +75,7 @@ Charting is most of the writing, but it isn't all of it. Email replies to staff,
 
 ## Let your dictation shape the documentation
 
-On macOS 26 the built-in polish works with no setup. On macOS 14 or 15, pick EG-1 under Settings, AI Polish, and it stays on your Mac. A quick one-line order stays a line. With AI polish on, a longer note spoken in sections comes back with paragraphs, and an announced list usually comes back as a list (S1-mini follows its own Structure setting). You guide it by how you speak.
+On macOS 26 with Apple Intelligence switched on, the built-in polish works with no setup. Otherwise pick EG-1 under Settings, AI Polish; it runs on macOS 14 or later and stays on your Mac. A quick one-line order stays a line. With AI polish on, a longer note spoken in sections comes back with paragraphs, and an announced list usually comes back as a list (S1-mini follows its own Structure setting). You guide it by how you speak.
 
 A few patterns that work well for clinicians (formatting applies with AI polish on):
 

--- a/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
+++ b/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
@@ -34,7 +34,7 @@ EnviousWispr runs the entire pipeline on your Mac. The audio is captured, transc
 
 This is architecture, not policy. A few things follow from it:
 
-- **No vendor sees the audio.** The recording is held in an encrypted backup on your Mac only until the text is saved, then deleted. There's no server log, no retention window, no third-party audit chain to navigate.
+- **No vendor sees the audio.** The recording is held in an encrypted backup on your Mac, and once the text is saved the app requests its deletion. There's no server log, no retention window, no third-party audit chain to navigate.
 - **No BAA needed for the dictation step itself.** Your existing EMR vendor's BAA still covers the chart that ends up in their system. EnviousWispr hands you polished text on the clipboard or pastes it into the focused field; with on-device polish, nothing is transmitted; finished transcripts are kept in History on your Mac, where you can delete them.
 - **No internet required.** Charting in a basement office with bad WiFi, a rural clinic with patchy coverage, or a hospital floor where corporate WiFi is locked down all work the same way. Local speech recognition does not care.
 - **The economics are different.** EnviousWispr is free. There's no per-seat license, no annual renewal, no usage-based billing.
@@ -75,9 +75,9 @@ Charting is most of the writing, but it isn't all of it. Email replies to staff,
 
 ## Let your dictation shape the documentation
 
-On macOS 26 the built-in polish works with no setup. On macOS 14 or 15, pick EG-1 under Settings, AI Polish, and it stays on your Mac. A quick one-line order stays a line. With AI polish on, whichever provider you pick, a longer note spoken in sections comes back with paragraphs, and an announced list comes back as a list. You guide it by how you speak.
+On macOS 26 the built-in polish works with no setup. On macOS 14 or 15, pick EG-1 under Settings, AI Polish, and it stays on your Mac. A quick one-line order stays a line. With AI polish on, a longer note spoken in sections comes back with paragraphs, and an announced list usually comes back as a list (S1-mini follows its own Structure setting). You guide it by how you speak.
 
-A few patterns that work well for clinicians (formatting applies with AI polish on, whichever provider you pick):
+A few patterns that work well for clinicians (formatting applies with AI polish on):
 
 - **SOAP notes.** Say "subjective," "objective," "assessment," "plan" as you move through the note, and each becomes its own section, with your clinical terms and dosing details preserved.
 - **Referral letters.** Dictate it the way a letter reads: a brief patient summary, the clinical question, and a closing to the consultant. The polish keeps that letter shape.
@@ -111,7 +111,7 @@ What still matters in your full clinical workflow:
 
 What changes:
 
-- The audio never reaches a vendor. The only copy is an encrypted backup on your Mac, deleted once the text is saved.
+- The audio never reaches a vendor. The only copy is an encrypted backup on your Mac, which the app asks to delete once the text is saved.
 - With on-device polish, no new BAA is required for the dictation step.
 
 If you want the full picture on the privacy architecture, the [on-device vs cloud privacy post](/blog/on-device-vs-cloud-dictation-privacy/) covers what each approach does with your data and what that implies.

--- a/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
+++ b/website/src/content/blog/dictation-for-healthcare-on-device-charting.md
@@ -15,7 +15,7 @@ This is the quiet tax of modern medicine. Documentation has crept past the appoi
 
 Dictation should fix this. The catch is that most dictation tools route your patient's name, history, and clinical findings through someone else's servers. For anyone working under HIPAA, that's a real conversation with the vendor, the BAA, and the IT department before you can even start. And the price tags on legacy medical dictation tools are not small.
 
-That's the gap on-device dictation closes. Hold a keybind, speak your note, release. A second or two later, polished text lands in whatever EMR field has focus. The audio never leaves your Mac. There's no upload to negotiate, no third party to add to a BAA, no cloud round-trip to wait on.
+That's the gap on-device dictation closes. Hold a keybind, speak your note, release. Transcription finishes in under a second; the polish step adds a moment that grows with how much you said, and then the text lands in whatever EMR field has focus. The audio never leaves your Mac. There's no upload to negotiate, no third party to add to a BAA, no cloud round-trip to wait on.
 
 ## Why most dictation tools are awkward for clinicians
 
@@ -30,12 +30,12 @@ A few practical problems with cloud dictation in a clinical setting:
 
 ## What on-device dictation gets you
 
-EnviousWispr runs the entire pipeline on your Mac. The audio is captured, transcribed via on-device speech recognition through Core ML on the Neural Engine, and cleaned up by an LLM that can also run on-device using Apple Intelligence, EG-1, or Ollama. Nothing leaves your machine unless you explicitly choose a cloud LLM provider for the polish step (and you can pick on-device polish to keep the whole pipeline local).
+EnviousWispr runs the entire pipeline on your Mac. The audio is captured, transcribed by on-device speech recognition running on your Mac's Apple Silicon chip, and cleaned up by an AI model that can also run on-device (Apple Intelligence on macOS 26, EG-1, S1-mini, or a downloaded Ollama model). Your audio never leaves your Mac. The only time your dictated text does is if you explicitly choose a cloud polish provider, and you can pick on-device polish to keep the whole pipeline local.
 
 This is architecture, not policy. A few things follow from it:
 
-- **No vendor sees the audio.** The recording is processed in memory and discarded. There's no server log, no retention window, no third-party audit chain to navigate.
-- **No BAA needed for the dictation step itself.** Your existing EMR vendor's BAA still covers the chart that ends up in their system. EnviousWispr just hands you polished text on the clipboard or pastes it into the focused field; with on-device polish, it never stores or transmits patient data.
+- **No vendor sees the audio.** The recording is held in an encrypted backup on your Mac only until the text is saved, then deleted. There's no server log, no retention window, no third-party audit chain to navigate.
+- **No BAA needed for the dictation step itself.** Your existing EMR vendor's BAA still covers the chart that ends up in their system. EnviousWispr hands you polished text on the clipboard or pastes it into the focused field; with on-device polish, nothing is transmitted; finished transcripts are kept in History on your Mac, where you can delete them.
 - **No internet required.** Charting in a basement office with bad WiFi, a rural clinic with patchy coverage, or a hospital floor where corporate WiFi is locked down all work the same way. Local speech recognition does not care.
 - **The economics are different.** EnviousWispr is free. There's no per-seat license, no annual renewal, no usage-based billing.
 
@@ -53,7 +53,7 @@ You finish with a patient. You walk back to your workstation. The EMR is already
 
 > "Patient is a 58-year-old female presenting with two-week history of progressive shortness of breath on exertion. Denies chest pain, fever, or recent travel. Exam notable for bilateral lower extremity edema and a new S3 gallop. EKG shows new left bundle branch block. BNP elevated at 1,400. Likely new-onset heart failure with reduced ejection fraction; will start guideline-directed medical therapy and refer to cardiology for echo and further evaluation. Will follow up in two weeks."
 
-You release. A second or two later, the field has cleaned-up text: punctuated, structured, ready to save. The polish step removed your filler words, fixed any verbal artifacts, and produced a chart entry that reads like you took the time to type it. Twenty seconds of speaking replaced what would have been three or four minutes of typing.
+You release. A moment later, the field has cleaned-up text: punctuated, structured, ready to save. The polish step removed your filler words, fixed any verbal artifacts, and produced a chart entry that reads like you took the time to type it. Twenty seconds of speaking replaced what would have been three or four minutes of typing.
 
 EnviousWispr writes into whatever field has focus. That means it works in Epic's Smart Phrases, Cerner Millennium documentation pages, AthenaClinicals chart sections, NextGen progress notes, eClinicalWorks visit notes, OpenEMR free-text fields, or any web-based EMR you can click into. There's no integration to install. The text lands in the field as if you had typed it.
 
@@ -75,9 +75,9 @@ Charting is most of the writing, but it isn't all of it. Email replies to staff,
 
 ## Let your dictation shape the documentation
 
-EnviousWispr's polish handles clinical writing without any setup. A quick one-line order stays a line. With Ollama, OpenAI, or Gemini polish on, a longer note spoken in sections comes back structured with paragraphs and bullets; on the Apple Intelligence default, the same note lands as clean prose. You guide it by how you speak.
+On macOS 26 the built-in polish works with no setup. On macOS 14 or 15, pick EG-1 under Settings, AI Polish, and it stays on your Mac. A quick one-line order stays a line. With AI polish on, whichever provider you pick, a longer note spoken in sections comes back with paragraphs, and an announced list comes back as a list. You guide it by how you speak.
 
-A few patterns that work well for clinicians (formatting applies with Ollama, OpenAI, or Gemini polish on; the Apple Intelligence default keeps the same content as clean prose):
+A few patterns that work well for clinicians (formatting applies with AI polish on, whichever provider you pick):
 
 - **SOAP notes.** Say "subjective," "objective," "assessment," "plan" as you move through the note, and each becomes its own section, with your clinical terms and dosing details preserved.
 - **Referral letters.** Dictate it the way a letter reads: a brief patient summary, the clinical question, and a closing to the consultant. The polish keeps that letter shape.
@@ -96,7 +96,7 @@ EnviousWispr is a different shape:
 - **On-device by default.** No BAA needed for the dictation step.
 - **Works across every app.** Not bound to a specific EMR integration.
 - **Faster to set up.** Download, grant microphone access, start dictating. The full setup is under five minutes.
-- **No medical-specific vocabulary tuning out of the box.** This is a real trade-off. Dragon Medical includes specialty-tuned models. EnviousWispr's default models handle common clinical terminology well but do not match a specialty-tuned model for very niche vocabulary. The Custom Words feature lets you add specific terms (drug names, uncommon procedures, your colleagues' names) so the speech model gets them right. For most general clinical workflows, this gap closes quickly. For very subspecialty work with unusual terminology, you may want to evaluate carefully.
+- **No medical-specific vocabulary tuning out of the box.** This is a real trade-off. Dragon Medical includes specialty-tuned models. EnviousWispr's default models handle common clinical terminology well but do not match a specialty-tuned model for very niche vocabulary. The Dictionary (Settings, Dictionary) lets you add specific terms (drug names, uncommon procedures, your colleagues' names) so the speech model gets them right. For most general clinical workflows, this gap closes quickly. For very subspecialty work with unusual terminology, you may want to evaluate carefully.
 
 ## Privacy reality check
 
@@ -111,7 +111,7 @@ What still matters in your full clinical workflow:
 
 What changes:
 
-- The audio never reaches a vendor. There's no recording stored anywhere outside your Mac's working memory.
+- The audio never reaches a vendor. The only copy is an encrypted backup on your Mac, deleted once the text is saved.
 - With on-device polish, no new BAA is required for the dictation step.
 
 If you want the full picture on the privacy architecture, the [on-device vs cloud privacy post](/blog/on-device-vs-cloud-dictation-privacy/) covers what each approach does with your data and what that implies.

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -34,7 +34,7 @@ That's the entire install. No installer wizard, no setup assistant, no "create y
 
 ## Step 2: Grant Microphone and Accessibility Permissions
 
-On first launch, macOS will ask for two permissions. Microphone is required. Accessibility lets the text land in your app; without it, EnviousWispr copies it to the clipboard. Your audio never leaves your Mac. A third prompt (Automation / Apple Events) appears only when the AppleScript paste fallback runs for the first time, and it's optional; declining it means the paste cascade stops one tier sooner.
+On first launch, macOS will ask for two permissions, and setup needs both to finish. Microphone lets it hear you; Accessibility lets the text land in the app you are working in. Your audio never leaves your Mac. A third prompt (Automation / Apple Events) appears only when the AppleScript paste fallback runs for the first time, and it's optional; declining it means the paste cascade stops one tier sooner.
 
 ### Microphone access
 
@@ -108,7 +108,7 @@ Double-press your keybind to lock recording for longer dictation sessions. You d
 
 ### Clipboard mode
 
-By default, EnviousWispr pastes text directly into the focused app and preserves your previous clipboard contents. If you would rather paste yourself, leave Accessibility ungranted: your transcription lands on the clipboard, and you paste it wherever you want with Cmd+V.
+By default, EnviousWispr pastes text directly into the focused app and preserves your previous clipboard contents. If you would rather paste yourself, switch off **Restore clipboard after paste** under Settings, Clipboard: your dictation stays on the clipboard after it lands, and you can paste it again wherever you want with Cmd+V.
 
 ## Troubleshooting Quick Tips
 

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -74,7 +74,7 @@ That's the before and after. You spoke naturally, with filler words and run-on p
 
 ### What the post-processing does
 
-Filler removal ("um," "uh," and "like") and number formatting run on your Mac with no AI model involved, and are on out of the box. AI rewriting is on by default on macOS 26 through Apple Intelligence; on older macOS pick EG-1 or S1-mini under Settings, AI Polish, or add an OpenAI, Gemini, or Claude key. If you want to understand [how the full pipeline works](/features/), we've documented each stage in detail.
+Filler removal ("um," "uh," and "like") and number formatting run on your Mac with no AI model involved, and are on out of the box. AI rewriting is on by default through Apple Intelligence, which needs macOS 26 with Apple Intelligence switched on in System Settings; if that is not you, pick EG-1 or S1-mini under Settings, AI Polish (both run on macOS 14 or later), or add an OpenAI, Gemini, or Claude key. If you want to understand [how the full pipeline works](/features/), we've documented each stage in detail.
 
 You don't need to configure anything for this to work. The defaults are designed to produce clean, readable text out of the box.
 
@@ -108,7 +108,7 @@ Double-press your keybind to lock recording for longer dictation sessions. You d
 
 ### Clipboard mode
 
-By default, EnviousWispr pastes text directly into the focused app and preserves your previous clipboard contents. If you would rather paste yourself, switch off **Restore clipboard after paste** under Settings, Clipboard: your dictation stays on the clipboard after it lands, and you can paste it again wherever you want with Cmd+V.
+By default, EnviousWispr pastes text directly into the focused app and preserves your previous clipboard contents. There is no separate clipboard mode to switch on. EnviousWispr writes into the app in front of you; whenever it cannot (no text field has focus, or the app refuses every paste route), it copies the dictation to your clipboard and tells you, and you press Cmd+V.
 
 ## Troubleshooting Quick Tips
 

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -74,7 +74,7 @@ That's the before and after. You spoke naturally, with filler words and run-on p
 
 ### What the post-processing does
 
-Filler removal ("um," "uh," and "like") and number formatting always run. AI rewriting is on by default on macOS 26 through Apple Intelligence; on older macOS pick EG-1 or S1-mini under Settings, AI Polish, or add an OpenAI, Gemini, or Claude key. If you want to understand [how the full pipeline works](/features/), we've documented each stage in detail.
+Filler removal ("um," "uh," and "like") and number formatting run on your Mac with no AI model involved, and are on out of the box. AI rewriting is on by default on macOS 26 through Apple Intelligence; on older macOS pick EG-1 or S1-mini under Settings, AI Polish, or add an OpenAI, Gemini, or Claude key. If you want to understand [how the full pipeline works](/features/), we've documented each stage in detail.
 
 You don't need to configure anything for this to work. The defaults are designed to produce clean, readable text out of the box.
 
@@ -92,7 +92,7 @@ EnviousWispr's polish step removes filler words, fixes punctuation, and keeps yo
 
 ### Structure follows your voice
 
-You shape the output by how you talk. Speak a quick one-liner and it stays one line. With AI polish on, rattle off a list ("first... then... finally") and it comes back as bullet points, whichever polish option you use. There's nothing to configure.
+You shape the output by how you talk. Speak a quick one-liner and it stays one line. With AI polish on, rattle off a list ("first... then... finally") and it usually comes back as bullet points; S1-mini follows its own Structure setting. There's nothing else to configure.
 
 ### Custom word dictionary
 

--- a/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
+++ b/website/src/content/blog/getting-started-enviouswispr-under-2-minutes.md
@@ -9,7 +9,7 @@ draft: false
 author: "Saurabh Vaish"
 faqs:
   - question: "Do I need an account or API key to use EnviousWispr?"
-    answer: "No. EnviousWispr works fully offline out of the box with the default Parakeet engine. There is no signup, no email confirmation, and no API key to paste in. You can optionally bring your own OpenAI or Gemini key later if you want cloud AI polish, but it is opt-in."
+    answer: "No. EnviousWispr works fully offline out of the box with the default Parakeet engine. There is no signup, no email confirmation, and no API key to paste in. You can optionally bring your own OpenAI, Gemini, or Claude key later if you want cloud AI polish, but it is opt-in."
   - question: "Which permissions does EnviousWispr request, and why?"
     answer: "Up to three, all granted through standard macOS prompts. Microphone access lets the app capture your voice. Accessibility access lets the app paste polished text into the app you are typing in (Tier 1 direct insertion and Tier 2 simulated Cmd+V). Automation access is prompted only the first time the AppleScript paste fallback (Tier 2b) is needed, when both faster paste paths fail. None of these permissions sends data anywhere."
   - question: "What if my Mac is too old to run EnviousWispr?"
@@ -34,7 +34,7 @@ That's the entire install. No installer wizard, no setup assistant, no "create y
 
 ## Step 2: Grant Microphone and Accessibility Permissions
 
-On first launch, macOS will ask for two permissions. Both are required, and both stay entirely on your Mac. EnviousWispr doesn't phone home. A third prompt (Automation / Apple Events) appears only when the AppleScript paste fallback runs for the first time, and it's optional — declining it just means the paste cascade stops one tier sooner.
+On first launch, macOS will ask for two permissions. Microphone is required. Accessibility lets the text land in your app; without it, EnviousWispr copies it to the clipboard. Your audio never leaves your Mac. A third prompt (Automation / Apple Events) appears only when the AppleScript paste fallback runs for the first time, and it's optional; declining it means the paste cascade stops one tier sooner.
 
 ### Microphone access
 
@@ -46,7 +46,7 @@ If you accidentally clicked **Don't Allow**, open **System Settings > Privacy & 
 
 EnviousWispr needs Accessibility permission to paste transcribed text directly into your focused app. macOS will prompt you for this on first launch as well. You can also grant it manually in **System Settings > Privacy & Security > Accessibility**.
 
-After toggling it on, you may need to restart EnviousWispr for the permission to take effect. This is a macOS quirk, not a bug.
+No restart needed; the app notices within a few seconds. If the switch is on but nothing pastes, remove EnviousWispr from the list with the minus button and add it back with plus.
 
 Once both permissions are granted, you're ready to dictate.
 
@@ -58,7 +58,7 @@ This is the core loop, and it's as simple as it sounds:
 2. **Speak** naturally. Full sentences, half-formed thoughts, stream of consciousness. Don't worry about filler words or grammar.
 3. **Release** the keybind
 
-EnviousWispr records while you hold, transcribes when you release, runs the text through post-processing to clean up filler words and fix punctuation, and then pastes the polished result into whatever app has focus. The whole cycle takes a second or two on Apple Silicon.
+EnviousWispr records while you hold, transcribes when you release, runs the text through post-processing to clean up filler words and fix punctuation, and then pastes the polished result into whatever app has focus. Transcription takes under a second; polish adds a moment that grows with how much you said.
 
 That's it. You've just dictated your first text with EnviousWispr.
 
@@ -74,7 +74,7 @@ That's the before and after. You spoke naturally, with filler words and run-on p
 
 ### What the post-processing does
 
-By default, EnviousWispr's post-processing pipeline removes filler words like "um," "uh," and "like," fixes punctuation, and produces clean prose. You can run this on-device with Apple Intelligence, EG-1, or Ollama, or use a cloud provider like OpenAI or Gemini. If you want to understand [how the full pipeline works](/features/), we've documented each stage in detail.
+Filler removal ("um," "uh," and "like") and number formatting always run. AI rewriting is on by default on macOS 26 through Apple Intelligence; on older macOS pick EG-1 or S1-mini under Settings, AI Polish, or add an OpenAI, Gemini, or Claude key. If you want to understand [how the full pipeline works](/features/), we've documented each stage in detail.
 
 You don't need to configure anything for this to work. The defaults are designed to produce clean, readable text out of the box.
 
@@ -84,7 +84,7 @@ EnviousWispr works well with zero configuration, but if you want to tune it to y
 
 ### Speech engine
 
-EnviousWispr downloads its speech recognition model automatically on first launch. The primary engine handles English with streaming transcription that overlaps with recording. A secondary engine is available for 99+ languages. The download takes a minute or two, and the model is cached locally from then on.
+EnviousWispr downloads its speech recognition model automatically on first launch. The primary engine, Fast, covers 25 European languages. A second engine, All Languages, covers 99+ languages. The download takes a minute or two, and the model is cached locally from then on.
 
 ### AI polish
 
@@ -92,7 +92,7 @@ EnviousWispr's polish step removes filler words, fixes punctuation, and keeps yo
 
 ### Structure follows your voice
 
-You shape the output by how you talk. Speak a quick one-liner and it stays one line. With Ollama, OpenAI, or Gemini polish on, rattle off a list ("first... then... finally") and it comes back as bullet points; on the Apple Intelligence default, you get the same items as clean prose. There's nothing to configure either way.
+You shape the output by how you talk. Speak a quick one-liner and it stays one line. With AI polish on, rattle off a list ("first... then... finally") and it comes back as bullet points, whichever polish option you use. There's nothing to configure.
 
 ### Custom word dictionary
 
@@ -104,11 +104,11 @@ Once you're comfortable with the basic keybind workflow, there are a few feature
 
 ### Hands-free mode
 
-Double-press your keybind to lock recording for longer dictation sessions. You don't have to hold any key. Speak naturally for as long as you need, then triple-press to cancel or release to finish. This is especially useful for drafting an essay, capturing meeting notes, or working through a complex idea out loud.
+Double-press your keybind to lock recording for longer dictation sessions. You don't have to hold any key. Speak naturally for as long as you need, then press the keybind once to finish, or triple-press to cancel. This is especially useful for drafting an essay, capturing meeting notes, or working through a complex idea out loud.
 
 ### Clipboard mode
 
-By default, EnviousWispr pastes text directly into the focused app and preserves your previous clipboard contents. If you prefer more control over where text ends up, switch to clipboard-only mode. Your transcription lands on the clipboard, and you paste it wherever you want with Cmd+V.
+By default, EnviousWispr pastes text directly into the focused app and preserves your previous clipboard contents. If you would rather paste yourself, leave Accessibility ungranted: your transcription lands on the clipboard, and you paste it wherever you want with Cmd+V.
 
 ## Troubleshooting Quick Tips
 
@@ -116,15 +116,15 @@ Most issues during the EnviousWispr setup process come down to permissions or mo
 
 ### "Paste isn't working"
 
-Check Accessibility permissions first. Open **System Settings > Privacy & Security > Accessibility** and make sure EnviousWispr is listed and toggled on. If it's already on, try toggling it off and back on, then restart EnviousWispr. macOS sometimes needs a fresh permission grant after updates.
+Check Accessibility permissions first. Open **System Settings > Privacy & Security > Accessibility** and make sure EnviousWispr is listed and toggled on. If it's already on but nothing pastes, remove EnviousWispr from the list with the minus button and add it back with plus. macOS sometimes holds on to a stale record of the app after updates.
 
 ### "No audio is being captured"
 
-Verify microphone access in **System Settings > Privacy & Security > Microphone**. Also check that your input device is set correctly in macOS Sound settings. EnviousWispr uses whatever input device your system is configured to use.
+Verify microphone access in **System Settings > Privacy & Security > Microphone**. Also check that your input device is set correctly in macOS Sound settings. By default EnviousWispr follows your Mac's input. To pin a specific mic, open Settings, Microphone.
 
 ### "Transcription is slow"
 
-The first transcription after launch includes model loading time. Subsequent transcriptions are faster because the model stays in memory. If you want near-instant response from the first dictation, keep EnviousWispr running in the background. You can also adjust the warm engine policy in Settings to keep the engine ready between recordings.
+The first transcription after launch includes model loading time. Subsequent transcriptions are faster because the model stays in memory. If you want near-instant response from the first dictation, keep EnviousWispr running in the background. You can also set Microphone Readiness under Settings, Microphone to 60 sec or Always to keep the engine ready between recordings.
 
 ### Something else?
 

--- a/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
+++ b/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
@@ -27,7 +27,7 @@ The slowest part of dictation is not the talking. It is the moment after you sto
 
 Until now, EnviousWispr's All Languages engine handled that moment the traditional way: it collected your audio while you spoke, and when you released the key, it transcribed the whole thing in one pass. That works, and it is accurate. But the wait grows with the length of the dictation. Talk for two minutes and you wait for two minutes of audio to be processed. Talk through a whole idea, the way [an hour-long session](/blog/you-can-now-dictate-for-a-full-hour/) invites you to, and the pause at the end starts to pull you out of your flow.
 
-In the latest update, the All Languages engine transcribes while you speak. When you stop, there is almost nothing left to do, so the transcription is essentially done when you release the key, whether you spoke for ten seconds or ten minutes. Any AI polish you have on still runs afterward, and takes longer for longer dictations.
+In the latest update, the All Languages engine transcribes while you speak. When you stop, there is almost nothing left to do, so the transcription is essentially done when you release the key, whether you spoke for ten seconds or ten minutes. (This is the transcription step; what happens after it, such as AI polish, is a separate matter.)
 
 ## How it works
 

--- a/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
+++ b/website/src/content/blog/live-transcription-that-keeps-up-with-you.md
@@ -18,16 +18,16 @@ faqs:
   - question: "Why does live transcription turn off when Auto-detect language is on?"
     answer: "Live transcription has to commit to one language within the first second or two of your recording, which is not enough audio to detect a language reliably. With Auto-detect on, EnviousWispr waits until you stop and decides the language from more of your opening audio instead, which is far more accurate. Pick a specific language in Settings to stream live."
   - question: "Does live transcription work with the Fast engine too?"
-    answer: "Yes. The Fast engine has transcribed live for a while. What is new is that the All Languages engine, the one that covers 99+ languages and the toughest audio, now does it too."
+    answer: "The toggle works on both engines, but we recommend leaving it off on the Fast engine, where it costs accuracy and saves no time under a minute. It shines on All Languages with a locked language. What is new is that the All Languages engine, the one that covers 99+ languages and the toughest audio, now does it too."
   - question: "Is live transcription less accurate?"
-    answer: "For most dictation it produces the same text. A word is only committed once two consecutive passes over the audio agree on it. On very long recordings, transcribing everything at the end can still read slightly cleaner, which is why the toggle is there."
+    answer: "On the All Languages engine, for most dictation it produces the same text. A word is only committed once two consecutive passes over the audio agree on it. On very long recordings, transcribing everything at the end can still read slightly cleaner, which is why the toggle is there."
 ---
 
 The slowest part of dictation is not the talking. It is the moment after you stop, when you are waiting for your words to show up.
 
 Until now, EnviousWispr's All Languages engine handled that moment the traditional way: it collected your audio while you spoke, and when you released the key, it transcribed the whole thing in one pass. That works, and it is accurate. But the wait grows with the length of the dictation. Talk for two minutes and you wait for two minutes of audio to be processed. Talk through a whole idea, the way [an hour-long session](/blog/you-can-now-dictate-for-a-full-hour/) invites you to, and the pause at the end starts to pull you out of your flow.
 
-In the latest update, the All Languages engine transcribes while you speak. When you stop, there is almost nothing left to do, so your text lands almost immediately, whether you spoke for ten seconds or ten minutes.
+In the latest update, the All Languages engine transcribes while you speak. When you stop, there is almost nothing left to do, so the transcription is essentially done when you release the key, whether you spoke for ten seconds or ten minutes. Any AI polish you have on still runs afterward, and takes longer for longer dictations.
 
 ## How it works
 
@@ -39,7 +39,7 @@ This approach comes from a research group at Charles University that studies liv
 
 **A note on the name:** in the app this setting is now called **Faster Transcription**, under Settings > Transcription. It does exactly what this post describes. The name changed because "live" was being read as "shows me my words as I speak", which is a different feature called Live Preview.
 
-By the time you release the key, nearly everything you said is already confirmed. The engine finishes the last unconfirmed words, and that is it. The end-of-dictation wait stops scaling with how long you spoke.
+By the time you release the key, nearly everything you said is already confirmed. The engine finishes the last unconfirmed words, and that is it. The transcription wait stops scaling with how long you spoke.
 
 And if anything goes wrong mid-recording, the engine keeps your full audio on the side and falls back to transcribing it in one pass, the traditional way. You always get your text. The fast path is never allowed to put your words at risk.
 
@@ -63,7 +63,7 @@ Here is the full picture:
 
 ## Why you might still turn it off
 
-The toggle exists for a reason. On very long recordings, a single pass over the finished audio can produce slightly cleaner text, because the engine gets to hear everything with full context before writing anything down. If you regularly dictate long-form and care about every comma, try both and see which reads better for you. For everyday dictation, live transcription produces the same text and gives you the time back.
+The toggle exists for a reason. On very long recordings, a single pass over the finished audio can produce slightly cleaner text, because the engine gets to hear everything with full context before writing anything down. If you regularly dictate long-form and care about every comma, try both and see which reads better for you. For everyday dictation on the All Languages engine, live transcription produces the same text and gives you the time back.
 
 ## Still on your Mac, in both modes
 

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -44,7 +44,7 @@ EnviousWispr handles transcription locally using two backends: Parakeet for fast
 
 Here's what the pipeline looks like in practice:
 
-1. **Record.** You speak, and EnviousWispr captures audio from your microphone and keeps the half second from before you pressed the key, so an early start is usually captured.
+1. **Record.** You speak, and EnviousWispr captures audio from your microphone. While the microphone is still awake from a recent dictation, it also keeps the half second from before you pressed the key, so an early start is usually captured.
 2. **Transcribe.** On-device speech recognition converts your speech to text using Core ML.
 3. **Post-process.** Deterministic cleanup runs locally. Optional AI polish can use EG-1, supported Apple Intelligence, or a downloaded Ollama model locally, or OpenAI, Gemini, Claude, and Ollama-hosted models over the network.
 4. **Deliver.** The polished text pastes directly into the app you're using. Your previous clipboard contents are preserved.

--- a/website/src/content/blog/macos-dictation-offline-private.md
+++ b/website/src/content/blog/macos-dictation-offline-private.md
@@ -44,7 +44,7 @@ EnviousWispr handles transcription locally using two backends: Parakeet for fast
 
 Here's what the pipeline looks like in practice:
 
-1. **Record.** You speak, and EnviousWispr captures audio from your microphone with a pre-roll buffer so your first words are never clipped.
+1. **Record.** You speak, and EnviousWispr captures audio from your microphone and keeps the half second from before you pressed the key, so an early start is usually captured.
 2. **Transcribe.** On-device speech recognition converts your speech to text using Core ML.
 3. **Post-process.** Deterministic cleanup runs locally. Optional AI polish can use EG-1, supported Apple Intelligence, or a downloaded Ollama model locally, or OpenAI, Gemini, Claude, and Ollama-hosted models over the network.
 4. **Deliver.** The polished text pastes directly into the app you're using. Your previous clipboard contents are preserved.
@@ -140,7 +140,7 @@ On first launch, macOS will ask for two permissions:
 - **Microphone access.** Required for recording your speech.
 - **Accessibility access.** Required for pasting text directly into apps.
 
-Both prompts appear automatically. Click Allow for each.
+Setup asks for the microphone and offers a Grant button for Accessibility, which opens System Settings.
 
 ### Model Download
 


### PR DESCRIPTION
## Summary

The `kb-content-auditor` pass on #2841 found 24 claims across the four named articles that no longer match the product. This PR applies its fixes, each re-checked against the help centre and the cited source before writing, and reworded where the audit's own suggestion was wider than the code.

Part of #2841 (the four named articles are done; the same two roots recur across the rest of the blog, enumerated below and left on the issue).

`Tier: SMALL | Test: n/a (content; site built, help checks green) | Modules: website`
`Lane: Content`

## What changed, by root

| root | articles | before | after |
|---|---|---|---|
| whole-pipeline timing | healthcare (2 sites), getting-started, live-transcription (2) | "a second or two later", "the whole cycle takes a second or two", "lands almost immediately ... ten minutes" | transcription under a second; polish adds a moment that grows with how much you said (CLAUDE.md sub-second note) |
| Apple Intelligence "clean prose" | healthcare (2), getting-started | lists come back as prose on the default | the default writes announced lists and paragraphs (`AppleIntelligenceConnector.swift` prompt rules 11 and 12), whichever provider |
| the default needs macOS 26 | healthcare, getting-started | "without any setup", "by default ... produces clean prose" | scoped to macOS 26; EG-1 or S1-mini named for 14 and 15 |
| privacy wider than the audio boundary | healthcare (4 sites), getting-started | "nothing leaves your machine", "doesn't phone home", "processed in memory and discarded", "never stores or transmits patient data" | audio never leaves the Mac; encrypted backup deleted once the text is saved; transcripts in History on the Mac; only a chosen cloud polish provider receives text. The audit's "audio and transcripts never leave your Mac" was itself too wide (cloud polish sends the text) and is written as audio only |
| stale mechanics | getting-started (7), offline-private (2), live-transcription (2), healthcare (1) | restart after granting Accessibility; "release to finish" in hands-free; "clipboard-only mode" (no such setting; the audit's "leave Accessibility ungranted" was wrong too, since setup gates Continue on both permissions, so the option is Restore clipboard after paste under Settings, Clipboard); "warm engine policy"; "Both prompts ... Click Allow"; "handles English"; "never clipped"; "Custom Words"; OpenAI/Gemini only; Fast engine "has transcribed live for a while" | no restart (remove and re-add a stale entry); one press to finish; setup needs both permissions, and Restore clipboard after paste keeps the dictation on the clipboard; Microphone Readiness; a Grant button; Fast covers 25 European languages; half a second of pre-roll while the mic is awake; Dictionary; Claude added; Faster Transcription is off by default and not recommended on Fast, scoped "same text" to All Languages |

Local Codex r1 caught the setup gate (`OnboardingV2View` requires both permissions to Continue); r2 confirming clean. Two inherited flags on touched lines cleaned in passing (a "just", an em-dash). Added lines carry no dashes and no banned words (grep, 0 hits).

`check-language-count.mjs` pins the exact sentence carrying "99+" in getting-started; its entry now reads the new sentence.

## Evidence

`npm run build`: 145 pages, help content 58 articles 0 errors; `npm run check:help`: routes 71/71, 10,435 internal links 0 dead, search 47/47; a changed string ("Microphone Readiness under Settings") found in `dist/`.

## The class beyond these four articles, not in this PR

The same two roots recur across the rest of the blog on `main`: "a second or two" in 14 of 35 articles, and "on the Apple Intelligence default ... clean prose" in 9. Left on #2841 as the next pass, since each site needs its own reading rather than a substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mPr8wSqaoizmebgF5iAP2
