### PR TITLE
docs(content): Dictation, Transcript, History: the vocabulary reaches the help centre, website, README and Settings (#2812)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Dictation is only useful if you can trust it mid-sentence, every time. EnviousWi
 | **Clear answers when AI polish has a problem** | If a cloud or local model fails (OpenAI, Gemini, Ollama), you get a specific, plain-language message, and your raw text still arrives. |
 | **Deterministic cleanup before AI** | For English, numbers, dates, and money are formatted by a fixed, predictable step, even when AI polish is off or unavailable. |
 | **Fast recovery after idle** | After the app sits idle, it re-wakes in a fraction of a second so your next press, and its first word, are not lost. |
-| **Privacy-safe diagnostics** | Crash reports carry counts and context, never your transcript or audio, and are redacted before they are sent. |
+| **Privacy-safe diagnostics** | Crash reports carry counts and context, never your dictations, transcripts or audio, and are redacted before they are sent. |
 | **Hardened releases** | Every build is signed, notarized, and Gatekeeper-checked before it ships. |
 
 ## Supported Models
@@ -118,7 +118,7 @@ On our own benchmark of 1,890 real dictation-cleanup cases, EG-1 passed 93.7%, a
 - 🎨 **Your choice of recording pill**: pick the recording indicator design you like in Appearance settings, and try a practice dictation before setup ends
 - ⌨️ **Global keybind** with push-to-talk, toggle, and hands-free modes (double-press to lock for long-form dictation)
 - 📋 **Auto-paste** directly into the active app, or just copy to clipboard
-- 🕘 **Transcript history** for browsing, searching, and reviewing past dictations
+- 🕘 **History** for browsing, searching, and reviewing past dictations and transcripts
 - 🧭 **Menu bar native** with minimal footprint
 - 🔄 **Auto-updates** via Sparkle
 
@@ -211,7 +211,7 @@ EnviousWispr is built on a simple principle: **your voice is yours.**
 - Audio is captured, transcribed, and discarded locally. Nothing is uploaded, stored, or shared.
 - LLM polish (if enabled) can run entirely on your Mac with EG-1 (our own model), Apple Intelligence, or a local Ollama model, so the polish step makes no network call. If you pick OpenAI, Gemini, or Claude, only text is sent (your transcript plus the polish instructions) using your own API key. If you pick a hosted Ollama model, the same text is sent to Ollama using your Ollama sign-in. Audio is never sent.
 - Anonymous product analytics (PostHog) can be disabled in Settings.
-- Crash reporting (Sentry) contains no transcript content, audio, or personal data.
+- Crash reporting (Sentry) contains no dictation or transcript content, audio, or personal data.
 
 ## Connect
 

--- a/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
+++ b/Sources/EnviousWisprAppKit/Views/Onboarding/OnboardingV2View.swift
@@ -1518,13 +1518,13 @@ private struct PermissionsPhaseView: View {
                   .font(.obLabel)
                   .foregroundStyle(Color.obTextPrimary)
                 Text(
-                  "macOS calls this permission \"Accessibility,\" but EnviousWispr uses it for exactly one thing: pasting your transcript into the app you're typing in. Without it, every dictation lands in the clipboard and you'd have to paste manually."
+                  "macOS calls this permission \"Accessibility,\" but EnviousWispr uses it for exactly one thing: pasting your dictation into the app you're typing in. Without it, every dictation lands in the clipboard and you'd have to paste manually."
                 )
                 .font(.obCaption)
                 .foregroundStyle(Color.obTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
                 Text(
-                  "We only use Accessibility at the moment we paste your transcript. Never to read your keystrokes, never to watch what happens in other apps."
+                  "We only use Accessibility at the moment we paste your dictation. Never to read your keystrokes, never to watch what happens in other apps."
                 )
                 .font(.obCaption)
                 .foregroundStyle(Color.obTextSecondary)

--- a/Sources/EnviousWisprAppKit/Views/Settings/ClipboardSettingsView.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ClipboardSettingsView.swift
@@ -28,7 +28,7 @@ struct ClipboardSettingsView: View {
               }
               .toggleStyle(BrandedToggleStyle())
               Text(
-                "Saves and restores whatever was on your clipboard before pasting the transcript."
+                "Saves and restores whatever was on your clipboard before pasting your dictation."
               )
               .settingsReadingCopy()
             }

--- a/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/LearningSection.swift
@@ -54,7 +54,7 @@ struct LearningSection: View {
     learnCard {
       VStack(alignment: .leading, spacing: 8) {
         HStack(alignment: .center, spacing: 8) {
-          Text("Learn from my transcripts")
+          Text("Learn from my edits")
             .settingsRowLabel()
           comingSoonPill
           Spacer(minLength: 8)

--- a/Sources/EnviousWisprAppKit/Views/Settings/ProviderSetup.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/ProviderSetup.swift
@@ -1182,7 +1182,7 @@ struct ProviderSetupSection: View {
   private var claudeExplainer: some View {
     VStack(alignment: .leading, spacing: 10) {
       Text(
-        "Claude is a strong fit for technical writing, code review comments, and identifiers. Haiku is the recommended starting point for dictation cleanup: it is Anthropic's fastest and cheapest current tier, and most cleanup runs finish in one to two seconds. Model names and availability come from your Claude Platform account, so the list shown here can vary by account and usage tier. Cloud polish sends the transcript to Anthropic under your API account."
+        "Claude is a strong fit for technical writing, code review comments, and identifiers. Haiku is the recommended starting point for dictation cleanup: it is Anthropic's fastest and cheapest current tier, and most cleanup runs finish in one to two seconds. Model names and availability come from your Claude Platform account, so the list shown here can vary by account and usage tier. Cloud polish sends your text to Anthropic under your API account."
       )
       .settingsReadingCopy()
 
@@ -1260,7 +1260,7 @@ struct ProviderSetupSection: View {
     if provider == .openAI {
       VStack(alignment: .leading, spacing: 10) {
         Text(
-          "Apple Intelligence cleans up short dictation well. OpenAI is a step up for longer recordings, lists, and code. You bring your own API key, you only pay OpenAI for what you use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to OpenAI under your API account."
+          "Apple Intelligence cleans up short dictation well. OpenAI is a step up for longer recordings, lists, and code. You bring your own API key, you only pay OpenAI for what you use, and most cleanup runs land in well under a second. Cloud polish sends your text to OpenAI under your API account."
         )
         .settingsReadingCopy()
 
@@ -1286,7 +1286,7 @@ struct ProviderSetupSection: View {
     } else if provider == .gemini {
       VStack(alignment: .leading, spacing: 10) {
         Text(
-          "Apple Intelligence cleans up short dictation well. Gemini is a step up for longer recordings, lists, and code. You bring your own API key, the free tier is generous for personal use, and most cleanup runs land in well under a second. Cloud polish sends the transcript to Google under your Gemini API account."
+          "Apple Intelligence cleans up short dictation well. Gemini is a step up for longer recordings, lists, and code. You bring your own API key, the free tier is generous for personal use, and most cleanup runs land in well under a second. Cloud polish sends your text to Google under your Gemini API account."
         )
         .settingsReadingCopy()
 

--- a/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
+++ b/Sources/EnviousWisprAppKit/Views/Settings/SettingsSection.swift
@@ -131,7 +131,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
       return "Improve recognition with your words and vocabulary."
     case .snippets:
       return "Say your keyword, then a snippet. The saved text lands for you."
-    case .clipboard: return "How your transcript reaches the clipboard and the app you're in."
+    case .clipboard: return "How your dictation reaches the clipboard and the app you're in."
     case .permissions: return "The microphone and accessibility access EnviousWispr needs."
     case .checkForUpdates: return ""
     case .openSourceLicenses:

--- a/website/src/content/help/ai-polish-and-cloud-data.md
+++ b/website/src/content/help/ai-polish-and-cloud-data.md
@@ -35,7 +35,7 @@ OpenAI, Gemini, Claude, and Ollama's hosted models all run on their own servers.
 #### What is never sent
 
 - Your audio. That holds on every single option without exception.
-- Your other transcripts, or your History.
+- Your other dictations and transcripts, or your History.
 
 EnviousWispr adds nothing to the request that identifies you or your Mac. The provider still sees the ordinary details of any internet connection, such as your IP address.
 

--- a/website/src/content/help/how-custom-word-correction-works.md
+++ b/website/src/content/help/how-custom-word-correction-works.md
@@ -27,5 +27,5 @@ Custom word correction runs early. Only [snippet expansion](/help/using-snippets
 If one of your custom words keeps slipping through, work through these checks.
 
 - **Verify your spelling.** Check that the spelling you saved is exactly what you want to see in your text.
-- **Inspect your history.** Say the word as you normally would, then open **History** to see what EnviousWispr actually heard. That transcript tells you which wrong version to add.
+- **Inspect your history.** Say the word as you normally would, then open **History** to see what EnviousWispr actually heard. That dictation tells you which wrong version to add.
 - **Consider the word's length.** Very short words are harder to match safely, because matching them broadly enough to catch would also change common words you did not mean to touch.

--- a/website/src/content/help/privacy-overview.md
+++ b/website/src/content/help/privacy-overview.md
@@ -16,7 +16,7 @@ EnviousWispr is a free dictation app for macOS. Your voice becomes text on your 
 You can use the app without an internet connection at all, and your dictation stays on your own hardware.
 
 - **Offline operation.** Recording, transcribing, and pasting need no internet connection. Both speech engines run on your Mac.
-- **Local transcripts.** Your transcripts are saved in your user folder. Envious Labs, the company that makes EnviousWispr, never receives a copy.
+- **Local History.** Your dictations and transcripts are saved in your user folder. Envious Labs, the company that makes EnviousWispr, never receives a copy.
 - **Open source verification.** You can read the code. EnviousWispr is open source, so every claim on this page can be checked against it.
 
 ### When EnviousWispr uses the network

--- a/website/src/content/help/transcript-history.md
+++ b/website/src/content/help/transcript-history.md
@@ -1,32 +1,34 @@
 ---
-title: "Transcript History"
-description: "Finding, reusing, and deleting your past dictations."
+title: "History"
+description: "Finding, reusing, and deleting your past dictations and transcripts."
 category: "features"
-section: "Transcript History"
+section: "History"
 order: 1
-keywords: ["history", "past dictations", "previous", "find an old dictation", "where did my text go", "recover", "lost text", "copy again", "log"]
+keywords: ["history", "past dictations", "transcripts", "speaker labels", "previous", "find an old dictation", "where did my text go", "recover", "lost text", "copy again", "log"]
 related: ["clipboard-preservation", "escape-recovery"]
-updated: 2026-09-01
+updated: 2026-09-13
 ---
-EnviousWispr saves each finished dictation so you can find it again later. To see your past dictations, click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **History**.
+EnviousWispr saves everything it transcribes so you can find it again later. History holds two kinds of item. A **dictation** is a recording you made with your keybind. A **transcript** is a recording you imported with Transcribe a File. To see them, click the EnviousWispr icon in your menu bar, choose **Settings**, and go to **History**.
 
-Recordings where no speech was found are not saved. A recording you cancel with your keybind IS saved, because [Escape Recovery](/help/escape-recovery/) is on unless you switch it off: it is kept here for 24 hours with a **Kept** badge and a countdown, and press **Keep** to make it permanent. Switch that setting off, or use the Cancel button in the recording bar, and nothing is saved. Until you do, it stays out of search and out of your dictation counts. If saving fails for a storage reason, EnviousWispr tells you.
+Each row says which kind it is. The **All**, **Dictations** and **Transcripts** buttons above the list show one kind or both. A transcript with more than one voice shows its speakers, named **Speaker 1**, **Speaker 2** and so on; click a name to rename it.
+
+Recordings where no speech was found are not saved. A dictation you cancel with your keybind IS saved, because [Escape Recovery](/help/escape-recovery/) is on unless you switch it off: it is kept here for 24 hours with a **Kept** badge and a countdown, and press **Keep** to make it permanent. Switch that setting off, or use the Cancel button in the recording bar, and nothing is saved. Until you do, it stays out of search and out of your counts. If saving fails for a storage reason, EnviousWispr tells you.
 
 ### What you can do
 
 History gives you several ways to work with past recordings.
 
-- **Search your past dictations.** Find text from an earlier session inside the history window.
-- **Copy or paste.** Copy a past dictation back to your clipboard, or paste it straight into the app you are in.
-- **Delete records.** Remove a single dictation you no longer need, or delete all of them at once.
+- **Search.** Type in **Search history** to find text from an earlier dictation or transcript, the name of an imported file, or a speaker you renamed.
+- **Copy or paste.** Copy a past dictation or transcript back to your clipboard, or paste it straight into the app you are in.
+- **Delete records.** Remove a single dictation or transcript you no longer need, or delete all of them at once. Delete all removes every item in History, including any a filter or search is hiding.
 
 ### Where it is kept
 
-Your past dictations are stored on your Mac, inside your user folder. They survive quitting the app, updating it, and restarting your computer. Envious Labs never receives a copy of your history, and there is no limit on how many dictations are kept.
+Your past dictations and transcripts are stored on your Mac, inside your user folder. They survive quitting the app, updating it, and restarting your computer. Envious Labs never receives a copy of your History, and there is no limit on how many items are kept.
 
 ### If History looks empty
 
 If the history view shows nothing, check these two things.
 
-- **Complete a dictation.** Finish at least one dictation, so there is something to display.
-- **Check the storage folder.** If dictations you know you recorded are missing, check whether `~/Library/Application Support/EnviousWispr` was moved or deleted. Every copy of the app on your Mac reads that same folder.
+- **Complete a dictation, or import a file.** Finish at least one, so there is something to display. If a filter is on, choose **All**.
+- **Check the storage folder.** If items you know you recorded are missing, check whether `~/Library/Application Support/EnviousWispr` was moved or deleted. Every copy of the app on your Mac reads that same folder.

--- a/website/src/content/help/what-data-is-collected.md
+++ b/website/src/content/help/what-data-is-collected.md
@@ -8,11 +8,11 @@ keywords: ["what data", "analytics", "telemetry", "collected", "do you see my te
 related: ["privacy-overview"]
 updated: 2026-09-01
 ---
-EnviousWispr collects anonymous usage data and crash reports. Nothing you say is part of that. Your audio and your transcripts never reach Envious Labs, the company that makes the app.
+EnviousWispr collects anonymous usage data and crash reports. Nothing you say is part of that. Your audio, your dictations and your transcripts never reach Envious Labs, the company that makes the app.
 
 ### What stays on your Mac
 
-Your transcripts are saved to your History so you can find them later. They sit in your user folder, and Envious Labs never receives a copy.
+Your dictations and transcripts are saved to your History so you can find them later. They sit in your user folder, and Envious Labs never receives a copy.
 
 [Escape Recovery](/help/escape-recovery/) is on unless you switch it off, so a recording you cancel with your keybind is transcribed and held in that same folder, letting you paste it back or press Keep to make it permanent. It stays available for 24 hours. After that it is removed while the app is running, or the next time you launch it. Its audio is deleted once its text is safely saved, exactly as with any other dictation.
 
@@ -23,7 +23,7 @@ Your custom words, settings, and API keys live here too. They stay on your Mac u
 ### What Envious Labs never receives
 
 - Your audio
-- Your transcripts, before or after polish
+- Your dictations and transcripts, before or after polish
 - Your custom words
 - The text around your cursor
 - Your API keys
@@ -39,8 +39,8 @@ If you would rather run without it, EnviousWispr is open source under the GPLv3 
 
 ### Where your text goes if you use cloud AI polish
 
-Polish runs on your Mac by default. If you choose OpenAI, Gemini, or Claude instead, you add your own API key. Your transcript is then sent to that provider, along with your custom words and the name of the app you are dictating into, so the model gets your spellings and tone right. Audio is never sent. The app tells you this when you set it up. That connection is your account with that company, governed by their terms.
+Polish runs on your Mac by default. If you choose OpenAI, Gemini, or Claude instead, you add your own API key. Your text is then sent to that provider, along with your custom words and the name of the app you are dictating into, so the model gets your spellings and tone right. Audio is never sent. The app tells you this when you set it up. That connection is your account with that company, governed by their terms.
 
-Ollama works in two ways, and only one of them keeps your transcript on your Mac. A model you download runs on your Mac and sends nothing anywhere. A hosted model runs on Ollama's servers, so your transcript goes to Ollama in the same way it would go to any other cloud provider. EnviousWispr lists the two kinds under separate headings so you can tell which you are picking.
+Ollama works in two ways, and only one of them keeps your text on your Mac. A model you download runs on your Mac and sends nothing anywhere. A hosted model runs on Ollama's servers, so your text goes to Ollama in the same way it would go to any other cloud provider. EnviousWispr lists the two kinds under separate headings so you can tell which you are picking.
 
 Envious Labs is not in the middle of any of these requests. Everything goes straight from your Mac to the provider, so Envious Labs never sees it either way.

--- a/website/src/pages/compare/apple-dictation.astro
+++ b/website/src/pages/compare/apple-dictation.astro
@@ -143,7 +143,7 @@ const faqJsonLd = JSON.stringify({
       "name": "Can I use both Apple Dictation and EnviousWispr at the same time?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. They use separate keybinds and separate audio pipelines. Keep Apple Dictation for quick inline corrections and voice commands. Use EnviousWispr for longer dictation where you want AI polish, custom vocabulary, and transcript history."
+        "text": "Yes. They use separate keybinds and separate audio pipelines. Keep Apple Dictation for quick inline corrections and voice commands. Use EnviousWispr for longer dictation where you want AI polish, custom vocabulary, and History."
       }
     }
   ]
@@ -473,8 +473,8 @@ const faqJsonLd = JSON.stringify({
             <td>Stops listening entirely after ~30s silence</td>
           </tr>
           <tr>
-            <td>Transcript history</td>
-            <td><span class="table-check">Yes</span> (searchable transcript log)</td>
+            <td>History</td>
+            <td><span class="table-check">Yes</span> (searchable dictations and transcripts)</td>
             <td><span class="table-cross">No history</span></td>
           </tr>
           <tr>
@@ -713,7 +713,7 @@ const faqJsonLd = JSON.stringify({
       </div>
       <div class="faq-item reveal">
         <div class="faq-q">Can I use both Apple Dictation and EnviousWispr at the same time?</div>
-        <p class="faq-a">Yes. They use separate keybinds and separate audio pipelines. Keep Apple Dictation for quick inline corrections and voice commands. Use EnviousWispr for longer dictation where you want AI polish, custom vocabulary, and transcript history. They do not interfere with each other.</p>
+        <p class="faq-a">Yes. They use separate keybinds and separate audio pipelines. Keep Apple Dictation for quick inline corrections and voice commands. Use EnviousWispr for longer dictation where you want AI polish, custom vocabulary, and History. They do not interfere with each other.</p>
       </div>
     </div>
   </div>

--- a/website/src/pages/compare/otter-ai.astro
+++ b/website/src/pages/compare/otter-ai.astro
@@ -713,7 +713,7 @@ const faqJsonLd = JSON.stringify({
       <div class="advantage-card reveal">
         <div class="advantage-icon">🔍</div>
         <div class="advantage-title">Search across meetings</div>
-        <p class="advantage-desc">Otter indexes all your past transcripts and lets you search across them. Find what was said in any meeting, by any speaker. EnviousWispr has no transcript history or search.</p>
+        <p class="advantage-desc">Otter indexes all your past transcripts and lets you search across them. Find what was said in any meeting, by any speaker. EnviousWispr lets you search the dictations and transcripts saved in History on your Mac.</p>
       </div>
       <div class="advantage-card reveal">
         <div class="advantage-icon">📱</div>

--- a/website/src/pages/features/history.astro
+++ b/website/src/pages/features/history.astro
@@ -12,7 +12,7 @@ import DownloadClosing from '../../components/DownloadClosing.astro';
 <FeatureShell
   path="/features/history/"
   title="History: read, copy and recover recent dictations on Mac"
-  description="Every dictation and transcript stays on your Mac to read and copy. Cancelled by accident? The text is kept for 24 hours. See how recovery works and stops."
+  description="Every dictation and transcript stays on your Mac to read and copy. Cancelled by accident? The text can be kept for 24 hours. See how recovery works."
 >
   <FeatureHero
     kind="history"

--- a/website/src/pages/features/history.astro
+++ b/website/src/pages/features/history.astro
@@ -12,12 +12,12 @@ import DownloadClosing from '../../components/DownloadClosing.astro';
 <FeatureShell
   path="/features/history/"
   title="History: read, copy and recover recent dictations on Mac"
-  description="Every transcript stays on your Mac to read and copy. Cancelled by accident? The text can be kept for 24 hours. See how recovery works and where it stops."
+  description="Every dictation and transcript stays on your Mac to read and copy. Cancelled by accident? The text is kept for 24 hours. See how recovery works and stops."
 >
   <FeatureHero
     kind="history"
     label="History"
-    title={'Your transcripts,<br><span class="accent-ink">saved on your Mac.</span>'}
+    title={'Your dictations and transcripts,<br><span class="accent-ink">saved on your Mac.</span>'}
     copy="History saves the text from your dictations and file transcriptions. Find something you said earlier, copy it, and use it again."
   >
     <HistoryFilm />
@@ -26,32 +26,32 @@ import DownloadClosing from '../../components/DownloadClosing.astro';
     <div>
       <span class="eyebrow">Cancelled recordings</span>
       <h2>Cancelled by mistake?</h2>
-      <p>With Escape Recovery enabled, cancelling with your keyboard shortcut keeps the transcript in History for 24 hours. Copy the text or select Keep to save it permanently.</p>
+      <p>With Escape Recovery enabled, cancelling with your keyboard shortcut keeps the dictation in History for 24 hours. Copy the text or select Keep to save it permanently.</p>
       <small>Escape Recovery is on by default. Clicking the Cancel button discards the recording.</small>
     </div>
     <div class="history-clock-card">
       <strong>24<span>hours</span></strong>
-      <p>To copy or keep<br />a cancelled transcript.</p>
+      <p>To copy or keep<br />a cancelled dictation.</p>
       <div><span>Kept</span><span>Copy or Keep</span></div>
     </div>
   </section>
   <section class="history-library wrap">
     <div class="section-top">
-      <div><span class="eyebrow">Saved transcripts</span><h2>Find and copy<br />your past transcripts.</h2></div>
-      <p>Open History to read a previous transcript. Search for a word or phrase, then copy the text you need.</p>
+      <div><span class="eyebrow">Saved dictations and transcripts</span><h2>Find and copy<br />your past dictations and transcripts.</h2></div>
+      <p>Open History to read a previous dictation or transcript. Search for a word or phrase, then copy the text you need.</p>
     </div>
     <div class="history-benefits">
       <div>
         <h3>Stored on your Mac.</h3>
-        <p>Your transcripts stay saved when you close the app or restart your Mac.</p>
+        <p>Your dictations and transcripts stay saved when you close the app or restart your Mac.</p>
         <details>
           <summary>What happens to the audio?</summary>
-          <p>History keeps transcripts. Dictation audio is normally cleared after processing; temporary audio can remain for recovery. Your original imported files are left alone.</p>
+          <p>History keeps dictations and transcripts. Dictation audio is normally cleared after processing; temporary audio can remain for recovery. Your original imported files are left alone.</p>
         </details>
       </div>
       <div>
         <h3>Copy or paste.</h3>
-        <p>Copy a transcript to your clipboard, or paste it directly into the app you are using.</p>
+        <p>Copy a dictation or transcript to your clipboard, or paste it directly into the app you are using.</p>
       </div>
     </div>
   </section>
@@ -65,7 +65,7 @@ import DownloadClosing from '../../components/DownloadClosing.astro';
     <div class="history-rescued recovery-example">
       <div><b>History</b><span>Recovered</span></div>
       <p>Let’s move the meeting to Friday.</p>
-      <small>Recovered transcript</small>
+      <small>Recovered dictation</small>
       <div class="history-actions"><span>Copy</span></div>
     </div>
   </section>


### PR DESCRIPTION
Closes #2812. Part of #2807 (phase 5 of 5).

## What the user gets

The same three words everywhere. A recording made with the keybind is a **dictation**, a recording imported with Transcribe a File is a **transcript**, and the collection is **History**. The app said so since phase 1; now the help centre, the website, the README, Settings and onboarding say so too. The History help page describes what History holds today: both kinds, the All / Dictations / Transcripts filter, speaker labels and rename, search over text, file names and speaker names.

## Method

`claim-sweep.sh transcript`: 1,471 mentions on 8 surfaces, 149 in copy a user reads. Every one classified in the plan (`docs/feature-requests/issue-2812-2026-09-13-vocabulary-sweep-addendum.md`, local): a sentence that names a saved item takes the item's word; a generic "transcript" meaning the text of speech (blog prose, comparison pages describing competitors, "only the text transcript is sent") stays; dated release notes stay as evidence of what shipped. Filenames, slugs, `related:` links, search keywords and identifiers unchanged.

## Changed

- Help centre: `transcript-history.md` (title and section "History", body rewritten), `what-data-is-collected.md` (six sentences), `privacy-overview.md`, `ai-polish-and-cloud-data.md`, `how-custom-word-correction-works.md`.
- Website: `features/history.astro` (ten sites, the description trimmed to the checked length), `compare/apple-dictation.astro` (four), `compare/otter-ai.astro` (its "EnviousWispr has no transcript history or search" has been false since #2808).
- README: three sentences.
- App: Settings Clipboard blurb and section subtitle, three cloud-polish provider blurbs ("Cloud polish sends your text"), two onboarding Accessibility sentences, and the Dictionary placeholder "Learn from my edits" (what its own card promises).
- Catalog (local, `data/076-macos-vocabulary-sweep.sql`, rebuilt): the four Settings/onboarding strings, and the rows phase 1 left stale.

Kept, with the reason in the plan: 80 comparison-page hits (competitor prose, generic speech output, MacWhisper's correctly named file-import transcripts), the features page's transcript player (file imports), 11 blog sentences, six dated What's New notes.

Filed separately: #2881, the help centre has no Transcribe a File article at all.

## Review

Two grounded Codex rounds on the disposition tables: round 1 added the features page, the two comparison pages, the provider blurbs and a second onboarding sentence, replaced "Learn from my History" with "Learn from my edits", and kept the dated notes; round 2 corrected two row descriptions and confirmed the Otter sentence against `TranscriptCoordinator`'s search. Coverage folded into those rounds (alerts, menus, notifications, features index, privacy policy, Sparkle appcast, release workflow checked clean by the reviewer; live Termly and App Store copy are not in the repo).

Tier: MEDIUM | Lane: Content | mixed_pr: true (14 in-app string edits) | Test: n/a (help checks)

## Checks

`npm run build` and `npm run check:help` in the worktree: help routes 71/71, search 47/47, features 9/9. `swift test` on the settings, onboarding, provider and What's New suites: 185/185 (informal). Xcode lane: `ProviderSetupOwnershipTests` (one of the changed files) locally; the full debug lane runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF9Bb42yHkgffHPuRzdBL2
